### PR TITLE
release: harden v17 publish package

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -3,10 +3,8 @@ name: Link Check
 on:
   push:
     branches: [main]
-    paths: ["**/*.md", ".lychee.toml"]
   pull_request:
     branches: [main]
-    paths: ["**/*.md", ".lychee.toml"]
 
 permissions:
   contents: read

--- a/docs/method/backlog/bad-code/README.md
+++ b/docs/method/backlog/bad-code/README.md
@@ -15,7 +15,7 @@ Existing filenames stay stable unless there is a strong reason to rename them. T
 | [PORT](../../legends/PORT.md) | Capability and port surfaces must tell the runtime truth. | 12 |
 | [OWN](../../legends/OWNERSHIP.md) | One owner per behavior: no gods, no duplication corridors, no mixed-concern facades. | 32 |
 | [SUB](../../legends/SUBSTRATE.md) | Substrate integrity: streaming, CAS, checkpoint, index, and versioned storage stay explicit. | 15 |
-| [SPEC](../../legends/SPEC.md) | Tests, docs, mocks, and coverage residue must reflect the real contract. | 118 |
+| [SPEC](../../legends/SPEC.md) | Tests, docs, mocks, and coverage residue must reflect the real contract. | 119 |
 
 ## Release Homes
 
@@ -30,7 +30,7 @@ card metadata or promoting bad-code into a release lane.
 
 | Release Home | Count |
 |--------------|------:|
-| `v17.0.0` | 194 |
+| `v17.0.0` | 195 |
 | `v18.0.0` | 13 |
 | `v19.0.0` | 13 |
 | `v20.0.0` | 15 |
@@ -192,6 +192,7 @@ card metadata or promoting bad-code into a release lane.
 - [SPEC_patch-session-untested.md](SPEC_patch-session-untested.md)
 - [SPEC_querybuilder-untested.md](SPEC_querybuilder-untested.md)
 - [SPEC_readtreeoids-mock-returns-array.md](SPEC_readtreeoids-mock-returns-array.md)
+- [SPEC_required-link-check-path-filter.md](SPEC_required-link-check-path-filter.md)
 - [SPEC_state-reader-untested.md](SPEC_state-reader-untested.md)
 - [SPEC_sync-controller-over-mocked.md](SPEC_sync-controller-over-mocked.md)
 - [SPEC_untested-controllers.md](SPEC_untested-controllers.md)

--- a/docs/method/backlog/bad-code/RELEASE_TRIAGE.md
+++ b/docs/method/backlog/bad-code/RELEASE_TRIAGE.md
@@ -13,7 +13,7 @@ After the first metadata cleanup pass:
 
 | Release Home | Count | Read |
 |--------------|------:|------|
-| `v17.0.0` | 194 | Current-engine cleanup bucket. Includes runtime-deletion fallout and stale-card rechecks. |
+| `v17.0.0` | 195 | Current-engine cleanup bucket. Includes runtime-deletion fallout and stale-card rechecks. |
 | `v18.0.0` | 13 | Graph-substrate cards promoted out of generic v17 cleanup. |
 | `v19.0.0` | 13 | Observer/admission/runtime-doctrine cleanup. |
 | `v20.0.0` | 15 | Slice-first read, index, traversal, and materialization-cost work. |

--- a/docs/method/backlog/bad-code/SPEC_required-link-check-path-filter.md
+++ b/docs/method/backlog/bad-code/SPEC_required-link-check-path-filter.md
@@ -1,0 +1,14 @@
+# SPEC required link check path filter
+
+## Smell
+
+`Check broken links` is a required main-branch context, but the Link
+Check workflow was path-filtered to Markdown and `.lychee.toml`
+changes. Code-only PRs could pass every relevant CI job and still be
+unmergeable because GitHub never received the required status context.
+
+## Paydown
+
+Keep required workflows unfiltered, or move filtering into job-level
+logic that still emits the required context on every protected-branch
+PR.

--- a/docs/method/backlog/bad-code/SPEC_required-link-check-path-filter.md
+++ b/docs/method/backlog/bad-code/SPEC_required-link-check-path-filter.md
@@ -1,3 +1,11 @@
+---
+id: SPEC_required-link-check-path-filter
+blocked_by: []
+blocks: []
+feature: tooling-release
+release_home: v17.0.0
+---
+
 # SPEC required link check path filter
 
 ## Smell

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "cli-table3": "^0.6.3",
         "elkjs": "^0.11.0",
         "figures": "^6.0.1",
