### PR TITLE
V18 content attachment cutover slices 21-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - V18 content cutover now exposes runtime-backed `ContentAttachmentOid`,
   `ContentAttachmentMime`, `ContentAttachmentSize`, and
   `ContentAttachmentPayload` nouns over the existing generic attachment plane.
+- V18 content cutover now projects legacy `_content*` state entries into typed
+  `ContentAttachmentRecord` values while preserving content metadata lineage.
 - V18 planning now records the post-slice-15 runway into graph-model substrate
   convergence, naming runtime-backed node records, stable edge records,
   attachment-plane substrate, and graph-op algebra as slices 17 through 20.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- V18 content attachment projection now preserves existing same-patch metadata
+  lineage semantics when `_content`, `_content.mime`, and `_content.size` are
+  separate operations in one patch.
 - V18 graph-substrate review follow-up now keeps the public entry point under
   the source-size policy, makes node-id equality total for invalid runtime
   inputs, avoids repeated full edge projection during attachment materializing,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- V18 planning now records the post-PR-96 content-cutover runway, clarifying
+  that generic attachments already exist and that the next batch cuts typed
+  content payload semantics over that attachment plane.
 - V18 planning now records the post-slice-15 runway into graph-model substrate
   convergence, naming runtime-backed node records, stable edge records,
   attachment-plane substrate, and graph-op algebra as slices 17 through 20.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ContentAttachmentPayload` nouns over the existing generic attachment plane.
 - V18 content cutover now projects legacy `_content*` state entries into typed
   `ContentAttachmentRecord` values while preserving content metadata lineage.
+- V18 content reads now route public node and edge content OID, metadata, byte,
+  and stream lookups through the typed content attachment projection.
 - V18 planning now records the post-slice-15 runway into graph-model substrate
   convergence, naming runtime-backed node records, stable edge records,
   attachment-plane substrate, and graph-op algebra as slices 17 through 20.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - V18 planning now records the post-PR-96 content-cutover runway, clarifying
   that generic attachments already exist and that the next batch cuts typed
   content payload semantics over that attachment plane.
+- V18 content cutover now exposes runtime-backed `ContentAttachmentOid`,
+  `ContentAttachmentMime`, `ContentAttachmentSize`, and
+  `ContentAttachmentPayload` nouns over the existing generic attachment plane.
 - V18 planning now records the post-slice-15 runway into graph-model substrate
   convergence, naming runtime-backed node records, stable edge records,
   attachment-plane substrate, and graph-op algebra as slices 17 through 20.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ContentAttachmentRecord` values while preserving content metadata lineage.
 - V18 content reads now route public node and edge content OID, metadata, byte,
   and stream lookups through the typed content attachment projection.
+- V18 content writes now construct typed `ContentAttachmentWriteIntent` values
+  before lowering to legacy `_content*` compatibility properties.
 - V18 planning now records the post-slice-15 runway into graph-model substrate
   convergence, naming runtime-backed node records, stable edge records,
   attachment-plane substrate, and graph-op algebra as slices 17 through 20.

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -63,7 +63,7 @@ Current branch state at this boundary:
 - Latest merged PR: #96, v18 Continuum slices 16 through 20 plus review
   repairs
 - Latest completed v18 implementation cycle:
-  `0171-v18-content-attachment-projection`
+  `0172-v18-query-content-projection-reads`
 
 The release ladder is now:
 
@@ -180,11 +180,12 @@ read-model groundwork, sync hardening, release gates, and package publishing.
 
 ## What comes next
 
-Run v18 slices 24 and 25 on this branch, then open the next PR. Generic
-attachments and content attachment projection now exist; the active work is
-routing reads and writes through the typed content cutover path. After that,
-continue with legacy property projection, graph-model migration tooling, and
-genesis replay equivalence.
+Run v18 slice 25 on this branch, then open the next PR. Generic attachments,
+content attachment projection, and projection-backed public content reads now
+exist; the active work is routing writes through typed content attachment
+intent before lowering to legacy compatibility properties. After that, continue
+with legacy property projection, graph-model migration tooling, and genesis
+replay equivalence.
 
 ## Running Task List
 
@@ -323,9 +324,12 @@ genesis replay equivalence.
   [0171-v18-content-attachment-projection](design/0171-v18-content-attachment-projection/v18-content-attachment-projection.md)
   adds `ContentAttachmentRecord` and `ContentAttachmentProjection.fromState()`
   with deterministic node/edge projection and lineage-sensitive metadata.
-- [ ] 24. Route content OID and metadata reads through the content attachment
-  projection while keeping public `getContent*` and `getEdgeContent*`
-  behavior stable.
+- [x] 24. Route content OID and metadata reads through the content attachment
+  projection:
+  [0172-v18-query-content-projection-reads](design/0172-v18-query-content-projection-reads/v18-query-content-projection-reads.md)
+  removes raw `_content*` register parsing from `QueryContent`, uses
+  targeted `ContentAttachmentProjection` selectors for node and edge reads,
+  and keeps malformed legacy content references out of public metadata.
 - [ ] 25. Make content writes construct typed content attachment intent before
   lowering to the current legacy `_content*` compatibility properties.
 - [ ] 26. Add the legacy property-bag projection service over attachment

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -63,7 +63,7 @@ Current branch state at this boundary:
 - Latest merged PR: #96, v18 Continuum slices 16 through 20 plus review
   repairs
 - Latest completed v18 implementation cycle:
-  `0168-v18-graph-op-algebra-convergence`
+  `0170-v18-content-attachment-payload-nouns`
 
 The release ladder is now:
 
@@ -180,10 +180,12 @@ read-model groundwork, sync hardening, release gates, and package publishing.
 
 ## What comes next
 
-Run v18 slices 21 through 25 on this branch, then open the next PR. Generic
-attachments already exist; the active work is content-specific attachment
-payload cutover over that plane. After that, continue with legacy property
-projection, graph-model migration tooling, and genesis replay equivalence.
+Run v18 slices 23 through 25 on this branch, then open the next PR. Generic
+attachments and content payload nouns now exist; the active work is projecting
+legacy `_content*` attachments into typed content attachments, then routing
+reads and writes through that cutover path. After that, continue with legacy
+property projection, graph-model migration tooling, and genesis replay
+equivalence.
 
 ## Running Task List
 
@@ -311,9 +313,12 @@ projection, graph-model migration tooling, and genesis replay equivalence.
   records merge commit `080a60eb`, clarifies that generic attachments already
   exist, and slices content-specific attachment cutover, legacy property
   projection, migration planning, and replay proof into tasks 22 through 30.
-- [ ] 22. Define content attachment payload nouns over the existing generic
-  attachment plane. This should introduce runtime-backed content OID,
-  metadata, and payload concepts without changing public reads or writes.
+- [x] 22. Define content attachment payload nouns over the existing generic
+  attachment plane:
+  [0170-v18-content-attachment-payload-nouns](design/0170-v18-content-attachment-payload-nouns/v18-content-attachment-payload-nouns.md)
+  adds `ContentAttachmentOid`, `ContentAttachmentMime`,
+  `ContentAttachmentSize`, and `ContentAttachmentPayload` without changing
+  public reads, writes, or persistence.
 - [ ] 23. Project legacy `_content`, `_content.mime`, and `_content.size`
   attachment records into typed content attachments for node and edge owners.
 - [ ] 24. Route content OID and metadata reads through the content attachment

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -46,22 +46,21 @@ native Continuum witnesses until that witnesshood is actually proven.
 
 Backlog fold-in: the repo-visible v18 lane is
 `WL-4A-v18-graph-substrate-convergence` in
-[WORKLOADS.md](method/backlog/WORKLOADS.md), backed by the eight notes in
-[method/backlog/v18.0.0](method/backlog/v18.0.0/). Treat that lane as the
-graph-model track inside this compatibility campaign: node and edge record
-identity, attachment slots, graph-op algebra, content cutover, legacy property
-projection, migration tooling, and genesis replay equivalence. Existing
-`echo-shaped` backlog identities are historical shorthand for graph-model
+[WORKLOADS.md](method/backlog/WORKLOADS.md). The four remaining live notes in
+[method/backlog/v18.0.0](method/backlog/v18.0.0/) are content cutover, legacy
+property projection, migration tooling, and genesis replay equivalence. Treat
+that lane as the graph-model track inside this compatibility campaign.
+Historical `echo-shaped` backlog identities were shorthand for graph-model
 pressure already exercised by Echo, not a claim that Echo owns `git-warp`'s
 Continuum role.
 
 Current branch state at this boundary:
 
-- Branch: `v18-continuum-slices-16-20`
+- Branch: `v18-continuum-slices-21-25`
 - Base branch: `main`
-- Latest remote head inspected: `origin/main` at `c848f5d4`
+- Latest remote head inspected: `origin/main` at `080a60eb`
 - Latest released package line: `17.0.1`
-- Latest merged PR: #95, v18 Continuum slices 11 through 15 plus review
+- Latest merged PR: #96, v18 Continuum slices 16 through 20 plus review
   repairs
 - Latest completed v18 implementation cycle:
   `0168-v18-graph-op-algebra-convergence`
@@ -80,10 +79,10 @@ The release ladder is now:
 - `v20.0.0`: slice-first read execution
 - `v21.0.0`: distributed observer geometry and admission reality
 
-The v18 compatibility work is bigger than fifteen slices. Slices 1 through 15
+The v18 compatibility work is bigger than twenty slices. Slices 1 through 15
 established the Continuum compatibility posture, generated-family authority,
 translated evidence posture, receipt-family projection, `warp-ttd` receipt
-smoke, and runtime-boundary source facts. Slices 17 through 20 now move into
+smoke, and runtime-boundary source facts. Slices 17 through 20 moved into
 the graph-model substrate lane by naming node, edge, attachment, and graph-op
 algebra surfaces that v18 must cut before migration and genesis replay proof
 are honest.
@@ -148,6 +147,11 @@ performance/correctness repair:
   generated-family readiness inventory, `TickPatch`/`TickReceipt` witness
   ladder, runtime-boundary reading-envelope source facts, and witnessed-suffix
   source facts.
+- PR #96 landed v18 Continuum slices 16 through 20: the post-slice-15
+  graph-model runway, runtime-backed node records, runtime-backed edge records,
+  generic attachment records, graph-op algebra projection, and review repairs
+  for entrypoint size, equality guards, attachment projection performance, and
+  constructor guard coverage.
 
 The shipped v17 scope remains: TypeScript migration, public API honesty,
 materialization-frontdoor deletion, readings/optics direction, query
@@ -176,10 +180,10 @@ read-model groundwork, sync hardening, release gates, and package publishing.
 
 ## What comes next
 
-Open the PR for v18 slices 16 through 20, then continue with the remaining
-`WL-4A-v18-graph-substrate-convergence` items. The next active lane item is
-content attachment-plane cutover, followed by legacy property projection,
-graph-model migration tooling, and genesis replay equivalence.
+Run v18 slices 21 through 25 on this branch, then open the next PR. Generic
+attachments already exist; the active work is content-specific attachment
+payload cutover over that plane. After that, continue with legacy property
+projection, graph-model migration tooling, and genesis replay equivalence.
 
 ## Running Task List
 
@@ -302,6 +306,31 @@ graph-model migration tooling, and genesis replay equivalence.
   `GraphOpAlgebra`, and `GraphOpAlgebraProjection`, and exposes a
   deterministic graph-operation substrate projection over the current
   node, edge, and attachment record views.
+- [x] 21. Reset BEARING after PR #96 and plan the content-cutover runway:
+  [0169-v18-post-20-content-cutover-runway](design/0169-v18-post-20-content-cutover-runway/v18-post-20-content-cutover-runway.md)
+  records merge commit `080a60eb`, clarifies that generic attachments already
+  exist, and slices content-specific attachment cutover, legacy property
+  projection, migration planning, and replay proof into tasks 22 through 30.
+- [ ] 22. Define content attachment payload nouns over the existing generic
+  attachment plane. This should introduce runtime-backed content OID,
+  metadata, and payload concepts without changing public reads or writes.
+- [ ] 23. Project legacy `_content`, `_content.mime`, and `_content.size`
+  attachment records into typed content attachments for node and edge owners.
+- [ ] 24. Route content OID and metadata reads through the content attachment
+  projection while keeping public `getContent*` and `getEdgeContent*`
+  behavior stable.
+- [ ] 25. Make content writes construct typed content attachment intent before
+  lowering to the current legacy `_content*` compatibility properties.
+- [ ] 26. Add the legacy property-bag projection service over attachment
+  records, making property bags an explicit compatibility view.
+- [ ] 27. Route query property reads through the legacy property projection
+  without changing public property-bag output shapes.
+- [ ] 28. Define the graph-model migration manifest runtime nouns for node,
+  edge, attachment, and content identity mappings.
+- [ ] 29. Add a dry-run graph-model migration planner that produces graph-op
+  algebra and a migration manifest without writing Git history.
+- [ ] 30. Add the first genesis replay equivalence harness for comparing
+  legacy replay with projected v18 graph readings.
 
 The loop stays strict: write or update the cycle doc, capture RED, green the
 slice, update this BEARING task list before the final commit, validate, then

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -63,7 +63,7 @@ Current branch state at this boundary:
 - Latest merged PR: #96, v18 Continuum slices 16 through 20 plus review
   repairs
 - Latest completed v18 implementation cycle:
-  `0172-v18-query-content-projection-reads`
+  `0173-v18-content-write-intent-cutover`
 
 The release ladder is now:
 
@@ -180,12 +180,11 @@ read-model groundwork, sync hardening, release gates, and package publishing.
 
 ## What comes next
 
-Run v18 slice 25 on this branch, then open the next PR. Generic attachments,
-content attachment projection, and projection-backed public content reads now
-exist; the active work is routing writes through typed content attachment
-intent before lowering to legacy compatibility properties. After that, continue
-with legacy property projection, graph-model migration tooling, and genesis
-replay equivalence.
+Open the PR for v18 slices 21 through 25. Generic attachments, content payload
+nouns, content projection, projection-backed public content reads, and typed
+content write intent now exist over the legacy compatibility property plane.
+After this PR, continue with legacy property projection, graph-model migration
+tooling, and genesis replay equivalence.
 
 ## Running Task List
 
@@ -330,8 +329,12 @@ replay equivalence.
   removes raw `_content*` register parsing from `QueryContent`, uses
   targeted `ContentAttachmentProjection` selectors for node and edge reads,
   and keeps malformed legacy content references out of public metadata.
-- [ ] 25. Make content writes construct typed content attachment intent before
-  lowering to the current legacy `_content*` compatibility properties.
+- [x] 25. Make content writes construct typed content attachment intent before
+  lowering to the current legacy `_content*` compatibility properties:
+  [0173-v18-content-write-intent-cutover](design/0173-v18-content-write-intent-cutover/v18-content-write-intent-cutover.md)
+  adds `ContentAttachmentWriteIntent`, routes `PatchBuilder` node and edge
+  content writes through typed payload construction, and preserves the current
+  legacy property patch shape.
 - [ ] 26. Add the legacy property-bag projection service over attachment
   records, making property bags an explicit compatibility view.
 - [ ] 27. Route query property reads through the legacy property projection

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -63,7 +63,7 @@ Current branch state at this boundary:
 - Latest merged PR: #96, v18 Continuum slices 16 through 20 plus review
   repairs
 - Latest completed v18 implementation cycle:
-  `0170-v18-content-attachment-payload-nouns`
+  `0171-v18-content-attachment-projection`
 
 The release ladder is now:
 
@@ -180,12 +180,11 @@ read-model groundwork, sync hardening, release gates, and package publishing.
 
 ## What comes next
 
-Run v18 slices 23 through 25 on this branch, then open the next PR. Generic
-attachments and content payload nouns now exist; the active work is projecting
-legacy `_content*` attachments into typed content attachments, then routing
-reads and writes through that cutover path. After that, continue with legacy
-property projection, graph-model migration tooling, and genesis replay
-equivalence.
+Run v18 slices 24 and 25 on this branch, then open the next PR. Generic
+attachments and content attachment projection now exist; the active work is
+routing reads and writes through the typed content cutover path. After that,
+continue with legacy property projection, graph-model migration tooling, and
+genesis replay equivalence.
 
 ## Running Task List
 
@@ -319,8 +318,11 @@ equivalence.
   adds `ContentAttachmentOid`, `ContentAttachmentMime`,
   `ContentAttachmentSize`, and `ContentAttachmentPayload` without changing
   public reads, writes, or persistence.
