### PR TITLE
release: v17.0.0 follow-up substrate closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded the Git Stunts substrate packages to current registry releases:
+  `@git-stunts/git-cas` `^6.0.0`, `@git-stunts/plumbing` `^3.0.3`, and
+  `@git-stunts/alfred` `^0.10.3`. The Deno runtime test import map now tracks
+  plumbing v3, and integration helpers await plumbing's async default factory.
+
 ## [17.0.0] — 2026-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `@git-stunts/git-cas` `^6.0.0`, `@git-stunts/plumbing` `^3.0.3`, and
   `@git-stunts/alfred` `^0.10.3`. The Deno runtime test import map now tracks
   plumbing v3, and integration helpers await plumbing's async default factory.
+- `npm run upgrade` now runs a top-level `scripts/upgrade-v16-to-v17.ts`
+  operator utility. It upgrades v16 checkpoint schemas for all discovered
+  graphs by default and clears rebuildable legacy cache refs that must be
+  rewritten through the current git-cas substrate.
 
 ## [17.0.0] — 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.0] — 2026-05-05
+
 ### Changed
 
 - Upgraded the Git Stunts substrate packages to current registry releases:
@@ -21,11 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `readBlobStream()` with an explicit adapter-boundary collector, and
   recursive tree OID scans use git-cas `iterateTree()` while preserving
   git-warp's path-preserving recursive map contract.
-
-## [17.0.0] — 2026-05-05
-
-### Changed
-
 - **v17.0.0 release cut** — Package and JSR versions agree at `17.0.0`, the
   release chronology is dated to the May 5 release cut, and the v17 release
   notes now preserve the honest bounded-query scope from the 0123 release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operator utility. It upgrades v16 checkpoint schemas for all discovered
   graphs by default and clears rebuildable legacy cache refs that must be
   rewritten through the current git-cas substrate.
+- `GitGraphAdapter` now reads graph blobs through git-cas v6
+  `readBlobStream()` with an explicit adapter-boundary collector, and
+  recursive tree OID scans use git-cas `iterateTree()` while preserving
+  git-warp's path-preserving recursive map contract.
 
 ## [17.0.0] — 2026-05-05
 

--- a/docs/method/backlog/up-next/INFRA_git-cas-vault-encryption.md
+++ b/docs/method/backlog/up-next/INFRA_git-cas-vault-encryption.md
@@ -1,0 +1,43 @@
+---
+id: INFRA_git-cas-vault-encryption
+blocked_by:
+  - INFRA_git-cas-adapter-parity
+blocks: []
+feature: runtime-boundaries
+---
+
+# Vault-backed git-cas encryption for graph content
+
+## Problem
+
+`git-warp` has narrow encryption hooks around CAS-backed blob and seek-cache
+storage, but they pass raw encryption keys directly. With git-cas v6,
+encryption should be treated as a vault-backed operator workflow, not as loose
+key plumbing scattered through adapters.
+
+## Direction
+
+If git-warp exposes encrypted CAS content, use git-cas vault facilities for key
+lookup, rotation, privacy-mode vault metadata, and operator diagnostics. Keep
+raw keys as an internal adapter detail only where a caller has already resolved
+them from an approved vault/key source.
+
+## Scope
+
+- Decide which surfaces may be encrypted: content attachments, seek cache,
+  trust records, checkpoint payloads, or all CAS-backed payloads.
+- Define an operator-facing configuration shape for vault-backed encryption.
+- Use git-cas v6 current schemes only: `whole`, `framed`, or `convergent`.
+- Surface `LEGACY_SCHEME` with migration guidance when old encrypted CAS
+  manifests are encountered.
+- Update `GUIDE.md` or `ADVANCED_GUIDE.md` in the same slice that introduces
+  the feature. The docs must explain vault setup, recovery, rotation, and the
+  confidentiality/deduplication tradeoff of convergent encryption.
+
+## Acceptance Criteria
+
+- No public git-warp API asks ordinary users to juggle anonymous raw
+  encryption keys for CAS content.
+- Vault-backed flows have tests for wrong passphrases, missing vault metadata,
+  rotation, and legacy scheme errors.
+- Documentation ships with the feature, not afterward.

--- a/docs/method/backlog/up-next/INFRA_policy-as-port-streaming-resilience.md
+++ b/docs/method/backlog/up-next/INFRA_policy-as-port-streaming-resilience.md
@@ -1,0 +1,52 @@
+---
+id: INFRA_policy-as-port-streaming-resilience
+blocked_by: []
+blocks:
+  - INFRA_git-cas-adapter-parity
+feature: runtime-boundaries
+---
+
+# Policy-as-a-port for retries, timeouts, and streams
+
+## Problem
+
+`git-warp` currently imports Alfred directly in a few runtime and
+infrastructure paths. That makes Alfred look like the policy model instead of
+one provider of a `PolicyPort`.
+
+The bigger issue is streaming. A plain `execute(() => Promise<T>)` wrapper is
+not enough for `readBlobStream()`, patch scans, index shard streams, sync body
+streams, and future git-cas streaming APIs. Resilience needs to preserve stream
+lifetime, cancellation, backpressure, and partial-consumption behavior.
+
+## Direction
+
+Define a port owned by git-warp, for example:
+
+```ts
+interface OperationPolicyPort {
+  execute<T>(operation: () => Promise<T>): Promise<T>;
+  stream<T>(operation: () => Promise<AsyncIterable<T>>): Promise<AsyncIterable<T>>;
+}
+```
+
+Alfred becomes an infrastructure adapter that implements the promise side and,
+only where the semantics are honest, stream setup retries/timeouts. Runtime code
+depends on the port, not on Alfred directly.
+
+## Constraints
+
+- Do not retry after a stream has yielded user-visible bytes unless the stream
+  protocol is explicitly replayable and idempotent.
+- Cancellation must be carried by an explicit signal or stream return path.
+- CAS compare-and-swap failures must not be retried.
+- Stream policies must be tested with partial consumption, thrown iterators,
+  cancellation, and slow consumers.
+
+## Acceptance Criteria
+
+- Domain and port code do not import `@git-stunts/alfred`.
+- Infrastructure adapters receive a `PolicyPort` or a named null policy.
+- `GitGraphAdapter`, sync HTTP clients, and git-cas adapters use the port.
+- Streaming APIs have tests proving no hidden buffering and no unsafe retry
+  after bytes are emitted.

--- a/docs/method/backlog/v17.0.0/INFRA_git-cas-adapter-parity.md
+++ b/docs/method/backlog/v17.0.0/INFRA_git-cas-adapter-parity.md
@@ -17,8 +17,14 @@ the originally proposed unification was not behaviorally safe.
 The current git-cas adapters do not yet expose every graph-persistence
 semantic git-warp needs:
 
-- `GitPersistenceAdapter.readBlob()` collects without git-warp's
-  explicit `maxBytes: Number.POSITIVE_INFINITY` read posture.
+- `GitPersistenceAdapter.readBlobStream()` now exists in git-cas v6; git-warp
+  should prefer that for graph blob reads instead of collecting first.
+- `GitPersistenceAdapter.readBlob()` still has metadata safety limits; git-warp
+  must keep an explicit unbounded read posture only where a caller knowingly
+  asks to collect a complete graph blob.
+- `GitPersistenceAdapter.iterateTree()` and `readTreeEntry()` now exist in
+  git-cas v6; git-warp can use them as the substrate for recursive,
+  path-preserving tree traversal instead of raw `ls-tree` calls.
 - `GitPersistenceAdapter.readTree()` returns one-level parsed tree
   entries, while git-warp's `readTreeOids()` returns a recursive
   path-to-OID map.
@@ -49,9 +55,11 @@ methods just to make the class look thinner.
 
 ## Acceptance Criteria
 
-- `GitGraphAdapter.readBlob()` keeps an explicit unbounded read or moves
-  to an equivalent streaming git-cas API.
+- `GitGraphAdapter.readBlob()` moves to `GitPersistenceAdapter.readBlobStream()`
+  plus an explicit collector at the adapter boundary.
 - recursive tree OID reads remain recursive and path-preserving.
+- one-entry tree reads and tree iteration use git-cas v6 APIs where semantics
+  match exactly.
 - commit creation continues to support multiple parents and signing.
 - ref CAS failures are not retried.
 - ref deletion remains available.

--- a/docs/method/backlog/v17.0.0/INFRA_git-cas-adapter-parity.md
+++ b/docs/method/backlog/v17.0.0/INFRA_git-cas-adapter-parity.md
@@ -53,6 +53,23 @@ Acceptable completion shapes:
 Do not replace current read/ref/commit behavior with weaker git-cas
 methods just to make the class look thinner.
 
+## Closed shape
+
+The repo-local completion path uses `GitCasGraphReaderAdapter` as the
+narrow infrastructure adapter around git-cas v6:
+
+- `GitGraphAdapter.readBlob()` delegates to
+  `GitPersistenceAdapter.readBlobStream()` and collects at the
+  graph-adapter boundary only.
+- `GitGraphAdapter.readTreeOids()` recursively walks
+  `GitPersistenceAdapter.iterateTree()` so git-warp keeps its
+  path-preserving recursive `Record<path, oid>` contract.
+- `GitGraphAdapter.readTree()` resolves blob payloads through the same
+  stream-backed read path.
+- commit creation, compare-and-swap ref updates, and ref deletion remain
+  in `GitGraphAdapter` because git-cas does not expose equivalent
+  multi-parent signing, non-retried CAS, or delete-ref semantics.
+
 ## Acceptance Criteria
 
 - `GitGraphAdapter.readBlob()` moves to `GitPersistenceAdapter.readBlobStream()`

--- a/docs/method/backlog/v17.0.0/INFRA_substrate-upgrade-tool.md
+++ b/docs/method/backlog/v17.0.0/INFRA_substrate-upgrade-tool.md
@@ -20,10 +20,10 @@ fallbacks or abandon old data.
 `npm run upgrade` / `git warp upgrade` runs offline, walks all existing
 objects in a WARP graph, and migrates them to the current substrate version.
 
-For the v17.0.0 ORSet/checkpoint break, the concrete repo-local entry
-point is `scripts/migrations/v17.0.0/migrate.ts`. Old checkpoint
-readers, old ORSet-backed materializers, and one-shot translation logic
-live there (and under its private helper modules), not in `src/`.
+For the v16 -> v17 git-cas shape transition, the concrete repo-local
+operator entry point is `scripts/upgrade-v16-to-v17.ts`. Versioned
+legacy readers and one-shot translation logic live under
+`scripts/migrations/v17.0.0/`, not in `src/`.
 
 The package-level command is:
 

--- a/docs/migrations/v17.0.0.md
+++ b/docs/migrations/v17.0.0.md
@@ -10,6 +10,27 @@ and worldline-scoped optics.
 
 ## Quick start
 
+### Graph repository upgrade
+
+Run the graph substrate upgrade from the Git repository that stores WARP graph
+data:
+
+```bash
+# Inspect all discovered graphs without moving refs
+npm run upgrade -- --dry-run
+
+# Upgrade all discovered graphs
+npm run upgrade
+```
+
+The top-level upgrader upgrades retired v16 checkpoint schemas to the current
+v17 checkpoint envelope and clears rebuildable legacy cache refs that must be
+rewritten through the current git-cas substrate. Use `--graph <name>` to target
+one graph, `--repo <path>` to run against another repository, and `--json` for
+machine-readable output.
+
+### Consumer source migration
+
 Run the mechanical migration scripts first, then address any remaining
 manual changes:
 

--- a/docs/releases/v17.0.0/README.md
+++ b/docs/releases/v17.0.0/README.md
@@ -174,7 +174,17 @@ LAYER 5 (launch-prep proof and release hardening tail):
                                           while read/ref/commit parity was
                                           split to
                                           `INFRA_git-cas-adapter-parity`
-  [ ] INFRA_git-cas-adapter-parity
+  [x] INFRA_git-cas-adapter-parity ← graph blob reads now delegate to
+                                      git-cas v6 `readBlobStream()`
+                                      through an explicit unbounded
+                                      adapter-boundary collector, and
+                                      recursive tree OID scans use
+                                      `iterateTree()` while preserving
+                                      git-warp's path map. Multi-parent
+                                      signed commits, non-retried ref
+                                      CAS, and ref deletion remain local
+                                      because git-cas does not expose
+                                      equivalent semantics.
   [x] INFRA_uniform-git-cas        ← cycle 0092 retired stale live card;
                                       default Git-backed runtime payloads route
                                       patches, checkpoints, indexes, and trust