-        "roaring": "^2.7.0",
         "roaring-wasm": "^1.1.0",
         "string-width": "^7.1.0",
         "wrap-ansi": "^9.0.0",
@@ -53,6 +52,9 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "roaring": "^2.7.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -639,6 +641,7 @@
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -679,6 +682,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
       "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "consola": "^3.2.3",
         "detect-libc": "^2.0.0",
@@ -1564,6 +1568,7 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
       "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
@@ -1596,6 +1601,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 14"
       }
@@ -2009,6 +2015,7 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -2148,6 +2155,7 @@
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
@@ -2178,6 +2186,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2254,6 +2263,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3136,6 +3146,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -4700,6 +4711,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -4839,6 +4851,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -4850,6 +4863,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4893,6 +4907,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -5005,6 +5020,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
       "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "^3.0.0"
       },
@@ -5461,6 +5477,7 @@
       "integrity": "sha512-gNVeV5H+xb2DB/umdvlPbTrKuCn8zexy6ROkfPL4FcSWxOGWrxfQz0pZeZER+kQLrSoPcz3BolYPM6eFYm96XQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "@mapbox/node-pre-gyp": "^2.0.3"
       },
@@ -5549,6 +5566,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5794,6 +5812,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
       "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -5893,7 +5912,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -6203,13 +6223,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6318,6 +6340,7 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -112,11 +112,13 @@
     "cli-table3": "^0.6.3",
     "elkjs": "^0.11.0",
     "figures": "^6.0.1",
-    "roaring": "^2.7.0",
     "roaring-wasm": "^1.1.0",
     "string-width": "^7.1.0",
     "wrap-ansi": "^9.0.0",
     "zod": "3.24.1"
