### PR TITLE
Fix recursive tree OID read fanout and release v17.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [17.0.1] — 2026-05-22
+
 ### Fixed
 
+- Recursive Git tree OID reads now use one `git ls-tree -rz` call instead
+  of recursing through one-level tree iteration, restoring checkpoint-open
+  latency for Think-scale tree indexes while preserving git-warp's recursive
+  path-to-OID map contract.
 - Continuum artifact ingestion now enforces artifact-kind/authority pairing at
   the domain policy layer, keeps review fixtures repo-neutral, and splits the
   JSON adapter into focused parser, validation, fixture, and Wesley inventory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recursive Git tree OID reads now use one `git ls-tree -rz` call instead
   of recursing through one-level tree iteration, restoring checkpoint-open
   latency for Think-scale tree indexes while preserving git-warp's recursive
-  path-to-OID map contract.
+  path-to-OID map contract, including prototype-like Git path names.
 - Continuum artifact ingestion now enforces artifact-kind/authority pairing at
   the domain policy layer, keeps review fixtures repo-neutral, and splits the
   JSON adapter into focused parser, validation, fixture, and Wesley inventory

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,9 +4,9 @@
 > See METHOD for the current process.
 > Completed items remain in `docs/ROADMAP/COMPLETED.md`. This file is kept for reference only.
 
-> **Current release on `main`:** v16.0.0
-> **Next intended release:** v16.0.1
-> **Last reconciled:** 2026-03-29 (v16.0.0 release. OG-014 streaming CAS blob storage, OG-015 JSR docs, deprecated TraversalService and createWriter removed.)
+> **Current release on `main`:** v17.0.1
+> **Next intended release:** v18.0.0
+> **Last reconciled:** 2026-05-22 (v17.0.1 patch. Recursive tree OID reads use one path-preserving Git command; v17.0.0 release delivered readings/worldlines, TypeScript source, and the generated npm type surface.)
 > **Completed milestones:** [docs/ROADMAP/COMPLETED.md](ROADMAP/COMPLETED.md)
 
 ---

