### PR TITLE
test: ratchet final v17 coverage

### DIFF
--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -93,8 +93,8 @@ fi
 
 # ── 7. Unit tests ────────────────────────────────────────────────────────────
 echo "Tests:"
-if npm run test:coverage --silent 2>/dev/null; then
-  pass "unit tests + coverage ratchet"
+if npm run test:coverage:ci --silent 2>/dev/null; then
+  pass "unit tests + coverage threshold"
 else
   fail "unit test or coverage failures"
 fi

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/ports/**/*.ts', 'src/**/*.d.ts'],
       thresholds: {
-        lines: 92.03,
+        lines: 91.90,
         autoUpdate: shouldAutoUpdateCoverageRatchet(),
       },
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/ports/**/*.ts', 'src/**/*.d.ts'],
       thresholds: {
-        lines: 91.87,
+        lines: 92.03,
         autoUpdate: shouldAutoUpdateCoverageRatchet(),
       },
     },


### PR DESCRIPTION
## Summary
- ratchet the v17 coverage threshold to a CI-stable 91.90% line coverage, above the previous 91.87% threshold
- make release preflight use the non-mutating CI coverage command so local preflight does not rewrite thresholds from platform-specific V8 coverage output

## Validation
- bash -n scripts/release-preflight.sh
- npx vitest run test/unit/scripts/release-policy-shape.test.ts test/unit/scripts/coverage-ratchet.test.ts
- npm run test:coverage:ci (445 files / 6796 tests, 92.03% local line coverage)
- pre-push IRONCLAD M9 passed, including link check, static gates, and test:local (445 files / 6796 tests)