-- [ ] 23. Project legacy `_content`, `_content.mime`, and `_content.size`
-  attachment records into typed content attachments for node and edge owners.
+- [x] 23. Project legacy `_content`, `_content.mime`, and `_content.size`
+  attachment records into typed content attachments for node and edge owners:
+  [0171-v18-content-attachment-projection](design/0171-v18-content-attachment-projection/v18-content-attachment-projection.md)
+  adds `ContentAttachmentRecord` and `ContentAttachmentProjection.fromState()`
+  with deterministic node/edge projection and lineage-sensitive metadata.
 - [ ] 24. Route content OID and metadata reads through the content attachment
   projection while keeping public `getContent*` and `getEdgeContent*`
   behavior stable.

--- a/docs/design/0169-v18-post-20-content-cutover-runway/v18-post-20-content-cutover-runway.md
+++ b/docs/design/0169-v18-post-20-content-cutover-runway/v18-post-20-content-cutover-runway.md
@@ -1,0 +1,119 @@
+---
+cycle: 0169
+task_id: V18_post_20_content_cutover_runway
+status: Complete
+sponsors:
+  human: James
+  agent: Codex
+started_at: 2026-05-23
+completed_at: 2026-05-23
+release_home: v18.0.0
+bearing_task: 21
+promotes_backlog: []
+---
+
+# V18 Post-20 Content Cutover Runway
+
+## Sponsor Human
+
+James.
+
+## Sponsor Agent
+
+Codex.
+
+## Hill
+
+Reset BEARING after PR #96 and slice the next v18 batch around content-specific
+attachment-plane cutover, not around re-adding generic attachments.
+
+## Playback Questions
+
+- Does BEARING name the actual merged state after PR #96?
+- Does the next batch distinguish the already-shipped generic attachment plane
+  from the not-yet-shipped content attachment cutover?
+- Are slices 21 through 30 small enough to review and test independently?
+- Is the next PR boundary clear before implementation starts?
+
+## Accessibility / Assistive Reading Posture
+
+The plan is text-only and uses explicit slice names. It does not rely on
+diagrams to explain the difference between generic attachments and content
+attachment payloads.
+
+## Localization / Directionality Posture
+
+The slice names are protocol planning identifiers and use direct English
+phrasing. No layout or directionality assumptions are introduced.
+
+## Agent Inspectability / Explainability Posture
+
+This cycle updates BEARING before code work resumes, so later agents can see
+that PR #96 shipped the generic attachment plane and graph-op algebra. The next
+tasks explicitly start from content payload semantics over that plane.
+
+## Existing Shape
+
+PR #96 landed:
+
+- runtime-backed node, edge, and attachment record nouns;
+- deterministic `WarpState` record projections;
+- graph-op algebra projection over those record views.
+
+The remaining v18 graph-substrate backlog has four live notes:
+
+- `PROTO_content-attachment-plane-cutover`;
+- `PROTO_legacy-props-as-projection`;
+- `INFRA_graph-model-migration-tool`;
+- `TRUST_genesis-replay-equivalence`.
+
+## Chosen Boundary
+
+This slice only rewrites BEARING and records the next ten planned moves. It
+does not touch runtime code. Runtime content work starts in slice 22 with
+content-specific payload nouns.
+
+## Non-Goals
+
+- Do not change content read behavior.
+- Do not add migration tooling.
+- Do not close any backlog note.
+- Do not claim native Continuum witnesshood.
+
+## RED
+
+Observed before GREEN:
+
+```text
+docs/BEARING.md still identified PR #95 and origin/main c848f5d4 as the latest
+boundary even though PR #96 had merged at 080a60eb.
+```
+
+## GREEN
+
+BEARING now names PR #96, merge commit `080a60eb`, the active branch
+`v18-continuum-slices-21-25`, and tasks 21 through 30.
+
+## Verification
+
+```text
+npx markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/design/0169-v18-post-20-content-cutover-runway/v18-post-20-content-cutover-runway.md
+git diff --check HEAD
+```
+
+## Closeout
+
+The next implementation slice should add content-specific attachment payload
+nouns. Generic attachments already exist; the open question is how content
+payload semantics use that attachment plane while legacy `_content*` properties
+remain a compatibility lowering/projection detail.
+
+## SSJS Scorecard
+
+- Runtime-backed forms: not applicable; this is a planning slice.
+- Boundary validation: green; BEARING now reflects inspectable repo state.
+- Behavior ownership: green; runtime behavior is untouched.
+- Message parsing: green; no behavior branches parse message text.
+- Ambient time or entropy: green; no clocks, dates, timers, or randomness in
+  runtime code.
+- Fake shape trust or cast-cosplay: green; no code assertions introduced.

--- a/docs/design/0170-v18-content-attachment-payload-nouns/v18-content-attachment-payload-nouns.md
+++ b/docs/design/0170-v18-content-attachment-payload-nouns/v18-content-attachment-payload-nouns.md
@@ -1,0 +1,130 @@
+---
+cycle: 0170
+task_id: V18_content_attachment_payload_nouns
+status: Complete
+sponsors:
+  human: James
+  agent: Codex
+started_at: 2026-05-23
+completed_at: 2026-05-23
+release_home: v18.0.0
+bearing_task: 22
+promotes_backlog:
+  - docs/method/backlog/v18.0.0/PROTO_content-attachment-plane-cutover.md
+---
+
+# V18 Content Attachment Payload Nouns
+
+## Sponsor Human
+
+James.
+
+## Sponsor Agent
+
+Codex.
+
+## Hill
+
+Name content-specific attachment payload concepts over the generic attachment
+plane without changing content reads, writes, or persistence.
+
+## Playback Questions
+
+- Can a content reference be represented as `ContentAttachmentOid` instead of a
+  raw `_content` string?
+- Can content MIME and byte length metadata be runtime-backed values?
+- Can content payload metadata represent absent MIME and size without optional
+  field soup?
+- Do public exports expose the new nouns without growing `index.ts`?
+
+## Accessibility / Assistive Reading Posture
+
+The nouns are explicit text concepts: OID, MIME, size, and payload. The design
+does not rely on visual notation to distinguish generic attachments from
+content payloads.
+
+## Localization / Directionality Posture
+
+Content OIDs and MIME hints are protocol/storage identifiers. Validation is
+byte-oriented and does not use locale-sensitive collation.
+
+## Agent Inspectability / Explainability Posture
+
+The slice adds the smallest content-specific vocabulary before projection or
+write-path work. Future agents can inspect the tests and see that no public
+content behavior changed.
+
+## Existing Shape
+
+Generic `AttachmentRecord` exists, and legacy content currently appears as
+attachment records with keys `_content`, `_content.mime`, and `_content.size`.
+Those keys still do not express a typed content payload.
+
+## Chosen Boundary
+
+This slice introduces:
+
+- `ContentAttachmentOid`;
+- `ContentAttachmentMime`;
+- `ContentAttachmentSize`;
+- `ContentAttachmentPayload`.
+
+The payload owns content metadata values only. Slice 23 should add owner-aware
+projection from legacy content attachment records into content attachment
+records.
+
+## Non-Goals
+
+- Do not change `QueryContent`.
+- Do not change `PatchBuilder.attachContent()` or `attachEdgeContent()`.
+- Do not remove `_content*` compatibility properties.
+- Do not close the content-cutover backlog note.
+
+## RED
+
+Observed before GREEN:
+
+```text
+test/unit/domain/graph/ContentAttachmentPayload.test.ts failed because
+ContentAttachmentOid, ContentAttachmentMime, ContentAttachmentSize, and
+ContentAttachmentPayload did not exist.
+```
+
+## GREEN
+
+The slice adds runtime-backed content payload classes, public exports, and tests
+covering:
+
+- OID, MIME, and size validation;
+- optional MIME and size metadata;
+- payload immutability;
+- fake envelope rejection.
+
+## Verification
+
+```text
+npx vitest run test/unit/domain/graph/ContentAttachmentPayload.test.ts test/unit/domain/index.exports.test.ts --reporter=verbose
+npx eslint src/domain/graph/ContentAttachmentOid.ts src/domain/graph/ContentAttachmentMime.ts src/domain/graph/ContentAttachmentSize.ts src/domain/graph/ContentAttachmentPayload.ts src/domain/graph/publicGraphSubstrate.ts test/unit/domain/graph/ContentAttachmentPayload.test.ts test/unit/domain/index.exports.test.ts
+npm run typecheck
+npm run lint
+npx markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/design/0170-v18-content-attachment-payload-nouns/v18-content-attachment-payload-nouns.md
+```
+
+## Closeout
+
+Content now has typed payload nouns over the generic attachment plane. Slice 23
+should project legacy `_content*` attachment records into owner-aware typed
+content attachment records.
+
+## SSJS Scorecard
+
+- Runtime-backed forms: green; OID, MIME, size, and payload are classes with
+  constructor validation and `Object.freeze`.
+- Boundary validation: green; raw legacy strings and numbers must pass
+  constructors before becoming content payload values.
+- Behavior ownership: green; content payload metadata lives on content payload
+  nouns, not on query controllers.
+- Message parsing: green; no behavior branches parse message text.
+- Ambient time or entropy: green; no clocks, dates, timers, or randomness.
+- Fake shape trust or cast-cosplay: green; no assertions or placeholder
+  `*Like` types introduced.

--- a/docs/design/0171-v18-content-attachment-projection/v18-content-attachment-projection.md
+++ b/docs/design/0171-v18-content-attachment-projection/v18-content-attachment-projection.md
@@ -1,0 +1,128 @@
+---
+cycle: 0171
+task_id: V18_content_attachment_projection
+status: Complete
+sponsors:
+  human: James
+  agent: Codex
+started_at: 2026-05-23
+completed_at: 2026-05-23
+release_home: v18.0.0
+bearing_task: 23
+promotes_backlog:
+  - docs/method/backlog/v18.0.0/PROTO_content-attachment-plane-cutover.md
+---
+
+# V18 Content Attachment Projection
+
+## Sponsor Human
+
+James.
+
+## Sponsor Agent
+
+Codex.
+
+## Hill
+
+Project legacy `_content*` state entries into typed node and edge content
+attachment records while preserving lineage-sensitive metadata behavior.
+
+## Playback Questions
+
+- Can current legacy content state produce typed content attachment records?
+- Can projection distinguish node-owned and edge-owned content?
+- Does stale metadata from earlier content lineages stay out of typed payloads?
+- Does projection avoid treating non-string content references as content?
+
+## Accessibility / Assistive Reading Posture
+
+The projection output names owner and payload explicitly. Tests describe records
+as plain text strings so the behavior is inspectable without visual context.
+
+## Localization / Directionality Posture
+
+Content storage references and MIME hints are protocol/storage identifiers.
+Projection ordering uses deterministic protocol strings, not locale collation.
+
+## Agent Inspectability / Explainability Posture
+
+The projection is an explicit service instead of hidden query-controller logic.
+Agents can inspect it before reads and writes are routed through the cutover
+path.
+
+## Existing Shape
+
+Slice 22 introduced content payload nouns. Current state still stores content
+through legacy properties:
+
+- `_content`;
+- `_content.mime`;
+- `_content.size`.
+
+## Chosen Boundary
+
+This slice introduces:
+
+- `ContentAttachmentRecord`, which binds a `ContentAttachmentPayload` to a
+  node or edge owner;
+- `ContentAttachmentProjection.fromState()`, which reads current `WarpState`
+  and returns deterministic typed content attachment records.
+
+The projection scans legacy state directly for this slice because content
+metadata lineage depends on property event ids. Generic `AttachmentRecord`
+values intentionally do not carry lineage details.
+
+## Non-Goals
+
+- Do not change public content reads yet.
+- Do not change content writes yet.
+- Do not remove legacy `_content*` properties.
+- Do not close the content-cutover backlog note.
+
+## RED
+
+Observed before GREEN:
+
+```text
+test/unit/domain/services/ContentAttachmentProjection.test.ts failed because
+ContentAttachmentProjection and ContentAttachmentRecord did not exist.
+```
+
+## GREEN
+
+The slice adds owner-aware content attachment records, a deterministic state
+projection, public exports, and tests covering:
+
+- node and edge content projection;
+- stale metadata filtering by event lineage;
+- non-string content reference exclusion;
+- fake state and record envelope rejection.
+
+## Verification
+
+```text
+npx vitest run test/unit/domain/graph/ContentAttachmentRecord.test.ts test/unit/domain/services/ContentAttachmentProjection.test.ts test/unit/domain/index.exports.test.ts --reporter=verbose
+npx eslint src/domain/graph/ContentAttachmentRecord.ts src/domain/services/ContentAttachmentProjection.ts src/domain/graph/publicGraphSubstrate.ts test/unit/domain/graph/ContentAttachmentRecord.test.ts test/unit/domain/services/ContentAttachmentProjection.test.ts test/unit/domain/index.exports.test.ts
+npm run typecheck
+npm run lint
+npx markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/design/0171-v18-content-attachment-projection/v18-content-attachment-projection.md
+```
+
+## Closeout
+
+Content can now be projected as typed attachment payloads over visible node and
+edge owners. Slice 24 should route content OID and metadata reads through this
+projection while preserving public behavior.
+
+## SSJS Scorecard
+
+- Runtime-backed forms: green; content attachment records are classes with
+  constructor validation and `Object.freeze`.
+- Boundary validation: green; `fromState()` requires a real `WarpState`.
+- Behavior ownership: green; content projection lives in a named projection
+  service instead of query-controller property parsing.
+- Message parsing: green; no behavior branches parse message text.
+- Ambient time or entropy: green; no clocks, dates, timers, or randomness.
+- Fake shape trust or cast-cosplay: green; no assertions or placeholder
+  `*Like` types introduced.