+  },
+  "optionalDependencies": {
+    "roaring": "^2.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/test/unit/domain/capabilities/MaterializedSnapshot.test.ts
+++ b/test/unit/domain/capabilities/MaterializedSnapshot.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import AdjacencyMap from '../../../../src/domain/capabilities/AdjacencyMap.ts';
+import MaterializedSnapshot from '../../../../src/domain/capabilities/MaterializedSnapshot.ts';
+import WarpState from '../../../../src/domain/services/state/WarpState.ts';
+
+describe('MaterializedSnapshot', () => {
+  it('freezes a materialized state, hash, and adjacency bundle', () => {
+    const state = WarpState.empty();
+    const adjacency = new AdjacencyMap({
+      outgoing: new Map(),
+      incoming: new Map(),
+    });
+
+    const snapshot = new MaterializedSnapshot({
+      state,
+      stateHash: 'sha1:state',
+      adjacency,
+    });
+
+    expect(snapshot.state).toBe(state);
+    expect(snapshot.stateHash).toBe('sha1:state');
+    expect(snapshot.adjacency).toBe(adjacency);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+  });
+});

--- a/test/unit/domain/errors/StateSessionError.test.ts
+++ b/test/unit/domain/errors/StateSessionError.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import StateSessionError from '../../../../src/domain/errors/StateSessionError.ts';
+import WarpError from '../../../../src/domain/errors/WarpError.ts';
+
+describe('StateSessionError', () => {
+  it('uses the state session input error code', () => {
+    const err = new StateSessionError('state session failed');
+
+    expect(err).toBeInstanceOf(WarpError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('StateSessionError');
+    expect(err.code).toBe('E_STATE_SESSION_INPUT');
+  });
+});

--- a/test/unit/domain/services/snapshot/SnapshotValues.test.ts
+++ b/test/unit/domain/services/snapshot/SnapshotValues.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { Dot } from '../../../../../src/domain/crdt/Dot.ts';
+import VersionVector from '../../../../../src/domain/crdt/VersionVector.ts';
+import ImmutableBytes from '../../../../../src/domain/services/snapshot/ImmutableBytes.ts';
+import SnapshotVersionVector from '../../../../../src/domain/services/snapshot/SnapshotVersionVector.ts';
+
+describe('ImmutableBytes', () => {
+  it('copies input and output byte arrays', () => {
+    const source = new Uint8Array([1, 2, 3]);
+    const value = new ImmutableBytes(source);
+
+    source[0] = 9;
+    const copy = value.toUint8Array();
+    copy[1] = 8;
+
+    expect(value.length).toBe(3);
+    expect(value.at(0)).toBe(1);
+    expect(value.at(1)).toBe(2);
+    expect(value.at(9)).toBeUndefined();
+    expect([...value]).toEqual([1, 2, 3]);
+    expect([...value.values()]).toEqual([1, 2, 3]);
+    expect(Object.isFrozen(value)).toBe(true);
+  });
+
+  it('returns a frozen plain array view', () => {
+    const value = new ImmutableBytes(new Uint8Array([4, 5]));
+    const array = value.toArray();
+
+    expect(array).toEqual([4, 5]);
+    expect(Object.isFrozen(array)).toBe(true);
+  });
+});
+
+describe('SnapshotVersionVector', () => {
+  it('captures an immutable point-in-time vector view', () => {
+    const source = VersionVector.from(new Map([
+      ['alice', 2],
+      ['bob', 1],
+    ]));
+    const snapshot = new SnapshotVersionVector(source);
+
+    source.set('alice', 5);
+
+    expect(snapshot.get('alice')).toBe(2);
+    expect(snapshot.get('carol')).toBeUndefined();
+    expect(snapshot.has('bob')).toBe(true);
+    expect(snapshot.has('carol')).toBe(false);
+    expect(snapshot.size).toBe(2);
+    expect([...snapshot]).toEqual([['alice', 2], ['bob', 1]]);
+    expect([...snapshot.keys()]).toEqual(['alice', 'bob']);
+    expect([...snapshot.values()]).toEqual([2, 1]);
+    expect([...snapshot.entries()]).toEqual([['alice', 2], ['bob', 1]]);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+  });
+
+  it('compares causal coverage with snapshot vectors and dots', () => {
+    const snapshot = new SnapshotVersionVector(VersionVector.from(new Map([
+      ['alice', 2],
+      ['bob', 1],
+    ])));
+    const previous = new SnapshotVersionVector(VersionVector.from(new Map([
+      ['alice', 1],
+    ])));
+    const future = new SnapshotVersionVector(VersionVector.from(new Map([
+      ['alice', 3],
+    ])));
+    const same = new SnapshotVersionVector(VersionVector.from(new Map([
+      ['alice', 2],
+      ['bob', 1],
+    ])));
+    const differentCounter = new SnapshotVersionVector(VersionVector.from(new Map([
+      ['alice', 2],
+      ['bob', 2],
+    ])));
+
+    expect(snapshot.descends(previous)).toBe(true);
+    expect(snapshot.descends(future)).toBe(false);
+    expect(snapshot.contains(new Dot('alice', 2))).toBe(true);
+    expect(snapshot.contains(new Dot('alice', 3))).toBe(false);
+    expect(snapshot.equals(same)).toBe(true);
+    expect(snapshot.equals(previous)).toBe(false);
+    expect(snapshot.equals(differentCounter)).toBe(false);
+  });
+});

--- a/test/unit/infrastructure/adapters/RoaringLoaderAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/RoaringLoaderAdapter.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  RoaringBitmap32Constructor,
+  RoaringBitmapSubset,
+} from '../../../../src/domain/utils/roaring.ts';
+
+async function importFreshAdapter(): Promise<
+  typeof import('../../../../src/infrastructure/adapters/RoaringLoaderAdapter.ts')
+> {
+  return import('../../../../src/infrastructure/adapters/RoaringLoaderAdapter.ts');
+}
+
+class FakeBitmap implements RoaringBitmapSubset {
+  readonly _values: Set<number>;
+
+  constructor(values?: Iterable<number>) {
+    this._values = new Set(values ?? []);
+  }
+
+  get size(): number {
+    return this._values.size;
+  }
+
+  add(value: number): void {
+    this._values.add(value);
+  }
+
+  clear(): void {
+    this._values.clear();
+  }
+
+  remove(value: number): void {
+    this._values.delete(value);
+  }
+
+  has(value: number): boolean {
+    return this._values.has(value);
+  }
+
+  orInPlace(other: Iterable<number>): void {
+    for (const value of other) {
+      this._values.add(value);
+    }
+  }
+
+  serialize(_portable: boolean): Uint8Array {
+    return new Uint8Array(this.toArray());
+  }
+
+  toArray(): number[] {
+    return [...this._values];
+  }
+
+  [Symbol.iterator](): Iterator<number> {
+    return this._values[Symbol.iterator]();
+  }
+}
+
+function createBitmapConstructor(options: {
+  readonly label: string;
+  readonly nativeAvailability?: boolean;
+}): RoaringBitmap32Constructor {
+  class BitmapCtor extends FakeBitmap {
+    static deserialize(data: Uint8Array | ArrayLike<number>): RoaringBitmapSubset {
+      return new BitmapCtor(Array.from(data));
+    }
+  }
+
+  Object.defineProperty(BitmapCtor, 'name', {
+    value: options.label,
+  });
+
+  if (options.nativeAvailability !== undefined) {
+    const nativeAvailability = options.nativeAvailability;
+    return Object.assign(BitmapCtor, {
+      isNativelyInstalled: (): boolean => nativeAvailability,
+    });
+  }
+
+  return BitmapCtor;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock('roaring');
+  vi.doUnmock('roaring-wasm');
+  vi.doUnmock('node:module');
+});
+
+describe('RoaringLoaderAdapter', () => {
+  it('reports constructor-based native availability', async () => {
+    const adapter = await importFreshAdapter();
+    const bitmap = createBitmapConstructor({
+      label: 'NativeBitmap',
+      nativeAvailability: true,
+    });
+
+    await adapter.initRoaring({
+      RoaringBitmap32: bitmap,
+    });
+
+    expect(adapter.getNativeRoaringAvailable()).toBe(true);
+  });
+
+  it('reports property-based native availability', async () => {
+    const adapter = await importFreshAdapter();
+    const bitmap = createBitmapConstructor({ label: 'PropertyBitmap' });
+
+    await adapter.initRoaring({
+      RoaringBitmap32: bitmap,
+      isNativelyInstalled: true,
+    });
+
+    expect(adapter.getNativeRoaringAvailable()).toBe(true);
+  });
+
+  it('reports null when native availability cannot be determined', async () => {
+    const adapter = await importFreshAdapter();
+    const bitmap = createBitmapConstructor({ label: 'UnknownBitmap' });
+
+    await adapter.initRoaring({
+      RoaringBitmap32: bitmap,
+    });
+
+    expect(adapter.getNativeRoaringAvailable()).toBeNull();
+  });
+
+  it('captures malformed injected modules as unavailable', async () => {
+    const adapter = await importFreshAdapter();
+
+    await adapter.initRoaring({});
+
+    expect(adapter.getNativeRoaringAvailable()).toBe(false);
+  });
+
+  it('surfaces aggregate load failure when no loader path succeeds', async () => {
+    vi.doMock('roaring', () => {
+      throw new Error('native import failed');
+    });
+    vi.doMock('node:module', () => ({
+      createRequire: () => () => {
+        throw new Error('cjs require failed');
+      },
+    }));
+    vi.doMock('roaring-wasm', () => {
+      throw new Error('wasm import failed');
+    });
+
+    const adapter = await importFreshAdapter();
+
+    await expect(adapter.initRoaring()).rejects.toThrow(AggregateError);
+    expect(adapter.getNativeRoaringAvailable()).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/ports/**/*.ts', 'src/**/*.d.ts'],
       thresholds: {
-        lines: 91.74,
+        lines: 91.87,
         autoUpdate: shouldAutoUpdateCoverageRatchet(),
       },
     },


### PR DESCRIPTION
## Summary

- ratchet v17 coverage threshold to the passing 91.87% line coverage value
- make native `roaring` an optional dependency so the package can install on runtimes where the native binding is unavailable
- keep `roaring-wasm` as the required runtime fallback used by the existing loader chain

## Why

Release preflight exposed that `roaring@2.7.0` cannot build under Node 26. The runtime loader already falls back to `roaring-wasm`, but npm never reached that fallback while native `roaring` was a hard dependency. Marking it optional lets npm continue and lets the loader use the WASM implementation.

## Validation

- `bash scripts/smoke-packed-artifact.sh` under Node 26
- `npx vitest run test/unit/domain/utils/roaring.test.ts`
- `npm run typecheck:surface`
- full `npm run release:preflight` under Node 22 via Node 22 on `PATH`
- pre-push IRONCLAD M9, including `npm run test:local`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies configuration to optimize installation behavior
  * Adjusted code quality testing thresholds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/git-stunts/git-warp/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->