--- a/docs/specs/CONTENT_ATTACHMENT.md
+++ b/docs/specs/CONTENT_ATTACHMENT.md
@@ -185,6 +185,8 @@ This makes content storage reachable via the writer ref chain (`refs/warp/<graph
 
 **Checkpoint anchoring:** checkpoint creation also scans `state.prop` for `_content` values and embeds the referenced storage OIDs in the checkpoint tree. This ensures content survives GC even if patch commits are ever pruned (e.g., by future compaction or writer-chain truncation). The invariant is: **content storage referenced by live state is always reachable from at least one ref** — either the writer ref (patch commit tree) or the checkpoint ref (checkpoint commit tree).
 
+Current content OIDs are CAS trees. Checkpoint anchoring also preserves legacy raw Git blob content by writing those anchors as blob tree entries instead of tree entries.
+
 Integration tests verify both anchoring paths with `git gc --prune=now`.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "packages/*"
       ],
       "dependencies": {
-        "@git-stunts/alfred": "^0.4.0",
-        "@git-stunts/git-cas": "^5.3.2",
-        "@git-stunts/plumbing": "^2.8.0",
+        "@git-stunts/alfred": "^0.10.3",
+        "@git-stunts/git-cas": "^6.0.0",
+        "@git-stunts/plumbing": "^3.0.3",
         "@git-stunts/trailer-codec": "^2.1.1",
         "@noble/hashes": "^2.2.0",
         "boxen": "^7.1.1",
@@ -204,26 +204,24 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -235,7 +233,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -412,43 +409,73 @@
       }
     },
     "node_modules/@flyingrobots/bijou": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou/-/bijou-0.2.0.tgz",
-      "integrity": "sha512-Oix2Kqq4w87KCkyK2W+8u4E4aGVQiraUy8BF3Bk/NRtT+UlUI0ETs+E7GwpwOyOvHvt0cIOjcMmVPxzKa52P4A==",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou/-/bijou-5.0.0.tgz",
+      "integrity": "sha512-Vmcs1jZYIxwb2NOn+LCDMK8ZmIKz64eTQI+gEk11Odn32s4ipIrzawrfrrAWZ4UTsdD5c9xWwwJH6SYgo5klBg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@flyingrobots/bijou-i18n": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-i18n/-/bijou-i18n-5.0.0.tgz",
+      "integrity": "sha512-S3HUHBBLh7fZlijcyuJvtrcJYa+rlhmfW5AAaMZmvIS1P9yd38t7P3JaPGsmKPJjCIVsVgiH3zrjWY15TKB6xA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@flyingrobots/bijou-node": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-node/-/bijou-node-0.2.0.tgz",
-      "integrity": "sha512-QaIaoBF0OMRHGtLsga1knplfFEmAeC6Lt4SxWkCKIJahMdNqXatCWM3RdzXcbjfcXqRIXyeEpm1agmmwi4gneQ==",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-node/-/bijou-node-5.0.0.tgz",
+      "integrity": "sha512-Ano8ydJKF/M8MGPeQDMjOuLouKFEOnEaTwYOKAHHMWxDh03G0Yt9HqZPPu364puzJuyFkY1APxtsxUCbru+5IA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou": "0.2.0",
-        "chalk": "^5.6.2"
+        "@flyingrobots/bijou-tui": "5.0.0",
+        "chalk": "^5.6.2",
+        "gifenc": "^1.0.3",
+        "oled-font-5x7": "^1.0.3"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@flyingrobots/bijou": "5.0.0"
       }
     },
     "node_modules/@flyingrobots/bijou-tui": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-tui/-/bijou-tui-0.2.0.tgz",
-      "integrity": "sha512-pXEo/Am6svRIKvez7926avdGUbfVndlSOpidBPc42YjCQHU5ZQrEuJpjI7niJb63N0ruxu0VXHci8N0wzBYSow==",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-tui/-/bijou-tui-5.0.0.tgz",
+      "integrity": "sha512-dJAWBIZ8osXIM5y6Mc2KsawHPYR/3JxQEO78yVzzdsQiAx9PZLTQvB8fY6oUQRf+/n3sU9l2Ep0UUsJIbhAmpA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou": "0.2.0"
+        "@flyingrobots/bijou-i18n": "5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@flyingrobots/bijou": "5.0.0"
+      }
+    },
+    "node_modules/@flyingrobots/bijou-tui-app": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-tui-app/-/bijou-tui-app-5.0.0.tgz",
+      "integrity": "sha512-NrmTalkI1uIEBosE4tzSF04pMbP+Rs32NNlCRY6njDawDYr8mDBLErziyomio/zhHVVKvnrLuo6g4aLsDPKqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@flyingrobots/bijou": "5.0.0",
+        "@flyingrobots/bijou-tui": "5.0.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@git-stunts/alfred": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@git-stunts/alfred/-/alfred-0.4.0.tgz",
-      "integrity": "sha512-80/W7x4pZYRyJB/AQs89aDbi+BcA7/N8G67zdJbKU7lbdrbbtglnY15/iSU66xvLD7/nFTTk9nGNhpw30h6QEQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@git-stunts/alfred/-/alfred-0.10.3.tgz",
+      "integrity": "sha512-dvy7Ej9Jyv9gPh4PtQuMfsZnUa7ycIwoFFnXLrQutRdoTTY4F4OOD2kcSJOs3w8UZhwOyLsHO7PcetaKB9g32w==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.0.0"
@@ -462,18 +489,20 @@
       "license": "Apache-2.0"
     },
     "node_modules/@git-stunts/git-cas": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@git-stunts/git-cas/-/git-cas-5.3.2.tgz",
-      "integrity": "sha512-DLh5fBxTTJTHOUjH0VifSZSHSmffrrdt5cLnFUxMZ/+dcfbnqdQLW0/7prNnDAT05qRXPWGNW27dCZNI/5eN0g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@git-stunts/git-cas/-/git-cas-6.0.0.tgz",
+      "integrity": "sha512-NyTOaCHq6VBGCbL6HKR0bmX3uarumLAR+s2R8pofMGC3WX3YaS1pNdwTJOOzpvcZGWu3FKWAUVU9U0rdEyRoaw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou": "^0.2.0",
-        "@flyingrobots/bijou-node": "^0.2.0",
-        "@flyingrobots/bijou-tui": "^0.2.0",
+        "@flyingrobots/bijou": "^5.0.0",
+        "@flyingrobots/bijou-node": "^5.0.0",
+        "@flyingrobots/bijou-tui": "^5.0.0",
+        "@flyingrobots/bijou-tui-app": "^5.0.0",
         "@git-stunts/alfred": "^0.10.0",
-        "@git-stunts/plumbing": "^2.8.0",
+        "@git-stunts/plumbing": "^3.0.3",
+        "@git-stunts/vault": "^1.0.1",
         "cbor-x": "^1.6.0",
-        "commander": "^14.0.3",
+        "commander": "14.0.3",
         "zod": "^3.24.1"
       },
       "bin": {
@@ -483,19 +512,10 @@
         "node": ">=22.0.0"
       }
     },
-    "node_modules/@git-stunts/git-cas/node_modules/@git-stunts/alfred": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@git-stunts/alfred/-/alfred-0.10.3.tgz",
-      "integrity": "sha512-dvy7Ej9Jyv9gPh4PtQuMfsZnUa7ycIwoFFnXLrQutRdoTTY4F4OOD2kcSJOs3w8UZhwOyLsHO7PcetaKB9g32w==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@git-stunts/plumbing": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@git-stunts/plumbing/-/plumbing-2.8.0.tgz",
-      "integrity": "sha512-wHZQAgPCG8MlcjrgwQx8OoFSxcKGqxCULxxE3XOZk5xiWW3AgSeZgiQ2Z6XCMz1fbaGVOWQOhIvCsyyzlRFbfw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@git-stunts/plumbing/-/plumbing-3.0.3.tgz",
+      "integrity": "sha512-LmPaq9c51bYA1Ta0KJrmewFTlAwueQv4EdguiI4/TNK9LOeJkkchC2RaOX09WXubauvUeEk8Z32rG8zxdk491g==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.24.1"
@@ -522,6 +542,29 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@git-stunts/vault": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@git-stunts/vault/-/vault-1.0.1.tgz",
+      "integrity": "sha512-oJSoqTUzNEF9QXJghene9Ia/T1tA8l3DZY4KQ2sQiZK1U8Qveqn+IhRDUhZeWcutTiCaI3BauZxhGr0UH53+gQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "bun": ">=1.3.5",
+        "deno": ">=2.0.0",
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@git-stunts/vault/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -653,9 +696,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -714,9 +757,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.130.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -724,9 +767,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
@@ -741,9 +784,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
@@ -758,9 +801,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
@@ -775,9 +818,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
@@ -792,9 +835,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
@@ -809,9 +852,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
@@ -829,9 +872,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
@@ -849,9 +892,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
@@ -869,9 +912,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
@@ -889,9 +932,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
@@ -909,9 +952,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
@@ -929,9 +972,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
@@ -946,9 +989,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
@@ -956,16 +999,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
@@ -980,9 +1025,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
@@ -997,9 +1042,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1024,9 +1069,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2883,6 +2928,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
@@ -3154,9 +3205,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4802,9 +4853,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -4990,6 +5041,12 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/oled-font-5x7": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/oled-font-5x7/-/oled-font-5x7-1.0.3.tgz",
+      "integrity": "sha512-l25WvKft8CgXYxtaqKdYrAS1P91rnUUUIiOXojAOvjNCsfFzIl1aEsE2JuaRgMh1Euo7slm5lX0w+1qNkL8PpQ==",
       "license": "MIT"
     },
     "node_modules/open": {
@@ -5250,9 +5307,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -5432,14 +5489,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.130.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -5448,21 +5505,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.1",
+        "@rolldown/binding-darwin-arm64": "1.0.1",
+        "@rolldown/binding-darwin-x64": "1.0.1",
+        "@rolldown/binding-freebsd-x64": "1.0.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.1",
+        "@rolldown/binding-linux-arm64-musl": "1.0.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-gnu": "1.0.1",
+        "@rolldown/binding-linux-x64-musl": "1.0.1",
+        "@rolldown/binding-openharmony-arm64": "1.0.1",
+        "@rolldown/binding-wasm32-wasi": "1.0.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.1",
+        "@rolldown/binding-win32-x64-msvc": "1.0.1"
       }
     },
     "node_modules/run-con": {
@@ -5766,14 +5823,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5983,17 +6040,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.13",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.1",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -6009,8 +6066,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prepare": "patch-package && node scripts/setup-hooks.ts",
     "prepack": "npm run build && npm run lint && npm run test:local && npm run typecheck:consumer",
     "release:preflight": "bash scripts/release-preflight.sh",
-    "upgrade": "npm run build --silent && node dist/scripts/migrations/v17.0.0/migrate.js",
+    "upgrade": "npm run build --silent && node dist/scripts/upgrade-v16-to-v17.js",
     "install:git-warp": "bash scripts/install-git-warp.sh",
     "uninstall:git-warp": "bash scripts/uninstall-git-warp.sh",
     "test:node20": "docker compose -f docker/docker-compose.test.yml --profile node20 run --build --rm test-node20",

--- a/package.json
+++ b/package.json
@@ -101,9 +101,9 @@
     "ratchet:delta": "node scripts/ratchet-delta.ts"
   },
   "dependencies": {
-    "@git-stunts/alfred": "^0.4.0",
-    "@git-stunts/git-cas": "^5.3.2",
-    "@git-stunts/plumbing": "^2.8.0",
+    "@git-stunts/alfred": "^0.10.3",
+    "@git-stunts/git-cas": "^6.0.0",
+    "@git-stunts/plumbing": "^3.0.3",
     "@git-stunts/trailer-codec": "^2.1.1",
     "@noble/hashes": "^2.2.0",
     "boxen": "^7.1.1",

--- a/scripts/upgrade-v16-to-v17.ts
+++ b/scripts/upgrade-v16-to-v17.ts
@@ -34,14 +34,27 @@ export class V16ToV17UpgradeArgumentError extends Error {
   }
 }
 
+type V16ToV17UpgradeArgsOptions = {
+  readonly repo: string;
+  readonly graphNames: readonly string[];
+  readonly dryRun: boolean;
+  readonly json: boolean;
+  readonly help: boolean;
+};
+
 export class V16ToV17UpgradeArgs {
-  constructor(
-    readonly repo: string,
-    readonly graphNames: readonly string[],
-    readonly dryRun: boolean,
-    readonly json: boolean,
-    readonly help: boolean,
-  ) {
+  readonly repo: string;
+  readonly graphNames: readonly string[];
+  readonly dryRun: boolean;
+  readonly json: boolean;
+  readonly help: boolean;
+
+  constructor(options: V16ToV17UpgradeArgsOptions) {
+    this.repo = options.repo;
+    this.graphNames = options.graphNames;
+    this.dryRun = options.dryRun;
+    this.json = options.json;
+    this.help = options.help;
     Object.freeze(this);
   }
 }
@@ -96,7 +109,7 @@ export function parseArgs(argv: readonly string[], cwd: string): V16ToV17Upgrade
     const arg = argv[i];
     if (arg === '--repo') {
       const value = argv[i + 1];
-      if (value === undefined) {
+      if (value === undefined || value.startsWith('-')) {
         throw new V16ToV17UpgradeArgumentError('--repo requires a path');
       }
       repo = value;
@@ -105,7 +118,7 @@ export function parseArgs(argv: readonly string[], cwd: string): V16ToV17Upgrade
     }
     if (arg === '--graph') {
       const value = argv[i + 1];
-      if (value === undefined) {
+      if (value === undefined || value.startsWith('-')) {
         throw new V16ToV17UpgradeArgumentError('--graph requires a graph name');
       }
       graphNames.push(value);
@@ -127,7 +140,7 @@ export function parseArgs(argv: readonly string[], cwd: string): V16ToV17Upgrade
     throw new V16ToV17UpgradeArgumentError(`Unknown argument: ${arg ?? ''}`);
   }
 
-  return new V16ToV17UpgradeArgs(repo, graphNames, dryRun, json, help);
+  return new V16ToV17UpgradeArgs({ repo, graphNames, dryRun, json, help });
 }
 
 export async function upgradeV16ToV17(

--- a/scripts/upgrade-v16-to-v17.ts
+++ b/scripts/upgrade-v16-to-v17.ts
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+
+/**
+ * Top-level v16 -> v17 graph substrate upgrade utility.
+ *
+ * Usage:
+ *   npm run upgrade -- [--repo <path>] [--graph <name>] [--dry-run] [--json]
+ */
+
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import NodeCryptoAdapter from '../src/infrastructure/adapters/NodeCryptoAdapter.ts';
+import { createPersistence } from '../bin/cli/shared.ts';
+import { REF_PREFIX } from '../src/domain/utils/RefLayout.ts';
+import CliJsonFormatterAdapter from '../src/infrastructure/adapters/CliJsonFormatterAdapter.ts';
+import {
+  upgradeCheckpointSchema,
+  type CheckpointSchemaUpgradeResult,
+} from './migrations/v17.0.0/checkpoint-schema-upgrade.ts';
+import type GraphPersistencePort from '../src/ports/GraphPersistencePort.ts';
+import type CryptoPort from '../src/ports/CryptoPort.ts';
+
+const LEGACY_REBUILDABLE_CACHE_REF_SUFFIXES = [
+  '/coverage/head',
+  '/seek-cache',
+] as const;
+
+type CacheRefAction = 'absent' | 'would-delete' | 'deleted';
+
+export class V16ToV17UpgradeArgumentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'V16ToV17UpgradeArgumentError';
+  }
+}
+
+export class V16ToV17UpgradeArgs {
+  constructor(
+    readonly repo: string,
+    readonly graphNames: readonly string[],
+    readonly dryRun: boolean,
+    readonly json: boolean,
+    readonly help: boolean,
+  ) {
+    Object.freeze(this);
+  }
+}
+
+export interface CacheRefMigrationResult {
+  readonly ref: string;
+  readonly action: CacheRefAction;
+  readonly previousOid: string | null;
+}
+
+export interface GraphV16ToV17UpgradeResult {
+  readonly graphName: string;
+  readonly checkpoint: CheckpointSchemaUpgradeResult;
+  readonly cacheRefs: readonly CacheRefMigrationResult[];
+}
+
+export interface V16ToV17UpgradeResult {
+  readonly dryRun: boolean;
+  readonly graphCount: number;
+  readonly graphs: readonly GraphV16ToV17UpgradeResult[];
+}
+
+export interface V16ToV17UpgradeOptions {
+  readonly persistence: GraphPersistencePort;
+  readonly graphNames: readonly string[];
+  readonly dryRun?: boolean;
+  readonly crypto?: CryptoPort;
+}
+
+function usage(): string {
+  return [
+    'Usage:',
+    '  npm run upgrade -- [--repo <path>] [--graph <name>] [--dry-run] [--json]',
+    '',
+    'Options:',
+    '  --repo <path>   Git repository path. Defaults to the current working directory.',
+    '  --graph <name>  Upgrade one graph. May be repeated. Defaults to all discovered graphs.',
+    '  --dry-run       Validate and report work without updating refs.',
+    '  --json          Emit machine-readable JSON.',
+    '  --help          Show this help.',
+  ].join('\n');
+}
+
+export function parseArgs(argv: readonly string[], cwd: string): V16ToV17UpgradeArgs {
+  let repo = cwd;
+  const graphNames: string[] = [];
+  let dryRun = false;
+  let json = false;
+  let help = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--repo') {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        throw new V16ToV17UpgradeArgumentError('--repo requires a path');
+      }
+      repo = value;
+      i++;
+      continue;
+    }
+    if (arg === '--graph') {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        throw new V16ToV17UpgradeArgumentError('--graph requires a graph name');
+      }
+      graphNames.push(value);
+      i++;
+      continue;
+    }
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    if (arg === '--json') {
+      json = true;
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+      continue;
+    }
+    throw new V16ToV17UpgradeArgumentError(`Unknown argument: ${arg ?? ''}`);
+  }
+
+  return new V16ToV17UpgradeArgs(repo, graphNames, dryRun, json, help);
+}
+
+export async function upgradeV16ToV17(
+  options: V16ToV17UpgradeOptions,
+): Promise<V16ToV17UpgradeResult> {
+  const crypto = options.crypto ?? new NodeCryptoAdapter();
+  const dryRun = options.dryRun === true;
+  const graphs: GraphV16ToV17UpgradeResult[] = [];
+
+  for (const graphName of options.graphNames) {
+    const checkpoint = await upgradeCheckpointSchema({
+      persistence: options.persistence,
+      graphName,
+      dryRun,
+      crypto,
+    });
+    const cacheRefs = await migrateRebuildableCacheRefs({
+      persistence: options.persistence,
+      graphName,
+      dryRun,
+    });
+    graphs.push(Object.freeze({ graphName, checkpoint, cacheRefs }));
+  }
+
+  return Object.freeze({
+    dryRun,
+    graphCount: graphs.length,
+    graphs,
+  });
+}
+
+async function migrateRebuildableCacheRefs(options: {
+  readonly persistence: GraphPersistencePort;
+  readonly graphName: string;
+  readonly dryRun: boolean;
+}): Promise<readonly CacheRefMigrationResult[]> {
+  const results: CacheRefMigrationResult[] = [];
+
+  for (const suffix of LEGACY_REBUILDABLE_CACHE_REF_SUFFIXES) {
+    const ref = `refs/warp/${options.graphName}${suffix}`;
+    const previousOid = await options.persistence.readRef(ref);
+    if (previousOid === null) {
+      results.push(Object.freeze({ ref, action: 'absent', previousOid }));
+      continue;
+    }
+    if (options.dryRun) {
+      results.push(Object.freeze({ ref, action: 'would-delete', previousOid }));
+      continue;
+    }
+    await options.persistence.deleteRef(ref);
+    results.push(Object.freeze({ ref, action: 'deleted', previousOid }));
+  }
+
+  return results;
+}
+
+function checkpointLine(checkpoint: CheckpointSchemaUpgradeResult): string {
+  if (checkpoint.status === 'missing-checkpoint') {
+    return `checkpoint: none found at ${checkpoint.checkpointRef}`;
+  }
+  if (checkpoint.status === 'already-current') {
+    return `checkpoint: already schema:${checkpoint.currentSchema}`;
+  }
+  if (checkpoint.status === 'would-upgrade') {
+    return `checkpoint: would upgrade schema:${String(checkpoint.previousSchema)} -> schema:${checkpoint.currentSchema}`;
+  }
+  return `checkpoint: upgraded schema:${String(checkpoint.previousSchema)} -> schema:${checkpoint.currentSchema}`;
+}
+
+export function formatHumanResult(result: V16ToV17UpgradeResult): string {
+  if (result.graphs.length === 0) {
+    return 'No WARP graphs found in this repository.';
+  }
+
+  const lines: string[] = [
+    result.dryRun
+      ? `Dry run: inspected ${result.graphCount} graph(s).`
+      : `Upgraded ${result.graphCount} graph(s).`,
+  ];
+
+  for (const graph of result.graphs) {
+    lines.push('', `Graph: ${graph.graphName}`, `  ${checkpointLine(graph.checkpoint)}`);
+    const changedRefs = graph.cacheRefs.filter((cacheRef) => cacheRef.action !== 'absent');
+    if (changedRefs.length === 0) {
+      lines.push('  rebuildable cache refs: none found');
+      continue;
+    }
+    for (const cacheRef of changedRefs) {
+      lines.push(`  rebuildable cache ref: ${cacheRef.action} ${cacheRef.ref}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+async function resolveGraphNames(
+  persistence: GraphPersistencePort,
+  explicitGraphNames: readonly string[],
+): Promise<readonly string[]> {
+  if (explicitGraphNames.length > 0) {
+    return [...new Set(explicitGraphNames)].sort();
+  }
+  return await discoverGraphNames(persistence);
+}
+
+async function discoverGraphNames(persistence: GraphPersistencePort): Promise<readonly string[]> {
+  const refs = await persistence.listRefs(REF_PREFIX);
+  const prefix = `${REF_PREFIX}/`;
+  const names: Set<string> = new Set();
+
+  for (const ref of refs) {
+    if (!ref.startsWith(prefix)) {
+      continue;
+    }
+    const rest = ref.slice(prefix.length);
+    const [graphName] = rest.split('/');
+    if (typeof graphName === 'string' && graphName.length > 0) {
+      names.add(graphName);
+    }
+  }
+
+  return [...names].sort();
+}
+
+async function run(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2), process.cwd());
+  if (args.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+
+  const { persistence } = await createPersistence(args.repo);
+  const graphNames = await resolveGraphNames(persistence, args.graphNames);
+  const result = await upgradeV16ToV17({
+    persistence,
+    graphNames,
+    dryRun: args.dryRun,
+  });
+
+  if (args.json) {
+    process.stdout.write(new CliJsonFormatterAdapter().format(result));
+    return;
+  }
+  process.stdout.write(`${formatHumanResult(result)}\n`);
+}
+
+function errorMessage(err: Error): string {
+  return err.message;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run().catch((err: Error) => {
+    process.stderr.write(`${errorMessage(err)}\n\n${usage()}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/domain/services/state/checkpointCreate.ts
+++ b/src/domain/services/state/checkpointCreate.ts
@@ -21,6 +21,7 @@ import {
   collectContentAnchorEntries,
   compareTreeEntriesByPath,
   CURRENT_CHECKPOINT_SCHEMA,
+  type ContentAnchorObjectType,
 } from './checkpointHelpers.ts';
 import type WarpState from './WarpState.ts';
 import type CommitPort from '../../../ports/CommitPort.ts';
@@ -34,7 +35,9 @@ import type StateHashService from './StateHashService.ts';
 import type { ProvenanceIndex } from '../provenance/ProvenanceIndex.ts';
 
 /** Combined persistence surface needed by checkpoint creation. */
-export type CheckpointPersistence = CommitPort & BlobPort & TreePort;
+export type CheckpointPersistence = CommitPort & BlobPort & TreePort & {
+  readObjectType?(_oid: string): Promise<ContentAnchorObjectType>;
+};
 
 /** Options for creating the current checkpoint envelope. */
 export interface CreateCheckpointOptions {
@@ -176,7 +179,10 @@ export async function createCheckpointEnvelope({
     indexSubtreeOid = await writeIndexSubtree(indexTree, persistence);
   }
 
-  const treeEntries = collectContentAnchorEntries(checkpointState.prop);
+  const treeEntries = await collectContentAnchorEntries(
+    checkpointState.prop,
+    persistence.readObjectType?.bind(persistence),
+  );
   treeEntries.push(
     `100644 blob ${appliedVVBlobOid}\tappliedVV.cbor`,
     `100644 blob ${frontierBlobOid}\tfrontier.cbor`,

--- a/src/domain/services/state/checkpointHelpers.ts
+++ b/src/domain/services/state/checkpointHelpers.ts
@@ -190,8 +190,8 @@ export async function collectContentAnchorEntries(
   return anchorEntries;
 }
 
-async function defaultContentAnchorObjectType(): Promise<ContentAnchorObjectType> {
-  return 'tree';
+function defaultContentAnchorObjectType(): Promise<ContentAnchorObjectType> {
+  return Promise.resolve('tree');
 }
 
 function contentAnchorEntry(oid: string, objectType: ContentAnchorObjectType): string {
@@ -201,8 +201,15 @@ function contentAnchorEntry(oid: string, objectType: ContentAnchorObjectType): s
   if (objectType === 'tree') {
     return `040000 tree ${oid}\t_content_${oid}`;
   }
+  return unsupportedContentAnchorObjectType(oid, objectType);
+}
+
+function unsupportedContentAnchorObjectType(
+  oid: string,
+  objectType: never,
+): never {
   throw new WarpError(
-    `Unsupported content anchor object type: ${objectType}`,
+    'Unsupported content anchor object type',
     'E_CHECKPOINT_CONTENT_ANCHOR_OBJECT_TYPE',
     { context: { oid, objectType } },
   );

--- a/src/domain/services/state/checkpointHelpers.ts
+++ b/src/domain/services/state/checkpointHelpers.ts
@@ -30,6 +30,10 @@ export function isCurrentCheckpointSchema(schema: number | undefined | null): bo
  */
 const CONTENT_ANCHOR_BATCH_SIZE = 256;
 
+export type ContentAnchorObjectType = 'blob' | 'tree';
+
+export type ContentAnchorObjectTypeReader = (oid: string) => Promise<ContentAnchorObjectType>;
+
 // ============================================================================
 // Internal Helpers
 // ============================================================================
@@ -146,9 +150,10 @@ export function mergeSortedUniqueStrings(existing: string[], incoming: string[])
  * once. Current content storage OIDs identify CAS trees, so checkpoint trees
  * must anchor them as tree entries.
  */
-export function collectContentAnchorEntries(
+export async function collectContentAnchorEntries(
   propMap: Map<string, { eventId: unknown; value: unknown }>, // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
-): string[] {
+  readObjectType: ContentAnchorObjectTypeReader = defaultContentAnchorObjectType,
+): Promise<string[]> {
   let sortedOids: string[] = [];
   let batch: Set<string> = new Set();
 
@@ -178,8 +183,27 @@ export function collectContentAnchorEntries(
 
   const anchorEntries: string[] = [];
   for (const oid of sortedOids) {
-    anchorEntries.push(`040000 tree ${oid}\t_content_${oid}`);
+    const objectType = await readObjectType(oid);
+    anchorEntries.push(contentAnchorEntry(oid, objectType));
   }
 
   return anchorEntries;
+}
+
+async function defaultContentAnchorObjectType(): Promise<ContentAnchorObjectType> {
+  return 'tree';
+}
+
+function contentAnchorEntry(oid: string, objectType: ContentAnchorObjectType): string {
+  if (objectType === 'blob') {
+    return `100644 blob ${oid}\t_content_${oid}`;
+  }
+  if (objectType === 'tree') {
+    return `040000 tree ${oid}\t_content_${oid}`;
+  }
+  throw new WarpError(
+    `Unsupported content anchor object type: ${objectType}`,
+    'E_CHECKPOINT_CONTENT_ANCHOR_OBJECT_TYPE',
+    { context: { oid, objectType } },
+  );
 }

--- a/src/infrastructure/adapters/CliJsonFormatterAdapter.ts
+++ b/src/infrastructure/adapters/CliJsonFormatterAdapter.ts
@@ -1,0 +1,5 @@
+export default class CliJsonFormatterAdapter {
+  format(value: object): string {
+    return `${JSON.stringify(value, null, 2)}\n`;
+  }
+}

--- a/src/infrastructure/adapters/GitCasGraphReaderAdapter.ts
+++ b/src/infrastructure/adapters/GitCasGraphReaderAdapter.ts
@@ -1,0 +1,72 @@
+import type { GitPersistenceAdapter } from '@git-stunts/git-cas';
+
+interface GitCasGraphReaderAdapterOptions {
+  readonly persistence: GitPersistenceAdapter;
+  readonly assertEmptyBlobExists: (oid: string) => Promise<void>;
+}
+
+export default class GitCasGraphReaderAdapter {
+  private readonly _persistence: GitPersistenceAdapter;
+  private readonly _assertEmptyBlobExists: (oid: string) => Promise<void>;
+
+  constructor(options: GitCasGraphReaderAdapterOptions) {
+    this._persistence = options.persistence;
+    this._assertEmptyBlobExists = options.assertEmptyBlobExists;
+  }
+
+  async readBlob(oid: string): Promise<Uint8Array> {
+    const stream = await this._persistence.readBlobStream(oid);
+    const bytes = await collectUnboundedGraphBlobStream(stream);
+    if (bytes.byteLength === 0) {
+      await this._assertEmptyBlobExists(oid);
+    }
+    return bytes;
+  }
+
+  async readTreeOids(treeOid: string): Promise<Record<string, string>> {
+    const oids: Record<string, string> = {};
+    await this._collectTreeOids(treeOid, '', oids);
+    return oids;
+  }
+
+  private async _collectTreeOids(
+    treeOid: string,
+    pathPrefix: string,
+    oids: Record<string, string>,
+  ): Promise<void> {
+    for await (const entry of this._persistence.iterateTree(treeOid)) {
+      const path = `${pathPrefix}${entry.name}`;
+      if (entry.type === 'tree') {
+        await this._collectTreeOids(entry.oid, `${path}/`, oids);
+        continue;
+      }
+      oids[path] = entry.oid;
+    }
+  }
+}
+
+async function collectUnboundedGraphBlobStream(source: AsyncIterable<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+
+  for await (const chunk of source) {
+    const bytes = normalizeBytes(chunk);
+    chunks.push(bytes);
+    byteLength += bytes.byteLength;
+  }
+
+  const output = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+function normalizeBytes(chunk: Uint8Array): Uint8Array {
+  if (chunk.constructor === Uint8Array) {
+    return chunk;
+  }
+  return new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+}

--- a/src/infrastructure/adapters/GitGraphAdapter.ts
+++ b/src/infrastructure/adapters/GitGraphAdapter.ts
@@ -18,6 +18,7 @@ import GraphPersistencePort from '../../ports/GraphPersistencePort.ts';
 import CasBlobAdapter from './CasBlobAdapter.ts';
 import GitTrieStoreAdapter from './GitTrieStoreAdapter.ts';
 import WarpStream from '../../domain/stream/WarpStream.ts';
+import type { ContentAnchorObjectType } from '../../domain/services/state/checkpointHelpers.ts';
 import { validateOid, validateRef, validateLimit, validateConfigKey } from './adapterValidation.ts';
 import {
   type GitPlumbing,
@@ -63,6 +64,20 @@ function createGitCasRetryPolicy(retryOptions: RetryOptions): GitCasPolicy {
       return await retry(operation, retryOptions);
     },
   });
+}
+
+function parseContentAnchorObjectType(
+  value: string,
+  oid: string,
+): ContentAnchorObjectType {
+  if (value === 'blob' || value === 'tree') {
+    return value;
+  }
+  throw new PersistenceError(
+    `Unsupported Git object type for content anchor ${oid}: ${value}`,
+    'E_UNSUPPORTED_CONTENT_ANCHOR_OBJECT_TYPE',
+    { context: { oid, objectType: value } },
+  );
 }
 
 export default class GitGraphAdapter extends GraphPersistencePort implements RuntimeStorageCapabilityPort {
@@ -303,6 +318,17 @@ export default class GitGraphAdapter extends GraphPersistencePort implements Run
     } catch (raw) {
       throw wrapGitError(toGitError(raw), { oid });
     }
+  }
+
+  async readObjectType(oid: string): Promise<ContentAnchorObjectType> {
+    validateOid(oid);
+    let output: string;
+    try {
+      output = await this._executeWithRetry({ args: ['cat-file', '-t', oid] });
+    } catch (raw) {
+      throw wrapGitError(toGitError(raw), { oid });
+    }
+    return parseContentAnchorObjectType(output.trim(), oid);
   }
 
   async updateRef(ref: string, oid: string): Promise<void> {

--- a/src/infrastructure/adapters/GitGraphAdapter.ts
+++ b/src/infrastructure/adapters/GitGraphAdapter.ts
@@ -18,6 +18,7 @@ import GraphPersistencePort from '../../ports/GraphPersistencePort.ts';
 import CasBlobAdapter from './CasBlobAdapter.ts';
 import GitTrieStoreAdapter from './GitTrieStoreAdapter.ts';
 import WarpStream from '../../domain/stream/WarpStream.ts';
+import { textEncode } from '../../domain/utils/bytes.ts';
 import type { ContentAnchorObjectType } from '../../domain/services/state/checkpointHelpers.ts';
 import { validateOid, validateRef, validateLimit, validateConfigKey } from './adapterValidation.ts';
 import {
@@ -48,11 +49,11 @@ interface GitCasPolicy {
 /**
  * Normalizes graph blob writes to the content shape expected by git-cas.
  */
-function toGitCasBlobContent(content: Uint8Array | string): Buffer | string {
+function toGitCasBlobContent(content: Uint8Array | string): Uint8Array {
   if (typeof content === 'string') {
-    return content;
+    return textEncode(content);
   }
-  return Buffer.from(content);
+  return content;
 }
 
 /**

--- a/src/infrastructure/adapters/GitGraphAdapter.ts
+++ b/src/infrastructure/adapters/GitGraphAdapter.ts
@@ -16,6 +16,7 @@ import AdapterValidationError from '../../domain/errors/AdapterValidationError.t
 import PersistenceError from '../../domain/errors/PersistenceError.ts';
 import GraphPersistencePort from '../../ports/GraphPersistencePort.ts';
 import CasBlobAdapter from './CasBlobAdapter.ts';
+import GitCasGraphReaderAdapter from './GitCasGraphReaderAdapter.ts';
 import GitTrieStoreAdapter from './GitTrieStoreAdapter.ts';
 import WarpStream from '../../domain/stream/WarpStream.ts';
 import { textEncode } from '../../domain/utils/bytes.ts';
@@ -85,6 +86,7 @@ export default class GitGraphAdapter extends GraphPersistencePort implements Run
   private readonly plumbing: GitPlumbing;
   private readonly _retryOptions: RetryOptions;
   private readonly _gitCasPersistence: GitPersistenceAdapter;
+  private readonly _gitCasGraphReader: GitCasGraphReaderAdapter;
 
   constructor({ plumbing, retryOptions = {} }: GitGraphAdapterOptions) {
     super();
@@ -96,6 +98,10 @@ export default class GitGraphAdapter extends GraphPersistencePort implements Run
     this._gitCasPersistence = new GitPersistenceAdapter({
       plumbing,
       policy: createGitCasRetryPolicy(this._retryOptions),
+    });
+    this._gitCasGraphReader = new GitCasGraphReaderAdapter({
+      persistence: this._gitCasPersistence,
+      assertEmptyBlobExists: (oid) => this._assertBlobExistsForEmptyRead(oid),
     });
   }
 
@@ -267,14 +273,14 @@ export default class GitGraphAdapter extends GraphPersistencePort implements Run
     const oids = await this.readTreeOids(treeOid);
     const files: Record<string, Uint8Array> = {};
     const entries = Object.entries(oids);
-    const BATCH_SIZE = 16;
-    for (let i = 0; i < entries.length; i += BATCH_SIZE) {
-      const batch = entries.slice(i, i + BATCH_SIZE);
+    const batchSize = 16;
+    for (let i = 0; i < entries.length; i += batchSize) {
+      const batch = entries.slice(i, i + batchSize);
       const results = await Promise.all(batch.map(([, oid]) => this.readBlob(oid)));
       for (let j = 0; j < batch.length; j++) {
         const entry = batch[j];
         const result = results[j];
-        if (entry !== null && entry !== undefined && result !== null && result !== undefined) {
+        if (entry !== undefined && result !== undefined) {
           files[entry[0]] = result;
         }
       }
@@ -284,38 +290,17 @@ export default class GitGraphAdapter extends GraphPersistencePort implements Run
 
   async readTreeOids(treeOid: string): Promise<Record<string, string>> {
     validateOid(treeOid);
-    let output: string;
     try {
-      output = await this._executeWithRetry({ args: ['ls-tree', '-r', '-z', treeOid] });
+      return await this._gitCasGraphReader.readTreeOids(treeOid);
     } catch (raw) {
       throw wrapGitError(toGitError(raw), { oid: treeOid });
     }
-    const oids: Record<string, string> = {};
-    for (const record of output.split('\0')) {
-      if (record === '') {
-        continue;
-      }
-      const tabIndex = record.indexOf('\t');
-      if (tabIndex === -1) {
-        continue;
-      }
-      const meta = record.slice(0, tabIndex);
-      const path = record.slice(tabIndex + 1);
-      const [, , oid] = meta.split(' ');
-      oids[path] = oid ?? '';
-    }
-    return oids;
   }
 
   async readBlob(oid: string): Promise<Uint8Array> {
     validateOid(oid);
     try {
-      const stream = await this.plumbing.executeStream({ args: ['cat-file', 'blob', oid] });
-      const raw = await stream.collect({ asString: false, maxBytes: Number.POSITIVE_INFINITY });
-      if (raw.length === 0) {
-        await this._assertBlobExistsForEmptyRead(oid);
-      }
-      return typeof raw === 'string' ? Buffer.from(raw) : raw;
+      return await this._gitCasGraphReader.readBlob(oid);
     } catch (raw) {
       throw wrapGitError(toGitError(raw), { oid });
     }

--- a/test/helpers/WarpGraphTestRepositories.ts
+++ b/test/helpers/WarpGraphTestRepositories.ts
@@ -5,7 +5,7 @@ import Plumbing from '@git-stunts/plumbing';
 import GitGraphAdapter from '../../src/infrastructure/adapters/GitGraphAdapter.ts';
 import InMemoryGraphAdapter from '../../src/infrastructure/adapters/InMemoryGraphAdapter.ts';
 
-type TestPlumbing = ReturnType<typeof Plumbing.createDefault>;
+type TestPlumbing = Awaited<ReturnType<typeof Plumbing.createDefault>>;
 
 export class GitRepoFixture {
   constructor(
@@ -30,7 +30,7 @@ export class InMemoryRepoFixture {
 export async function createGitRepo(label = 'test'): Promise<GitRepoFixture> {
   const tempDir = await mkdtemp(join(tmpdir(), `warp-${label}-`));
   try {
-    const plumbing = Plumbing.createDefault({ cwd: tempDir });
+    const plumbing = await Plumbing.createDefault({ cwd: tempDir });
     await plumbing.execute({ args: ['init'] });
     await plumbing.execute({ args: ['config', 'user.email', 'test@test.com'] });
     await plumbing.execute({ args: ['config', 'user.name', 'Test'] });

--- a/test/integration/WarpGraph.integration.test.ts
+++ b/test/integration/WarpGraph.integration.test.ts
@@ -19,7 +19,7 @@ describe('WarpCore Integration', () => {
   beforeEach(async () => {
     // Create temp directory and init git repo
     tempDir = await mkdtemp(join(tmpdir(), 'emptygraph-test-'));
-    plumbing = Plumbing.createDefault({ cwd: tempDir });
+    plumbing = await Plumbing.createDefault({ cwd: tempDir });
     await plumbing.execute({ args: ['init'] });
     await plumbing.execute({ args: ['config', 'user.email', 'test@test.com'] });
     await plumbing.execute({ args: ['config', 'user.name', 'Test'] });

--- a/test/integration/api/helpers/setup.ts
+++ b/test/integration/api/helpers/setup.ts
@@ -24,7 +24,7 @@ export async function createTestRepo(label = 'api-test') {
   const crypto = new WebCryptoAdapter();
 
   try {
-    const plumbing = Plumbing.createDefault({ cwd: tempDir });
+    const plumbing = await Plumbing.createDefault({ cwd: tempDir });
     await plumbing.execute({ args: ['init'] });
     await plumbing.execute({ args: ['config', 'user.email', 'test@test.com'] });
     await plumbing.execute({ args: ['config', 'user.name', 'Test'] });

--- a/test/integration/domain/orset/trie/TrieCursor.flush.integration.test.ts
+++ b/test/integration/domain/orset/trie/TrieCursor.flush.integration.test.ts
@@ -42,7 +42,7 @@ function newPageCache(): PageCache {
 async function createHarness(): Promise<Harness> {
   const tempDir = await mkdtemp(join(tmpdir(), "warp-trie-flush-integration-"));
   try {
-    const plumbing = Plumbing.createDefault({ cwd: tempDir });
+    const plumbing = await Plumbing.createDefault({ cwd: tempDir });
     await plumbing.execute({ args: ["init", "-q"] });
     await plumbing.execute({ args: ["config", "user.email", "test@test.com"] });
     await plumbing.execute({ args: ["config", "user.name", "Test"] });

--- a/test/integration/infrastructure/adapters/GitTrieStoreAdapter.integration.test.ts
+++ b/test/integration/infrastructure/adapters/GitTrieStoreAdapter.integration.test.ts
@@ -32,7 +32,7 @@ interface HarnessContext {
 async function createHarness(): Promise<HarnessContext> {
   const tempDir = await mkdtemp(join(tmpdir(), 'warp-trie-store-adapter-'));
   try {
-    const plumbing = Plumbing.createDefault({ cwd: tempDir });
+    const plumbing = await Plumbing.createDefault({ cwd: tempDir });
     await plumbing.execute({ args: ['init', '-q'] });
     await plumbing.execute({ args: ['config', 'user.email', 'test@test.com'] });
     await plumbing.execute({ args: ['config', 'user.name', 'Test'] });

--- a/test/runtime/deno/deno.json
+++ b/test/runtime/deno/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "@git-stunts/plumbing": "npm:@git-stunts/plumbing@^2.8.0"
+    "@git-stunts/plumbing": "npm:@git-stunts/plumbing@^3.0.3"
   },
   "nodeModulesDir": "auto"
 }

--- a/test/runtime/deno/helpers.ts
+++ b/test/runtime/deno/helpers.ts
@@ -41,7 +41,7 @@ export async function createTestRepo(label = "deno-test") {
   const tempDir = await mkdtemp(join(tmpdir(), `warp-${label}-`));
   const crypto = new WebCryptoAdapter();
 
-  const plumbing = Plumbing.createDefault({ cwd: tempDir });
+  const plumbing = await Plumbing.createDefault({ cwd: tempDir });
   await plumbing.execute({ args: ["init"] });
   await plumbing.execute({ args: ["config", "user.email", "test@test.com"] });
   await plumbing.execute({ args: ["config", "user.name", "Test"] });

--- a/test/unit/domain/services/CheckpointService.anchors.test.ts
+++ b/test/unit/domain/services/CheckpointService.anchors.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import { createCheckpointEnvelope, type CheckpointPersistence } from '../../../../src/domain/services/state/checkpointCreate.ts';
+import { createFrontier, updateFrontier } from '../../../../src/domain/services/Frontier.ts';
+import { createEmptyState, encodePropKey as encodePropKeyV5 } from '../../../../src/domain/services/JoinReducer.ts';
+import { Dot } from '../../../../src/domain/crdt/Dot.ts';
+import { CONTENT_PROPERTY_KEY } from '../../../../src/domain/services/KeyCodec.ts';
+import type { ContentAnchorObjectType } from '../../../../src/domain/services/state/checkpointHelpers.ts';
+import NodeCryptoAdapter from '../../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
+import type WarpStream from '../../../../src/domain/stream/WarpStream.ts';
+import type {
+  CommitLogChunk,
+  CommitNodeOptions,
+  CommitNodeWithTreeOptions,
+  LogNodesOptions,
+  NodeInfo,
+  PingResult,
+} from '../../../../src/ports/CommitPort.ts';
+
+const crypto = new NodeCryptoAdapter();
+
+function makeOid(prefix: string): string {
+  const base = prefix.replace(/[^0-9a-f]/gi, '0').toLowerCase();
+  return (base + '0'.repeat(40)).slice(0, 40);
+}
+
+function makeSequentialOid(index: number): string {
+  return index.toString(16).padStart(40, '0');
+}
+
+class AnchorCheckpointPersistenceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AnchorCheckpointPersistenceError';
+  }
+}
+
+class AnchorCheckpointPersistence implements CheckpointPersistence {
+  readonly writtenTrees: string[][] = [];
+  private readonly _objectTypes = new Map<string, ContentAnchorObjectType>();
+  private _blobIndex = 0;
+
+  get emptyTree(): string {
+    return makeOid('empty');
+  }
+
+  setObjectType(oid: string, objectType: ContentAnchorObjectType): void {
+    this._objectTypes.set(oid, objectType);
+  }
+
+  envelopeTreeEntries(): readonly string[] {
+    const entries = this.writtenTrees[1];
+    if (entries === undefined) {
+      throw new AnchorCheckpointPersistenceError('Missing checkpoint envelope tree write');
+    }
+    return entries;
+  }
+
+  async writeBlob(_content: Uint8Array | string): Promise<string> {
+    this._blobIndex += 1;
+    return makeOid(`blob${this._blobIndex}`);
+  }
+
+  async readBlob(_oid: string): Promise<Uint8Array> {
+    throw new AnchorCheckpointPersistenceError('readBlob is not used by anchor creation tests');
+  }
+
+  async writeTree(entries: string[]): Promise<string> {
+    this.writtenTrees.push([...entries]);
+    return makeOid(`tree${this.writtenTrees.length}`);
+  }
+
+  async readTree(_treeOid: string): Promise<Record<string, Uint8Array>> {
+    throw new AnchorCheckpointPersistenceError('readTree is not used by anchor creation tests');
+  }
+
+  async readTreeOids(_treeOid: string): Promise<Record<string, string>> {
+    throw new AnchorCheckpointPersistenceError('readTreeOids is not used by anchor creation tests');
+  }
+
+  async commitNode(_options: CommitNodeOptions): Promise<string> {
+    throw new AnchorCheckpointPersistenceError('commitNode is not used by anchor creation tests');
+  }
+
+  async commitNodeWithTree(_options: CommitNodeWithTreeOptions): Promise<string> {
+    return makeOid('checkpoint');
+  }
+
+  async showNode(_sha: string): Promise<string> {
+    throw new AnchorCheckpointPersistenceError('showNode is not used by anchor creation tests');
+  }
+
+  async getNodeInfo(_sha: string): Promise<NodeInfo> {
+    throw new AnchorCheckpointPersistenceError('getNodeInfo is not used by anchor creation tests');
+  }
+
+  async logNodes(_options: LogNodesOptions): Promise<string> {
+    throw new AnchorCheckpointPersistenceError('logNodes is not used by anchor creation tests');
+  }
+
+  async logNodesStream(_options: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
+    throw new AnchorCheckpointPersistenceError('logNodesStream is not used by anchor creation tests');
+  }
+
+  async countNodes(_ref: string): Promise<number> {
+    throw new AnchorCheckpointPersistenceError('countNodes is not used by anchor creation tests');
+  }
+
+  async nodeExists(_sha: string): Promise<boolean> {
+    throw new AnchorCheckpointPersistenceError('nodeExists is not used by anchor creation tests');
+  }
+
+  async getCommitTree(_sha: string): Promise<string> {
+    throw new AnchorCheckpointPersistenceError('getCommitTree is not used by anchor creation tests');
+  }
+
+  async ping(): Promise<PingResult> {
+    throw new AnchorCheckpointPersistenceError('ping is not used by anchor creation tests');
+  }
+
+  async readObjectType(oid: string): Promise<ContentAnchorObjectType> {
+    return this._objectTypes.get(oid) ?? 'tree';
+  }
+}
+
+describe('CheckpointService content anchors', () => {
+  it('preserves legacy raw blob content anchors when creating a checkpoint', async () => {
+    const persistence = new AnchorCheckpointPersistence();
+    const state = createEmptyState();
+    state.nodeAlive.add('legacy', Dot.create('alice', 1));
+    state.nodeAlive.add('cas', Dot.create('alice', 2));
+
+    const legacyBlobOid = makeSequentialOid(1);
+    const casTreeOid = makeSequentialOid(2);
+    persistence.setObjectType(legacyBlobOid, 'blob');
+    persistence.setObjectType(casTreeOid, 'tree');
+
+    state.prop.set(encodePropKeyV5('legacy', CONTENT_PROPERTY_KEY), {
+      eventId: { lamport: 1, writerId: 'alice', patchSha: makeOid('patch1'), opIndex: 0 },
+      value: legacyBlobOid,
+    });
+    state.prop.set(encodePropKeyV5('cas', CONTENT_PROPERTY_KEY), {
+      eventId: { lamport: 2, writerId: 'alice', patchSha: makeOid('patch2'), opIndex: 0 },
+      value: casTreeOid,
+    });
+
+    const frontier = createFrontier();
+    updateFrontier(frontier, 'alice', makeOid('sha1'));
+
+    await createCheckpointEnvelope({
+      persistence,
+      graphName: 'test',
+      state,
+      frontier,
+      crypto,
+    });
+
+    expect(persistence.envelopeTreeEntries()).toEqual([
+      `100644 blob ${legacyBlobOid}\t_content_${legacyBlobOid}`,
+      `040000 tree ${casTreeOid}\t_content_${casTreeOid}`,
+      expect.stringContaining('\tappliedVV.cbor'),
+      expect.stringContaining('\tfrontier.cbor'),
+      expect.stringContaining('\tstate'),
+    ]);
+  });
+});

--- a/test/unit/domain/services/CheckpointService.test.ts
+++ b/test/unit/domain/services/CheckpointService.test.ts
@@ -1029,51 +1029,6 @@ describe('CheckpointService', () => {
         ]);
       });
 
-      it('preserves legacy raw blob content anchors when creating a checkpoint', async () => {
-        const state = createEmptyState();
-        state.nodeAlive.add('legacy', Dot.create('alice', 1));
-        state.nodeAlive.add('cas', Dot.create('alice', 2));
-
-        const legacyBlobOid = makeSequentialOid(1);
-        const casTreeOid = makeSequentialOid(2);
-
-        state.prop.set(encodePropKeyV5('legacy', CONTENT_PROPERTY_KEY), {
-          eventId: { lamport: 1, writerId: 'alice', patchSha: makeOid('patch1'), opIndex: 0 },
-          value: legacyBlobOid,
-        });
-        state.prop.set(encodePropKeyV5('cas', CONTENT_PROPERTY_KEY), {
-          eventId: { lamport: 2, writerId: 'alice', patchSha: makeOid('patch2'), opIndex: 0 },
-          value: casTreeOid,
-        });
-
-        const frontier = createFrontier();
-        updateFrontier(frontier, 'alice', makeOid('sha1'));
-
-        mockPersistence.writeBlob.mockResolvedValue(makeOid('blob'));
-        mockPersistence.writeTree.mockResolvedValue(makeOid('tree'));
-        mockPersistence.commitNodeWithTree.mockResolvedValue(makeOid('checkpoint'));
-        mockPersistence.readObjectType = vi.fn(async (oid: string) => (
-          oid === legacyBlobOid ? 'blob' : 'tree'
-        ));
-
-        await createCheckpointEnvelope({
-          persistence: mockPersistence,
-          graphName: 'test',
-          state,
-          frontier,
-          crypto,
-        });
-
-        const treeEntries = mockPersistence.writeTree.mock.calls[1][0];
-        expect(treeEntries).toEqual([
-          `100644 blob ${legacyBlobOid}\t_content_${legacyBlobOid}`,
-          `040000 tree ${casTreeOid}\t_content_${casTreeOid}`,
-          expect.stringContaining('\tappliedVV.cbor'),
-          expect.stringContaining('\tfrontier.cbor'),
-          expect.stringContaining('\tstate'),
-        ]);
-      });
-
       it('anchors large content sets without duplicate entries when batch flushes occur', async () => {
         const state = createEmptyState();
         const frontier = createFrontier();

--- a/test/unit/domain/services/CheckpointService.test.ts
+++ b/test/unit/domain/services/CheckpointService.test.ts
@@ -1029,6 +1029,51 @@ describe('CheckpointService', () => {
         ]);
       });
 
+      it('preserves legacy raw blob content anchors when creating a checkpoint', async () => {
+        const state = createEmptyState();
+        state.nodeAlive.add('legacy', Dot.create('alice', 1));
+        state.nodeAlive.add('cas', Dot.create('alice', 2));
+
+        const legacyBlobOid = makeSequentialOid(1);
+        const casTreeOid = makeSequentialOid(2);
+
+        state.prop.set(encodePropKeyV5('legacy', CONTENT_PROPERTY_KEY), {
+          eventId: { lamport: 1, writerId: 'alice', patchSha: makeOid('patch1'), opIndex: 0 },
+          value: legacyBlobOid,
+        });
+        state.prop.set(encodePropKeyV5('cas', CONTENT_PROPERTY_KEY), {
+          eventId: { lamport: 2, writerId: 'alice', patchSha: makeOid('patch2'), opIndex: 0 },
+          value: casTreeOid,
+        });
+
+        const frontier = createFrontier();
+        updateFrontier(frontier, 'alice', makeOid('sha1'));
+
+        mockPersistence.writeBlob.mockResolvedValue(makeOid('blob'));
+        mockPersistence.writeTree.mockResolvedValue(makeOid('tree'));
+        mockPersistence.commitNodeWithTree.mockResolvedValue(makeOid('checkpoint'));
+        mockPersistence.readObjectType = vi.fn(async (oid: string) => (
+          oid === legacyBlobOid ? 'blob' : 'tree'
+        ));
+
+        await createCheckpointEnvelope({
+          persistence: mockPersistence,
+          graphName: 'test',
+          state,
+          frontier,
+          crypto,
+        });
+
+        const treeEntries = mockPersistence.writeTree.mock.calls[1][0];
+        expect(treeEntries).toEqual([
+          `100644 blob ${legacyBlobOid}\t_content_${legacyBlobOid}`,
+          `040000 tree ${casTreeOid}\t_content_${casTreeOid}`,
+          expect.stringContaining('\tappliedVV.cbor'),
+          expect.stringContaining('\tfrontier.cbor'),
+          expect.stringContaining('\tstate'),
+        ]);
+      });
+
       it('anchors large content sets without duplicate entries when batch flushes occur', async () => {
         const state = createEmptyState();
         const frontier = createFrontier();

--- a/test/unit/domain/services/GitGraphAdapter.test.ts
+++ b/test/unit/domain/services/GitGraphAdapter.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import GitGraphAdapter from '../../../../src/infrastructure/adapters/GitGraphAdapter.ts';
 import PersistenceError from '../../../../src/domain/errors/PersistenceError.ts';
 
+function streamFromBytes(bytes: Uint8Array): AsyncIterable<Uint8Array> {
+  return {
+    async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+      if (bytes.byteLength > 0) {
+        yield bytes;
+      }
+    },
+  };
+}
+
 describe('GitGraphAdapter', () => {
   describe('constructor', () => {
     it('requires plumbing', () => {
@@ -24,9 +34,7 @@ describe('GitGraphAdapter', () => {
     });
 
     it('throws E_MISSING_OBJECT when blob stream is empty and object does not exist', async () => {
-      mockPlumbing.executeStream.mockResolvedValue({
-        collect: vi.fn().mockResolvedValue(Buffer.alloc(0)),
-      });
+      mockPlumbing.executeStream.mockResolvedValue(streamFromBytes(Buffer.alloc(0)));
       const err = (new Error('fatal: bad object deadbeef') as any);
       err.details = { code: 128, stderr: 'fatal: bad object deadbeef' };
       mockPlumbing.execute.mockRejectedValue(err);
@@ -43,9 +51,7 @@ describe('GitGraphAdapter', () => {
     });
 
     it('throws E_MISSING_OBJECT for ambiguous exit-1 empty-read failures', async () => {
-      mockPlumbing.executeStream.mockResolvedValue({
-        collect: vi.fn().mockResolvedValue(Buffer.alloc(0)),
-      });
+      mockPlumbing.executeStream.mockResolvedValue(streamFromBytes(Buffer.alloc(0)));
       const err = (new Error('Git command failed with code 1') as any);
       err.name = 'GitPlumbingError';
       err.details = { code: 1, stderr: '', stdout: '' };
@@ -59,9 +65,7 @@ describe('GitGraphAdapter', () => {
     });
 
     it('rethrows unrelated exit-128 errors from the existence check', async () => {
-      mockPlumbing.executeStream.mockResolvedValue({
-        collect: vi.fn().mockResolvedValue(Buffer.alloc(0)),
-      });
+      mockPlumbing.executeStream.mockResolvedValue(streamFromBytes(Buffer.alloc(0)));
       const err = (new Error('fatal: not a git repository') as any);
       err.details = { code: 128, stderr: 'fatal: not a git repository (or any of the parent directories): .git' };
       mockPlumbing.execute.mockRejectedValue(err);
@@ -71,16 +75,14 @@ describe('GitGraphAdapter', () => {
     });
 
     it('returns empty blob bytes when the object exists', async () => {
-      const collect = vi.fn().mockResolvedValue(Buffer.alloc(0));
-      mockPlumbing.executeStream.mockResolvedValue({ collect });
+      mockPlumbing.executeStream.mockResolvedValue(streamFromBytes(Buffer.alloc(0)));
       mockPlumbing.execute.mockResolvedValue('');
 
       const result = await adapter.readBlob('abcd');
 
-      expect(result).toEqual(Buffer.alloc(0));
-      expect(collect).toHaveBeenCalledWith({
-        asString: false,
-        maxBytes: Number.POSITIVE_INFINITY,
+      expect(result).toEqual(new Uint8Array(0));
+      expect(mockPlumbing.executeStream).toHaveBeenCalledWith({
+        args: ['cat-file', 'blob', 'abcd'],
       });
       expect(mockPlumbing.execute).toHaveBeenCalledWith({
         args: ['cat-file', '-e', 'abcd'],

--- a/test/unit/infrastructure/adapters/CliJsonFormatterAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/CliJsonFormatterAdapter.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import CliJsonFormatterAdapter from '../../../../src/infrastructure/adapters/CliJsonFormatterAdapter.ts';
+
+describe('CliJsonFormatterAdapter', () => {
+  it('formats JSON with a trailing newline for CLI output', () => {
+    const adapter = new CliJsonFormatterAdapter();
+
+    expect(adapter.format({ dryRun: true, graphCount: 0, graphs: [] })).toBe([
+      '{',
+      '  "dryRun": true,',
+      '  "graphCount": 0,',
+      '  "graphs": []',
+      '}',
+      '',
+    ].join('\n'));
+  });
+});

--- a/test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts
+++ b/test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts
@@ -4,6 +4,16 @@ import GitGraphAdapter from '../../../../src/infrastructure/adapters/GitGraphAda
 import { createGitRepo } from '../../../helpers/warpGraphTestUtils.ts';
 import { describeAdapterConformance } from './AdapterConformance.ts';
 
+function streamFromText(text: string): AsyncIterable<Uint8Array> {
+  return {
+    async *[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+      if (text.length > 0) {
+        yield Buffer.from(text);
+      }
+    },
+  };
+}
+
 let mockPlumbing;
 let adapter;
 
@@ -121,38 +131,33 @@ describe('GitGraphAdapter coverage', () => {
   describe('readTree()', () => {
     it('reads each blob content for entries in the tree', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      // ls-tree output: NUL-separated records
-      mockPlumbing.execute.mockResolvedValue(
+      const treeOutput =
         `100644 blob deadbeef01234567890123456789012345678901\tfile_a.json\0` +
-        `100644 blob cafebabe01234567890123456789012345678901\tfile_b.json\0`
-      );
-
-      // First call returns content for file_a, second for file_b
-      let callCount = 0;
-      mockPlumbing.executeStream.mockImplementation(async () => {
-        callCount += 1;
-        return {
-          collect: vi.fn().mockResolvedValue(
-            Buffer.from(callCount === 1 ? 'content_a' : 'content_b')
-          ),
-        };
+        `100644 blob cafebabe01234567890123456789012345678901\tfile_b.json\0`;
+      mockPlumbing.executeStream.mockImplementation(async ({ args }) => {
+        if (args[0] === 'ls-tree') {
+          return streamFromText(treeOutput);
+        }
+        return streamFromText(args[2] === 'deadbeef01234567890123456789012345678901' ? 'content_a' : 'content_b');
       });
 
       const result = await adapter.readTree(treeOid);
 
-      expect(result['file_a.json']).toEqual(Buffer.from('content_a'));
-      expect(result['file_b.json']).toEqual(Buffer.from('content_b'));
-      expect(mockPlumbing.executeStream).toHaveBeenCalledTimes(2);
+      expect(result['file_a.json']).toEqual(new TextEncoder().encode('content_a'));
+      expect(result['file_b.json']).toEqual(new TextEncoder().encode('content_b'));
+      expect(mockPlumbing.executeStream).toHaveBeenCalledTimes(3);
     });
 
     it('returns empty map for empty tree', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.execute.mockResolvedValue('');
+      mockPlumbing.executeStream.mockResolvedValue(streamFromText(''));
 
       const result = await adapter.readTree(treeOid);
 
       expect(result).toEqual({});
-      expect(mockPlumbing.executeStream).not.toHaveBeenCalled();
+      expect(mockPlumbing.executeStream).toHaveBeenCalledWith({
+        args: ['ls-tree', '-z', treeOid],
+      });
     });
 
     it('validates tree OID', async () => {
@@ -166,10 +171,10 @@ describe('GitGraphAdapter coverage', () => {
   describe('readTreeOids()', () => {
     it('parses NUL-separated ls-tree output into path-oid map', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.execute.mockResolvedValue(
+      mockPlumbing.executeStream.mockResolvedValue(streamFromText(
         '100644 blob deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tindex.json\0' +
         '100644 blob cafebabecafebabecafebabecafebabecafebabe\tdata.json\0'
-      );
+      ));
 
       const result = await adapter.readTreeOids(treeOid);
 
@@ -177,37 +182,36 @@ describe('GitGraphAdapter coverage', () => {
         'index.json': 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
         'data.json': 'cafebabecafebabecafebabecafebabecafebabe',
       });
-      expect(mockPlumbing.execute).toHaveBeenCalledWith({
-        args: ['ls-tree', '-r', '-z', treeOid],
+      expect(mockPlumbing.executeStream).toHaveBeenCalledWith({
+        args: ['ls-tree', '-z', treeOid],
       });
     });
 
     it('returns empty map when tree has no entries', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.execute.mockResolvedValue('');
+      mockPlumbing.executeStream.mockResolvedValue(streamFromText(''));
 
       const result = await adapter.readTreeOids(treeOid);
 
       expect(result).toEqual({});
     });
 
-    it('skips records without a tab separator', async () => {
+    it('throws on records without a tab separator', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.execute.mockResolvedValue(
+      mockPlumbing.executeStream.mockResolvedValue(streamFromText(
         '100644 blob deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tvalid.json\0' +
         'malformed-no-tab\0'
-      );
+      ));
 
-      const result = await adapter.readTreeOids(treeOid);
-
-      expect(Object.keys(result)).toEqual(['valid.json']);
+      await expect(adapter.readTreeOids(treeOid))
+        .rejects.toThrow(/Malformed ls-tree entry/);
     });
 
     it('handles single entry with trailing NUL', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.execute.mockResolvedValue(
+      mockPlumbing.executeStream.mockResolvedValue(streamFromText(
         '100644 blob abcdef1234567890abcdef1234567890abcdef12\tonly.json\0'
-      );
+      ));
 
       const result = await adapter.readTreeOids(treeOid);
 
@@ -216,11 +220,35 @@ describe('GitGraphAdapter coverage', () => {
       });
     });
 
+    it('recursively preserves paths through nested trees', async () => {
+      const rootTreeOid = 'aabb' + '0'.repeat(36);
+      const nestedTreeOid = 'bbcc' + '0'.repeat(36);
+      const blobOid = 'ccdd' + '0'.repeat(36);
+      mockPlumbing.executeStream.mockImplementation(async ({ args }) => {
+        if (args[2] === rootTreeOid) {
+          return streamFromText(`040000 tree ${nestedTreeOid}\tnested\0`);
+        }
+        return streamFromText(`100644 blob ${blobOid}\titem.cbor\0`);
+      });
+
+      const result = await adapter.readTreeOids(rootTreeOid);
+
+      expect(result).toEqual({
+        'nested/item.cbor': blobOid,
+      });
+      expect(mockPlumbing.executeStream).toHaveBeenCalledWith({
+        args: ['ls-tree', '-z', rootTreeOid],
+      });
+      expect(mockPlumbing.executeStream).toHaveBeenCalledWith({
+        args: ['ls-tree', '-z', nestedTreeOid],
+      });
+    });
+
     it('validates tree OID', async () => {
       await expect(adapter.readTreeOids('bad!'))
         .rejects.toThrow(/Invalid OID format/);
 
-      expect(mockPlumbing.execute).not.toHaveBeenCalled();
+      expect(mockPlumbing.executeStream).not.toHaveBeenCalled();
     });
 
     it('rejects empty OID', async () => {
@@ -232,7 +260,7 @@ describe('GitGraphAdapter coverage', () => {
       const treeOid = 'aabb' + '0'.repeat(36);
       const err = (new Error(`fatal: bad object ${treeOid}`) as any);
       err.details = { code: 128, stderr: `fatal: bad object ${treeOid}` };
-      mockPlumbing.execute.mockRejectedValue(err);
+      mockPlumbing.executeStream.mockRejectedValue(err);
 
       await expect(adapter.readTreeOids(treeOid))
         .rejects.toMatchObject({

--- a/test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts
+++ b/test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts
@@ -270,6 +270,50 @@ describe('GitGraphAdapter coverage', () => {
     });
   });
 
+  describe('readObjectType()', () => {
+    it('returns blob and tree object types from cat-file output', async () => {
+      const blobOid = 'a'.repeat(40);
+      const treeOid = 'b'.repeat(40);
+      mockPlumbing.execute
+        .mockResolvedValueOnce('blob\n')
+        .mockResolvedValueOnce('tree\n');
+
+      await expect(adapter.readObjectType(blobOid)).resolves.toBe('blob');
+      await expect(adapter.readObjectType(treeOid)).resolves.toBe('tree');
+
+      expect(mockPlumbing.execute).toHaveBeenCalledWith({
+        args: ['cat-file', '-t', blobOid],
+      });
+      expect(mockPlumbing.execute).toHaveBeenCalledWith({
+        args: ['cat-file', '-t', treeOid],
+      });
+    });
+
+    it('rejects unsupported git object types for content anchors', async () => {
+      const oid = 'a'.repeat(40);
+      mockPlumbing.execute.mockResolvedValue('commit\n');
+
+      await expect(adapter.readObjectType(oid))
+        .rejects.toMatchObject({
+          code: 'E_UNSUPPORTED_CONTENT_ANCHOR_OBJECT_TYPE',
+          message: `Unsupported Git object type for content anchor ${oid}: commit`,
+        });
+    });
+
+    it('wraps object-type read failures with object context', async () => {
+      const oid = 'a'.repeat(40);
+      const err = new Error(`fatal: bad object ${oid}`);
+      Object.assign(err, { details: { code: 128, stderr: `fatal: bad object ${oid}` } });
+      mockPlumbing.execute.mockRejectedValue(err);
+
+      await expect(adapter.readObjectType(oid))
+        .rejects.toMatchObject({
+          code: PersistenceError.E_MISSING_OBJECT,
+          message: `Missing Git object: ${oid}`,
+        });
+    });
+  });
+
   describe('getCommitTree()', () => {
     it('returns the trimmed tree OID for a commit', async () => {
       const commitOid = 'a'.repeat(40);

--- a/test/unit/infrastructure/adapters/GitGraphAdapter.gitCasPersistence.test.ts
+++ b/test/unit/infrastructure/adapters/GitGraphAdapter.gitCasPersistence.test.ts
@@ -8,7 +8,7 @@ const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
 
 interface GitExecuteOptions {
   readonly args: string[];
-  readonly input?: string | Buffer;
+  readonly input?: string | Uint8Array;
 }
 
 class EmptyCollectableStream implements CollectableStream {
@@ -72,9 +72,9 @@ describe('GitGraphAdapter git-cas persistence bridge', () => {
 
     expect(plumbing.calls).toEqual([{
       args: ['hash-object', '-w', '--stdin'],
-      input: Buffer.from([1, 2, 3]),
+      input: new Uint8Array([1, 2, 3]),
     }]);
-    expect(Buffer.isBuffer(plumbing.calls[0]?.input)).toBe(true);
+    expect(plumbing.calls[0]?.input).toBeInstanceOf(Uint8Array);
   });
 
   it('preserves string blob writes through the delegated git-cas path', async () => {
@@ -86,7 +86,7 @@ describe('GitGraphAdapter git-cas persistence bridge', () => {
 
     expect(plumbing.calls).toEqual([{
       args: ['hash-object', '-w', '--stdin'],
-      input: 'payload',
+      input: new TextEncoder().encode('payload'),
     }]);
   });
 

--- a/test/unit/infrastructure/adapters/GitGraphAdapter.gitCasPersistence.test.ts
+++ b/test/unit/infrastructure/adapters/GitGraphAdapter.gitCasPersistence.test.ts
@@ -126,6 +126,7 @@ describe('GitGraphAdapter git-cas persistence bridge', () => {
 
   it('ratchets write delegation while keeping non-equivalent read/ref semantics local', () => {
     const adapter = readRepoFile('src/infrastructure/adapters/GitGraphAdapter.ts');
+    const reader = readRepoFile('src/infrastructure/adapters/GitCasGraphReaderAdapter.ts');
     const successorCard = join(
       repoRoot,
       'docs/method/backlog/v17.0.0/INFRA_git-cas-adapter-parity.md',
@@ -136,10 +137,13 @@ describe('GitGraphAdapter git-cas persistence bridge', () => {
     expect(adapter).toContain('policy: createGitCasRetryPolicy(this._retryOptions)');
     expect(adapter).toContain('this._gitCasPersistence.writeBlob');
     expect(adapter).toContain('this._gitCasPersistence.writeTree');
-    expect(adapter).not.toContain('this._gitCasPersistence.readBlob');
-    expect(adapter).not.toContain('this._gitCasPersistence.readTree');
+    expect(adapter).toContain('new GitCasGraphReaderAdapter');
+    expect(adapter).toContain('this._gitCasGraphReader.readBlob');
+    expect(adapter).toContain('this._gitCasGraphReader.readTreeOids');
     expect(adapter).not.toContain('this._gitCasPersistence.createCommit');
-    expect(adapter).toContain('maxBytes: Number.POSITIVE_INFINITY');
+    expect(reader).toContain('this._persistence.readBlobStream');
+    expect(reader).toContain('collectUnboundedGraphBlobStream');
+    expect(reader).toContain('this._persistence.iterateTree');
     expect(existsSync(successorCard)).toBe(true);
   });
 });

--- a/test/unit/infrastructure/adapters/GitGraphAdapter.listRefs.test.ts
+++ b/test/unit/infrastructure/adapters/GitGraphAdapter.listRefs.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import PersistenceError from '../../../../src/domain/errors/PersistenceError.ts';
 import GitGraphAdapter from '../../../../src/infrastructure/adapters/GitGraphAdapter.ts';
 
 describe('GitGraphAdapter', () => {
@@ -203,6 +204,19 @@ describe('GitGraphAdapter', () => {
       expect(mockPlumbing.execute).toHaveBeenCalledWith({
         args: ['for-each-ref', '--format=%(refname)', '--count=1', 'refs/warp/g/writers/'],
       });
+    });
+
+    it('wraps git failures with ref context', async () => {
+      const prefix = 'refs/warp/g/writers/';
+      const err = new Error('fatal: permission denied');
+      Object.assign(err, { details: { code: 128, stderr: 'fatal: permission denied' } });
+      mockPlumbing.execute.mockRejectedValue(err);
+
+      await expect(adapter.listRefs(prefix))
+        .rejects.toMatchObject({
+          code: PersistenceError.E_REF_IO,
+          message: `Ref I/O error: ${prefix}`,
+        });
     });
   });
 });

--- a/test/unit/scripts/streaming-memory-audit-closeout.test.ts
+++ b/test/unit/scripts/streaming-memory-audit-closeout.test.ts
@@ -15,12 +15,14 @@ describe('streaming memory audit closeout', () => {
 
   it('ratchets the shipped unbounded blob-read fix', () => {
     const adapter = readRepoFile('src/infrastructure/adapters/GitGraphAdapter.ts');
-    const gitErrorClassification = readRepoFile('src/infrastructure/adapters/gitErrorClassification.ts');
+    const reader = readRepoFile('src/infrastructure/adapters/GitCasGraphReaderAdapter.ts');
     const adapterTest = readRepoFile('test/unit/domain/services/GitGraphAdapter.test.ts');
 
-    expect(adapter).toContain("stream.collect({ asString: false, maxBytes: Number.POSITIVE_INFINITY })");
-    expect(gitErrorClassification).toContain('collect(opts?: { asString?: boolean; maxBytes?: number })');
-    expect(adapterTest).toContain('maxBytes: Number.POSITIVE_INFINITY');
+    expect(adapter).toContain('this._gitCasGraphReader.readBlob');
+    expect(reader).toContain('this._persistence.readBlobStream');
+    expect(reader).toContain('collectUnboundedGraphBlobStream');
+    expect(reader).toContain('byteLength += bytes.byteLength');
+    expect(adapterTest).toContain("args: ['cat-file', 'blob', 'abcd']");
   });
 
   it('keeps broader out-of-core work live outside the v17 crash-fix card', () => {

--- a/test/unit/scripts/uniform-git-cas-closeout.test.ts
+++ b/test/unit/scripts/uniform-git-cas-closeout.test.ts
@@ -95,8 +95,9 @@ describe('uniform git-cas closeout', () => {
     expect(backlogReadme).not.toContain('INFRA_unify-persistence-on-git-cas');
     expect(backlogReadme).toContain('INFRA_git-cas-adapter-parity');
     expect(releaseLedger).toContain('INFRA_unify-persistence-on-git-cas');
-    expect(releaseLedger).toContain('[ ] INFRA_git-cas-adapter-parity');
-    expect(successor).toContain('GitPersistenceAdapter.readBlob');
-    expect(successor).toContain('GitRefAdapter.createCommit');
+    expect(releaseLedger).toContain('[x] INFRA_git-cas-adapter-parity');
+    expect(successor).toContain('GitPersistenceAdapter.readBlobStream()');
+    expect(successor).toContain('GitPersistenceAdapter.iterateTree()');
+    expect(successor).toContain('compare-and-swap ref updates');
   });
 });

--- a/test/unit/scripts/uniform-git-cas-closeout.test.ts
+++ b/test/unit/scripts/uniform-git-cas-closeout.test.ts
@@ -70,9 +70,10 @@ describe('uniform git-cas closeout', () => {
     const design = readRepoFile('docs/design/0092-close-uniform-git-cas.md');
     const releaseLedger = readRepoFile('docs/releases/v17.0.0/README.md');
     const upgradeTool = readRepoFile('docs/method/backlog/v17.0.0/INFRA_substrate-upgrade-tool.md');
-    const migrationEntrypoint = readRepoFile('scripts/migrations/v17.0.0/migrate.ts');
+    const upgradeEntrypoint = readRepoFile('scripts/upgrade-v16-to-v17.ts');
+    const migrationHelper = readRepoFile('scripts/migrations/v17.0.0/migrate.ts');
 
-    expect(packageJson).toContain('"upgrade": "npm run build --silent && node dist/scripts/migrations/v17.0.0/migrate.js"');
+    expect(packageJson).toContain('"upgrade": "npm run build --silent && node dist/scripts/upgrade-v16-to-v17.js"');
     expect(packageJson).toContain('"dist"');
     expect(design).not.toContain('legacy raw blobs may still be read');
     expect(releaseLedger).not.toContain('legacy raw reads');
@@ -80,8 +81,9 @@ describe('uniform git-cas closeout', () => {
     expect(upgradeTool).toContain('The package-level command is:');
     expect(upgradeTool).toContain('npm run upgrade -- --graph <name>');
     expect(upgradeTool).toContain('Mainline cleanup requirement');
-    expect(migrationEntrypoint).toContain('npm run upgrade -- --graph <name>');
-    expect(migrationEntrypoint).toContain('not in shipped runtime code under src/');
+    expect(upgradeEntrypoint).toContain('Top-level v16 -> v17 graph substrate upgrade utility');
+    expect(upgradeEntrypoint).toContain('upgradeCheckpointSchema');
+    expect(migrationHelper).toContain('not in shipped runtime code under src/');
   });
 
   it('tracks broader adapter parity as a split successor', () => {

--- a/test/unit/scripts/v16-to-v17-upgrade.test.ts
+++ b/test/unit/scripts/v16-to-v17-upgrade.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { createEmptyState } from '../../../src/domain/services/JoinReducer.ts';
+import { createFrontier } from '../../../src/domain/services/Frontier.ts';
+import { createCheckpointEnvelope } from '../../../src/domain/services/state/checkpointCreate.ts';
+import InMemoryGraphAdapter from '../../../src/infrastructure/adapters/InMemoryGraphAdapter.ts';
+import NodeCryptoAdapter from '../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
+import {
+  formatHumanResult,
+  parseArgs,
+  upgradeV16ToV17,
+} from '../../../scripts/upgrade-v16-to-v17.ts';
+
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(`${repoRoot}${relativePath}`, 'utf8');
+}
+
+function oid(hex: string): string {
+  return hex.repeat(40).slice(0, 40);
+}
+
+describe('v16 to v17 top-level upgrade utility', () => {
+  it('parses repeated graph names and defaults repo to cwd', () => {
+    const args = parseArgs([
+      '--graph', 'alpha',
+      '--graph', 'beta',
+      '--dry-run',
+      '--json',
+    ], '/repo');
+
+    expect(args.repo).toBe('/repo');
+    expect(args.graphNames).toEqual(['alpha', 'beta']);
+    expect(args.dryRun).toBe(true);
+    expect(args.json).toBe(true);
+  });
+
+  it('dry-runs rebuildable cache ref deletion without moving refs', async () => {
+    const persistence = new InMemoryGraphAdapter();
+    await persistence.updateRef('refs/warp/alpha/coverage/head', oid('a'));
+    await persistence.updateRef('refs/warp/alpha/seek-cache', oid('b'));
+
+    const result = await upgradeV16ToV17({
+      persistence,
+      graphNames: ['alpha'],
+      dryRun: true,
+    });
+
+    expect(result.graphs[0]?.checkpoint.status).toBe('missing-checkpoint');
+    expect(result.graphs[0]?.cacheRefs).toEqual([
+      { ref: 'refs/warp/alpha/coverage/head', action: 'would-delete', previousOid: oid('a') },
+      { ref: 'refs/warp/alpha/seek-cache', action: 'would-delete', previousOid: oid('b') },
+    ]);
+    expect(await persistence.readRef('refs/warp/alpha/coverage/head')).toBe(oid('a'));
+    expect(await persistence.readRef('refs/warp/alpha/seek-cache')).toBe(oid('b'));
+  });
+
+  it('deletes rebuildable cache refs while leaving checkpoint refs under checkpoint migration control', async () => {
+    const persistence = new InMemoryGraphAdapter();
+    const checkpointSha = await createCheckpointEnvelope({
+      persistence,
+      graphName: 'alpha',
+      state: createEmptyState(),
+      frontier: createFrontier(),
+      crypto: new NodeCryptoAdapter(),
+    });
+    await persistence.updateRef('refs/warp/alpha/checkpoints/head', checkpointSha);
+    await persistence.updateRef('refs/warp/alpha/coverage/head', oid('a'));
+    await persistence.updateRef('refs/warp/alpha/seek-cache', oid('b'));
+
+    const result = await upgradeV16ToV17({
+      persistence,
+      graphNames: ['alpha'],
+    });
+
+    expect(result.graphs[0]?.cacheRefs.map((entry) => entry.action)).toEqual(['deleted', 'deleted']);
+    expect(await persistence.readRef('refs/warp/alpha/coverage/head')).toBeNull();
+    expect(await persistence.readRef('refs/warp/alpha/seek-cache')).toBeNull();
+    expect(await persistence.readRef('refs/warp/alpha/checkpoints/head')).toBe(checkpointSha);
+  });
+
+  it('formats an empty repo without implying an error', () => {
+    expect(formatHumanResult({ dryRun: true, graphCount: 0, graphs: [] }))
+      .toBe('No WARP graphs found in this repository.');
+  });
+
+  it('wires npm run upgrade through the top-level operator script', () => {
+    const pkg = readRepoFile('package.json');
+    const publishConfig = readRepoFile('tsconfig.publish.json');
+
+    expect(pkg).toContain('node dist/scripts/upgrade-v16-to-v17.js');
+    expect(publishConfig).toContain('"scripts/**/*.ts"');
+  });
+});

--- a/test/unit/scripts/v16-to-v17-upgrade.test.ts
+++ b/test/unit/scripts/v16-to-v17-upgrade.test.ts
@@ -37,6 +37,16 @@ describe('v16 to v17 top-level upgrade utility', () => {
     expect(args.json).toBe(true);
   });
 
+  it('rejects a missing repo path when the next token is another flag', () => {
+    expect(() => parseArgs(['--repo', '--dry-run'], '/repo'))
+      .toThrow('--repo requires a path');
+  });
+
+  it('rejects a missing graph name when the next token is another flag', () => {
+    expect(() => parseArgs(['--graph', '--json'], '/repo'))
+      .toThrow('--graph requires a graph name');
+  });
+
   it('dry-runs rebuildable cache ref deletion without moving refs', async () => {
     const persistence = new InMemoryGraphAdapter();
     await persistence.updateRef('refs/warp/alpha/coverage/head', oid('a'));

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -14,7 +14,7 @@
     "src/**/*.ts",
     "src/globals.d.ts",
     "bin/**/*.ts",
-    "scripts/migrations/**/*.ts"
+    "scripts/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary

This is the tiny v17 closure PR after PR #84 merged. It lands the local substrate/runtime commits that were still ahead of `origin/main`, so v17 does not split into archaeology about which substrate shape actually shipped.

Included substrate/runtime commits:

- `b99a9b4c` fix(checkpoint): preserve legacy blob content anchors
- `b62d51ff` chore: upgrade git stunts substrate packages
- `ad673d39` feat: add v16 to v17 upgrade utility
- `cb4c5802` feat: route git graph reads through git-cas streams

Additional CI closure commit:

- `80a3d19a` test: cover git graph object type reads

Deferred from this PR:

- intent-bound resilience doctrine/design docs
- footprint resilience doctrine/design docs
- v18/resilience/architecture follow-up work

## Status

v17 PR #84 is merged, but release closeout is blocked on landing these substrate/runtime commits. After this PR lands, validate on `main`, then tag and publish v17.

## Validation

Local branch validation:

- `npm run lint`
- `npm run typecheck`
- `npx vitest run test/unit/scripts/v16-to-v17-upgrade.test.ts test/unit/infrastructure/adapters/CliJsonFormatterAdapter.test.ts test/unit/domain/services/CheckpointService.test.ts test/unit/domain/services/GitGraphAdapter.test.ts test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts test/unit/infrastructure/adapters/GitGraphAdapter.gitCasPersistence.test.ts test/unit/scripts/uniform-git-cas-closeout.test.ts` — 7 files / 191 tests
- `npm run build`
- `npm run lint:md`
- `npm exec vitest -- run test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts test/unit/infrastructure/adapters/GitGraphAdapter.listRefs.test.ts` — 2 files / 98 tests
- `npm run test:coverage:ci` — 440 files / 6783 tests, line coverage 91.87% against 91.74% threshold
- pre-push IRONCLAD M9 gate: static gates plus `npm run test:local` — 440 files / 6783 tests

GitHub validation is green on PR #85:

- Check broken links
- CodeRabbit
- coverage-threshold
- preflight
- test-bun
- test-deno
- test-node (22)
- type-firewall
- typecheck-test-advisory


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Documentation**
  * Added v17.0.0 migration guide with graph repository upgrade instructions.
  * Updated infrastructure modernization specifications and vault encryption approach documentation.
  
* **Chores**
  * Bumped `@git-stunts/alfred`, `@git-stunts/git-cas`, and `@git-stunts/plumbing` dependencies.
  * Added `npm run upgrade` command for automated v16→v17 graph repository migration with dry-run support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/git-stunts/git-warp/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->