--- a/docs/design/0150-path-keyed-boundary-accumulator-audit/path-keyed-boundary-accumulator-audit.md
+++ b/docs/design/0150-path-keyed-boundary-accumulator-audit/path-keyed-boundary-accumulator-audit.md
@@ -1,0 +1,77 @@
+---
+cycle: 0150
+task_id: BND_path_keyed_boundary_accumulator_audit
+status: Planned
+sponsors:
+  human: James
+  agent: Codex
+started_at: 2026-05-22
+release_home: v18.0.0
+backlog:
+  - docs/method/backlog/bad-code/BND_path-keyed-object-accumulators.md
+---
+
+# Path-Keyed Boundary Accumulator Audit
+
+## Pull
+
+PR #93 fixed one concrete instance of a path-keyed plain object
+accumulator in recursive tree OID parsing. The finding is broader than
+that file: repository paths, transport field names, and generated
+artifact identifiers are untrusted data until a boundary has validated
+them.
+
+## Hill
+
+Every touched path-keyed accumulator at Git or transport boundaries
+uses a runtime-honest intermediate representation before exposing any
+record-shaped API.
+
+## Playback Questions
+
+- Which adapters accept path-like or identifier-like strings from Git,
+  transport, generated artifacts, or file input?
+- Which of those adapters write untrusted keys into plain objects before
+  validation?
+- Does each corrected site prove prototype-like keys are preserved as
+  data?
+- Does the public API shape stay stable where callers already expect a
+  record?
+
+## Design
+
+1. Inventory boundary files under `src/infrastructure/adapters/`,
+   transport codecs, and generated-artifact ingestion seams.
+2. Mark each path-keyed accumulator as safe, unsafe, or intentionally
+   record-shaped after validation.
+3. For unsafe sites, accumulate in `Map` or another typed runtime
+   collection before final materialization.
+4. Add focused tests for `__proto__`, `constructor`, and nested path
+   examples at each repaired boundary.
+
+## Non-Goals
+
+- Do not replace stable public record APIs solely for aesthetic reasons.
+- Do not create a generic helper before at least two real call sites
+  justify one.
+- Do not move parsing behavior into domain code.
+
+## Verification
+
+- Targeted tests for each repaired boundary.
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:local`
+
+## SSJS Scorecard
+
+- Runtime-backed forms: planned; untrusted key collections use real
+  runtime collections before record materialization.
+- Boundary validation: planned; validation remains in adapters and
+  parser seams.
+- Behavior ownership: planned; each boundary owns its own input shape.
+- Message parsing: green; no behavior depends on free-form messages.
+- Ambient time or entropy: green; no time or entropy is involved.
+- Fake shape trust or cast-cosplay: planned; no casts should be needed
+  for accumulator safety.
+

--- a/docs/design/0151-safe-path-map-materialization/safe-path-map-materialization.md
+++ b/docs/design/0151-safe-path-map-materialization/safe-path-map-materialization.md
@@ -1,0 +1,72 @@
+---
+cycle: 0151
+task_id: PROTO_safe_path_map_materialization
+status: Planned
+sponsors:
+  human: James
+  agent: Codex
+started_at: 2026-05-22
+release_home: v18.0.0
+backlog:
+  - docs/method/backlog/cool-ideas/PROTO_safe-path-map-materialization.md
+---
+
+# Safe Path-Map Materialization
+
+## Pull
+
+The recursive tree OID parser now uses `Map<string, string>` before
+returning a public record. That pattern should be deliberate rather
+than rediscovered during each review.
+
+## Hill
+
+The repo has a documented pattern for path-keyed materialization that
+preserves existing record-shaped APIs without trusting untrusted keys as
+object structure.
+
+## Playback Questions
+
+- When is `Map` the right intermediate representation?
+- When is a null-prototype object acceptable?
+- Where should validation happen before materializing a public record?
+- What test cases prove the materialization is not prototype-sensitive?
+
+## Design
+
+The default pattern is:
+
+1. Parse or collect untrusted path-like inputs into `Map`.
+2. Validate each key and value as boundary data.
+3. Convert to a public record only at the adapter edge that already
+   promises a record.
+4. Test prototype-like keys and normal nested paths together.
+
+If repeated call sites appear, introduce a named helper with a narrow
+type signature and no `any`, `unknown`, or cast-cosplay. Until then,
+prefer local code that keeps each boundary easy to read.
+
+## Non-Goals
+
+- Do not introduce a universal collection abstraction.
+- Do not widen public APIs to `Map` without a separate compatibility
+  decision.
+- Do not normalize or reject valid Git path names merely because they
+  are awkward object keys.
+
+## Verification
+
+- Markdown docs lint for the pattern doc.
+- Focused unit tests if a helper is introduced.
+- Typecheck if any helper lands.
+
+## SSJS Scorecard
+
+- Runtime-backed forms: planned; `Map` is the explicit runtime form.
+- Boundary validation: planned; validation remains at the boundary.
+- Behavior ownership: green; materialization belongs to adapter edges.
+- Message parsing: green.
+- Ambient time or entropy: green.
+- Fake shape trust or cast-cosplay: planned; helper design must not
+  require casts.
+

--- a/docs/design/0152-review-bot-warning-policy/review-bot-warning-policy.md
+++ b/docs/design/0152-review-bot-warning-policy/review-bot-warning-policy.md
@@ -1,0 +1,71 @@
+---
+cycle: 0152
+task_id: DX_review_bot_warning_policy
+status: Planned
+sponsors:
+  human: James
+  agent: Codex
+started_at: 2026-05-22
+release_home: v18.0.0
+backlog:
+  - docs/method/backlog/DX_review-bot-warning-policy.md
+---
+
+# Review Bot Warning Policy
+
+## Pull
+
+PR review bots can produce both useful findings and generic warnings.
+PR #93 had both: the prototype-like path issue was valid, while the
+docstring coverage warning did not map to this repository's gates.
+
+## Hill
+
+Contributors have a repo-visible rule for classifying review-bot
+warnings as required work, false positives, or backlog fuel.
+
+## Playback Questions
+
+- Does the warning map to a repository script, CI check, policy doc, or
+  product contract?
+- If the warning is valid, what RED test or failing gate proves it?
+- If the warning is false, what local evidence proves that answer?
+- If the warning is not a merge blocker but still useful, where does it
+  enter the backlog?
+
+## Design
+
+Add a contributor-facing review policy that requires:
+
+1. Verify the warning against current code.
+2. Search local scripts, workflows, and policy docs for an owning gate.
+3. Fix valid issues with RED/GREEN, docs, and commit evidence.
+4. Reply to false positives with file, command, and CI evidence.
+5. Convert useful but non-blocking warnings into backlog notes with a
+   design link.
+
+## Non-Goals
+
+- Do not turn generic bot suggestions into automatic policy.
+- Do not silence review bots globally.
+- Do not add documentation churn when no repo rule asks for it.
+
+## Verification
+
+- The policy doc links to the existing PR template and review hygiene
+  guidance.
+- Markdown lint passes.
+- A future PR feedback loop can cite the policy instead of relying on
+  chat-only precedent.
+
+## SSJS Scorecard
+
+- Runtime-backed forms: not applicable; docs/process slice.
+- Boundary validation: green; process requires local evidence before
+  adopting external warnings.
+- Behavior ownership: green; repo gates own repo policy.
+- Message parsing: green; bot text is evidence to verify, not authority.
+- Ambient time or entropy: green.
+- Fake shape trust or cast-cosplay: green; false positives require
+  inspectable proof.
+

--- a/docs/design/0153-recursive-tree-path-benchmark/recursive-tree-path-benchmark.md
+++ b/docs/design/0153-recursive-tree-path-benchmark/recursive-tree-path-benchmark.md
@@ -1,0 +1,74 @@
+---
+cycle: 0153
+task_id: PERF_recursive_tree_path_benchmark
+status: Planned
+sponsors:
+  human: James
+  agent: Codex
+started_at: 2026-05-22
+release_home: v18.0.0
+backlog:
+  - docs/method/backlog/PERF_recursive-tree-path-benchmark.md
+---
+
+# Recursive Tree Path Benchmark
+
+## Pull
+
+The v17.0.1 release fix proved that recursive tree OID reads should use
+one `git ls-tree -rz` call. The next useful performance proof is a
+repeatable fixture that mixes depth, width, and awkward but valid path
+names.
+
+## Hill
+
+Recursive tree OID reading has a benchmark or regression fixture that
+proves single-command behavior and path integrity for deep, wide, and
+prototype-like path names.
+
+## Playback Questions
+
+- Does the reader still issue one recursive tree command for a large
+  fixture?
+- Are nested paths preserved exactly?
+- Are `__proto__` and `constructor` paths returned as data?
+- Does the fixture fail if recursive one-level fanout comes back?
+
+## Design
+
+Build a deterministic fixture with:
+
+- a deep path chain;
+- a wide sibling set;
+- prototype-like path segments;
+- enough entries to make process fanout visible.
+
+The test should count command invocations at the adapter seam and assert
+the returned path/OID map. If promoted to a benchmark, record the
+baseline command count and wall-clock envelope without making noisy
+timing a unit-test gate.
+
+## Non-Goals
+
+- Do not require a live external repository.
+- Do not make wall-clock timing the only correctness signal.
+- Do not broaden the recursive reader API.
+
+## Verification
+
+- Targeted adapter test or benchmark fixture.
+- `npm run test:local` if the fixture is a unit test.
+- `npm run benchmark:local` if it becomes a benchmark.
+
+## SSJS Scorecard
+
+- Runtime-backed forms: green; no new domain model is required.
+- Boundary validation: planned; fixture exercises adapter parsing only.
+- Behavior ownership: green; recursive tree command behavior belongs to
+  the Git adapter.
+- Message parsing: green; command output stays parser-owned.
+- Ambient time or entropy: green for deterministic tests; benchmark
+  timing is advisory only.
+- Fake shape trust or cast-cosplay: green; assertions inspect returned
+  path/OID data.
+

--- a/docs/method/backlog/DX_review-bot-warning-policy.md
+++ b/docs/method/backlog/DX_review-bot-warning-policy.md
@@ -1,0 +1,32 @@
+---
+id: DX_review-bot-warning-policy
+feature: tooling-release
+blocked_by: []
+blocks: []
+---
+
+# Review bot warning policy
+
+**Effort:** S
+
+## Design
+
+[0152 review bot warning policy](../../design/0152-review-bot-warning-policy/review-bot-warning-policy.md)
+
+## Problem
+
+PR #93 showed two different review-bot outcomes:
+
+- a real inline issue that needed RED/GREEN repair;
+- a generic docstring coverage warning that did not map to any local
+  script, workflow, or repository policy.
+
+The review loop needs a clear local rule for when warnings become work
+and when they should be answered as false positives with evidence.
+
+## Suggested Fix
+
+Document the evidence bundle required for review-bot false positives:
+local gate search, CI status, affected files, and the reason a proposed
+fix would add churn or violate local style. Fold this into contributor
+review-loop hygiene instead of relying on chat memory.

--- a/docs/method/backlog/PERF_recursive-tree-path-benchmark.md
+++ b/docs/method/backlog/PERF_recursive-tree-path-benchmark.md
@@ -1,0 +1,34 @@
+---
+id: PERF_recursive-tree-path-benchmark
+feature: trie-state-storage
+blocked_by: []
+blocks: []
+---
+
+# Recursive tree path edge-case benchmark
+
+**Effort:** M
+
+## Design
+
+[0153 recursive tree path benchmark](../../design/0153-recursive-tree-path-benchmark/recursive-tree-path-benchmark.md)
+
+## Problem
+
+The v17.0.1 fix reduced recursive tree OID reads to one `git ls-tree
+-rz` call and added correctness coverage for prototype-like path
+names. The remaining benchmark evidence focuses on fanout and Think
+latency, not a repeatable fixture that combines deep trees, wide trees,
+and unusual but valid Git path names.
+
+## Suggested Fix
+
+Add a benchmark or regression fixture that exercises recursive tree OID
+reads across:
+
+- deep nested paths;
+- wide sibling sets;
+- prototype-like path names;
+- enough entries to expose accidental process fanout.
+
+The benchmark should verify both runtime shape and path/OID integrity.

--- a/docs/method/backlog/README.md
+++ b/docs/method/backlog/README.md
@@ -19,25 +19,25 @@ such as `README.md`, `SCORECARD.md`, and `WORKLOADS.md`:
 
 | Metric | Count |
 |--------|------:|
-| Live backlog items | 371 |
-| Root backlog items | 31 |
+| Live backlog items | 490 |
+| Root backlog items | 33 |
 | `asap/` | 0 |
-| `bad-code/` | 143 |
-| `cool-ideas/` | 94 |
+| `bad-code/` | 244 |
+| `cool-ideas/` | 108 |
 | `inbox/` | 5 |
-| `up-next/` | 35 |
+| `up-next/` | 37 |
 | `v17.0.0/` | 38 |
 | `v18.0.0/` | 8 |
 | `v19.0.0/` | 11 |
 | `v20.0.0/` | 2 |
 | `v21.0.0/` | 4 |
-| Items with YAML frontmatter | 371 |
+| Items with YAML frontmatter | 490 |
 | Items without YAML frontmatter | 0 |
-| Items with explicit `id` | 371 |
-| Items declaring dependency fields | 371 |
-| Items with explicit `feature` | 366 |
-| Distinct explicit feature values | 12 |
-| `bad-code/` items with explicit `release_home` | 143 |
+| Items with explicit `id` | 490 |
+| Items declaring dependency fields | 490 |
+| Items with explicit `feature` | 485 |
+| Distinct explicit feature values | 17 |
+| `bad-code/` items with explicit `release_home` | 244 |
 | Items with non-empty explicit dependency edges | 59 |
 
 ## Dependency Law
@@ -165,10 +165,10 @@ justifies a stronger sequencing rule.
 
 Current explicit-graph totals:
 
-- `371` notes define an `id`
-- `371` notes declare `blocks` and `blocked_by` fields
-- `366` notes currently declare an explicit `feature`
-- `143` `bad-code/` notes currently declare an explicit `release_home`
+- `490` notes define an `id`
+- `490` notes declare `blocks` and `blocked_by` fields
+- `485` notes currently declare an explicit `feature`
+- `244` `bad-code/` notes currently declare an explicit `release_home`
 - `59` notes currently name at least one non-empty upstream or
   downstream edge
 
@@ -221,6 +221,7 @@ Items:
 - [DX_public-api-catalog-playground.md](DX_public-api-catalog-playground.md)
 - [DX_pure-typescript-example-app.md](DX_pure-typescript-example-app.md)
 - [DX_readme-install-section.md](DX_readme-install-section.md)
+- [DX_review-bot-warning-policy.md](DX_review-bot-warning-policy.md)
 - [DX_rfc-field-count-drift-detector.md](DX_rfc-field-count-drift-detector.md)
 - [DX_security-sync-docs.md](DX_security-sync-docs.md)
 - [DX_test-file-wildcard-ratchet.md](DX_test-file-wildcard-ratchet.md)
@@ -230,6 +231,7 @@ Items:
 - [DX_warpgraph-invisible-api-docs.md](DX_warpgraph-invisible-api-docs.md)
 - [PERF_benchmark-budgets-ci-gate.md](PERF_benchmark-budgets-ci-gate.md)
 - [PERF_out-of-core-materialization.md](PERF_out-of-core-materialization.md)
+- [PERF_recursive-tree-path-benchmark.md](PERF_recursive-tree-path-benchmark.md)
 - [TRUST_keystore-prevalidated-cache.md](TRUST_keystore-prevalidated-cache.md)
 - [TRUST_property-based-fuzz-test.md](TRUST_property-based-fuzz-test.md)
 - [TRUST_record-round-trip-snapshot.md](TRUST_record-round-trip-snapshot.md)
@@ -255,15 +257,15 @@ Invariant counts:
 
 | Legend | Count |
 |--------|------:|
-| `BND` | 7 |
+| `BND` | 9 |
 | `CAST` | 9 |
 | `DX` | 1 |
-| `HEX` | 18 |
+| `HEX` | 19 |
 | `MODEL` | 22 |
-| `OWN` | 31 |
-| `PORT` | 11 |
-| `SPEC` | 31 |
-| `SUB` | 13 |
+| `OWN` | 32 |
+| `PORT` | 12 |
+| `SPEC` | 119 |
+| `SUB` | 15 |
 
 ### `v17.0.0/` — `B3` Active Release Graph
 
@@ -285,14 +287,14 @@ Prefix counts:
 
 | Prefix | Count |
 |--------|------:|
-| `API` | 1 |
+| `API` | 2 |
 | `CLI` | 2 |
 | `DX` | 7 |
 | `GOD` | 3 |
 | `INFRA` | 7 |
 | `MCP` | 1 |
 | `PORT` | 1 |
-| `PROTO` | 4 |
+| `PROTO` | 3 |
 | `SLUDGE` | 1 |
 | `TS` | 11 |
 
@@ -395,12 +397,12 @@ Prefix counts:
 | Prefix | Count |
 |--------|------:|
 | `CC` | 1 |
-| `DX` | 17 |
+| `DX` | 10 |
+| `INFRA` | 2 |
 | `NDNM` | 4 |
 | `PERF` | 4 |
 | `PROTO` | 14 |
 | `TRUST` | 1 |
-| `TS` | 1 |
 | `VIZ` | 1 |
 
 ### `cool-ideas/` — `B6` Speculative Orbit
@@ -415,11 +417,14 @@ Prefix counts:
 
 | Prefix | Count |
 |--------|------:|
-| `DX` | 43 |
+| `ARCH` | 1 |
+| `COOL` | 8 |
+| `CORE` | 1 |
+| `DX` | 44 |
 | `IDEA` | 6 |
 | `INFRA` | 1 |
 | `PERF` | 8 |
-| `PROTO` | 24 |
+| `PROTO` | 27 |
 | `THEORY` | 1 |
 | `TRUST` | 3 |
 | `VIZ` | 8 |

--- a/docs/method/backlog/bad-code/BND_path-keyed-object-accumulators.md
+++ b/docs/method/backlog/bad-code/BND_path-keyed-object-accumulators.md
@@ -1,0 +1,33 @@
+---
+id: BND_path-keyed-object-accumulators
+blocked_by: []
+blocks: []
+feature: trie-state-storage
+release_home: v18.0.0
+---
+
+# Path-keyed object accumulators at Git boundaries
+
+**Effort:** M
+
+## Design
+
+[0150 path-keyed boundary accumulator audit](../../../design/0150-path-keyed-boundary-accumulator-audit/path-keyed-boundary-accumulator-audit.md)
+
+## What's Wrong
+
+The v17.0.1 recursive tree read review found a real boundary smell:
+Git path names were being used as keys on a plain object accumulator.
+The specific `readTreeOids()` parser is fixed, but the pattern can
+reappear anywhere Git paths, transport field names, or generated
+artifact identifiers become object keys before validation.
+
+That is boundary debt. Path strings from Git or transport inputs are
+data, not trusted object-member names.
+
+## Suggested Fix
+
+Audit adapters and transport parsers for path-keyed plain object
+accumulators. Replace risky accumulators with `Map` or an explicitly
+validated materialization step, then add regression coverage for
+prototype-like path names such as `__proto__` and `constructor`.

--- a/docs/method/backlog/bad-code/README.md
+++ b/docs/method/backlog/bad-code/README.md
@@ -9,7 +9,7 @@ Existing filenames stay stable unless there is a strong reason to rename them. T
 | Code | Invariant | Count |
 |------|-----------|------:|
 | [HEX](../../legends/HEX.md) | No host, infrastructure, raw Git, ambient time, or ambient entropy leaks into core. | 19 |
-| [BND](../../legends/BOUNDARY.md) | Decode, validate, and schema-check at the boundary; raw transport shapes do not leak inward. | 8 |
+| [BND](../../legends/BOUNDARY.md) | Decode, validate, and schema-check at the boundary; raw transport shapes do not leak inward. | 9 |
 | [MODEL](../../legends/MODEL.md) | Runtime truth wins: real classes, constructor invariants, and honest domain forms. | 22 |
 | [CAST](../../legends/CAST.md) | No cast-cosplay, escape hatches, or type lies. | 9 |
 | [PORT](../../legends/PORT.md) | Capability and port surfaces must tell the runtime truth. | 12 |
@@ -31,7 +31,7 @@ card metadata or promoting bad-code into a release lane.
 | Release Home | Count |
 |--------------|------:|
 | `v17.0.0` | 195 |
-| `v18.0.0` | 13 |
+| `v18.0.0` | 14 |
 | `v19.0.0` | 13 |
 | `v20.0.0` | 15 |
 | `v21.0.0` | 7 |
@@ -60,7 +60,7 @@ card metadata or promoting bad-code into a release lane.
 - [HEX_warpserve-domain-infra-blur.md](HEX_warpserve-domain-infra-blur.md)
 - [HEX_domain-crypto-hex.md](HEX_domain-crypto-hex.md)
 
-### Boundary Decode (`BND`) — 8
+### Boundary Decode (`BND`) — 9
 
 - [BND_checkpoint-schema-contract-drift.md](BND_checkpoint-schema-contract-drift.md)
 - [BND_cbor-no-depth-limits.md](BND_cbor-no-depth-limits.md)
@@ -70,6 +70,7 @@ card metadata or promoting bad-code into a release lane.
 - [BND_trailer-codec-type-poison.md](BND_trailer-codec-type-poison.md)
 - [BND_http-request-typedef.md](BND_http-request-typedef.md)
 - [BND_schemas-refine-mutation.md](BND_schemas-refine-mutation.md)
+- [BND_path-keyed-object-accumulators.md](BND_path-keyed-object-accumulators.md)
 
 ### Runtime Model (`MODEL`) — 22
 

--- a/docs/method/backlog/bad-code/RELEASE_TRIAGE.md
+++ b/docs/method/backlog/bad-code/RELEASE_TRIAGE.md
@@ -14,7 +14,7 @@ After the first metadata cleanup pass:
 | Release Home | Count | Read |
 |--------------|------:|------|
 | `v17.0.0` | 195 | Current-engine cleanup bucket. Includes runtime-deletion fallout and stale-card rechecks. |
-| `v18.0.0` | 13 | Graph-substrate cards promoted out of generic v17 cleanup. |
+| `v18.0.0` | 14 | Graph-substrate cards promoted out of generic v17 cleanup. |
 | `v19.0.0` | 13 | Observer/admission/runtime-doctrine cleanup. |
 | `v20.0.0` | 15 | Slice-first read, index, traversal, and materialization-cost work. |
 | `v21.0.0` | 7 | Strand, wormhole, conflict, and plural/distributed cleanup. |
@@ -76,6 +76,8 @@ The first metadata pass promoted only graph-model bad-code into
 Cards now pinned to v18 for the graph-model convergence cycle:
 
 - `CAST_warpstate-prop-unknown-value`: property value truth belongs with typed attachment/payload substrate decisions.
+- `BND_path-keyed-object-accumulators`: path-keyed boundary accumulation
+  belongs with generated artifacts and graph-substrate input validation.
 - `MODEL_neighbor-edge-typedef`: neighbor edge shape should line up with stable edge identity and edge-record nouns.
 - `MODEL_patchdiff-no-validation`: diff entries are graph-change substrate forms, not just generic test debt.
 - `MODEL_patchv2-no-validation`: patch/op validation must line up with the graph-op algebra.

--- a/docs/method/backlog/cool-ideas/PROTO_safe-path-map-materialization.md
+++ b/docs/method/backlog/cool-ideas/PROTO_safe-path-map-materialization.md
@@ -1,0 +1,31 @@
+---
+id: PROTO_safe-path-map-materialization
+blocked_by: []
+blocks: []
+feature: trie-state-storage
+---
+
+# Safe path-map materialization pattern
+
+**Effort:** S
+
+## Design
+
+[0151 safe path-map materialization](../../../design/0151-safe-path-map-materialization/safe-path-map-materialization.md)
+
+## Idea
+
+Write down a small, reusable pattern for turning untrusted path-keyed
+collections into public records without writing untrusted keys through
+a plain object accumulator.
+
+The default implementation shape should be boring:
+
+- accumulate in `Map<string, string>` or another typed map;
+- validate each key before public materialization;
+- materialize only at the boundary where callers already expect a
+  record-shaped API;
+- cover prototype-like keys in tests.
+
+This may become a helper only if repeated call sites justify it. Until
+then, the design can serve as the rule.

--- a/docs/method/backlog/v17.0.0/INFRA_git-cas-adapter-parity.md
+++ b/docs/method/backlog/v17.0.0/INFRA_git-cas-adapter-parity.md
@@ -23,8 +23,9 @@ semantic git-warp needs:
   must keep an explicit unbounded read posture only where a caller knowingly
   asks to collect a complete graph blob.
 - `GitPersistenceAdapter.iterateTree()` and `readTreeEntry()` now exist in
-  git-cas v6; git-warp can use them as the substrate for recursive,
-  path-preserving tree traversal instead of raw `ls-tree` calls.
+  git-cas v6 for one-level tree reads. They are not equivalent to
+  git-warp's recursive checkpoint-tree read contract because a recursive
+  walk fans out into one process per subtree.
 - `GitPersistenceAdapter.readTree()` returns one-level parsed tree
   entries, while git-warp's `readTreeOids()` returns a recursive
   path-to-OID map.
@@ -61,9 +62,11 @@ narrow infrastructure adapter around git-cas v6:
 - `GitGraphAdapter.readBlob()` delegates to
   `GitPersistenceAdapter.readBlobStream()` and collects at the
   graph-adapter boundary only.
-- `GitGraphAdapter.readTreeOids()` recursively walks
-  `GitPersistenceAdapter.iterateTree()` so git-warp keeps its
-  path-preserving recursive `Record<path, oid>` contract.
+- `GitGraphAdapter.readTreeOids()` delegates through
+  `GitCasGraphReaderAdapter` to `GitRecursiveTreeOidReaderAdapter`, which
+  issues one recursive `git ls-tree -rz` call so git-warp keeps its
+  path-preserving recursive `Record<path, oid>` contract without
+  process-per-subtree fanout.
 - `GitGraphAdapter.readTree()` resolves blob payloads through the same
   stream-backed read path.
 - commit creation, compare-and-swap ref updates, and ref deletion remain
@@ -76,7 +79,7 @@ narrow infrastructure adapter around git-cas v6:
   plus an explicit collector at the adapter boundary.
 - recursive tree OID reads remain recursive and path-preserving.
 - one-entry tree reads and tree iteration use git-cas v6 APIs where semantics
-  match exactly.
+  match exactly; recursive graph-tree reads keep the one-shot Git primitive.
 - commit creation continues to support multiple parents and signing.
 - ref CAS failures are not retried.
 - ref deletion remains available.

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/git-warp",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "imports": {
     "roaring": "npm:roaring@^2.7.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@git-stunts/git-warp",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@git-stunts/git-warp",
-      "version": "17.0.0",
+      "version": "17.0.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/git-warp",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "description": "Deterministic WARP graph over Git: graph-native storage, traversal, and tooling.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/infrastructure/adapters/GitCasGraphReaderAdapter.ts
+++ b/src/infrastructure/adapters/GitCasGraphReaderAdapter.ts
@@ -1,17 +1,24 @@
 import type { GitPersistenceAdapter } from '@git-stunts/git-cas';
 
+type TreeOidReader = {
+  readTreeOids(treeOid: string): Promise<Record<string, string>>;
+};
+
 interface GitCasGraphReaderAdapterOptions {
   readonly persistence: GitPersistenceAdapter;
   readonly assertEmptyBlobExists: (oid: string) => Promise<void>;
+  readonly treeOidReader: TreeOidReader;
 }
 
 export default class GitCasGraphReaderAdapter {
   private readonly _persistence: GitPersistenceAdapter;
   private readonly _assertEmptyBlobExists: (oid: string) => Promise<void>;
+  private readonly _treeOidReader: TreeOidReader;
 
   constructor(options: GitCasGraphReaderAdapterOptions) {
     this._persistence = options.persistence;
     this._assertEmptyBlobExists = options.assertEmptyBlobExists;
+    this._treeOidReader = options.treeOidReader;
   }
 
   async readBlob(oid: string): Promise<Uint8Array> {
@@ -24,24 +31,7 @@ export default class GitCasGraphReaderAdapter {
   }
 
   async readTreeOids(treeOid: string): Promise<Record<string, string>> {
-    const oids: Record<string, string> = {};
-    await this._collectTreeOids(treeOid, '', oids);
-    return oids;
-  }
-
-  private async _collectTreeOids(
-    treeOid: string,
-    pathPrefix: string,
-    oids: Record<string, string>,
-  ): Promise<void> {
-    for await (const entry of this._persistence.iterateTree(treeOid)) {
-      const path = `${pathPrefix}${entry.name}`;
-      if (entry.type === 'tree') {
-        await this._collectTreeOids(entry.oid, `${path}/`, oids);
-        continue;
-      }
-      oids[path] = entry.oid;
-    }
+    return await this._treeOidReader.readTreeOids(treeOid);
   }
 }
 

--- a/src/infrastructure/adapters/GitGraphAdapter.ts
+++ b/src/infrastructure/adapters/GitGraphAdapter.ts
@@ -17,6 +17,7 @@ import PersistenceError from '../../domain/errors/PersistenceError.ts';
 import GraphPersistencePort from '../../ports/GraphPersistencePort.ts';
 import CasBlobAdapter from './CasBlobAdapter.ts';
 import GitCasGraphReaderAdapter from './GitCasGraphReaderAdapter.ts';
+import GitRecursiveTreeOidReaderAdapter from './GitRecursiveTreeOidReaderAdapter.ts';
 import GitTrieStoreAdapter from './GitTrieStoreAdapter.ts';
 import WarpStream from '../../domain/stream/WarpStream.ts';
 import { textEncode } from '../../domain/utils/bytes.ts';
@@ -87,6 +88,7 @@ export default class GitGraphAdapter extends GraphPersistencePort implements Run
   private readonly _retryOptions: RetryOptions;
   private readonly _gitCasPersistence: GitPersistenceAdapter;
   private readonly _gitCasGraphReader: GitCasGraphReaderAdapter;
+  private readonly _recursiveTreeOidReader: GitRecursiveTreeOidReaderAdapter;
 
   constructor({ plumbing, retryOptions = {} }: GitGraphAdapterOptions) {
     super();
@@ -99,9 +101,14 @@ export default class GitGraphAdapter extends GraphPersistencePort implements Run
       plumbing,
       policy: createGitCasRetryPolicy(this._retryOptions),
     });
+    this._recursiveTreeOidReader = new GitRecursiveTreeOidReaderAdapter({
+      plumbing,
+      retryOptions: this._retryOptions,
+    });
     this._gitCasGraphReader = new GitCasGraphReaderAdapter({
       persistence: this._gitCasPersistence,
       assertEmptyBlobExists: (oid) => this._assertBlobExistsForEmptyRead(oid),
+      treeOidReader: this._recursiveTreeOidReader,
     });
   }
 

--- a/src/infrastructure/adapters/GitRecursiveTreeOidReaderAdapter.ts
+++ b/src/infrastructure/adapters/GitRecursiveTreeOidReaderAdapter.ts
@@ -53,17 +53,17 @@ export default class GitRecursiveTreeOidReaderAdapter {
 }
 
 function parseRecursiveTreeOidOutput(output: string): Record<string, string> {
-  const oids: Record<string, string> = {};
+  const oids = new Map<string, string>();
   for (const record of output.split(LS_TREE_RECORD_SEPARATOR)) {
     if (record.length === 0) {
       continue;
     }
     const entry = parseRecursiveTreeEntry(record);
     if (entry.objectType !== TREE_OBJECT_TYPE) {
-      oids[entry.path] = entry.oid;
+      oids.set(entry.path, entry.oid);
     }
   }
-  return oids;
+  return Object.fromEntries(oids);
 }
 
 function parseRecursiveTreeEntry(record: string): RecursiveTreeEntry {

--- a/src/infrastructure/adapters/GitRecursiveTreeOidReaderAdapter.ts
+++ b/src/infrastructure/adapters/GitRecursiveTreeOidReaderAdapter.ts
@@ -1,0 +1,114 @@
+import { retry, type RetryOptions } from '@git-stunts/alfred';
+import PersistenceError from '../../domain/errors/PersistenceError.ts';
+import { validateOid } from './adapterValidation.ts';
+import {
+  type GitPlumbing,
+  toGitError,
+  wrapGitError,
+} from './gitErrorClassification.ts';
+
+type GitRecursiveTreeOidReaderAdapterOptions = {
+  readonly plumbing: GitPlumbing;
+  readonly retryOptions: RetryOptions;
+};
+
+type RecursiveTreeEntry = {
+  readonly objectType: string;
+  readonly oid: string;
+  readonly path: string;
+};
+
+type RecursiveTreeMetadata = {
+  readonly objectType: string;
+  readonly oid: string;
+};
+
+const LS_TREE_RECORD_SEPARATOR = '\0';
+const LS_TREE_METADATA_SEPARATOR = '\t';
+const LS_TREE_METADATA_FIELD_COUNT = 3;
+const TREE_OBJECT_TYPE = 'tree';
+const TREE_PARSE_ERROR = 'E_TREE_PARSE_ERROR';
+
+export default class GitRecursiveTreeOidReaderAdapter {
+  private readonly _plumbing: GitPlumbing;
+  private readonly _retryOptions: RetryOptions;
+
+  constructor(options: GitRecursiveTreeOidReaderAdapterOptions) {
+    this._plumbing = options.plumbing;
+    this._retryOptions = options.retryOptions;
+  }
+
+  async readTreeOids(treeOid: string): Promise<Record<string, string>> {
+    validateOid(treeOid);
+    try {
+      const output = await retry(
+        () => this._plumbing.execute({ args: ['ls-tree', '-rz', treeOid] }),
+        this._retryOptions,
+      );
+      return parseRecursiveTreeOidOutput(output);
+    } catch (raw) {
+      throw wrapGitError(toGitError(raw), { oid: treeOid });
+    }
+  }
+}
+
+function parseRecursiveTreeOidOutput(output: string): Record<string, string> {
+  const oids: Record<string, string> = {};
+  for (const record of output.split(LS_TREE_RECORD_SEPARATOR)) {
+    if (record.length === 0) {
+      continue;
+    }
+    const entry = parseRecursiveTreeEntry(record);
+    if (entry.objectType !== TREE_OBJECT_TYPE) {
+      oids[entry.path] = entry.oid;
+    }
+  }
+  return oids;
+}
+
+function parseRecursiveTreeEntry(record: string): RecursiveTreeEntry {
+  const tabIndex = record.indexOf(LS_TREE_METADATA_SEPARATOR);
+  if (tabIndex === -1) {
+    throw malformedTreeEntry(record);
+  }
+
+  const metadata = record.slice(0, tabIndex);
+  const parsedMetadata = parseRecursiveTreeMetadata(record, metadata);
+  const path = record.slice(tabIndex + 1);
+  if (path.length === 0) {
+    throw malformedTreeEntry(record);
+  }
+
+  return Object.freeze({
+    objectType: parsedMetadata.objectType,
+    oid: parsedMetadata.oid,
+    path,
+  });
+}
+
+function parseRecursiveTreeMetadata(record: string, metadata: string): RecursiveTreeMetadata {
+  const fields = metadata.split(' ');
+  if (fields.length !== LS_TREE_METADATA_FIELD_COUNT) {
+    throw malformedTreeEntry(record);
+  }
+  requireTreeMetadataField(record, fields[0]);
+  return Object.freeze({
+    objectType: requireTreeMetadataField(record, fields[1]),
+    oid: requireTreeMetadataField(record, fields[2]),
+  });
+}
+
+function requireTreeMetadataField(record: string, field: string | undefined): string {
+  if (field === undefined || field.length === 0) {
+    throw malformedTreeEntry(record);
+  }
+  return field;
+}
+
+function malformedTreeEntry(record: string): PersistenceError {
+  return new PersistenceError(
+    `Malformed ls-tree entry: ${record}`,
+    TREE_PARSE_ERROR,
+    { context: { record } },
+  );
+}

--- a/test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts
+++ b/test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts
@@ -269,6 +269,23 @@ describe('GitGraphAdapter coverage', () => {
       });
     });
 
+    it('preserves prototype-like path names from recursive ls-tree output', async () => {
+      const treeOid = 'aabb' + '0'.repeat(36);
+      const protoOid = 'beef' + '0'.repeat(36);
+      const constructorOid = 'feed' + '0'.repeat(36);
+      mockPlumbing.execute.mockResolvedValue(
+        `100644 blob ${protoOid}\t__proto__\0` +
+        `100644 blob ${constructorOid}\tconstructor\0`
+      );
+
+      const result = await adapter.readTreeOids(treeOid);
+
+      expect(Object.hasOwn(result, '__proto__')).toBe(true);
+      expect(Object.hasOwn(result, 'constructor')).toBe(true);
+      expect(result['__proto__']).toBe(protoOid);
+      expect(result['constructor']).toBe(constructorOid);
+    });
+
     it('recursively preserves paths through nested trees with one git command', async () => {
       const rootTreeOid = 'aabb' + '0'.repeat(36);
       const blobOid = 'ccdd' + '0'.repeat(36);

--- a/test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts
+++ b/test/unit/infrastructure/adapters/GitGraphAdapter.coverage.test.ts
@@ -134,10 +134,8 @@ describe('GitGraphAdapter coverage', () => {
       const treeOutput =
         `100644 blob deadbeef01234567890123456789012345678901\tfile_a.json\0` +
         `100644 blob cafebabe01234567890123456789012345678901\tfile_b.json\0`;
+      mockPlumbing.execute.mockResolvedValue(treeOutput);
       mockPlumbing.executeStream.mockImplementation(async ({ args }) => {
-        if (args[0] === 'ls-tree') {
-          return streamFromText(treeOutput);
-        }
         return streamFromText(args[2] === 'deadbeef01234567890123456789012345678901' ? 'content_a' : 'content_b');
       });
 
@@ -145,19 +143,23 @@ describe('GitGraphAdapter coverage', () => {
 
       expect(result['file_a.json']).toEqual(new TextEncoder().encode('content_a'));
       expect(result['file_b.json']).toEqual(new TextEncoder().encode('content_b'));
-      expect(mockPlumbing.executeStream).toHaveBeenCalledTimes(3);
+      expect(mockPlumbing.execute).toHaveBeenCalledWith({
+        args: ['ls-tree', '-rz', treeOid],
+      });
+      expect(mockPlumbing.executeStream).toHaveBeenCalledTimes(2);
     });
 
     it('returns empty map for empty tree', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.executeStream.mockResolvedValue(streamFromText(''));
+      mockPlumbing.execute.mockResolvedValue('');
 
       const result = await adapter.readTree(treeOid);
 
       expect(result).toEqual({});
-      expect(mockPlumbing.executeStream).toHaveBeenCalledWith({
-        args: ['ls-tree', '-z', treeOid],
+      expect(mockPlumbing.execute).toHaveBeenCalledWith({
+        args: ['ls-tree', '-rz', treeOid],
       });
+      expect(mockPlumbing.executeStream).not.toHaveBeenCalled();
     });
 
     it('validates tree OID', async () => {
@@ -171,10 +173,10 @@ describe('GitGraphAdapter coverage', () => {
   describe('readTreeOids()', () => {
     it('parses NUL-separated ls-tree output into path-oid map', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.executeStream.mockResolvedValue(streamFromText(
+      mockPlumbing.execute.mockResolvedValue(
         '100644 blob deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tindex.json\0' +
         '100644 blob cafebabecafebabecafebabecafebabecafebabe\tdata.json\0'
-      ));
+      );
 
       const result = await adapter.readTreeOids(treeOid);
 
@@ -182,14 +184,15 @@ describe('GitGraphAdapter coverage', () => {
         'index.json': 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
         'data.json': 'cafebabecafebabecafebabecafebabecafebabe',
       });
-      expect(mockPlumbing.executeStream).toHaveBeenCalledWith({
-        args: ['ls-tree', '-z', treeOid],
+      expect(mockPlumbing.execute).toHaveBeenCalledWith({
+        args: ['ls-tree', '-rz', treeOid],
       });
+      expect(mockPlumbing.executeStream).not.toHaveBeenCalled();
     });
 
     it('returns empty map when tree has no entries', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.executeStream.mockResolvedValue(streamFromText(''));
+      mockPlumbing.execute.mockResolvedValue('');
 
       const result = await adapter.readTreeOids(treeOid);
 
@@ -198,10 +201,40 @@ describe('GitGraphAdapter coverage', () => {
 
     it('throws on records without a tab separator', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.executeStream.mockResolvedValue(streamFromText(
+      mockPlumbing.execute.mockResolvedValue(
         '100644 blob deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tvalid.json\0' +
         'malformed-no-tab\0'
-      ));
+      );
+
+      await expect(adapter.readTreeOids(treeOid))
+        .rejects.toThrow(/Malformed ls-tree entry/);
+    });
+
+    it('throws on records with malformed metadata field counts', async () => {
+      const treeOid = 'aabb' + '0'.repeat(36);
+      mockPlumbing.execute.mockResolvedValue(
+        '100644 blob deadbeefdeadbeefdeadbeefdeadbeefdeadbeef extra\tbad.json\0'
+      );
+
+      await expect(adapter.readTreeOids(treeOid))
+        .rejects.toThrow(/Malformed ls-tree entry/);
+    });
+
+    it('throws on records with empty metadata fields', async () => {
+      const treeOid = 'aabb' + '0'.repeat(36);
+      mockPlumbing.execute.mockResolvedValue(
+        '100644  deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\tbad.json\0'
+      );
+
+      await expect(adapter.readTreeOids(treeOid))
+        .rejects.toThrow(/Malformed ls-tree entry/);
+    });
+
+    it('throws on records with empty paths', async () => {
+      const treeOid = 'aabb' + '0'.repeat(36);
+      mockPlumbing.execute.mockResolvedValue(
+        '100644 blob deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\t\0'
+      );
 
       await expect(adapter.readTreeOids(treeOid))
         .rejects.toThrow(/Malformed ls-tree entry/);
@@ -209,9 +242,9 @@ describe('GitGraphAdapter coverage', () => {
 
     it('handles single entry with trailing NUL', async () => {
       const treeOid = 'aabb' + '0'.repeat(36);
-      mockPlumbing.executeStream.mockResolvedValue(streamFromText(
+      mockPlumbing.execute.mockResolvedValue(
         '100644 blob abcdef1234567890abcdef1234567890abcdef12\tonly.json\0'
-      ));
+      );
 
       const result = await adapter.readTreeOids(treeOid);
 
@@ -220,28 +253,42 @@ describe('GitGraphAdapter coverage', () => {
       });
     });
 
-    it('recursively preserves paths through nested trees', async () => {
-      const rootTreeOid = 'aabb' + '0'.repeat(36);
+    it('ignores tree entries if recursive ls-tree includes them', async () => {
+      const treeOid = 'aabb' + '0'.repeat(36);
       const nestedTreeOid = 'bbcc' + '0'.repeat(36);
       const blobOid = 'ccdd' + '0'.repeat(36);
-      mockPlumbing.executeStream.mockImplementation(async ({ args }) => {
-        if (args[2] === rootTreeOid) {
-          return streamFromText(`040000 tree ${nestedTreeOid}\tnested\0`);
-        }
-        return streamFromText(`100644 blob ${blobOid}\titem.cbor\0`);
+      mockPlumbing.execute.mockResolvedValue(
+        `040000 tree ${nestedTreeOid}\tnested\0` +
+        `100644 blob ${blobOid}\tnested/item.cbor\0`
+      );
+
+      const result = await adapter.readTreeOids(treeOid);
+
+      expect(result).toEqual({
+        'nested/item.cbor': blobOid,
       });
+    });
+
+    it('recursively preserves paths through nested trees with one git command', async () => {
+      const rootTreeOid = 'aabb' + '0'.repeat(36);
+      const blobOid = 'ccdd' + '0'.repeat(36);
+      const rootBlobOid = 'ddcc' + '0'.repeat(36);
+      mockPlumbing.execute.mockResolvedValue(
+        `100644 blob ${blobOid}\tnested/item.cbor\0` +
+        `100644 blob ${rootBlobOid}\troot.json\0`
+      );
 
       const result = await adapter.readTreeOids(rootTreeOid);
 
       expect(result).toEqual({
         'nested/item.cbor': blobOid,
+        'root.json': rootBlobOid,
       });
-      expect(mockPlumbing.executeStream).toHaveBeenCalledWith({
-        args: ['ls-tree', '-z', rootTreeOid],
+      expect(mockPlumbing.execute).toHaveBeenCalledTimes(1);
+      expect(mockPlumbing.execute).toHaveBeenCalledWith({
+        args: ['ls-tree', '-rz', rootTreeOid],
       });
-      expect(mockPlumbing.executeStream).toHaveBeenCalledWith({
-        args: ['ls-tree', '-z', nestedTreeOid],
-      });
+      expect(mockPlumbing.executeStream).not.toHaveBeenCalled();
     });
 
     it('validates tree OID', async () => {
@@ -249,6 +296,7 @@ describe('GitGraphAdapter coverage', () => {
         .rejects.toThrow(/Invalid OID format/);
 
       expect(mockPlumbing.executeStream).not.toHaveBeenCalled();
+      expect(mockPlumbing.execute).not.toHaveBeenCalled();
     });
 
     it('rejects empty OID', async () => {
@@ -260,7 +308,7 @@ describe('GitGraphAdapter coverage', () => {
       const treeOid = 'aabb' + '0'.repeat(36);
       const err = (new Error(`fatal: bad object ${treeOid}`) as any);
       err.details = { code: 128, stderr: `fatal: bad object ${treeOid}` };
-      mockPlumbing.executeStream.mockRejectedValue(err);
+      mockPlumbing.execute.mockRejectedValue(err);
 
       await expect(adapter.readTreeOids(treeOid))
         .rejects.toMatchObject({

--- a/test/unit/infrastructure/adapters/GitGraphAdapter.gitCasPersistence.test.ts
+++ b/test/unit/infrastructure/adapters/GitGraphAdapter.gitCasPersistence.test.ts
@@ -127,6 +127,7 @@ describe('GitGraphAdapter git-cas persistence bridge', () => {
   it('ratchets write delegation while keeping non-equivalent read/ref semantics local', () => {
     const adapter = readRepoFile('src/infrastructure/adapters/GitGraphAdapter.ts');
     const reader = readRepoFile('src/infrastructure/adapters/GitCasGraphReaderAdapter.ts');
+    const recursiveTreeReader = readRepoFile('src/infrastructure/adapters/GitRecursiveTreeOidReaderAdapter.ts');
     const successorCard = join(
       repoRoot,
       'docs/method/backlog/v17.0.0/INFRA_git-cas-adapter-parity.md',
@@ -138,12 +139,16 @@ describe('GitGraphAdapter git-cas persistence bridge', () => {
     expect(adapter).toContain('this._gitCasPersistence.writeBlob');
     expect(adapter).toContain('this._gitCasPersistence.writeTree');
     expect(adapter).toContain('new GitCasGraphReaderAdapter');
+    expect(adapter).toContain('new GitRecursiveTreeOidReaderAdapter');
     expect(adapter).toContain('this._gitCasGraphReader.readBlob');
     expect(adapter).toContain('this._gitCasGraphReader.readTreeOids');
+    expect(adapter).toContain('treeOidReader: this._recursiveTreeOidReader');
     expect(adapter).not.toContain('this._gitCasPersistence.createCommit');
     expect(reader).toContain('this._persistence.readBlobStream');
     expect(reader).toContain('collectUnboundedGraphBlobStream');
-    expect(reader).toContain('this._persistence.iterateTree');
+    expect(reader).not.toContain('this._persistence.iterateTree');
+    expect(recursiveTreeReader).toContain("args: ['ls-tree', '-rz', treeOid]");
+    expect(recursiveTreeReader).toContain('parseRecursiveTreeEntry');
     expect(existsSync(successorCard)).toBe(true);
   });
 });

--- a/test/unit/scripts/release-policy-shape.test.ts
+++ b/test/unit/scripts/release-policy-shape.test.ts
@@ -36,7 +36,7 @@ const roadmap = readFileSync(
 describe('release policy shape', () => {
   it('keeps package and jsr versions aligned on the release branch', () => {
     expect(packageJson.version).toBe(jsrJson.version);
-    expect(packageJson.version).toBe('17.0.0');
+    expect(packageJson.version).toBe('17.0.1');
   });
 
   it('does not require a README release feed anymore', () => {
@@ -52,9 +52,9 @@ describe('release policy shape', () => {
   });
 
   it('keeps the roadmap header honest about the current release and correction patch', () => {
-    expect(roadmap).toContain('**Current release on `main`:** v16.0.0');
-    expect(roadmap).toContain('**Next intended release:** v16.0.1');
-    expect(roadmap).toContain('v16.0.0 release');
+    expect(roadmap).toContain('**Current release on `main`:** v17.0.1');
+    expect(roadmap).toContain('**Next intended release:** v18.0.0');
+    expect(roadmap).toContain('v17.0.1 patch');
   });
 
   it('keeps publish artifacts slim instead of shipping the full repo corpus', () => {

--- a/test/unit/scripts/uniform-git-cas-closeout.test.ts
+++ b/test/unit/scripts/uniform-git-cas-closeout.test.ts
@@ -97,7 +97,8 @@ describe('uniform git-cas closeout', () => {
     expect(releaseLedger).toContain('INFRA_unify-persistence-on-git-cas');
     expect(releaseLedger).toContain('[x] INFRA_git-cas-adapter-parity');
     expect(successor).toContain('GitPersistenceAdapter.readBlobStream()');
-    expect(successor).toContain('GitPersistenceAdapter.iterateTree()');
+    expect(successor).toContain('GitRecursiveTreeOidReaderAdapter');
+    expect(successor).toContain('one recursive `git ls-tree -rz` call');
     expect(successor).toContain('compare-and-swap ref updates');
   });
 });


### PR DESCRIPTION
## Summary
- Replace recursive git-cas one-level tree walking with a dedicated one-shot `git ls-tree -rz` reader for recursive tree OID maps.
- Keep blob reads on git-cas `readBlobStream()` while preserving git-warp's path-to-OID contract.
- Prepare `v17.0.1` release metadata and align the release policy ratchet/roadmap.

## Profiling Evidence
- Before: `codex-think --remember --brief --limit=1 --json --verbose` was ~69s, with recursive checkpoint tree reads doing ~1,200+ nested `ls-tree` stream setups per open/materialize pass.
- After: the same CLI path is ~34s locally; instrumented Think read shows two `ls-tree -rz` calls totaling ~87ms.
- Remaining Think cost is outside the tree-walk fanout: ~9.7s materialization and ~11.5s from `listRecentStoredEntries(limit: 2000)`.

## Test plan
- `npm run lint`
- `npm run typecheck`
- `npm run test:local`
- `npm run test:coverage:ci`
- `npm run release:preflight`
- pre-push Ironclad M9 gates

## ADR checks
- [x] This PR does **not** implement ADR 2 without satisfying ADR 3.
- [x] This PR does not touch persisted op formats; no ADR 3 readiness issue is required.
- [x] This PR does not touch wire compatibility; canonical-only op rejection is unchanged.
- [x] This PR does not touch schema constants; patch and checkpoint namespaces remain distinct.