--- a/docs/design/0172-v18-query-content-projection-reads/v18-query-content-projection-reads.md
+++ b/docs/design/0172-v18-query-content-projection-reads/v18-query-content-projection-reads.md
@@ -1,0 +1,150 @@
+---
+cycle: 0172
+task_id: V18_query_content_projection_reads
+status: Complete
+sponsors:
+  human: James
+  agent: Codex
+started_at: 2026-05-23
+completed_at: 2026-05-23
+release_home: v18.0.0
+bearing_task: 24
+promotes_backlog:
+  - docs/method/backlog/v18.0.0/PROTO_content-attachment-plane-cutover.md
+---
+
+# V18 Query Content Projection Reads
+
+## Sponsor Human
+
+James.
+
+## Sponsor Agent
+
+Codex.
+
+## Hill
+
+Route public content OID, metadata, bytes, and stream reads through the typed
+content attachment projection instead of re-parsing legacy `_content*`
+registers in `QueryContent`.
+
+## Playback Questions
+
+- Do node content reads find content by projected node-owned attachment
+  records?
+- Do edge content reads find content by projected edge-owned attachment
+  records?
+- Do malformed legacy content references stay out of public content metadata?
+- Do malformed MIME hints become absent metadata instead of leaking as public
+  content metadata?
+
+## Accessibility / Assistive Reading Posture
+
+The read path still returns the same simple public content metadata shape:
+`oid`, `mime`, and `size`. Tests name the malformed cases directly so the
+behavior is inspectable without diagrams.
+
+## Localization / Directionality Posture
+
+Content storage OIDs, MIME hints, and edge labels remain protocol/storage
+strings. Matching uses exact protocol identity, not locale collation.
+
+## Agent Inspectability / Explainability Posture
+
+Agents now have one explicit interpretation point for content attachments:
+`ContentAttachmentProjection`. `QueryContent` only asks for the owner-specific
+projected record and resolves blobs.
+
+## Existing Shape
+
+Before this slice, `QueryContent` duplicated legacy register parsing:
+
+- node reads directly looked up `_content`, `_content.mime`, and
+  `_content.size`;
+- edge reads directly looked up `edge:_content*` registers and repeated edge
+  birth visibility checks;
+- MIME validation allowed any string, including malformed empty strings.
+
+Slice 23 introduced typed projection but did not route public reads through it.
+
+## Chosen Boundary
+
+`QueryContent` now asks `ContentAttachmentProjection.forNode()` and
+`ContentAttachmentProjection.forEdge()` for typed content attachment records
+and then performs only public read duties:
+
+- select a node-owned or edge-owned record;
+- translate runtime-backed payload nouns into `ContentMeta`;
+- resolve blob bytes or blob streams from the selected content OID.
+
+The projection also skips malformed legacy content OID strings before record
+construction so public reads receive `null` instead of throwing on corrupt
+legacy state. Whole-state `fromState()` remains available for deterministic
+materialization views, but point reads use targeted selectors to avoid a
+whole-graph projection scan per lookup.
+
+## Non-Goals
+
+- Do not change content write storage yet.
+- Do not remove legacy `_content*` compatibility properties.
+- Do not route general property-bag reads through attachment projection yet.
+- Do not close the content-cutover backlog note.
+
+## RED
+
+Observed before GREEN:
+
+```text
+test/unit/domain/services/ContentAttachmentProjection.test.ts failed because
+malformed legacy content OIDs still reached ContentAttachmentOid construction.
+
+test/unit/domain/services/controllers/QueryContentProjectionReads.test.ts
+failed because
+QueryContent returned empty content OIDs and empty MIME strings directly from
+legacy registers.
+```
+
+## GREEN
+
+The slice removes the raw content-register parser from `QueryContent`, routes
+content reads through `ContentAttachmentProjection`, and adds regression tests
+for:
+
+- malformed node content storage references;
+- malformed edge content storage references;
+- malformed node MIME hints;
+- malformed edge MIME hints;
+- projection-level malformed content OID exclusion.
+
+## Verification
+
+```text
+npx vitest run test/unit/domain/services/ContentAttachmentProjection.test.ts test/unit/domain/services/controllers/QueryContentProjectionReads.test.ts test/unit/domain/services/controllers/QueryController.test.ts --reporter=verbose
+npx eslint src/domain/services/ContentAttachmentProjection.ts src/domain/services/controllers/QueryContent.ts test/unit/domain/services/ContentAttachmentProjection.test.ts test/unit/domain/services/controllers/QueryContentProjectionReads.test.ts
+npm run typecheck
+npm run lint
+npm run lint:sludge
+npm run lint:quarantine-graduate
+npx markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/design/0172-v18-query-content-projection-reads/v18-query-content-projection-reads.md
+git diff --check HEAD
+```
+
+## Closeout
+
+Public content reads now sit on the typed content attachment projection. Slice
+25 can make content writes construct typed content attachment intent before
+lowering to the same legacy compatibility registers.
+
+## SSJS Scorecard
+
+- Runtime-backed forms: green; public reads use targeted
+  `ContentAttachmentRecord` selectors and runtime-backed content payload nouns.
+- Boundary validation: green; malformed content OIDs and MIME hints are
+  excluded at projection time.
+- Behavior ownership: green; attachment interpretation belongs to
+  `ContentAttachmentProjection`, while blob I/O stays in `QueryContent`.
+- Message parsing: green; no behavior branches parse message text.
+- Ambient time or entropy: green; no clocks, dates, timers, or randomness.
+- Fake shape trust or cast-cosplay: green; this slice removes
+  content-register assertions from `QueryContent`.

--- a/docs/design/0173-v18-content-write-intent-cutover/v18-content-write-intent-cutover.md
+++ b/docs/design/0173-v18-content-write-intent-cutover/v18-content-write-intent-cutover.md
@@ -1,0 +1,149 @@
+---
+cycle: 0173
+task_id: V18_content_write_intent_cutover
+status: Complete
+sponsors:
+  human: James
+  agent: Codex
+started_at: 2026-05-23
+completed_at: 2026-05-23
+release_home: v18.0.0
+bearing_task: 25
+promotes_backlog:
+  - docs/method/backlog/v18.0.0/PROTO_content-attachment-plane-cutover.md
+---
+
+# V18 Content Write Intent Cutover
+
+## Sponsor Human
+
+James.
+
+## Sponsor Agent
+
+Codex.
+
+## Hill
+
+Make content writes construct runtime-backed typed content attachment intent
+before lowering to the existing legacy `_content*` compatibility properties.
+
+## Playback Questions
+
+- Does a content write have a named runtime-backed intent before legacy
+  property emission?
+- Does PatchBuilder reject malformed blob-storage OIDs before `_content*`
+  operations are appended?
+- Do streamed content writes validate MIME and size through typed content
+  payload nouns before edge property lowering?
+- Does the public output remain the same legacy property patch shape for
+  compatibility?
+
+## Accessibility / Assistive Reading Posture
+
+The intent noun exposes simple target and payload accessors. Tests describe the
+node target, edge target, storage OID, MIME, and size as plain values.
+
+## Localization / Directionality Posture
+
+Write targets, storage OIDs, and MIME hints remain protocol identifiers.
+Lowering preserves exact strings and does not apply locale-sensitive
+normalization.
+
+## Agent Inspectability / Explainability Posture
+
+Agents can now distinguish content write intent from legacy compatibility
+lowering. `ContentAttachmentWriteIntent` owns typed target/payload binding;
+`PatchBuilder` owns blob storage and compatibility property emission.
+
+## Existing Shape
+
+Before this slice, `PatchBuilder.attachContent()` and
+`PatchBuilder.attachEdgeContent()` stored blobs, then wrote `_content`,
+`_content.size`, and `_content.mime` properties directly. That meant invalid
+blob-storage OIDs or malformed streamed MIME hints could reach patch ops before
+the typed content payload nouns had any chance to validate them.
+
+## Chosen Boundary
+
+This slice introduces `ContentAttachmentWriteIntent` in the graph substrate
+package. The intent binds a `ContentAttachmentPayload` to either a node target
+or an edge target using existing runtime-backed owner records.
+
+`PatchBuilder` now:
+
+- stores buffered or streamed content through the existing blob storage port;
+- constructs a `ContentAttachmentPayload` from the returned OID and metadata;
+- constructs a `ContentAttachmentWriteIntent` for the node or edge target;
+- lowers that intent to the current legacy `_content*` compatibility
+  properties.
+
+The persistence shape intentionally does not change in this slice.
+
+## Non-Goals
+
+- Do not remove legacy `_content*` properties.
+- Do not change the public content write API.
+- Do not change blob storage adapters.
+- Do not route general property writes through graph-op algebra yet.
+- Do not close the content-cutover backlog note.
+
+## RED
+
+Observed before GREEN:
+
+```text
+test/unit/domain/graph/ContentAttachmentWriteIntent.test.ts failed because
+ContentAttachmentWriteIntent did not exist.
+
+test/unit/domain/services/PatchBuilderContentWriteIntent.test.ts failed
+because PatchBuilder accepted an empty blob-storage OID and an empty streamed
+edge MIME hint, lowering both into legacy content properties.
+```
+
+## GREEN
+
+The slice adds `ContentAttachmentWriteIntent`, exports it through the graph
+substrate public surface, and routes PatchBuilder content writes through typed
+intent construction before property lowering.
+
+Regression coverage now proves:
+
+- node write intents expose node target and typed payload values;
+- edge write intents expose edge target and typed payload values;
+- wrong target accessor use is rejected;
+- malformed stored OIDs do not lower into node `_content*` ops;
+- malformed streamed edge MIME hints do not lower into edge `_content*` ops.
+
+## Verification
+
+```text
+npx vitest run test/unit/domain/graph/ContentAttachmentWriteIntent.test.ts test/unit/domain/services/PatchBuilderContentWriteIntent.test.ts test/unit/domain/index.exports.test.ts --reporter=verbose
+npx eslint src/domain/graph/ContentAttachmentWriteIntent.ts src/domain/graph/publicGraphSubstrate.ts src/domain/services/PatchBuilder.ts test/unit/domain/graph/ContentAttachmentWriteIntent.test.ts test/unit/domain/services/PatchBuilderContentWriteIntent.test.ts test/unit/domain/index.exports.test.ts
+npm run typecheck
+npm run lint
+npm run lint:sludge
+npm run lint:quarantine-graduate
+npx markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/design/0173-v18-content-write-intent-cutover/v18-content-write-intent-cutover.md
+git diff --check HEAD
+```
+
+## Closeout
+
+The content cutover path now has typed read projection and typed write intent
+over the legacy compatibility property plane. The next branch can move to
+legacy property-bag projection, graph-model migration tooling, and genesis
+replay equivalence.
+
+## SSJS Scorecard
+
+- Runtime-backed forms: green; `ContentAttachmentWriteIntent` is a frozen
+  class over typed content payloads and owner records.
+- Boundary validation: green; blob-storage OIDs, MIME hints, and sizes pass
+  through runtime-backed content payload constructors before lowering.
+- Behavior ownership: green; intent construction is separate from legacy
+  property emission.
+- Message parsing: green; no behavior branches parse message text.
+- Ambient time or entropy: green; no clocks, dates, timers, or randomness.
+- Fake shape trust or cast-cosplay: green; no assertions or placeholder
+  `*Like` types introduced.

--- a/index.ts
+++ b/index.ts
@@ -184,6 +184,7 @@ import { NoOpEffectSink } from './src/infrastructure/adapters/NoOpEffectSink.ts'
 import { ConsoleEffectSink } from './src/infrastructure/adapters/ConsoleEffectSink.ts';
 import { ChunkEffectSink } from './src/infrastructure/adapters/ChunkEffectSink.ts';
 import SyncSecret from './src/domain/services/sync/SyncSecret.ts';
+import ContentAttachmentProjection from './src/domain/services/ContentAttachmentProjection.ts';
 import GraphOpAlgebraProjection from './src/domain/services/GraphOpAlgebraProjection.ts';
 import { openWarpGraph } from './src/domain/WarpGraph.ts';
 import { PatchBuilder } from './src/domain/services/PatchBuilder.ts';
@@ -455,6 +456,7 @@ export {
   ConsoleEffectSink,
   ChunkEffectSink,
   SyncSecret,
+  ContentAttachmentProjection,
 };
 
 export type {

--- a/src/domain/graph/ContentAttachmentMime.ts
+++ b/src/domain/graph/ContentAttachmentMime.ts
@@ -1,0 +1,37 @@
+import WarpError from '../errors/WarpError.ts';
+
+const FIELD_SEPARATOR = '\x00';
+
+/** Runtime-backed MIME hint for a content attachment. */
+export default class ContentAttachmentMime {
+  private readonly value: string;
+
+  constructor(value: string) {
+    this.value = requireMimeValue(value);
+    Object.freeze(this);
+  }
+
+  /** Returns the stable MIME hint string. */
+  toString(): string {
+    return this.value;
+  }
+
+  /** Compares two MIME hints by runtime value. */
+  equals(other: ContentAttachmentMime | null | undefined): boolean {
+    if (!(other instanceof ContentAttachmentMime)) {
+      return false;
+    }
+    return this.value === other.value;
+  }
+}
+
+/** Validates a content attachment MIME hint. */
+function requireMimeValue(value: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError('ContentAttachmentMime must be a non-empty string', 'E_VALIDATION');
+  }
+  if (value.includes(FIELD_SEPARATOR)) {
+    throw new WarpError('ContentAttachmentMime must not contain NUL bytes', 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/graph/ContentAttachmentOid.ts
+++ b/src/domain/graph/ContentAttachmentOid.ts
@@ -1,0 +1,37 @@
+import WarpError from '../errors/WarpError.ts';
+
+const FIELD_SEPARATOR = '\x00';
+
+/** Runtime-backed reference to content storage used by a content attachment. */
+export default class ContentAttachmentOid {
+  private readonly value: string;
+
+  constructor(value: string) {
+    this.value = requireOidValue(value);
+    Object.freeze(this);
+  }
+
+  /** Returns the stable content storage reference string. */
+  toString(): string {
+    return this.value;
+  }
+
+  /** Compares two content storage references by runtime value. */
+  equals(other: ContentAttachmentOid | null | undefined): boolean {
+    if (!(other instanceof ContentAttachmentOid)) {
+      return false;
+    }
+    return this.value === other.value;
+  }
+}
+
+/** Validates a content attachment storage reference. */
+function requireOidValue(value: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError('ContentAttachmentOid must be a non-empty string', 'E_VALIDATION');
+  }
+  if (value.includes(FIELD_SEPARATOR)) {
+    throw new WarpError('ContentAttachmentOid must not contain NUL bytes', 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/graph/ContentAttachmentPayload.ts
+++ b/src/domain/graph/ContentAttachmentPayload.ts
@@ -1,0 +1,69 @@
+import ContentAttachmentMime from './ContentAttachmentMime.ts';
+import ContentAttachmentOid from './ContentAttachmentOid.ts';
+import ContentAttachmentSize from './ContentAttachmentSize.ts';
+import WarpError from '../errors/WarpError.ts';
+
+export type ContentAttachmentPayloadFields = {
+  readonly oid: ContentAttachmentOid;
+  readonly mime: ContentAttachmentMime | null;
+  readonly size: ContentAttachmentSize | null;
+};
+
+/** Runtime-backed content attachment payload metadata. */
+export default class ContentAttachmentPayload {
+  readonly oid: ContentAttachmentOid;
+  readonly mime: ContentAttachmentMime | null;
+  readonly size: ContentAttachmentSize | null;
+
+  constructor(fields: ContentAttachmentPayloadFields) {
+    const checkedFields = requireFields(fields);
+    this.oid = requireOid(checkedFields.oid);
+    this.mime = requireMime(checkedFields.mime);
+    this.size = requireSize(checkedFields.size);
+    Object.freeze(this);
+  }
+
+  /** Returns true when a MIME hint is present. */
+  hasMime(): boolean {
+    return this.mime instanceof ContentAttachmentMime;
+  }
+
+  /** Returns true when a byte length is present. */
+  hasSize(): boolean {
+    return this.size instanceof ContentAttachmentSize;
+  }
+}
+
+/** Validates the content payload constructor envelope. */
+function requireFields(
+  fields: ContentAttachmentPayloadFields | null | undefined,
+): ContentAttachmentPayloadFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('ContentAttachmentPayload fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Requires a runtime-backed content storage reference. */
+function requireOid(value: ContentAttachmentOid): ContentAttachmentOid {
+  if (!(value instanceof ContentAttachmentOid)) {
+    throw new WarpError('ContentAttachmentPayload oid must be a ContentAttachmentOid', 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Requires absent metadata or a runtime-backed MIME hint. */
+function requireMime(value: ContentAttachmentMime | null): ContentAttachmentMime | null {
+  if (value === null || value instanceof ContentAttachmentMime) {
+    return value;
+  }
+  throw new WarpError('ContentAttachmentPayload mime must be null or a ContentAttachmentMime', 'E_VALIDATION');
+}
+
+/** Requires absent metadata or a runtime-backed byte length. */
+function requireSize(value: ContentAttachmentSize | null): ContentAttachmentSize | null {
+  if (value === null || value instanceof ContentAttachmentSize) {
+    return value;
+  }
+  throw new WarpError('ContentAttachmentPayload size must be null or a ContentAttachmentSize', 'E_VALIDATION');
+}

--- a/src/domain/graph/ContentAttachmentRecord.ts
+++ b/src/domain/graph/ContentAttachmentRecord.ts
@@ -1,0 +1,59 @@
+import ContentAttachmentPayload from './ContentAttachmentPayload.ts';
+import EdgeRecord from './EdgeRecord.ts';
+import NodeRecord from './NodeRecord.ts';
+import WarpError from '../errors/WarpError.ts';
+import type { AttachmentOwnerRecord } from './AttachmentRecord.ts';
+
+export type ContentAttachmentRecordFields = {
+  readonly owner: AttachmentOwnerRecord;
+  readonly payload: ContentAttachmentPayload;
+};
+
+/** Runtime-backed content attachment bound to a node or edge owner. */
+export default class ContentAttachmentRecord {
+  readonly owner: AttachmentOwnerRecord;
+  readonly payload: ContentAttachmentPayload;
+
+  constructor(fields: ContentAttachmentRecordFields) {
+    const checkedFields = requireFields(fields);
+    this.owner = requireOwner(checkedFields.owner);
+    this.payload = requirePayload(checkedFields.payload);
+    Object.freeze(this);
+  }
+
+  /** Returns true when this content is owned by a node record. */
+  isNodeContent(): boolean {
+    return this.owner instanceof NodeRecord;
+  }
+
+  /** Returns true when this content is owned by an edge record. */
+  isEdgeContent(): boolean {
+    return this.owner instanceof EdgeRecord;
+  }
+}
+
+/** Validates the content attachment record constructor envelope. */
+function requireFields(
+  fields: ContentAttachmentRecordFields | null | undefined,
+): ContentAttachmentRecordFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('ContentAttachmentRecord fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Requires a runtime-backed content owner. */
+function requireOwner(value: AttachmentOwnerRecord): AttachmentOwnerRecord {
+  if (value instanceof NodeRecord || value instanceof EdgeRecord) {
+    return value;
+  }
+  throw new WarpError('ContentAttachmentRecord owner must be a NodeRecord or EdgeRecord', 'E_VALIDATION');
+}
+
+/** Requires a runtime-backed content payload. */
+function requirePayload(value: ContentAttachmentPayload): ContentAttachmentPayload {
+  if (!(value instanceof ContentAttachmentPayload)) {
+    throw new WarpError('ContentAttachmentRecord payload must be a ContentAttachmentPayload', 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/graph/ContentAttachmentSize.ts
+++ b/src/domain/graph/ContentAttachmentSize.ts
@@ -1,0 +1,32 @@
+import WarpError from '../errors/WarpError.ts';
+
+/** Runtime-backed byte length for a content attachment. */
+export default class ContentAttachmentSize {
+  private readonly value: number;
+
+  constructor(value: number) {
+    this.value = requireSizeValue(value);
+    Object.freeze(this);
+  }
+
+  /** Returns the byte length. */
+  toNumber(): number {
+    return this.value;
+  }
+
+  /** Compares two content sizes by runtime value. */
+  equals(other: ContentAttachmentSize | null | undefined): boolean {
+    if (!(other instanceof ContentAttachmentSize)) {
+      return false;
+    }
+    return this.value === other.value;
+  }
+}
+
+/** Validates a content attachment byte length. */
+function requireSizeValue(value: number): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new WarpError('ContentAttachmentSize must be a non-negative integer', 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/graph/ContentAttachmentWriteIntent.ts
+++ b/src/domain/graph/ContentAttachmentWriteIntent.ts
@@ -1,0 +1,86 @@
+import ContentAttachmentRecord from './ContentAttachmentRecord.ts';
+import EdgeRecord from './EdgeRecord.ts';
+import NodeRecord from './NodeRecord.ts';
+import WarpError from '../errors/WarpError.ts';
+import type ContentAttachmentPayload from './ContentAttachmentPayload.ts';
+
+export type ContentAttachmentEdgeWriteTarget = {
+  readonly from: string;
+  readonly to: string;
+  readonly label: string;
+};
+
+/** Runtime-backed intent to write content before legacy property lowering. */
+export default class ContentAttachmentWriteIntent {
+  private readonly record: ContentAttachmentRecord;
+
+  constructor(record: ContentAttachmentRecord) {
+    this.record = requireRecord(record);
+    Object.freeze(this);
+  }
+
+  /** Builds a node-owned content write intent. */
+  static forNode(nodeId: string, payload: ContentAttachmentPayload): ContentAttachmentWriteIntent {
+    return new ContentAttachmentWriteIntent(new ContentAttachmentRecord({
+      owner: NodeRecord.fromLegacyNodeId(nodeId),
+      payload,
+    }));
+  }
+
+  /** Builds an edge-owned content write intent. */
+  static forEdge(
+    edge: ContentAttachmentEdgeWriteTarget,
+    payload: ContentAttachmentPayload,
+  ): ContentAttachmentWriteIntent {
+    return new ContentAttachmentWriteIntent(new ContentAttachmentRecord({
+      owner: EdgeRecord.fromLegacyEdge(edge),
+      payload,
+    }));
+  }
+
+  /** Returns the node target id for a node-owned content write intent. */
+  nodeId(): string {
+    if (!(this.record.owner instanceof NodeRecord)) {
+      throw new WarpError('ContentAttachmentWriteIntent is not a node content target', 'E_VALIDATION');
+    }
+    return this.record.owner.id.toString();
+  }
+
+  /** Returns the edge target for an edge-owned content write intent. */
+  edgeTarget(): ContentAttachmentEdgeWriteTarget {
+    if (!(this.record.owner instanceof EdgeRecord)) {
+      throw new WarpError('ContentAttachmentWriteIntent is not an edge content target', 'E_VALIDATION');
+    }
+    return Object.freeze({
+      from: this.record.owner.from.toString(),
+      to: this.record.owner.to.toString(),
+      label: this.record.owner.typeId.toString(),
+    });
+  }
+
+  /** Returns the validated content storage reference. */
+  oid(): string {
+    return this.record.payload.oid.toString();
+  }
+
+  /** Returns the validated MIME hint, when present. */
+  mime(): string | null {
+    return this.record.payload.mime?.toString() ?? null;
+  }
+
+  /** Returns the validated byte size, when present. */
+  size(): number | null {
+    return this.record.payload.size?.toNumber() ?? null;
+  }
+}
+
+/** Requires a runtime-backed content attachment record. */
+function requireRecord(record: ContentAttachmentRecord): ContentAttachmentRecord {
+  if (!(record instanceof ContentAttachmentRecord)) {
+    throw new WarpError(
+      'ContentAttachmentWriteIntent record must be a ContentAttachmentRecord',
+      'E_VALIDATION',
+    );
+  }
+  return record;
+}

--- a/src/domain/graph/publicGraphSubstrate.ts
+++ b/src/domain/graph/publicGraphSubstrate.ts
@@ -4,6 +4,7 @@ export { default as AttachmentSchemaVersion } from './AttachmentSchemaVersion.ts
 export { default as ContentAttachmentMime } from './ContentAttachmentMime.ts';
 export { default as ContentAttachmentOid } from './ContentAttachmentOid.ts';
 export { default as ContentAttachmentPayload } from './ContentAttachmentPayload.ts';
+export { default as ContentAttachmentRecord } from './ContentAttachmentRecord.ts';
 export { default as ContentAttachmentSize } from './ContentAttachmentSize.ts';
 export { default as EdgeId } from './EdgeId.ts';
 export { default as EdgeRecord } from './EdgeRecord.ts';
@@ -37,6 +38,7 @@ export type {
   AttachmentRecordFields,
 } from './AttachmentRecord.ts';
 export type { ContentAttachmentPayloadFields } from './ContentAttachmentPayload.ts';
+export type { ContentAttachmentRecordFields } from './ContentAttachmentRecord.ts';
 export type { EdgeRecordFields, LegacyEdgeFields } from './EdgeRecord.ts';
 export type { GraphAttachmentSetOpFields } from './GraphAttachmentSetOp.ts';
 export type { GraphEdgeRecordSetOpFields } from './GraphEdgeRecordSetOp.ts';

--- a/src/domain/graph/publicGraphSubstrate.ts
+++ b/src/domain/graph/publicGraphSubstrate.ts
@@ -6,6 +6,7 @@ export { default as ContentAttachmentOid } from './ContentAttachmentOid.ts';
 export { default as ContentAttachmentPayload } from './ContentAttachmentPayload.ts';
 export { default as ContentAttachmentRecord } from './ContentAttachmentRecord.ts';
 export { default as ContentAttachmentSize } from './ContentAttachmentSize.ts';
+export { default as ContentAttachmentWriteIntent } from './ContentAttachmentWriteIntent.ts';
 export { default as EdgeId } from './EdgeId.ts';
 export { default as EdgeRecord } from './EdgeRecord.ts';
 export { default as EdgeTypeId } from './EdgeTypeId.ts';
@@ -39,6 +40,7 @@ export type {
 } from './AttachmentRecord.ts';
 export type { ContentAttachmentPayloadFields } from './ContentAttachmentPayload.ts';
 export type { ContentAttachmentRecordFields } from './ContentAttachmentRecord.ts';
+export type { ContentAttachmentEdgeWriteTarget } from './ContentAttachmentWriteIntent.ts';
 export type { EdgeRecordFields, LegacyEdgeFields } from './EdgeRecord.ts';
 export type { GraphAttachmentSetOpFields } from './GraphAttachmentSetOp.ts';
 export type { GraphEdgeRecordSetOpFields } from './GraphEdgeRecordSetOp.ts';

--- a/src/domain/graph/publicGraphSubstrate.ts
+++ b/src/domain/graph/publicGraphSubstrate.ts
@@ -1,6 +1,10 @@
 export { default as AttachmentKey } from './AttachmentKey.ts';
 export { default as AttachmentRecord } from './AttachmentRecord.ts';
 export { default as AttachmentSchemaVersion } from './AttachmentSchemaVersion.ts';
+export { default as ContentAttachmentMime } from './ContentAttachmentMime.ts';
+export { default as ContentAttachmentOid } from './ContentAttachmentOid.ts';
+export { default as ContentAttachmentPayload } from './ContentAttachmentPayload.ts';
+export { default as ContentAttachmentSize } from './ContentAttachmentSize.ts';
 export { default as EdgeId } from './EdgeId.ts';
 export { default as EdgeRecord } from './EdgeRecord.ts';
 export { default as EdgeTypeId } from './EdgeTypeId.ts';
@@ -32,6 +36,7 @@ export type {
   AttachmentOwnerRecord,
   AttachmentRecordFields,
 } from './AttachmentRecord.ts';
+export type { ContentAttachmentPayloadFields } from './ContentAttachmentPayload.ts';
 export type { EdgeRecordFields, LegacyEdgeFields } from './EdgeRecord.ts';
 export type { GraphAttachmentSetOpFields } from './GraphAttachmentSetOp.ts';
 export type { GraphEdgeRecordSetOpFields } from './GraphEdgeRecordSetOp.ts';

--- a/src/domain/services/ContentAttachmentProjection.ts
+++ b/src/domain/services/ContentAttachmentProjection.ts
@@ -1,0 +1,212 @@
+import ContentAttachmentMime from '../graph/ContentAttachmentMime.ts';
+import ContentAttachmentOid from '../graph/ContentAttachmentOid.ts';
+import ContentAttachmentPayload from '../graph/ContentAttachmentPayload.ts';
+import ContentAttachmentRecord from '../graph/ContentAttachmentRecord.ts';
+import ContentAttachmentSize from '../graph/ContentAttachmentSize.ts';
+import NodeRecord from '../graph/NodeRecord.ts';
+import WarpError from '../errors/WarpError.ts';
+import {
+  CONTENT_MIME_PROPERTY_KEY,
+  CONTENT_PROPERTY_KEY,
+  CONTENT_SIZE_PROPERTY_KEY,
+  encodeEdgeKey,
+  encodeEdgePropKey,
+  encodePropKey,
+} from './KeyCodec.ts';
+import { compareEventIds, type EventId } from '../utils/EventId.ts';
+import WarpState from './state/WarpState.ts';
+import type { LWWRegister } from '../crdt/LWW.ts';
+import type EdgeRecord from '../graph/EdgeRecord.ts';
+import type { PropValue } from '../types/PropValue.ts';
+
+type Register = LWWRegister<PropValue>;
+type ContentRegister = Register & { readonly value: string };
+
+type ContentRegisters = {
+  readonly content: ContentRegister;
+  readonly mime: Register | null;
+  readonly size: Register | null;
+};
+
+/** Projects legacy content properties into typed content attachment records. */
+export default class ContentAttachmentProjection {
+  /** Returns visible content attachments ordered by deterministic owner id. */
+  static fromState(state: WarpState): readonly ContentAttachmentRecord[] {
+    const checkedState = requireWarpState(state);
+    const records: ContentAttachmentRecord[] = [];
+    for (const owner of checkedState.nodeRecords()) {
+      const record = contentRecordForNode(checkedState, owner);
+      if (record !== null) {
+        records.push(record);
+      }
+    }
+    for (const owner of checkedState.edgeRecords()) {
+      const record = contentRecordForEdge(checkedState, owner);
+      if (record !== null) {
+        records.push(record);
+      }
+    }
+    records.sort(compareContentAttachmentRecords);
+    return Object.freeze(records);
+  }
+}
+
+/** Requires a runtime-backed WarpState projection source. */
+function requireWarpState(state: WarpState): WarpState {
+  if (!(state instanceof WarpState)) {
+    throw new WarpError('ContentAttachmentProjection source must be a WarpState', 'E_VALIDATION');
+  }
+  return state;
+}
+
+/** Builds a typed content attachment record for a visible node owner. */
+function contentRecordForNode(state: WarpState, owner: NodeRecord): ContentAttachmentRecord | null {
+  const nodeId = owner.id.toString();
+  const content = state.prop.get(encodePropKey(nodeId, CONTENT_PROPERTY_KEY));
+  if (!isStringContentRegister(content)) {
+    return null;
+  }
+  return contentRecordFromRegisters(owner, {
+    content,
+    mime: state.prop.get(encodePropKey(nodeId, CONTENT_MIME_PROPERTY_KEY)) ?? null,
+    size: state.prop.get(encodePropKey(nodeId, CONTENT_SIZE_PROPERTY_KEY)) ?? null,
+  });
+}
+
+/** Builds a typed content attachment record for a visible edge owner. */
+function contentRecordForEdge(state: WarpState, owner: EdgeRecord): ContentAttachmentRecord | null {
+  const from = owner.from.toString();
+  const to = owner.to.toString();
+  const label = owner.typeId.toString();
+  const edgeKey = encodeEdgeKey(from, to, label);
+  const birthEvent = state.edgeBirthEvent.get(edgeKey);
+  const content = visibleEdgeRegister(
+    state.prop.get(encodeEdgePropKey(from, to, label, CONTENT_PROPERTY_KEY)),
+    birthEvent,
+  );
+  if (!isStringContentRegister(content)) {
+    return null;
+  }
+  return contentRecordFromRegisters(owner, {
+    content,
+    mime: visibleEdgeRegister(
+      state.prop.get(encodeEdgePropKey(from, to, label, CONTENT_MIME_PROPERTY_KEY)),
+      birthEvent,
+    ),
+    size: visibleEdgeRegister(
+      state.prop.get(encodeEdgePropKey(from, to, label, CONTENT_SIZE_PROPERTY_KEY)),
+      birthEvent,
+    ),
+  });
+}
+
+/** Returns a typed content record from visible legacy registers. */
+function contentRecordFromRegisters(
+  owner: NodeRecord | EdgeRecord,
+  registers: ContentRegisters,
+): ContentAttachmentRecord {
+  return new ContentAttachmentRecord({
+    owner,
+    payload: new ContentAttachmentPayload({
+      oid: new ContentAttachmentOid(registers.content.value),
+      mime: contentMimeFromRegister(registers.content, registers.mime),
+      size: contentSizeFromRegister(registers.content, registers.size),
+    }),
+  });
+}
+
+/** Returns true when a register can supply a content storage reference. */
+function isStringContentRegister(register: Register | null | undefined): register is ContentRegister {
+  return register !== null && register !== undefined && typeof register.value === 'string';
+}
+
+/** Filters edge registers hidden by edge rebirth. */
+function visibleEdgeRegister(
+  register: Register | undefined,
+  birthEvent: EventId | undefined,
+): Register | null {
+  if (register === undefined) {
+    return null;
+  }
+  if (birthEvent !== undefined && register.eventId !== null && compareEventIds(register.eventId, birthEvent) < 0) {
+    return null;
+  }
+  return register;
+}
+
+/** Returns true when metadata belongs to the same content write lineage. */
+function isSameLineage(left: EventId | null | undefined, right: EventId | null | undefined): boolean {
+  if (left === null || left === undefined || right === null || right === undefined) {
+    return false;
+  }
+  return compareEventIds(left, right) === 0;
+}
+
+/** Projects a MIME register into optional typed metadata. */
+function contentMimeFromRegister(content: Register, mime: Register | null): ContentAttachmentMime | null {
+  if (mime === null || !isSameLineage(content.eventId, mime.eventId)) {
+    return null;
+  }
+  return contentMimeFromValue(mime.value);
+}
+
+/** Projects a raw MIME value into optional typed metadata. */
+function contentMimeFromValue(value: PropValue): ContentAttachmentMime | null {
+  if (!isProjectableMimeValue(value)) {
+    return null;
+  }
+  return new ContentAttachmentMime(value);
+}
+
+/** Projects a size register into optional typed metadata. */
+function contentSizeFromRegister(content: Register, size: Register | null): ContentAttachmentSize | null {
+  if (size === null || !isSameLineage(content.eventId, size.eventId)) {
+    return null;
+  }
+  return contentSizeFromValue(size.value);
+}
+
+/** Projects a raw size value into optional typed metadata. */
+function contentSizeFromValue(value: PropValue): ContentAttachmentSize | null {
+  if (!isProjectableSizeValue(value)) {
+    return null;
+  }
+  return new ContentAttachmentSize(value);
+}
+
+/** Returns true when a value can become attachment MIME metadata. */
+function isProjectableMimeValue(value: PropValue): value is string {
+  return typeof value === 'string' && value.length > 0 && !value.includes('\0');
+}
+
+/** Returns true when a value can become attachment size metadata. */
+function isProjectableSizeValue(value: PropValue): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+/** Compares content attachment records by deterministic owner order. */
+function compareContentAttachmentRecords(
+  left: ContentAttachmentRecord,
+  right: ContentAttachmentRecord,
+): number {
+  return compareStrings(contentAttachmentSortKey(left), contentAttachmentSortKey(right));
+}
+
+/** Returns the deterministic sort key for a content attachment record. */
+function contentAttachmentSortKey(record: ContentAttachmentRecord): string {
+  if (record.owner instanceof NodeRecord) {
+    return `node:${record.owner.id.toString()}`;
+  }
+  return `edge:${record.owner.id.toString()}`;
+}
+
+/** Compares protocol strings without locale-sensitive collation. */
+function compareStrings(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}

--- a/src/domain/services/ContentAttachmentProjection.ts
+++ b/src/domain/services/ContentAttachmentProjection.ts
@@ -3,6 +3,7 @@ import ContentAttachmentOid from '../graph/ContentAttachmentOid.ts';
 import ContentAttachmentPayload from '../graph/ContentAttachmentPayload.ts';
 import ContentAttachmentRecord from '../graph/ContentAttachmentRecord.ts';
 import ContentAttachmentSize from '../graph/ContentAttachmentSize.ts';
+import EdgeRecord from '../graph/EdgeRecord.ts';
 import NodeRecord from '../graph/NodeRecord.ts';
 import WarpError from '../errors/WarpError.ts';
 import {
@@ -16,11 +17,16 @@ import {
 import { compareEventIds, type EventId } from '../utils/EventId.ts';
 import WarpState from './state/WarpState.ts';
 import type { LWWRegister } from '../crdt/LWW.ts';
-import type EdgeRecord from '../graph/EdgeRecord.ts';
 import type { PropValue } from '../types/PropValue.ts';
 
 type Register = LWWRegister<PropValue>;
 type ContentRegister = Register & { readonly value: string };
+
+export type ContentAttachmentProjectionEdge = {
+  readonly from: string;
+  readonly to: string;
+  readonly label: string;
+};
 
 type ContentRegisters = {
   readonly content: ContentRegister;
@@ -49,6 +55,29 @@ export default class ContentAttachmentProjection {
     records.sort(compareContentAttachmentRecords);
     return Object.freeze(records);
   }
+
+  /** Returns the visible content attachment for one node, if present. */
+  static forNode(state: WarpState, nodeId: string): ContentAttachmentRecord | null {
+    const checkedState = requireWarpState(state);
+    const owner = checkedState.getNodeRecord(nodeId);
+    if (owner === null) {
+      return null;
+    }
+    return contentRecordForNode(checkedState, owner);
+  }
+
+  /** Returns the visible content attachment for one edge, if present. */
+  static forEdge(
+    state: WarpState,
+    edge: ContentAttachmentProjectionEdge,
+  ): ContentAttachmentRecord | null {
+    const checkedState = requireWarpState(state);
+    const owner = checkedState.getEdgeRecord(EdgeRecord.fromLegacyEdge(edge).id);
+    if (owner === null) {
+      return null;
+    }
+    return contentRecordForEdge(checkedState, owner);
+  }
 }
 
 /** Requires a runtime-backed WarpState projection source. */
@@ -63,7 +92,7 @@ function requireWarpState(state: WarpState): WarpState {
 function contentRecordForNode(state: WarpState, owner: NodeRecord): ContentAttachmentRecord | null {
   const nodeId = owner.id.toString();
   const content = state.prop.get(encodePropKey(nodeId, CONTENT_PROPERTY_KEY));
-  if (!isStringContentRegister(content)) {
+  if (!isProjectableContentRegister(content)) {
     return null;
   }
   return contentRecordFromRegisters(owner, {
@@ -84,7 +113,7 @@ function contentRecordForEdge(state: WarpState, owner: EdgeRecord): ContentAttac
     state.prop.get(encodeEdgePropKey(from, to, label, CONTENT_PROPERTY_KEY)),
     birthEvent,
   );
-  if (!isStringContentRegister(content)) {
+  if (!isProjectableContentRegister(content)) {
     return null;
   }
   return contentRecordFromRegisters(owner, {
@@ -116,8 +145,10 @@ function contentRecordFromRegisters(
 }
 
 /** Returns true when a register can supply a content storage reference. */
-function isStringContentRegister(register: Register | null | undefined): register is ContentRegister {
-  return register !== null && register !== undefined && typeof register.value === 'string';
+function isProjectableContentRegister(register: Register | null | undefined): register is ContentRegister {
+  return register !== null
+    && register !== undefined
+    && isProjectableContentOidValue(register.value);
 }
 
 /** Filters edge registers hidden by edge rebirth. */
@@ -176,6 +207,11 @@ function contentSizeFromValue(value: PropValue): ContentAttachmentSize | null {
 
 /** Returns true when a value can become attachment MIME metadata. */
 function isProjectableMimeValue(value: PropValue): value is string {
+  return typeof value === 'string' && value.length > 0 && !value.includes('\0');
+}
+
+/** Returns true when a value can become an attachment storage reference. */
+function isProjectableContentOidValue(value: PropValue): value is string {
   return typeof value === 'string' && value.length > 0 && !value.includes('\0');
 }
 

--- a/src/domain/services/ContentAttachmentProjection.ts
+++ b/src/domain/services/ContentAttachmentProjection.ts
@@ -167,10 +167,25 @@ function visibleEdgeRegister(
 
 /** Returns true when metadata belongs to the same content write lineage. */
 function isSameLineage(left: EventId | null | undefined, right: EventId | null | undefined): boolean {
-  if (left === null || left === undefined || right === null || right === undefined) {
+  if (!hasEventId(left)) {
     return false;
   }
-  return compareEventIds(left, right) === 0;
+  if (!hasEventId(right)) {
+    return false;
+  }
+  return isSamePatchIdentity(left, right);
+}
+
+/** Returns true when a nullable event slot carries an event id. */
+function hasEventId(eventId: EventId | null | undefined): eventId is EventId {
+  return eventId !== null && eventId !== undefined;
+}
+
+/** Returns true when two operations belong to the same patch identity. */
+function isSamePatchIdentity(left: EventId, right: EventId): boolean {
+  return left.lamport === right.lamport
+    && left.writerId === right.writerId
+    && left.patchSha === right.patchSha;
 }
 
 /** Projects a MIME register into optional typed metadata. */

--- a/src/domain/services/PatchBuilder.ts
+++ b/src/domain/services/PatchBuilder.ts
@@ -17,6 +17,11 @@ import EdgeAdd from '../types/ops/EdgeAdd.ts';
 import EdgeRemove from '../types/ops/EdgeRemove.ts';
 import NodePropSet from '../types/ops/NodePropSet.ts';
 import EdgePropSet from '../types/ops/EdgePropSet.ts';
+import ContentAttachmentMime from '../graph/ContentAttachmentMime.ts';
+import ContentAttachmentOid from '../graph/ContentAttachmentOid.ts';
+import ContentAttachmentPayload from '../graph/ContentAttachmentPayload.ts';
+import ContentAttachmentSize from '../graph/ContentAttachmentSize.ts';
+import ContentAttachmentWriteIntent from '../graph/ContentAttachmentWriteIntent.ts';
 import type { OpV2, CanonicalOpV2 } from '../types/ops/unions.ts';
 import { encodeEdgeKey, CONTENT_PROPERTY_KEY, CONTENT_MIME_PROPERTY_KEY, CONTENT_SIZE_PROPERTY_KEY, EFFECT_NODE_PREFIX } from './KeyCodec.ts';
 import { lowerCanonicalOp } from './OpNormalizer.ts';
@@ -35,7 +40,11 @@ import type RefPort from '../../ports/RefPort.ts';
 import type PatchJournalPort from '../../ports/PatchJournalPort.ts';
 import type LoggerPort from '../../ports/LoggerPort.ts';
 import type BlobStoragePort from '../../ports/BlobStoragePort.ts';
+import type { BlobStorageOptions } from '../../ports/BlobStoragePort.ts';
 import type CommitMessageCodecPort from '../../ports/CommitMessageCodecPort.ts';
+
+type ContentInput = AsyncIterable<Uint8Array> | ReadableStream<Uint8Array> | Uint8Array | string;
+type ContentMetadataInput = { mime?: string | null; size?: number | null };
 
 type PersistencePorts = CommitPort & BlobPort & TreePort & RefPort;
 type DeletePolicy = 'reject' | 'cascade' | 'warn';
@@ -255,8 +264,8 @@ export class PatchBuilder {
 
   async attachContent(
     nodeId: string,
-    content: AsyncIterable<Uint8Array> | ReadableStream<Uint8Array> | Uint8Array | string,
-    metadata?: { mime?: string | null; size?: number | null },
+    content: ContentInput,
+    metadata?: ContentMetadataInput,
   ): Promise<PatchBuilder> {
     this._assertNotCommitted();
     assertNoReservedBytes(nodeId, 'nodeId');
@@ -266,24 +275,10 @@ export class PatchBuilder {
       throw new WriterError('NO_BLOB_STORAGE', 'Cannot attach content without blob storage — inject blobStorage via open() or use InMemoryBlobStorageAdapter');
     }
     const slug = `${this._graphName}/${nodeId}`;
-    let oid: string;
-    let mime: string | null;
-    let size: number | null;
-    if (isStreamingInput(content)) {
-      mime = metadata?.mime ?? null;
-      size = metadata?.size ?? null;
-      oid = await this._blobStorage.storeStream(normalizeToAsyncIterable(content), { slug, mime, size });
-    } else {
-      const buffered = content as Uint8Array | string;
-      const normalizedMeta = normalizeContentMetadata(buffered, metadata);
-      mime = normalizedMeta.mime;
-      size = normalizedMeta.size;
-      oid = await this._blobStorage.store(buffered, { slug, mime, size });
-    }
-    this.setProperty(nodeId, CONTENT_PROPERTY_KEY, oid);
-    this.setProperty(nodeId, CONTENT_SIZE_PROPERTY_KEY, size);
-    this.setProperty(nodeId, CONTENT_MIME_PROPERTY_KEY, mime);
-    this._contentBlobs.push(oid);
+    const payload = await storeContentAttachmentPayload(this._blobStorage, content, metadata, slug);
+    const intent = ContentAttachmentWriteIntent.forNode(nodeId, payload);
+    this._lowerNodeContentIntent(intent);
+    this._contentBlobs.push(intent.oid());
     return this;
   }
 
@@ -300,8 +295,8 @@ export class PatchBuilder {
 
   async attachEdgeContent(
     from: string, to: string, label: string,
-    content: AsyncIterable<Uint8Array> | ReadableStream<Uint8Array> | Uint8Array | string,
-    metadata?: { mime?: string | null; size?: number | null },
+    content: ContentInput,
+    metadata?: ContentMetadataInput,
   ): Promise<PatchBuilder> {
     this._assertNotCommitted();
     assertNoReservedBytes(from, 'from');
@@ -313,24 +308,10 @@ export class PatchBuilder {
       throw new WriterError('NO_BLOB_STORAGE', 'Cannot attach content without blob storage — inject blobStorage via open() or use InMemoryBlobStorageAdapter');
     }
     const slug = `${this._graphName}/${from}/${to}/${label}`;
-    let oid: string;
-    let mime: string | null;
-    let size: number | null;
-    if (isStreamingInput(content)) {
-      mime = metadata?.mime ?? null;
-      size = metadata?.size ?? null;
-      oid = await this._blobStorage.storeStream(normalizeToAsyncIterable(content), { slug, mime, size });
-    } else {
-      const buffered = content as Uint8Array | string;
-      const normalizedMeta = normalizeContentMetadata(buffered, metadata);
-      mime = normalizedMeta.mime;
-      size = normalizedMeta.size;
-      oid = await this._blobStorage.store(buffered, { slug, mime, size });
-    }
-    this.setEdgeProperty(from, to, label, CONTENT_PROPERTY_KEY, oid);
-    this.setEdgeProperty(from, to, label, CONTENT_SIZE_PROPERTY_KEY, size);
-    this.setEdgeProperty(from, to, label, CONTENT_MIME_PROPERTY_KEY, mime);
-    this._contentBlobs.push(oid);
+    const payload = await storeContentAttachmentPayload(this._blobStorage, content, metadata, slug);
+    const intent = ContentAttachmentWriteIntent.forEdge({ from, to, label }, payload);
+    this._lowerEdgeContentIntent(intent);
+    this._contentBlobs.push(intent.oid());
     return this;
   }
 
@@ -345,6 +326,20 @@ export class PatchBuilder {
     this.setEdgeProperty(from, to, label, CONTENT_SIZE_PROPERTY_KEY, null);
     this.setEdgeProperty(from, to, label, CONTENT_MIME_PROPERTY_KEY, null);
     return this;
+  }
+
+  private _lowerNodeContentIntent(intent: ContentAttachmentWriteIntent): void {
+    const nodeId = intent.nodeId();
+    this.setProperty(nodeId, CONTENT_PROPERTY_KEY, intent.oid());
+    this.setProperty(nodeId, CONTENT_SIZE_PROPERTY_KEY, intent.size());
+    this.setProperty(nodeId, CONTENT_MIME_PROPERTY_KEY, intent.mime());
+  }
+
+  private _lowerEdgeContentIntent(intent: ContentAttachmentWriteIntent): void {
+    const target = intent.edgeTarget();
+    this.setEdgeProperty(target.from, target.to, target.label, CONTENT_PROPERTY_KEY, intent.oid());
+    this.setEdgeProperty(target.from, target.to, target.label, CONTENT_SIZE_PROPERTY_KEY, intent.size());
+    this.setEdgeProperty(target.from, target.to, target.label, CONTENT_MIME_PROPERTY_KEY, intent.mime());
   }
 
   // ── Existence guards ───────────────────────────────────────────────
@@ -432,4 +427,61 @@ export class PatchBuilder {
    * snapshot of blob OIDs to persist alongside the patch entry.
    */
   get contentBlobs(): readonly string[] { return [...this._contentBlobs]; }
+}
+
+async function storeContentAttachmentPayload(
+  blobStorage: BlobStoragePort,
+  content: ContentInput,
+  metadata: ContentMetadataInput | undefined,
+  slug: string,
+): Promise<ContentAttachmentPayload> {
+  if (isBufferedContent(content)) {
+    const normalizedMeta = normalizeContentMetadata(content, metadata);
+    const options = contentStorageOptions(slug, normalizedMeta.mime, normalizedMeta.size);
+    const oid = await blobStorage.store(content, options);
+    return contentAttachmentPayload(oid, normalizedMeta.mime, normalizedMeta.size);
+  }
+  const mime = metadata?.mime ?? null;
+  const size = metadata?.size ?? null;
+  const typedMime = contentAttachmentMime(mime);
+  const typedSize = contentAttachmentSize(size);
+  const options = contentStorageOptions(slug, typedMime?.toString() ?? null, typedSize?.toNumber() ?? null);
+  const oid = await blobStorage.storeStream(normalizeToAsyncIterable(content), options);
+  return new ContentAttachmentPayload({
+    oid: new ContentAttachmentOid(oid),
+    mime: typedMime,
+    size: typedSize,
+  });
+}
+
+function isBufferedContent(content: ContentInput): content is Uint8Array | string {
+  return !isStreamingInput(content);
+}
+
+function contentAttachmentPayload(
+  oid: string,
+  mime: string | null,
+  size: number | null,
+): ContentAttachmentPayload {
+  return new ContentAttachmentPayload({
+    oid: new ContentAttachmentOid(oid),
+    mime: contentAttachmentMime(mime),
+    size: contentAttachmentSize(size),
+  });
+}
+
+function contentAttachmentMime(mime: string | null): ContentAttachmentMime | null {
+  return mime === null ? null : new ContentAttachmentMime(mime);
+}
+
+function contentAttachmentSize(size: number | null): ContentAttachmentSize | null {
+  return size === null ? null : new ContentAttachmentSize(size);
+}
+
+function contentStorageOptions(
+  slug: string,
+  mime: string | null,
+  size: number | null,
+): BlobStorageOptions {
+  return { slug, mime, size };
 }

--- a/src/domain/services/controllers/QueryContent.ts
+++ b/src/domain/services/controllers/QueryContent.ts
@@ -5,37 +5,16 @@
  * CRDT state and resolving blob bytes from storage.
  */
 
-import {
-  encodePropKey,
-  encodeEdgePropKey,
-  encodeEdgeKey,
-  CONTENT_PROPERTY_KEY,
-  CONTENT_MIME_PROPERTY_KEY,
-  CONTENT_SIZE_PROPERTY_KEY,
-} from '../KeyCodec.ts';
-import { compareEventIds, type EventId } from '../../utils/EventId.ts';
+import ContentAttachmentProjection from '../ContentAttachmentProjection.ts';
 import QueryError from '../../errors/QueryError.ts';
+import type ContentAttachmentRecord from '../../graph/ContentAttachmentRecord.ts';
+import type { ContentMeta } from '../../types/ContentMeta.ts';
 import type WarpState from '../state/WarpState.ts';
-import type { PropValue } from '../../types/PropValue.ts';
 import type { QueryContentHost } from './ReadGraphHost.ts';
 
 // ── Types ───────────────────────────────────────────────────────────
 
-type Register = {
-  eventId: EventId | null;
-  value: PropValue;
-};
-
-type ContentRegister = {
-  eventId: EventId | null;
-  value: string;
-};
-
-type ContentRegisters = {
-  contentRegister: ContentRegister;
-  mimeRegister: Register | null;
-  sizeRegister: Register | null;
-};
+export type { ContentMeta };
 
 /** Identifies an edge by its three-part key. */
 export type EdgeId = {
@@ -44,109 +23,26 @@ export type EdgeId = {
   label: string;
 };
 
-/** Content metadata for a node or edge attachment. */
-export type ContentMeta = {
-  oid: string;
-  mime: string | null;
-  size: number | null;
-};
+// ── Content attachment projection ───────────────────────────────────
 
-// ── Lineage check ───────────────────────────────────────────────────
-
-function isSameLineage(a: EventId | null | undefined, b: EventId | null | undefined): boolean {
-  if (!a || !b) { return false; }
-  return a.lamport === b.lamport && a.writerId === b.writerId && a.patchSha === b.patchSha;
-}
-
-// ── Edge register visibility ────────────────────────────────────────
-
-function visibleRegister(register: Register | undefined, birthEvent: EventId | undefined): Register | null {
-  if (!register) { return null; }
-  if (birthEvent && register.eventId && compareEventIds(register.eventId, birthEvent) < 0) {
-    return null;
-  }
-  return register;
-}
-
-// ── Node content registers ──────────────────────────────────────────
-
-function nodeContentRegister(state: WarpState, nodeId: string): ContentRegister | null {
-  if (!state.nodeAlive.contains(nodeId)) { return null; }
-  const reg = state.prop.get(encodePropKey(nodeId, CONTENT_PROPERTY_KEY));
-  if (!reg || typeof reg.value !== 'string') { return null; }
-  return reg as ContentRegister;
-}
-
-export function getNodeContentRegisters(state: WarpState, nodeId: string): ContentRegisters | null {
-  const content = nodeContentRegister(state, nodeId);
-  if (!content) { return null; }
+function contentMetaFromRecord(record: ContentAttachmentRecord): ContentMeta {
   return {
-    contentRegister: content,
-    mimeRegister: state.prop.get(encodePropKey(nodeId, CONTENT_MIME_PROPERTY_KEY)) ?? null,
-    sizeRegister: state.prop.get(encodePropKey(nodeId, CONTENT_SIZE_PROPERTY_KEY)) ?? null,
+    oid: record.payload.oid.toString(),
+    mime: record.payload.mime?.toString() ?? null,
+    size: record.payload.size?.toNumber() ?? null,
   };
 }
 
-// ── Edge content registers ──────────────────────────────────────────
-
-function edgeAliveWithEndpoints(state: WarpState, edge: EdgeId): string | null {
-  const edgeKey = encodeEdgeKey(edge.from, edge.to, edge.label);
-  if (!state.edgeAlive.contains(edgeKey)) { return null; }
-  if (!state.nodeAlive.contains(edge.from)) { return null; }
-  if (!state.nodeAlive.contains(edge.to)) { return null; }
-  return edgeKey;
+function contentOidFromRecord(record: ContentAttachmentRecord): string {
+  return record.payload.oid.toString();
 }
 
-function edgeContentRegister(state: WarpState, edge: EdgeId, edgeKey: string): ContentRegister | null {
-  const birthEvent = state.edgeBirthEvent?.get(edgeKey);
-  const reg = visibleRegister(
-    state.prop.get(encodeEdgePropKey(edge.from, edge.to, edge.label, CONTENT_PROPERTY_KEY)),
-    birthEvent,
-  );
-  if (!reg || typeof reg.value !== 'string') { return null; }
-  return reg as ContentRegister;
+function nodeContentAttachment(state: WarpState, nodeId: string): ContentAttachmentRecord | null {
+  return ContentAttachmentProjection.forNode(state, nodeId);
 }
 
-function edgeSiblingRegisters(state: WarpState, edge: EdgeId, edgeKey: string): { mime: Register | null; size: Register | null } {
-  const birthEvent = state.edgeBirthEvent?.get(edgeKey);
-  return {
-    mime: visibleRegister(state.prop.get(encodeEdgePropKey(edge.from, edge.to, edge.label, CONTENT_MIME_PROPERTY_KEY)), birthEvent),
-    size: visibleRegister(state.prop.get(encodeEdgePropKey(edge.from, edge.to, edge.label, CONTENT_SIZE_PROPERTY_KEY)), birthEvent),
-  };
-}
-
-export function getEdgeContentRegisters(state: WarpState, edge: EdgeId): ContentRegisters | null {
-  const edgeKey = edgeAliveWithEndpoints(state, edge);
-  if (edgeKey === null) { return null; }
-  const content = edgeContentRegister(state, edge, edgeKey);
-  if (!content) { return null; }
-  const siblings = edgeSiblingRegisters(state, edge, edgeKey);
-  return { contentRegister: content, mimeRegister: siblings.mime, sizeRegister: siblings.size };
-}
-
-// ── Metadata extraction ─────────────────────────────────────────────
-
-function isValidSize(v: PropValue | undefined): v is number {
-  return typeof v === 'number' && Number.isInteger(v) && v >= 0;
-}
-
-function extractSize(contentReg: ContentRegister, sizeReg: Register | null): number | null {
-  if (!isSameLineage(contentReg.eventId, sizeReg?.eventId)) { return null; }
-  return isValidSize(sizeReg?.value) ? sizeReg.value : null;
-}
-
-function extractMime(contentReg: ContentRegister, mimeReg: Register | null): string | null {
-  if (!isSameLineage(contentReg.eventId, mimeReg?.eventId)) { return null; }
-  const v = mimeReg?.value;
-  return typeof v === 'string' ? v : null;
-}
-
-export function extractContentMeta(regs: ContentRegisters): ContentMeta {
-  return {
-    oid: regs.contentRegister.value,
-    mime: extractMime(regs.contentRegister, regs.mimeRegister),
-    size: extractSize(regs.contentRegister, regs.sizeRegister),
-  };
+function edgeContentAttachment(state: WarpState, edge: EdgeId): ContentAttachmentRecord | null {
+  return ContentAttachmentProjection.forEdge(state, edge);
 }
 
 // ── Blob resolution ─────────────────────────────────────────────────
@@ -192,58 +88,60 @@ async function ensureAndGetState(host: QueryContentHost): Promise<WarpState> {
 
 export async function getContentOidImpl(host: QueryContentHost, nodeId: string): Promise<string | null> {
   const state = await ensureAndGetState(host);
-  const regs = getNodeContentRegisters(state, nodeId);
-  return regs?.contentRegister.value ?? null;
+  const record = nodeContentAttachment(state, nodeId);
+  return record === null ? null : contentOidFromRecord(record);
 }
 
 export async function getContentMetaImpl(host: QueryContentHost, nodeId: string): Promise<ContentMeta | null> {
   const state = await ensureAndGetState(host);
-  const regs = getNodeContentRegisters(state, nodeId);
-  return regs ? extractContentMeta(regs) : null;
+  const record = nodeContentAttachment(state, nodeId);
+  return record === null ? null : contentMetaFromRecord(record);
 }
 
 export async function getContentImpl(host: QueryContentHost, nodeId: string): Promise<Uint8Array | null> {
   const state = await ensureAndGetState(host);
-  const regs = getNodeContentRegisters(state, nodeId);
-  if (!regs) { return null; }
-  return await resolveBlob(host, regs.contentRegister.value);
+  const record = nodeContentAttachment(state, nodeId);
+  if (record === null) { return null; }
+  return await resolveBlob(host, contentOidFromRecord(record));
 }
 
 export async function getContentStreamImpl(host: QueryContentHost, nodeId: string): Promise<AsyncIterable<Uint8Array> | null> {
   const state = await ensureAndGetState(host);
-  const regs = getNodeContentRegisters(state, nodeId);
-  if (!regs) { return null; }
-  const stream = resolveBlobStream(host, regs.contentRegister.value);
+  const record = nodeContentAttachment(state, nodeId);
+  if (record === null) { return null; }
+  const oid = contentOidFromRecord(record);
+  const stream = resolveBlobStream(host, oid);
   if (stream) { return stream; }
-  return singleChunkIterable(await resolveBlob(host, regs.contentRegister.value));
+  return singleChunkIterable(await resolveBlob(host, oid));
 }
 
 // ── Host-dependent edge content ─────────────────────────────────────
 
 export async function getEdgeContentOidImpl(host: QueryContentHost, edge: EdgeId): Promise<string | null> {
   const state = await ensureAndGetState(host);
-  const regs = getEdgeContentRegisters(state, edge);
-  return regs?.contentRegister.value ?? null;
+  const record = edgeContentAttachment(state, edge);
+  return record === null ? null : contentOidFromRecord(record);
 }
 
 export async function getEdgeContentMetaImpl(host: QueryContentHost, edge: EdgeId): Promise<ContentMeta | null> {
   const state = await ensureAndGetState(host);
-  const regs = getEdgeContentRegisters(state, edge);
-  return regs ? extractContentMeta(regs) : null;
+  const record = edgeContentAttachment(state, edge);
+  return record === null ? null : contentMetaFromRecord(record);
 }
 
 export async function getEdgeContentImpl(host: QueryContentHost, edge: EdgeId): Promise<Uint8Array | null> {
   const state = await ensureAndGetState(host);
-  const regs = getEdgeContentRegisters(state, edge);
-  if (!regs) { return null; }
-  return await resolveBlob(host, regs.contentRegister.value);
+  const record = edgeContentAttachment(state, edge);
+  if (record === null) { return null; }
+  return await resolveBlob(host, contentOidFromRecord(record));
 }
 
 export async function getEdgeContentStreamImpl(host: QueryContentHost, edge: EdgeId): Promise<AsyncIterable<Uint8Array> | null> {
   const state = await ensureAndGetState(host);
-  const regs = getEdgeContentRegisters(state, edge);
-  if (!regs) { return null; }
-  const stream = resolveBlobStream(host, regs.contentRegister.value);
+  const record = edgeContentAttachment(state, edge);
+  if (record === null) { return null; }
+  const oid = contentOidFromRecord(record);
+  const stream = resolveBlobStream(host, oid);
   if (stream) { return stream; }
-  return singleChunkIterable(await resolveBlob(host, regs.contentRegister.value));
+  return singleChunkIterable(await resolveBlob(host, oid));
 }

--- a/test/unit/domain/graph/ContentAttachmentPayload.test.ts
+++ b/test/unit/domain/graph/ContentAttachmentPayload.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import ContentAttachmentMime from '../../../../src/domain/graph/ContentAttachmentMime.ts';
+import ContentAttachmentOid from '../../../../src/domain/graph/ContentAttachmentOid.ts';
+import ContentAttachmentPayload from '../../../../src/domain/graph/ContentAttachmentPayload.ts';
+import ContentAttachmentSize from '../../../../src/domain/graph/ContentAttachmentSize.ts';
+import WarpError from '../../../../src/domain/errors/WarpError.ts';
+
+describe('ContentAttachmentPayload graph substrate nouns', () => {
+  it('validates content OIDs as runtime-backed attachment references', () => {
+    const oid = new ContentAttachmentOid('abc123');
+
+    expect(oid.toString()).toBe('abc123');
+    expect(oid.equals(new ContentAttachmentOid('abc123'))).toBe(true);
+    expect(oid.equals(new ContentAttachmentOid('def456'))).toBe(false);
+    expect(oid.equals(null)).toBe(false);
+    expect(Object.isFrozen(oid)).toBe(true);
+    expect(() => new ContentAttachmentOid('')).toThrow(WarpError);
+    expect(() => new ContentAttachmentOid('bad\0oid')).toThrow(WarpError);
+  });
+
+  it('validates optional MIME hints as runtime-backed metadata', () => {
+    const mime = new ContentAttachmentMime('text/markdown');
+
+    expect(mime.toString()).toBe('text/markdown');
+    expect(mime.equals(new ContentAttachmentMime('text/markdown'))).toBe(true);
+    expect(mime.equals(new ContentAttachmentMime('text/plain'))).toBe(false);
+    expect(mime.equals(undefined)).toBe(false);
+    expect(Object.isFrozen(mime)).toBe(true);
+    expect(() => new ContentAttachmentMime('')).toThrow(WarpError);
+    expect(() => new ContentAttachmentMime('text/\0plain')).toThrow(WarpError);
+  });
+
+  it('validates content sizes as runtime-backed byte lengths', () => {
+    const size = new ContentAttachmentSize(42);
+
+    expect(size.toNumber()).toBe(42);
+    expect(size.equals(new ContentAttachmentSize(42))).toBe(true);
+    expect(size.equals(new ContentAttachmentSize(43))).toBe(false);
+    expect(size.equals(null)).toBe(false);
+    expect(Object.isFrozen(size)).toBe(true);
+    expect(() => new ContentAttachmentSize(-1)).toThrow(WarpError);
+    expect(() => new ContentAttachmentSize(1.5)).toThrow(WarpError);
+  });
+
+  it('represents typed content attachment payload metadata', () => {
+    const payload = new ContentAttachmentPayload({
+      oid: new ContentAttachmentOid('abc123'),
+      mime: new ContentAttachmentMime('text/markdown'),
+      size: new ContentAttachmentSize(42),
+    });
+
+    expect(payload.oid.toString()).toBe('abc123');
+    expect(payload.mime?.toString()).toBe('text/markdown');
+    expect(payload.size?.toNumber()).toBe(42);
+    expect(payload.hasMime()).toBe(true);
+    expect(payload.hasSize()).toBe(true);
+    expect(Object.isFrozen(payload)).toBe(true);
+  });
+
+  it('allows absent MIME and size metadata without losing the OID', () => {
+    const payload = new ContentAttachmentPayload({
+      oid: new ContentAttachmentOid('abc123'),
+      mime: null,
+      size: null,
+    });
+
+    expect(payload.oid.toString()).toBe('abc123');
+    expect(payload.mime).toBeNull();
+    expect(payload.size).toBeNull();
+    expect(payload.hasMime()).toBe(false);
+    expect(payload.hasSize()).toBe(false);
+  });
+
+  it('rejects fake payload envelopes', () => {
+    expect(() => {
+      // @ts-expect-error exercising runtime validation
+      new ContentAttachmentPayload(null);
+    }).toThrow(WarpError);
+    expect(() => {
+      new ContentAttachmentPayload({
+        // @ts-expect-error exercising runtime validation
+        oid: 'abc123',
+        mime: null,
+        size: null,
+      });
+    }).toThrow(WarpError);
+    expect(() => {
+      new ContentAttachmentPayload({
+        oid: new ContentAttachmentOid('abc123'),
+        // @ts-expect-error exercising runtime validation
+        mime: 'text/plain',
+        size: null,
+      });
+    }).toThrow(WarpError);
+    expect(() => {
+      new ContentAttachmentPayload({
+        oid: new ContentAttachmentOid('abc123'),
+        mime: null,
+        // @ts-expect-error exercising runtime validation
+        size: 42,
+      });
+    }).toThrow(WarpError);
+  });
+});

--- a/test/unit/domain/graph/ContentAttachmentRecord.test.ts
+++ b/test/unit/domain/graph/ContentAttachmentRecord.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import ContentAttachmentOid from '../../../../src/domain/graph/ContentAttachmentOid.ts';
+import ContentAttachmentPayload from '../../../../src/domain/graph/ContentAttachmentPayload.ts';
+import ContentAttachmentRecord from '../../../../src/domain/graph/ContentAttachmentRecord.ts';
+import EdgeRecord from '../../../../src/domain/graph/EdgeRecord.ts';
+import NodeRecord from '../../../../src/domain/graph/NodeRecord.ts';
+import WarpError from '../../../../src/domain/errors/WarpError.ts';
+
+describe('ContentAttachmentRecord graph substrate noun', () => {
+  it('binds a content payload to a node or edge attachment owner', () => {
+    const nodeOwner = NodeRecord.fromLegacyNodeId('doc:1');
+    const edgeOwner = EdgeRecord.fromLegacyEdge({ from: 'doc:1', to: 'doc:2', label: 'links' });
+    const payload = new ContentAttachmentPayload({
+      oid: new ContentAttachmentOid('abc123'),
+      mime: null,
+      size: null,
+    });
+    const nodeRecord = new ContentAttachmentRecord({ owner: nodeOwner, payload });
+    const edgeRecord = new ContentAttachmentRecord({ owner: edgeOwner, payload });
+
+    expect(nodeRecord.owner).toBe(nodeOwner);
+    expect(nodeRecord.payload).toBe(payload);
+    expect(nodeRecord.isNodeContent()).toBe(true);
+    expect(nodeRecord.isEdgeContent()).toBe(false);
+    expect(edgeRecord.isNodeContent()).toBe(false);
+    expect(edgeRecord.isEdgeContent()).toBe(true);
+    expect(Object.isFrozen(nodeRecord)).toBe(true);
+  });
+
+  it('rejects fake content attachment record envelopes', () => {
+    const owner = NodeRecord.fromLegacyNodeId('doc:1');
+    const payload = new ContentAttachmentPayload({
+      oid: new ContentAttachmentOid('abc123'),
+      mime: null,
+      size: null,
+    });
+
+    expect(() => {
+      // @ts-expect-error exercising runtime validation
+      new ContentAttachmentRecord(null);
+    }).toThrow(WarpError);
+    expect(() => {
+      new ContentAttachmentRecord({
+        // @ts-expect-error exercising runtime validation
+        owner: {},
+        payload,
+      });
+    }).toThrow(WarpError);
+    expect(() => {
+      new ContentAttachmentRecord({
+        owner,
+        // @ts-expect-error exercising runtime validation
+        payload: {},
+      });
+    }).toThrow(WarpError);
+  });
+});

--- a/test/unit/domain/graph/ContentAttachmentWriteIntent.test.ts
+++ b/test/unit/domain/graph/ContentAttachmentWriteIntent.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import ContentAttachmentMime from '../../../../src/domain/graph/ContentAttachmentMime.ts';
+import ContentAttachmentOid from '../../../../src/domain/graph/ContentAttachmentOid.ts';
+import ContentAttachmentPayload from '../../../../src/domain/graph/ContentAttachmentPayload.ts';
+import ContentAttachmentSize from '../../../../src/domain/graph/ContentAttachmentSize.ts';
+import ContentAttachmentWriteIntent from '../../../../src/domain/graph/ContentAttachmentWriteIntent.ts';
+
+describe('ContentAttachmentWriteIntent graph substrate noun', () => {
+  it('binds a typed content payload to a node write target', () => {
+    const intent = ContentAttachmentWriteIntent.forNode('doc:1', payload());
+
+    expect(intent.nodeId()).toBe('doc:1');
+    expect(intent.oid()).toBe('content-oid');
+    expect(intent.mime()).toBe('text/plain');
+    expect(intent.size()).toBe(12);
+  });
+
+  it('binds a typed content payload to an edge write target', () => {
+    const intent = ContentAttachmentWriteIntent.forEdge({
+      from: 'doc:1',
+      to: 'doc:2',
+      label: 'links',
+    }, payload());
+
+    expect(intent.edgeTarget()).toEqual({
+      from: 'doc:1',
+      to: 'doc:2',
+      label: 'links',
+    });
+    expect(intent.oid()).toBe('content-oid');
+  });
+
+  it('rejects reading a node target from an edge write intent', () => {
+    const intent = ContentAttachmentWriteIntent.forEdge({
+      from: 'doc:1',
+      to: 'doc:2',
+      label: 'links',
+    }, payload());
+
+    expect(() => intent.nodeId()).toThrow(/node content target/);
+  });
+});
+
+function payload(): ContentAttachmentPayload {
+  return new ContentAttachmentPayload({
+    oid: new ContentAttachmentOid('content-oid'),
+    mime: new ContentAttachmentMime('text/plain'),
+    size: new ContentAttachmentSize(12),
+  });
+}

--- a/test/unit/domain/index.exports.test.ts
+++ b/test/unit/domain/index.exports.test.ts
@@ -19,6 +19,8 @@ import WarpAppDefault, {
   ContentAttachmentMime,
   ContentAttachmentOid,
   ContentAttachmentPayload,
+  ContentAttachmentProjection,
+  ContentAttachmentRecord,
   ContentAttachmentSize,
   EdgeId,
   EdgeRecord,
@@ -184,6 +186,10 @@ describe('index.ts exports', () => {
       expect(typeof ContentAttachmentOid).toBe('function');
       expect(ContentAttachmentPayload).toBeDefined();
       expect(typeof ContentAttachmentPayload).toBe('function');
+      expect(ContentAttachmentProjection).toBeDefined();
+      expect(typeof ContentAttachmentProjection).toBe('function');
+      expect(ContentAttachmentRecord).toBeDefined();
+      expect(typeof ContentAttachmentRecord).toBe('function');
       expect(ContentAttachmentSize).toBeDefined();
       expect(typeof ContentAttachmentSize).toBe('function');
     });

--- a/test/unit/domain/index.exports.test.ts
+++ b/test/unit/domain/index.exports.test.ts
@@ -22,6 +22,7 @@ import WarpAppDefault, {
   ContentAttachmentProjection,
   ContentAttachmentRecord,
   ContentAttachmentSize,
+  ContentAttachmentWriteIntent,
   EdgeId,
   EdgeRecord,
   EdgeTypeId,
@@ -192,6 +193,8 @@ describe('index.ts exports', () => {
       expect(typeof ContentAttachmentRecord).toBe('function');
       expect(ContentAttachmentSize).toBeDefined();
       expect(typeof ContentAttachmentSize).toBe('function');
+      expect(ContentAttachmentWriteIntent).toBeDefined();
+      expect(typeof ContentAttachmentWriteIntent).toBe('function');
     });
 
     it('exports graph-op algebra substrate nouns', () => {

--- a/test/unit/domain/index.exports.test.ts
+++ b/test/unit/domain/index.exports.test.ts
@@ -16,6 +16,10 @@ import WarpAppDefault, {
   AttachmentKey,
   AttachmentRecord,
   AttachmentSchemaVersion,
+  ContentAttachmentMime,
+  ContentAttachmentOid,
+  ContentAttachmentPayload,
+  ContentAttachmentSize,
   EdgeId,
   EdgeRecord,
   EdgeTypeId,
@@ -171,6 +175,17 @@ describe('index.ts exports', () => {
       expect(typeof AttachmentRecord).toBe('function');
       expect(AttachmentSchemaVersion).toBeDefined();
       expect(typeof AttachmentSchemaVersion).toBe('function');
+    });
+
+    it('exports content attachment payload nouns', () => {
+      expect(ContentAttachmentMime).toBeDefined();
+      expect(typeof ContentAttachmentMime).toBe('function');
+      expect(ContentAttachmentOid).toBeDefined();
+      expect(typeof ContentAttachmentOid).toBe('function');
+      expect(ContentAttachmentPayload).toBeDefined();
+      expect(typeof ContentAttachmentPayload).toBe('function');
+      expect(ContentAttachmentSize).toBeDefined();
+      expect(typeof ContentAttachmentSize).toBe('function');
     });
 
     it('exports graph-op algebra substrate nouns', () => {

--- a/test/unit/domain/services/ContentAttachmentProjection.test.ts
+++ b/test/unit/domain/services/ContentAttachmentProjection.test.ts
@@ -94,6 +94,27 @@ describe('ContentAttachmentProjection', () => {
     ]);
   });
 
+  it('keeps metadata from the same patch lineage with different operation indexes', () => {
+    const state = WarpState.empty();
+    state.nodeAlive.add('doc:1', Dot.create('writer-a', 1));
+    state.prop.set(encodePropKey('doc:1', CONTENT_PROPERTY_KEY), {
+      eventId: event(2, 0),
+      value: 'same-patch-oid',
+    });
+    state.prop.set(encodePropKey('doc:1', CONTENT_MIME_PROPERTY_KEY), {
+      eventId: event(2, 1),
+      value: 'text/plain',
+    });
+    state.prop.set(encodePropKey('doc:1', CONTENT_SIZE_PROPERTY_KEY), {
+      eventId: event(2, 2),
+      value: 14,
+    });
+
+    expect(ContentAttachmentProjection.fromState(state).map(describeContent)).toEqual([
+      'node:doc:1:same-patch-oid:text/plain:14',
+    ]);
+  });
+
   it('does not project absent, malformed, or non-string legacy content OIDs', () => {
     const state = WarpState.empty();
     state.nodeAlive.add('doc:1', Dot.create('writer-a', 1));
@@ -129,6 +150,6 @@ function describeContent(record: ContentAttachmentRecord | null): string {
   return 'unknown';
 }
 
-function event(lamport: number): EventId {
-  return new EventId(lamport, 'writer-a', PATCH_SHA, 0);
+function event(lamport: number, opIndex = 0): EventId {
+  return new EventId(lamport, 'writer-a', PATCH_SHA, opIndex);
 }

--- a/test/unit/domain/services/ContentAttachmentProjection.test.ts
+++ b/test/unit/domain/services/ContentAttachmentProjection.test.ts
@@ -48,6 +48,31 @@ describe('ContentAttachmentProjection', () => {
     expect(Object.isFrozen(records)).toBe(true);
   });
 
+  it('finds targeted node and edge content records without full projection callers', () => {
+    const state = WarpState.empty();
+    state.nodeAlive.add('doc:1', Dot.create('writer-a', 1));
+    state.nodeAlive.add('doc:2', Dot.create('writer-a', 2));
+    state.edgeAlive.add(encodeEdgeKey('doc:1', 'doc:2', 'links'), Dot.create('writer-a', 3));
+    const nodeEvent = event(4);
+    const edgeEvent = event(5);
+    state.prop.set(encodePropKey('doc:1', CONTENT_PROPERTY_KEY), { eventId: nodeEvent, value: 'node-oid' });
+    state.prop.set(encodeEdgePropKey('doc:1', 'doc:2', 'links', CONTENT_PROPERTY_KEY), {
+      eventId: edgeEvent,
+      value: 'edge-oid',
+    });
+
+    expect(describeContent(ContentAttachmentProjection.forNode(state, 'doc:1')))
+      .toBe('node:doc:1:node-oid:null:null');
+    expect(describeContent(ContentAttachmentProjection.forEdge(state, {
+      from: 'doc:1',
+      to: 'doc:2',
+      label: 'links',
+    }))).toBe(
+      'edge:legacy-edge:5:doc:1:5:doc:2:5:links:edge-oid:null:null',
+    );
+    expect(ContentAttachmentProjection.forNode(state, 'missing')).toBeNull();
+  });
+
   it('ignores stale metadata from earlier content lineages', () => {
     const state = WarpState.empty();
     state.nodeAlive.add('doc:1', Dot.create('writer-a', 1));
@@ -69,11 +94,14 @@ describe('ContentAttachmentProjection', () => {
     ]);
   });
 
-  it('does not project absent or non-string legacy content OIDs', () => {
+  it('does not project absent, malformed, or non-string legacy content OIDs', () => {
     const state = WarpState.empty();
     state.nodeAlive.add('doc:1', Dot.create('writer-a', 1));
     state.nodeAlive.add('doc:2', Dot.create('writer-a', 2));
+    state.nodeAlive.add('doc:3', Dot.create('writer-a', 3));
     state.prop.set(encodePropKey('doc:1', CONTENT_PROPERTY_KEY), { eventId: event(2), value: 123 });
+    state.prop.set(encodePropKey('doc:2', CONTENT_PROPERTY_KEY), { eventId: event(3), value: '' });
+    state.prop.set(encodePropKey('doc:3', CONTENT_PROPERTY_KEY), { eventId: event(4), value: 'bad\0oid' });
 
     expect(ContentAttachmentProjection.fromState(state)).toEqual([]);
   });
@@ -86,7 +114,10 @@ describe('ContentAttachmentProjection', () => {
   });
 });
 
-function describeContent(record: ContentAttachmentRecord): string {
+function describeContent(record: ContentAttachmentRecord | null): string {
+  if (record === null) {
+    return 'null';
+  }
   const mime = record.payload.mime?.toString() ?? 'null';
   const size = record.payload.size?.toNumber() ?? 'null';
   if (record.owner instanceof NodeRecord) {

--- a/test/unit/domain/services/ContentAttachmentProjection.test.ts
+++ b/test/unit/domain/services/ContentAttachmentProjection.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { Dot } from '../../../../src/domain/crdt/Dot.ts';
+import ContentAttachmentRecord from '../../../../src/domain/graph/ContentAttachmentRecord.ts';
+import EdgeRecord from '../../../../src/domain/graph/EdgeRecord.ts';
+import NodeRecord from '../../../../src/domain/graph/NodeRecord.ts';
+import ContentAttachmentProjection from '../../../../src/domain/services/ContentAttachmentProjection.ts';
+import {
+  CONTENT_MIME_PROPERTY_KEY,
+  CONTENT_PROPERTY_KEY,
+  CONTENT_SIZE_PROPERTY_KEY,
+  encodeEdgeKey,
+  encodeEdgePropKey,
+  encodePropKey,
+} from '../../../../src/domain/services/KeyCodec.ts';
+import WarpState from '../../../../src/domain/services/state/WarpState.ts';
+import { EventId } from '../../../../src/domain/utils/EventId.ts';
+
+const PATCH_SHA = 'c'.repeat(40);
+
+describe('ContentAttachmentProjection', () => {
+  it('projects legacy node and edge content attachments into typed records', () => {
+    const state = WarpState.empty();
+    state.nodeAlive.add('doc:1', Dot.create('writer-a', 1));
+    state.nodeAlive.add('doc:2', Dot.create('writer-a', 2));
+    state.edgeAlive.add(encodeEdgeKey('doc:1', 'doc:2', 'links'), Dot.create('writer-a', 3));
+    const nodeEvent = event(4);
+    const edgeEvent = event(5);
+    state.prop.set(encodePropKey('doc:1', CONTENT_PROPERTY_KEY), { eventId: nodeEvent, value: 'node-oid' });
+    state.prop.set(encodePropKey('doc:1', CONTENT_MIME_PROPERTY_KEY), { eventId: nodeEvent, value: 'text/markdown' });
+    state.prop.set(encodePropKey('doc:1', CONTENT_SIZE_PROPERTY_KEY), { eventId: nodeEvent, value: 42 });
+    state.prop.set(encodeEdgePropKey('doc:1', 'doc:2', 'links', CONTENT_PROPERTY_KEY), {
+      eventId: edgeEvent,
+      value: 'edge-oid',
+    });
+    state.prop.set(encodeEdgePropKey('doc:1', 'doc:2', 'links', CONTENT_SIZE_PROPERTY_KEY), {
+      eventId: edgeEvent,
+      value: 7,
+    });
+
+    const records = ContentAttachmentProjection.fromState(state);
+
+    expect(records.map(describeContent)).toEqual([
+      'edge:legacy-edge:5:doc:1:5:doc:2:5:links:edge-oid:null:7',
+      'node:doc:1:node-oid:text/markdown:42',
+    ]);
+    expect(records.every((record) => record instanceof ContentAttachmentRecord)).toBe(true);
+    expect(Object.isFrozen(records)).toBe(true);
+  });
+
+  it('ignores stale metadata from earlier content lineages', () => {
+    const state = WarpState.empty();
+    state.nodeAlive.add('doc:1', Dot.create('writer-a', 1));
+    state.prop.set(encodePropKey('doc:1', CONTENT_PROPERTY_KEY), {
+      eventId: event(3),
+      value: 'current-oid',
+    });
+    state.prop.set(encodePropKey('doc:1', CONTENT_MIME_PROPERTY_KEY), {
+      eventId: event(2),
+      value: 'text/plain',
+    });
+    state.prop.set(encodePropKey('doc:1', CONTENT_SIZE_PROPERTY_KEY), {
+      eventId: event(2),
+      value: 100,
+    });
+
+    expect(ContentAttachmentProjection.fromState(state).map(describeContent)).toEqual([
+      'node:doc:1:current-oid:null:null',
+    ]);
+  });
+
+  it('does not project absent or non-string legacy content OIDs', () => {
+    const state = WarpState.empty();
+    state.nodeAlive.add('doc:1', Dot.create('writer-a', 1));
+    state.nodeAlive.add('doc:2', Dot.create('writer-a', 2));
+    state.prop.set(encodePropKey('doc:1', CONTENT_PROPERTY_KEY), { eventId: event(2), value: 123 });
+
+    expect(ContentAttachmentProjection.fromState(state)).toEqual([]);
+  });
+
+  it('rejects fake state projection sources', () => {
+    expect(() => {
+      // @ts-expect-error exercising runtime validation
+      ContentAttachmentProjection.fromState({ nodeRecords: () => [] });
+    }).toThrow(/WarpState/);
+  });
+});
+
+function describeContent(record: ContentAttachmentRecord): string {
+  const mime = record.payload.mime?.toString() ?? 'null';
+  const size = record.payload.size?.toNumber() ?? 'null';
+  if (record.owner instanceof NodeRecord) {
+    return `node:${record.owner.id.toString()}:${record.payload.oid.toString()}:${mime}:${size}`;
+  }
+  if (record.owner instanceof EdgeRecord) {
+    return `edge:${record.owner.id.toString()}:${record.payload.oid.toString()}:${mime}:${size}`;
+  }
+  return 'unknown';
+}
+
+function event(lamport: number): EventId {
+  return new EventId(lamport, 'writer-a', PATCH_SHA, 0);
+}

--- a/test/unit/domain/services/PatchBuilderContentWriteIntent.test.ts
+++ b/test/unit/domain/services/PatchBuilderContentWriteIntent.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+
+import BlobPort from '../../../../src/ports/BlobPort.ts';
+import BlobStoragePort, { type BlobStorageOptions } from '../../../../src/ports/BlobStoragePort.ts';
+import CommitPort, {
+  type CommitLogChunk,
+  type CommitNodeOptions,
+  type CommitNodeWithTreeOptions,
+  type LogNodesOptions,
+  type NodeInfo,
+  type PingResult,
+} from '../../../../src/ports/CommitPort.ts';
+import RefPort, { type ListRefsOptions } from '../../../../src/ports/RefPort.ts';
+import TreePort from '../../../../src/ports/TreePort.ts';
+import { Dot } from '../../../../src/domain/crdt/Dot.ts';
+import VersionVector from '../../../../src/domain/crdt/VersionVector.ts';
+import WarpStream from '../../../../src/domain/stream/WarpStream.ts';
+import { PatchBuilder } from '../../../../src/domain/services/PatchBuilder.ts';
+import { encodeEdgeKey } from '../../../../src/domain/services/KeyCodec.ts';
+import WarpState from '../../../../src/domain/services/state/WarpState.ts';
+
+describe('PatchBuilder content write intent lowering', () => {
+  it('rejects malformed stored node content OIDs before lowering legacy properties', async () => {
+    const state = WarpState.empty();
+    state.nodeAlive.add('doc:1', Dot.create('writer-a', 1));
+    const builder = contentBuilder(state, new IntentBlobStorage(''));
+
+    await expect(builder.attachContent('doc:1', 'hello')).rejects.toThrow(/ContentAttachmentOid/);
+    expect(builder.build().ops).toEqual([]);
+  });
+
+  it('rejects malformed streamed edge MIME hints before lowering legacy properties', async () => {
+    const state = WarpState.empty();
+    state.edgeAlive.add(encodeEdgeKey('doc:1', 'doc:2', 'links'), Dot.create('writer-a', 1));
+    const blobStorage = new IntentBlobStorage('edge-oid');
+    const builder = contentBuilder(state, blobStorage);
+
+    await expect(
+      builder.attachEdgeContent('doc:1', 'doc:2', 'links', chunks(), { mime: '' }),
+    ).rejects.toThrow(/ContentAttachmentMime/);
+    expect(blobStorage.storeStreamCount()).toBe(0);
+    expect(builder.build().ops).toEqual([]);
+  });
+});
+
+function contentBuilder(state: WarpState, blobStorage: BlobStoragePort): PatchBuilder {
+  return new PatchBuilder({
+    persistence: new IntentPersistence(),
+    graphName: 'g',
+    writerId: 'writer-a',
+    lamport: 1,
+    versionVector: VersionVector.empty(),
+    getCurrentState: () => state,
+    blobStorage,
+  });
+}
+
+async function* chunks(): AsyncIterable<Uint8Array> {
+  yield new TextEncoder().encode('edge');
+}
+
+class IntentBlobStorage extends BlobStoragePort {
+  private readonly oid: string;
+  private storedStreamCount = 0;
+
+  constructor(oid: string) {
+    super();
+    this.oid = oid;
+  }
+
+  async store(
+    _content: Uint8Array | string,
+    _options?: BlobStorageOptions,
+  ): Promise<string> {
+    return this.oid;
+  }
+
+  async retrieve(_oid: string): Promise<Uint8Array> {
+    return new Uint8Array();
+  }
+
+  async storeStream(
+    _source: AsyncIterable<Uint8Array>,
+    _options?: BlobStorageOptions,
+  ): Promise<string> {
+    this.storedStreamCount += 1;
+    return this.oid;
+  }
+
+  retrieveStream(_oid: string): AsyncIterable<Uint8Array> {
+    return chunks();
+  }
+
+  storeStreamCount(): number {
+    return this.storedStreamCount;
+  }
+}
+
+class IntentPersistence extends CommitPort implements BlobPort, TreePort, RefPort {
+  readonly emptyTree = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+  async commitNode(_options: CommitNodeOptions): Promise<string> {
+    return 'c'.repeat(40);
+  }
+
+  async showNode(_sha: string): Promise<string> {
+    return '';
+  }
+
+  async getNodeInfo(_sha: string): Promise<NodeInfo> {
+    return {
+      sha: 'c'.repeat(40),
+      message: '',
+      author: '',
+      date: '',
+      parents: [],
+    };
+  }
+
+  async logNodes(_options: LogNodesOptions): Promise<string> {
+    return '';
+  }
+
+  async logNodesStream(_options: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
+    return WarpStream.from<CommitLogChunk>([]);
+  }
+
+  async countNodes(_ref: string): Promise<number> {
+    return 0;
+  }
+
+  async commitNodeWithTree(_options: CommitNodeWithTreeOptions): Promise<string> {
+    return 'c'.repeat(40);
+  }
+
+  async nodeExists(_sha: string): Promise<boolean> {
+    return false;
+  }
+
+  async getCommitTree(_sha: string): Promise<string> {
+    return this.emptyTree;
+  }
+
+  async ping(): Promise<PingResult> {
+    return { ok: true, latencyMs: 0 };
+  }
+
+  async writeBlob(_content: Uint8Array | string): Promise<string> {
+    return 'b'.repeat(40);
+  }
+
+  async readBlob(_oid: string): Promise<Uint8Array> {
+    return new Uint8Array();
+  }
+
+  async writeTree(_entries: string[]): Promise<string> {
+    return 't'.repeat(40);
+  }
+
+  async readTree(_treeOid: string): Promise<Record<string, Uint8Array>> {
+    return {};
+  }
+
+  async readTreeOids(_treeOid: string): Promise<Record<string, string>> {
+    return {};
+  }
+
+  async updateRef(_ref: string, _oid: string): Promise<void> {
+  }
+
+  async readRef(_ref: string): Promise<string | null> {
+    return null;
+  }
+
+  async deleteRef(_ref: string): Promise<void> {
+  }
+
+  async listRefs(_prefix: string, _options?: ListRefsOptions): Promise<string[]> {
+    return [];
+  }
+
+  async compareAndSwapRef(
+    _ref: string,
+    _newOid: string,
+    _expectedOid: string | null,
+  ): Promise<void> {
+  }
+}

--- a/test/unit/domain/services/controllers/QueryContentProjectionReads.test.ts
+++ b/test/unit/domain/services/controllers/QueryContentProjectionReads.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import ORSet from '../../../../../src/domain/crdt/ORSet.ts';
+import { Dot } from '../../../../../src/domain/crdt/Dot.ts';
+import VersionVector from '../../../../../src/domain/crdt/VersionVector.ts';
+import type { LWWRegister } from '../../../../../src/domain/crdt/LWW.ts';
+import type { QueryContentHost } from '../../../../../src/domain/services/controllers/ReadGraphHost.ts';
+import {
+  getContentMetaImpl,
+  getContentOidImpl,
+  getEdgeContentMetaImpl,
+  getEdgeContentOidImpl,
+} from '../../../../../src/domain/services/controllers/QueryContent.ts';
+import {
+  CONTENT_MIME_PROPERTY_KEY,
+  CONTENT_PROPERTY_KEY,
+  encodeEdgeKey,
+  encodeEdgePropKey,
+  encodePropKey,
+} from '../../../../../src/domain/services/KeyCodec.ts';
+import WarpState from '../../../../../src/domain/services/state/WarpState.ts';
+import { EventId } from '../../../../../src/domain/utils/EventId.ts';
+import type { PropValue } from '../../../../../src/domain/types/PropValue.ts';
+
+const PATCH_SHA = 'd'.repeat(40);
+
+type EdgeSpec = {
+  readonly from: string;
+  readonly to: string;
+  readonly label: string;
+};
+
+type NodePropSpec = {
+  readonly nodeId: string;
+  readonly key: string;
+  readonly value: PropValue;
+  readonly eventId: EventId;
+};
+
+type EdgePropSpec = EdgeSpec & {
+  readonly key: string;
+  readonly value: PropValue;
+  readonly eventId: EventId;
+};
+
+type StateSpec = {
+  readonly nodes: readonly string[];
+  readonly edges?: readonly EdgeSpec[];
+  readonly props?: readonly NodePropSpec[];
+  readonly edgeProps?: readonly EdgePropSpec[];
+};
+
+describe('QueryContent projection-backed reads', () => {
+  it('returns null node content OID and metadata for malformed storage references', async () => {
+    const eid = event(5);
+    const host = hostWithState(buildState({
+      nodes: ['alice'],
+      props: [
+        { nodeId: 'alice', key: CONTENT_PROPERTY_KEY, value: '', eventId: eid },
+        { nodeId: 'alice', key: CONTENT_MIME_PROPERTY_KEY, value: 'text/plain', eventId: eid },
+      ],
+    }));
+
+    await expect(getContentOidImpl(host, 'alice')).resolves.toBeNull();
+    await expect(getContentMetaImpl(host, 'alice')).resolves.toBeNull();
+  });
+
+  it('returns null edge content OID and metadata for malformed storage references', async () => {
+    const eid = event(5);
+    const edge = { from: 'alice', to: 'bob', label: 'knows' };
+    const host = hostWithState(buildState({
+      nodes: ['alice', 'bob'],
+      edges: [edge],
+      edgeProps: [
+        { ...edge, key: CONTENT_PROPERTY_KEY, value: '', eventId: eid },
+        { ...edge, key: CONTENT_MIME_PROPERTY_KEY, value: 'image/png', eventId: eid },
+      ],
+    }));
+
+    await expect(getEdgeContentOidImpl(host, edge)).resolves.toBeNull();
+    await expect(getEdgeContentMetaImpl(host, edge)).resolves.toBeNull();
+  });
+
+  it('drops malformed node MIME hints from projected metadata', async () => {
+    const eid = event(5);
+    const host = hostWithState(buildState({
+      nodes: ['alice'],
+      props: [
+        { nodeId: 'alice', key: CONTENT_PROPERTY_KEY, value: 'deadbeef', eventId: eid },
+        { nodeId: 'alice', key: CONTENT_MIME_PROPERTY_KEY, value: '', eventId: eid },
+      ],
+    }));
+
+    await expect(getContentMetaImpl(host, 'alice')).resolves.toEqual({
+      oid: 'deadbeef',
+      mime: null,
+      size: null,
+    });
+  });
+
+  it('drops malformed edge MIME hints from projected metadata', async () => {
+    const eid = event(5);
+    const edge = { from: 'alice', to: 'bob', label: 'knows' };
+    const host = hostWithState(buildState({
+      nodes: ['alice', 'bob'],
+      edges: [edge],
+      edgeProps: [
+        { ...edge, key: CONTENT_PROPERTY_KEY, value: 'cafebabe', eventId: eid },
+        { ...edge, key: CONTENT_MIME_PROPERTY_KEY, value: '', eventId: eid },
+      ],
+    }));
+
+    await expect(getEdgeContentMetaImpl(host, edge)).resolves.toEqual({
+      oid: 'cafebabe',
+      mime: null,
+      size: null,
+    });
+  });
+});
+
+function event(lamport: number): EventId {
+  return new EventId(lamport, 'writer-a', PATCH_SHA, 0);
+}
+
+function hostWithState(state: WarpState): QueryContentHost {
+  return {
+    _autoMaterialize: true,
+    _cachedState: state,
+    _ensureFreshState: vi.fn(async () => undefined),
+    _blobStorage: null,
+    _persistence: {
+      readBlob: vi.fn(async () => new Uint8Array([1, 2, 3])),
+    },
+  };
+}
+
+function buildState(spec: StateSpec): WarpState {
+  const nodeAlive = orsetWith(spec.nodes);
+  const edgeAlive = orsetWith((spec.edges ?? []).map((edge) => encodeEdgeKey(edge.from, edge.to, edge.label)));
+  const prop = new Map<string, LWWRegister<PropValue>>();
+
+  for (const nodeProp of spec.props ?? []) {
+    prop.set(encodePropKey(nodeProp.nodeId, nodeProp.key), register(nodeProp.value, nodeProp.eventId));
+  }
+  for (const edgeProp of spec.edgeProps ?? []) {
+    prop.set(
+      encodeEdgePropKey(edgeProp.from, edgeProp.to, edgeProp.label, edgeProp.key),
+      register(edgeProp.value, edgeProp.eventId),
+    );
+  }
+
+  return new WarpState({
+    nodeAlive,
+    edgeAlive,
+    prop,
+    observedFrontier: VersionVector.empty(),
+  });
+}
+
+function register(value: PropValue, eventId: EventId): LWWRegister<PropValue> {
+  return { value, eventId };
+}
+
+function orsetWith(values: readonly string[]): ORSet {
+  const set = ORSet.empty();
+  values.forEach((value, index) => {
+    set.add(value, Dot.create('writer-a', index + 1));
+  });
+  return set;
+}


### PR DESCRIPTION
## Summary
- Plans the post-PR-96 v18 content-cutover runway in BEARING and design docs.
- Adds runtime-backed content attachment payload, record, projection, and write-intent nouns.
- Routes public content reads through typed projection and content writes through typed intent before legacy _content* lowering.
- Preserves same-patch metadata lineage compatibility for existing content writes.

## Validation
- npm run test:local
- npm run typecheck
- npm run lint
- npm run lint:sludge
- npm run lint:quarantine-graduate
- npx markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/design/0169-v18-post-20-content-cutover-runway/v18-post-20-content-cutover-runway.md docs/design/0170-v18-content-attachment-payload-nouns/v18-content-attachment-payload-nouns.md docs/design/0171-v18-content-attachment-projection/v18-content-attachment-projection.md docs/design/0172-v18-query-content-projection-reads/v18-query-content-projection-reads.md docs/design/0173-v18-content-write-intent-cutover/v18-content-write-intent-cutover.md
- git diff --check HEAD
- pre-push IRONCLAD M9 gate: passed, including 480 unit test files / 6930 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added typed content attachment support with validated metadata handling for MIME types and file sizes
  * Implemented projection layer for routing content reads and writes through typed attachments
  * Maintained full backward compatibility with existing content properties during V18 cutover

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/git-stunts/git-warp/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->