### PR TITLE
Add v18 migration dry-run planning substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inventory for adapter-collected graph identity, source basis, writer chains,
   patch descriptors, state snapshot references, content/blob sources,
   warnings, and fatal collection errors.
+- V18 graph-model migration dry-run work now includes a pure planner that
+  consumes source inventory, produces manifest and planned graph-operation
+  facts for complete input, and returns fatal result values for incomplete
+  source facts without writing graph history.
 - V18 property projection closeout now records the remaining raw
   legacy-property boundaries as compatibility, serialization, replay,
   reducer, index, or migration-source boundaries before graph-model migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- V18 graph-model migration dry-run work now exposes runtime-backed migration
+  manifest nouns for source and target basis, node, edge, property, and
+  content mappings, warnings, and fatal planning failures without adding any
+  graph-history write path.
 - V18 property projection closeout now records the remaining raw
   legacy-property boundaries as compatibility, serialization, replay,
   reducer, index, or migration-source boundaries before graph-model migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- V18 graph-model migration dry-run review follow-up now removes boolean-trap
+  notice validation helpers, encodes planned target property keys with a named
+  length-prefixed format, and raises focused constructor-guard coverage for the
+  migration domain.
 - V18 snapshot-backed state-reader hydration now rejects cyclic property
   values, prototype-polluting object keys, custom-prototype property bags, and
   accessor-backed property objects at the snapshot boundary before converting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nouns for writer segments, patch identity, per-writer patch sequence,
   per-patch operation indexes, and frontier evidence needed by later replay
   equivalence checks.
+- V18 graph-model migration dry-run work now includes an infrastructure
+  manifest JSON adapter with deterministic output, field-specific parse
+  failures, round-trip coverage, and no domain-level JSON parsing.
 - V18 property projection closeout now records the remaining raw
   legacy-property boundaries as compatibility, serialization, replay,
   reducer, index, or migration-source boundaries before graph-model migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consumes source inventory, produces manifest and planned graph-operation
   facts for complete input, and returns fatal result values for incomplete
   source facts without writing graph history.
+- V18 graph-model migration dry-run work now exposes ordered history input
+  nouns for writer segments, patch identity, per-writer patch sequence,
+  per-patch operation indexes, and frontier evidence needed by later replay
+  equivalence checks.
 - V18 property projection closeout now records the remaining raw
   legacy-property boundaries as compatibility, serialization, replay,
   reducer, index, or migration-source boundaries before graph-model migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   manifest nouns for source and target basis, node, edge, property, and
   content mappings, warnings, and fatal planning failures without adding any
   graph-history write path.
+- V18 graph-model migration dry-run work now exposes a runtime-backed source
+  inventory for adapter-collected graph identity, source basis, writer chains,
+  patch descriptors, state snapshot references, content/blob sources,
+  warnings, and fatal collection errors.
 - V18 property projection closeout now records the remaining raw
   legacy-property boundaries as compatibility, serialization, replay,
   reducer, index, or migration-source boundaries before graph-model migration

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -80,6 +80,10 @@ The current v18 graph-model posture is:
   graph identity, optional source basis, writer chains, patch descriptors,
   state snapshot references, content/blob sources, warnings, and fatal
   collection errors.
+- A pure dry-run graph-model migration planner exists. It consumes source
+  inventory, returns result values for incomplete inputs, emits a migration
+  manifest and planned graph-operation facts, and still writes no graph
+  history.
 
 That is useful progress, not a finish line. The repo still needs property
 projection beyond replay/serialization boundaries, graph-model migration
@@ -147,6 +151,11 @@ Slice 37 is complete on this branch. The migration source inventory now
 separates adapter-collected facts from planner input, rejects duplicate or
 inconsistent patch facts, records missing source basis as a fatal collection
 condition, and still performs no Git I/O.
+
+Slice 38 is complete on this branch. The dry-run planner consumes migration
+source inventory and planned mapping inputs, emits a manifest plus planned
+operation facts for complete input, and fails closed as a value when source
+inventory or required content sources are incomplete.
 
 ## What Feels Wrong
 
@@ -254,7 +263,7 @@ and concrete checks live in `docs/invariants/`.
   [0184](design/0184-v18-graph-model-migration-manifest/v18-graph-model-migration-manifest.md).
 - [x] 37. Add migration source inventory:
   [0185](design/0185-v18-migration-source-inventory/v18-migration-source-inventory.md).
-- [ ] 38. Add the dry-run state migration planner:
+- [x] 38. Add the dry-run state migration planner:
   [0186](design/0186-v18-dry-run-state-migration-planner/v18-dry-run-state-migration-planner.md).
 - [ ] 39. Add ordered migration history input:
   [0187](design/0187-v18-migration-history-input/v18-migration-history-input.md).

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -73,6 +73,9 @@ The current v18 graph-model posture is:
   nouns, not raw property-map entries.
 - Query read-model node props, translation-cost property-key accounting, and
   public property counts use property projection nouns.
+- Runtime-backed graph-model migration manifest nouns exist for dry-run
+  planning, including source/target basis, node, edge, property, content
+  mapping entries, warnings, and fatal planning failures.
 
 That is useful progress, not a finish line. The repo still needs property
 projection beyond replay/serialization boundaries, graph-model migration
@@ -131,6 +134,10 @@ This branch starts PR C, v18 slices 36 through 40:
 - dry-run state migration planner;
 - ordered migration history input;
 - migration manifest serialization.
+
+Slice 36 is complete on this branch. The migration manifest root now exists
+as a frozen domain noun, with runtime-backed basis, mapping, warning, and
+fatal-error entries. It does not serialize, read Git, or write graph history.
 
 ## What Feels Wrong
 
@@ -234,7 +241,7 @@ and concrete checks live in `docs/invariants/`.
   [0182](design/0182-v18-graph-op-projection-property-cutover/v18-graph-op-projection-property-cutover.md).
 - [x] 35. Close out legacy-property projection with evidence:
   [0183](design/0183-v18-property-projection-closeout/v18-property-projection-closeout.md).
-- [ ] 36. Add graph-model migration manifest nouns:
+- [x] 36. Add graph-model migration manifest nouns:
   [0184](design/0184-v18-graph-model-migration-manifest/v18-graph-model-migration-manifest.md).
 - [ ] 37. Add migration source inventory:
   [0185](design/0185-v18-migration-source-inventory/v18-migration-source-inventory.md).

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -39,17 +39,17 @@ of handwritten adapter folklore.
 
 Current branch state at this boundary:
 
-- Branch: `v18-continuum-slices-31-35`
+- Branch: `v18-continuum-slices-36-40`
 - Base branch: `main`
-- Current `origin/main`: `35e5a6a9`
-- Latest merged PR: #100, post-PR-99 BEARING cleanup checkpoint
+- Current `origin/main`: `f9230f09`
+- Latest merged PR: #101, v18 property projection cutover
 - Latest released package line: `17.0.1`
 - Latest completed implementation cycle:
   `0183-v18-property-projection-closeout`
-- Current work: v18 slices 31 through 35 are implemented on this branch and
-  ready for PR verification.
-- Cleanup checkpoint: before this slice branch, there were no open PRs and
-  remote refs had been pruned to `origin/main`.
+- Current work: v18 slices 36 through 40 are the active dry-run migration
+  batch on this branch.
+- Cleanup checkpoint: `main` has been fast-forwarded to `origin/main` after
+  PR #101 merged; this branch starts from that merge commit.
 
 The current v18 graph-model posture is:
 
@@ -110,7 +110,7 @@ PR #99 landed v18 slices 26 through 30:
   malformed-record skipping, shared legacy content keys, and plain-object
   property carrier guards.
 
-This branch implements v18 slices 31 through 35:
+PR #101 landed v18 slices 31 through 35:
 
 - state-reader node, edge, and content property views route through typed
   projections;
@@ -121,6 +121,16 @@ This branch implements v18 slices 31 through 35:
   nouns;
 - closeout routed the remaining live read-model property views through
   projections and documented the remaining raw legacy-property boundaries.
+- review follow-up hardened CI action pinning, property-value recursion and
+  prototype guards, and hostile `SnapshotWarpState` hydration boundaries.
+
+This branch starts PR C, v18 slices 36 through 40:
+
+- graph-model migration manifest nouns;
+- migration source inventory;
+- dry-run state migration planner;
+- ordered migration history input;
+- migration manifest serialization.
 
 ## What Feels Wrong
 

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -76,6 +76,10 @@ The current v18 graph-model posture is:
 - Runtime-backed graph-model migration manifest nouns exist for dry-run
   planning, including source/target basis, node, edge, property, content
   mapping entries, warnings, and fatal planning failures.
+- Runtime-backed migration source inventory nouns exist for adapter-collected
+  graph identity, optional source basis, writer chains, patch descriptors,
+  state snapshot references, content/blob sources, warnings, and fatal
+  collection errors.
 
 That is useful progress, not a finish line. The repo still needs property
 projection beyond replay/serialization boundaries, graph-model migration
@@ -138,6 +142,11 @@ This branch starts PR C, v18 slices 36 through 40:
 Slice 36 is complete on this branch. The migration manifest root now exists
 as a frozen domain noun, with runtime-backed basis, mapping, warning, and
 fatal-error entries. It does not serialize, read Git, or write graph history.
+
+Slice 37 is complete on this branch. The migration source inventory now
+separates adapter-collected facts from planner input, rejects duplicate or
+inconsistent patch facts, records missing source basis as a fatal collection
+condition, and still performs no Git I/O.
 
 ## What Feels Wrong
 
@@ -243,7 +252,7 @@ and concrete checks live in `docs/invariants/`.
   [0183](design/0183-v18-property-projection-closeout/v18-property-projection-closeout.md).
 - [x] 36. Add graph-model migration manifest nouns:
   [0184](design/0184-v18-graph-model-migration-manifest/v18-graph-model-migration-manifest.md).
-- [ ] 37. Add migration source inventory:
+- [x] 37. Add migration source inventory:
   [0185](design/0185-v18-migration-source-inventory/v18-migration-source-inventory.md).
 - [ ] 38. Add the dry-run state migration planner:
   [0186](design/0186-v18-dry-run-state-migration-planner/v18-dry-run-state-migration-planner.md).

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -87,6 +87,8 @@ The current v18 graph-model posture is:
 - Ordered migration history input nouns exist for writer segments, patch
   identity, per-writer patch sequence, per-patch operation indexes, and
   frontier evidence needed by later genesis equivalence work.
+- Manifest JSON serialization exists as an infrastructure adapter boundary.
+  Domain migration nouns still do not parse or stringify JSON.
 
 That is useful progress, not a finish line. The repo still needs property
 projection beyond replay/serialization boundaries, graph-model migration
@@ -163,6 +165,11 @@ inventory or required content sources are incomplete.
 Slice 39 is complete on this branch. Ordered history input now preserves
 writer, patch, operation, and frontier boundaries as frozen migration-domain
 values so future equivalence checks can report exact divergence locations.
+
+Slice 40 is complete on this branch. Manifest JSON serialization now
+round-trips through an infrastructure adapter with deterministic output,
+field-specific parse errors, and domain construction enforcing duplicate
+mapping invariants.
 
 ## What Feels Wrong
 
@@ -274,7 +281,7 @@ and concrete checks live in `docs/invariants/`.
   [0186](design/0186-v18-dry-run-state-migration-planner/v18-dry-run-state-migration-planner.md).
 - [x] 39. Add ordered migration history input:
   [0187](design/0187-v18-migration-history-input/v18-migration-history-input.md).
-- [ ] 40. Add migration manifest serialization:
+- [x] 40. Add migration manifest serialization:
   [0188](design/0188-v18-migration-manifest-serialization/v18-migration-manifest-serialization.md).
 - [ ] 41. Add the migration dry-run CLI:
   [0189](design/0189-v18-migration-dry-run-cli/v18-migration-dry-run-cli.md).

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -84,6 +84,9 @@ The current v18 graph-model posture is:
   inventory, returns result values for incomplete inputs, emits a migration
   manifest and planned graph-operation facts, and still writes no graph
   history.
+- Ordered migration history input nouns exist for writer segments, patch
+  identity, per-writer patch sequence, per-patch operation indexes, and
+  frontier evidence needed by later genesis equivalence work.
 
 That is useful progress, not a finish line. The repo still needs property
 projection beyond replay/serialization boundaries, graph-model migration
@@ -156,6 +159,10 @@ Slice 38 is complete on this branch. The dry-run planner consumes migration
 source inventory and planned mapping inputs, emits a manifest plus planned
 operation facts for complete input, and fails closed as a value when source
 inventory or required content sources are incomplete.
+
+Slice 39 is complete on this branch. Ordered history input now preserves
+writer, patch, operation, and frontier boundaries as frozen migration-domain
+values so future equivalence checks can report exact divergence locations.
 
 ## What Feels Wrong
 
@@ -265,7 +272,7 @@ and concrete checks live in `docs/invariants/`.
   [0185](design/0185-v18-migration-source-inventory/v18-migration-source-inventory.md).
 - [x] 38. Add the dry-run state migration planner:
   [0186](design/0186-v18-dry-run-state-migration-planner/v18-dry-run-state-migration-planner.md).
-- [ ] 39. Add ordered migration history input:
+- [x] 39. Add ordered migration history input:
   [0187](design/0187-v18-migration-history-input/v18-migration-history-input.md).
 - [ ] 40. Add migration manifest serialization:
   [0188](design/0188-v18-migration-manifest-serialization/v18-migration-manifest-serialization.md).

--- a/docs/design/0184-v18-graph-model-migration-manifest/v18-graph-model-migration-manifest.md
+++ b/docs/design/0184-v18-graph-model-migration-manifest/v18-graph-model-migration-manifest.md
@@ -1,7 +1,7 @@
 ---
 cycle: 0184
 task_id: V18_graph_model_migration_manifest
-status: Planned
+status: Complete
 sponsors:
   human: James
   agent: Codex
@@ -95,11 +95,37 @@ npm run lint:sludge
 git diff --check HEAD
 ```
 
+## Evidence
+
+The slice adds runtime-backed migration manifest nouns under
+`src/domain/migrations/`:
+
+- `GraphModelMigrationManifestVersion`;
+- `GraphModelMigrationBasis`;
+- node, edge, property, and content mapping entries;
+- `GraphModelMigrationNotice`;
+- `GraphModelMigrationManifest`.
+
+The manifest constructor validates the source and target basis, freezes each
+mapping section, rejects duplicate legacy node, edge, property, and content
+mapping keys, and keeps warnings separate from fatal planning failures.
+Expected migration planning failures are represented as notice values rather
+than script side effects.
+
+No serializer, Git adapter, filesystem access, wall-clock access, or graph
+history write path was added in this slice.
+
 ## Closeout Criteria
 
 - Migration manifest nouns exist and are covered by constructor tests.
 - No serialization or filesystem code enters the domain.
 - Dry-run planning can target a manifest root in the next slices.
+
+## Closeout Outcome
+
+The manifest root is ready for migration source inventory and dry-run planner
+work. It is intentionally not yet a public API and intentionally not yet a
+transport schema; slice 40 owns the adapter-boundary serialization surface.
 
 ## SSJS Scorecard
 

--- a/docs/design/0185-v18-migration-source-inventory/v18-migration-source-inventory.md
+++ b/docs/design/0185-v18-migration-source-inventory/v18-migration-source-inventory.md
@@ -1,7 +1,7 @@
 ---
 cycle: 0185
 task_id: V18_migration_source_inventory
-status: Planned
+status: Complete
 sponsors:
   human: James
   agent: Codex
@@ -100,12 +100,38 @@ npm run lint:sludge
 git diff --check HEAD
 ```
 
+## Evidence
+
+The slice adds source inventory nouns under `src/domain/migrations/`:
+
+- `GraphModelMigrationWriterChainDescriptor`;
+- `GraphModelMigrationPatchDescriptor`;
+- `GraphModelMigrationStateSnapshotReference`;
+- `GraphModelMigrationContentSource`;
+- `GraphModelMigrationSourceInventory`.
+
+The inventory root validates graph identity, optional source basis, writer
+chains, per-writer patch sequence, patch descriptor consistency, state snapshot
+references, content source facts, warnings, and fatal collection errors.
+Patch descriptors are exposed in deterministic writer/sequence order. Missing
+source basis is retained as an explicit fatal source condition, not hidden as
+an adapter exception.
+
+The inventory does not read Git, serialize JSON, use wall-clock time, or write
+graph history.
+
 ## Closeout Criteria
 
 - Migration planner input facts are named.
 - Fatal versus warning source conditions are explicit.
 - No Git adapter calls enter domain code.
 - The dry-run planner can be designed against inventory plus manifest.
+
+## Closeout Outcome
+
+Dry-run planning can now consume a domain inventory value rather than probing
+adapter surfaces directly. Slice 38 can focus on translating source inventory
+facts into a dry-run manifest and planned graph operations.
 
 ## SSJS Scorecard
 

--- a/docs/design/0186-v18-dry-run-state-migration-planner/v18-dry-run-state-migration-planner.md
+++ b/docs/design/0186-v18-dry-run-state-migration-planner/v18-dry-run-state-migration-planner.md
@@ -1,7 +1,7 @@
 ---
 cycle: 0186
 task_id: V18_dry_run_state_migration_planner
-status: Planned
+status: Complete
 sponsors:
   human: James
   agent: Codex
@@ -94,12 +94,37 @@ npm run lint:sludge
 git diff --check HEAD
 ```
 
+## Evidence
+
+The slice adds pure domain planner nouns under `src/domain/migrations/`:
+
+- `DryRunGraphModelMigrationPlanRequest`;
+- `GraphModelMigrationPlannedGraphOperation`;
+- `DryRunGraphModelMigrationPlan`;
+- `DryRunGraphModelMigrationPlanner`.
+
+The planner consumes a `GraphModelMigrationSourceInventory`, explicit planned
+mapping inputs, and required content keys. Complete input produces a
+`GraphModelMigrationManifest` plus deterministic planned graph-operation
+facts. Incomplete source inventory or missing required content sources produce
+a failed plan value with fatal notices and no manifest.
+
+The planned operation facts deliberately do not pretend to be live graph writes.
+They are dry-run facts that describe what the planner would later lower into a
+write-capable migration, after equivalence work proves that path safe.
+
 ## Closeout Criteria
 
 - Dry-run planner exists and writes nothing.
 - Planner output includes manifest, facts, warnings, and failures.
 - Expected planning failures are returned as values.
 - The next slice can feed ordered patch history into the inventory.
+
+## Closeout Outcome
+
+The planner is now a pure domain service. It does not read Git, inspect the
+filesystem, parse JSON, create timestamps, or update refs. Slice 39 can add
+ordered patch-history input without changing the planner into an adapter.
 
 ## SSJS Scorecard
 

--- a/docs/design/0187-v18-migration-history-input/v18-migration-history-input.md
+++ b/docs/design/0187-v18-migration-history-input/v18-migration-history-input.md
@@ -1,7 +1,7 @@
 ---
 cycle: 0187
 task_id: V18_migration_history_input
-status: Planned
+status: Complete
 sponsors:
   human: James
   agent: Codex
@@ -88,12 +88,32 @@ at exact patch and operation boundaries.
 ## Verification
 
 ```text
-npx vitest run test/unit/domain/migrations/MigrationHistoryInput.test.ts --reporter=verbose
-npx eslint src/domain/migrations test/unit/domain/migrations/MigrationHistoryInput.test.ts
+npx vitest run test/unit/domain/migrations/GraphModelMigrationHistoryInput.test.ts --reporter=verbose
+npx eslint src/domain/migrations test/unit/domain/migrations/GraphModelMigrationHistoryInput.test.ts
 npm run typecheck
 npm run lint:sludge
 git diff --check HEAD
 ```
+
+## Evidence
+
+The slice adds ordered history input nouns under `src/domain/migrations/`:
+
+- `GraphModelMigrationPatchOperationFact`;
+- `GraphModelMigrationPatchFrontierEvidence`;
+- `GraphModelMigrationHistoryPatchInput`;
+- `GraphModelMigrationHistorySegment`;
+- `GraphModelMigrationHistoryInput`.
+
+Patch inputs preserve writer id, patch id, per-writer sequence, contiguous
+operation indexes, and frontier evidence. Writer segments sort patches by
+sequence and reject wrong-writer entries. The history root sorts writer
+segments deterministically, rejects duplicate patch ids across writers, and
+requires frontier evidence so later equivalence checks have exact replay
+boundaries.
+
+No Git walking, timestamp inference, migrated-history writing, or equivalence
+comparison was added in this slice.
 
 ## Closeout Criteria
 
@@ -101,6 +121,12 @@ git diff --check HEAD
 - Patch and operation boundaries are preserved.
 - No adapter behavior leaks into domain code.
 - The manifest serializer slice can focus on persistence boundaries.
+
+## Closeout Outcome
+
+History input is now a domain value, not an adapter side channel. Slice 40 can
+focus on manifest transport serialization while later equivalence slices can
+reuse these patch and operation boundaries.
 
 ## SSJS Scorecard
 

--- a/docs/design/0188-v18-migration-manifest-serialization/v18-migration-manifest-serialization.md
+++ b/docs/design/0188-v18-migration-manifest-serialization/v18-migration-manifest-serialization.md
@@ -1,7 +1,7 @@
 ---
 cycle: 0188
 task_id: V18_migration_manifest_serialization
-status: Planned
+status: Complete
 sponsors:
   human: James
   agent: Codex
@@ -83,13 +83,28 @@ a large generic manifest helper.
 ## Verification
 
 ```text
-npx vitest run test/unit/infrastructure/migrations/GraphModelMigrationManifestSerialization.test.ts --reporter=verbose
-npx eslint src/infrastructure scripts test/unit/infrastructure/migrations/GraphModelMigrationManifestSerialization.test.ts
+npx vitest run test/unit/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.test.ts --reporter=verbose
+npx eslint src/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.ts test/unit/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.test.ts
 npm run typecheck
 npm run lint
 npm run lint:sludge
 git diff --check HEAD
 ```
+
+## Evidence
+
+The slice adds `GraphModelMigrationManifestJsonAdapter` under
+`src/infrastructure/adapters/` plus focused adapter tests. The adapter:
+
+- serializes a `GraphModelMigrationManifest` into deterministic JSON text;
+- parses valid JSON into runtime-backed domain manifest nouns;
+- keeps `JSON.parse` and `JSON.stringify` outside `src/domain/`;
+- reports malformed transport fields with field-specific errors;
+- lets domain construction enforce manifest invariants such as duplicate
+  mapping rejection.
+
+No public package API, CLI, graph-history write path, version bump, or domain
+JSON parser was added.
 
 ## Closeout Criteria
 
@@ -97,6 +112,12 @@ git diff --check HEAD
 - Round-trip and malformed input tests pass.
 - Deterministic fixture output is covered.
 - The dry-run CLI can emit a manifest in the next slice.
+
+## Closeout Outcome
+
+The dry-run manifest has a transport boundary ready for the future CLI. The
+next batch can focus on operator command wiring and equivalence evidence
+without moving JSON concerns into the migration domain model.
 
 ## SSJS Scorecard
 

--- a/src/domain/migrations/DryRunGraphModelMigrationPlan.ts
+++ b/src/domain/migrations/DryRunGraphModelMigrationPlan.ts
@@ -21,8 +21,8 @@ export default class DryRunGraphModelMigrationPlan {
     const checkedFields = requireFields(fields);
     this.manifest = requireOptionalManifest(checkedFields.manifest);
     this.plannedOperations = freezePlannedOperations(checkedFields.plannedOperations);
-    this.warnings = freezeNotices(checkedFields.warnings, false, 'warnings');
-    this.fatalErrors = freezeNotices(checkedFields.fatalErrors, true, 'fatalErrors');
+    this.warnings = freezeWarningNotices(checkedFields.warnings);
+    this.fatalErrors = freezeFatalNotices(checkedFields.fatalErrors);
     requireManifestMatchesFatality(this.manifest, this.fatalErrors);
     Object.freeze(this);
   }
@@ -61,16 +61,27 @@ function freezePlannedOperations(
   return Object.freeze(checked);
 }
 
-/** Validates and freezes warning or fatal notices. */
-function freezeNotices(
+/** Validates and freezes warning notices. */
+function freezeWarningNotices(
   notices: readonly GraphModelMigrationNotice[],
-  fatal: boolean,
-  label: string,
 ): readonly GraphModelMigrationNotice[] {
-  const checked = requireArray(notices, label).map(requireNotice);
+  const checked = requireArray(notices, 'warnings').map(requireNotice);
   for (const notice of checked) {
-    if (notice.isFatal() !== fatal) {
-      throw new WarpError(`${label} contains the wrong notice kind`, 'E_VALIDATION');
+    if (notice.isFatal()) {
+      throw new WarpError('warnings contains the wrong notice kind', 'E_VALIDATION');
+    }
+  }
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes fatal notices. */
+function freezeFatalNotices(
+  notices: readonly GraphModelMigrationNotice[],
+): readonly GraphModelMigrationNotice[] {
+  const checked = requireArray(notices, 'fatalErrors').map(requireNotice);
+  for (const notice of checked) {
+    if (!notice.isFatal()) {
+      throw new WarpError('fatalErrors contains the wrong notice kind', 'E_VALIDATION');
     }
   }
   return Object.freeze(checked);

--- a/src/domain/migrations/DryRunGraphModelMigrationPlan.ts
+++ b/src/domain/migrations/DryRunGraphModelMigrationPlan.ts
@@ -1,0 +1,117 @@
+import GraphModelMigrationManifest from './GraphModelMigrationManifest.ts';
+import GraphModelMigrationNotice from './GraphModelMigrationNotice.ts';
+import GraphModelMigrationPlannedGraphOperation from './GraphModelMigrationPlannedGraphOperation.ts';
+import WarpError from '../errors/WarpError.ts';
+
+export type DryRunGraphModelMigrationPlanFields = {
+  readonly manifest: GraphModelMigrationManifest | null;
+  readonly plannedOperations: readonly GraphModelMigrationPlannedGraphOperation[];
+  readonly warnings: readonly GraphModelMigrationNotice[];
+  readonly fatalErrors: readonly GraphModelMigrationNotice[];
+};
+
+/** Runtime-backed result value from a dry-run graph-model migration plan. */
+export default class DryRunGraphModelMigrationPlan {
+  readonly manifest: GraphModelMigrationManifest | null;
+  readonly plannedOperations: readonly GraphModelMigrationPlannedGraphOperation[];
+  readonly warnings: readonly GraphModelMigrationNotice[];
+  readonly fatalErrors: readonly GraphModelMigrationNotice[];
+
+  constructor(fields: DryRunGraphModelMigrationPlanFields) {
+    const checkedFields = requireFields(fields);
+    this.manifest = requireOptionalManifest(checkedFields.manifest);
+    this.plannedOperations = freezePlannedOperations(checkedFields.plannedOperations);
+    this.warnings = freezeNotices(checkedFields.warnings, false, 'warnings');
+    this.fatalErrors = freezeNotices(checkedFields.fatalErrors, true, 'fatalErrors');
+    requireManifestMatchesFatality(this.manifest, this.fatalErrors);
+    Object.freeze(this);
+  }
+
+  /** Returns true when dry-run planning failed closed. */
+  hasFatalErrors(): boolean {
+    return this.fatalErrors.length > 0;
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: DryRunGraphModelMigrationPlanFields | null | undefined,
+): DryRunGraphModelMigrationPlanFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('DryRunGraphModelMigrationPlan fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Requires a manifest when one exists. */
+function requireOptionalManifest(
+  manifest: GraphModelMigrationManifest | null,
+): GraphModelMigrationManifest | null {
+  if (manifest !== null && !(manifest instanceof GraphModelMigrationManifest)) {
+    throw new WarpError('manifest must be a GraphModelMigrationManifest', 'E_VALIDATION');
+  }
+  return manifest;
+}
+
+/** Validates and freezes planned graph operation facts. */
+function freezePlannedOperations(
+  operations: readonly GraphModelMigrationPlannedGraphOperation[],
+): readonly GraphModelMigrationPlannedGraphOperation[] {
+  const checked = requireArray(operations, 'plannedOperations').map(requirePlannedOperation);
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes warning or fatal notices. */
+function freezeNotices(
+  notices: readonly GraphModelMigrationNotice[],
+  fatal: boolean,
+  label: string,
+): readonly GraphModelMigrationNotice[] {
+  const checked = requireArray(notices, label).map(requireNotice);
+  for (const notice of checked) {
+    if (notice.isFatal() !== fatal) {
+      throw new WarpError(`${label} contains the wrong notice kind`, 'E_VALIDATION');
+    }
+  }
+  return Object.freeze(checked);
+}
+
+/** Requires no manifest when fatal planning errors exist. */
+function requireManifestMatchesFatality(
+  manifest: GraphModelMigrationManifest | null,
+  fatalErrors: readonly GraphModelMigrationNotice[],
+): void {
+  if (fatalErrors.length > 0 && manifest !== null) {
+    throw new WarpError('fatal dry-run plans must not contain a manifest', 'E_VALIDATION');
+  }
+  if (fatalErrors.length === 0 && manifest === null) {
+    throw new WarpError('successful dry-run plans must contain a manifest', 'E_VALIDATION');
+  }
+}
+
+/** Requires an array field. */
+function requireArray<T>(items: readonly T[] | null | undefined, label: string): readonly T[] {
+  if (items === null || items === undefined || !Array.isArray(items)) {
+    throw new WarpError(`DryRunGraphModelMigrationPlan ${label} must be an array`, 'E_VALIDATION');
+  }
+  const checkedItems: readonly T[] = items;
+  return checkedItems;
+}
+
+/** Requires a planned graph operation instance. */
+function requirePlannedOperation(
+  operation: GraphModelMigrationPlannedGraphOperation,
+): GraphModelMigrationPlannedGraphOperation {
+  if (!(operation instanceof GraphModelMigrationPlannedGraphOperation)) {
+    throw new WarpError('plannedOperations must contain planned graph operations', 'E_VALIDATION');
+  }
+  return operation;
+}
+
+/** Requires a migration notice instance. */
+function requireNotice(notice: GraphModelMigrationNotice): GraphModelMigrationNotice {
+  if (!(notice instanceof GraphModelMigrationNotice)) {
+    throw new WarpError('dry-run plan notices must be GraphModelMigrationNotice instances', 'E_VALIDATION');
+  }
+  return notice;
+}

--- a/src/domain/migrations/DryRunGraphModelMigrationPlanRequest.ts
+++ b/src/domain/migrations/DryRunGraphModelMigrationPlanRequest.ts
@@ -1,0 +1,135 @@
+import GraphModelMigrationEdgeMapping from './GraphModelMigrationEdgeMapping.ts';
+import GraphModelMigrationNodeMapping from './GraphModelMigrationNodeMapping.ts';
+import GraphModelMigrationPropertyMapping from './GraphModelMigrationPropertyMapping.ts';
+import GraphModelMigrationSourceInventory from './GraphModelMigrationSourceInventory.ts';
+import WarpError from '../errors/WarpError.ts';
+
+export type DryRunGraphModelMigrationPlanRequestFields = {
+  readonly inventory: GraphModelMigrationSourceInventory;
+  readonly requiredContentKeys: readonly string[];
+  readonly nodeMappings: readonly GraphModelMigrationNodeMapping[];
+  readonly edgeMappings: readonly GraphModelMigrationEdgeMapping[];
+  readonly propertyMappings: readonly GraphModelMigrationPropertyMapping[];
+};
+
+/** Runtime-backed request for a pure dry-run graph-model migration plan. */
+export default class DryRunGraphModelMigrationPlanRequest {
+  readonly inventory: GraphModelMigrationSourceInventory;
+  readonly requiredContentKeys: readonly string[];
+  readonly nodeMappings: readonly GraphModelMigrationNodeMapping[];
+  readonly edgeMappings: readonly GraphModelMigrationEdgeMapping[];
+  readonly propertyMappings: readonly GraphModelMigrationPropertyMapping[];
+
+  constructor(fields: DryRunGraphModelMigrationPlanRequestFields) {
+    const checkedFields = requireFields(fields);
+    this.inventory = requireInventory(checkedFields.inventory);
+    this.requiredContentKeys = freezeRequiredContentKeys(checkedFields.requiredContentKeys);
+    this.nodeMappings = freezeNodeMappings(checkedFields.nodeMappings);
+    this.edgeMappings = freezeEdgeMappings(checkedFields.edgeMappings);
+    this.propertyMappings = freezePropertyMappings(checkedFields.propertyMappings);
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: DryRunGraphModelMigrationPlanRequestFields | null | undefined,
+): DryRunGraphModelMigrationPlanRequestFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('DryRunGraphModelMigrationPlanRequest fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Requires a source inventory instance. */
+function requireInventory(inventory: GraphModelMigrationSourceInventory): GraphModelMigrationSourceInventory {
+  if (!(inventory instanceof GraphModelMigrationSourceInventory)) {
+    throw new WarpError('inventory must be a GraphModelMigrationSourceInventory', 'E_VALIDATION');
+  }
+  return inventory;
+}
+
+/** Validates and freezes required content keys. */
+function freezeRequiredContentKeys(keys: readonly string[]): readonly string[] {
+  const checked = requireArray(keys, 'requiredContentKeys').map((key) => requireNonEmptyString(key, 'contentKey'));
+  requireUnique(checked, 'required content key');
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes node mappings. */
+function freezeNodeMappings(
+  mappings: readonly GraphModelMigrationNodeMapping[],
+): readonly GraphModelMigrationNodeMapping[] {
+  const checked = requireArray(mappings, 'nodeMappings').map(requireNodeMapping);
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes edge mappings. */
+function freezeEdgeMappings(
+  mappings: readonly GraphModelMigrationEdgeMapping[],
+): readonly GraphModelMigrationEdgeMapping[] {
+  const checked = requireArray(mappings, 'edgeMappings').map(requireEdgeMapping);
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes property mappings. */
+function freezePropertyMappings(
+  mappings: readonly GraphModelMigrationPropertyMapping[],
+): readonly GraphModelMigrationPropertyMapping[] {
+  const checked = requireArray(mappings, 'propertyMappings').map(requirePropertyMapping);
+  return Object.freeze(checked);
+}
+
+/** Requires an array field. */
+function requireArray<T>(items: readonly T[] | null | undefined, label: string): readonly T[] {
+  if (items === null || items === undefined || !Array.isArray(items)) {
+    throw new WarpError(`DryRunGraphModelMigrationPlanRequest ${label} must be an array`, 'E_VALIDATION');
+  }
+  const checkedItems: readonly T[] = items;
+  return checkedItems;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Requires no duplicate keys in a request section. */
+function requireUnique(keys: readonly string[], label: string): void {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) {
+      throw new WarpError(`DryRunGraphModelMigrationPlanRequest duplicates ${label} ${key}`, 'E_VALIDATION');
+    }
+    seen.add(key);
+  }
+}
+
+/** Requires a node mapping instance. */
+function requireNodeMapping(mapping: GraphModelMigrationNodeMapping): GraphModelMigrationNodeMapping {
+  if (!(mapping instanceof GraphModelMigrationNodeMapping)) {
+    throw new WarpError('nodeMappings must contain node mappings', 'E_VALIDATION');
+  }
+  return mapping;
+}
+
+/** Requires an edge mapping instance. */
+function requireEdgeMapping(mapping: GraphModelMigrationEdgeMapping): GraphModelMigrationEdgeMapping {
+  if (!(mapping instanceof GraphModelMigrationEdgeMapping)) {
+    throw new WarpError('edgeMappings must contain edge mappings', 'E_VALIDATION');
+  }
+  return mapping;
+}
+
+/** Requires a property mapping instance. */
+function requirePropertyMapping(
+  mapping: GraphModelMigrationPropertyMapping,
+): GraphModelMigrationPropertyMapping {
+  if (!(mapping instanceof GraphModelMigrationPropertyMapping)) {
+    throw new WarpError('propertyMappings must contain property mappings', 'E_VALIDATION');
+  }
+  return mapping;
+}

--- a/src/domain/migrations/DryRunGraphModelMigrationPlanner.ts
+++ b/src/domain/migrations/DryRunGraphModelMigrationPlanner.ts
@@ -14,6 +14,8 @@ import type GraphModelMigrationPropertyMapping from './GraphModelMigrationProper
 const MISSING_CONTENT_SOURCE_CODE = 'E_MISSING_CONTENT_SOURCE';
 const DRY_RUN_TARGET_BASIS_SUFFIX = ':v18-dry-run';
 const CONTENT_ATTACHMENT_PREFIX = 'content-attachment:';
+const PROPERTY_TARGET_KEY_FORMAT = 'property-target-key:length-prefixed-v1';
+const PROPERTY_TARGET_KEY_SEPARATOR = ':';
 
 /** Pure domain planner for graph-model migration dry runs. */
 export default class DryRunGraphModelMigrationPlanner {
@@ -160,8 +162,19 @@ function plannedPropertyOperation(
 ): GraphModelMigrationPlannedGraphOperation {
   return GraphModelMigrationPlannedGraphOperation.property(
     propertyMapping.legacyKey(),
-    `${propertyMapping.targetOwnerId}\0${propertyMapping.targetPropertyKey}`,
+    encodePropertyTargetKey(propertyMapping.targetOwnerId, propertyMapping.targetPropertyKey),
   );
+}
+
+/** Encodes target property identity without delimiter collisions. */
+function encodePropertyTargetKey(ownerId: string, propertyKey: string): string {
+  return [
+    PROPERTY_TARGET_KEY_FORMAT,
+    ownerId.length,
+    ownerId,
+    propertyKey.length,
+    propertyKey,
+  ].join(PROPERTY_TARGET_KEY_SEPARATOR);
 }
 
 /** Returns the deterministic dry-run target attachment key. */

--- a/src/domain/migrations/DryRunGraphModelMigrationPlanner.ts
+++ b/src/domain/migrations/DryRunGraphModelMigrationPlanner.ts
@@ -1,0 +1,186 @@
+import { compareStrings } from '../utils/StringComparison.ts';
+import DryRunGraphModelMigrationPlan from './DryRunGraphModelMigrationPlan.ts';
+import DryRunGraphModelMigrationPlanRequest from './DryRunGraphModelMigrationPlanRequest.ts';
+import GraphModelMigrationBasis from './GraphModelMigrationBasis.ts';
+import GraphModelMigrationContentMapping from './GraphModelMigrationContentMapping.ts';
+import GraphModelMigrationManifest from './GraphModelMigrationManifest.ts';
+import GraphModelMigrationManifestVersion from './GraphModelMigrationManifestVersion.ts';
+import GraphModelMigrationNotice from './GraphModelMigrationNotice.ts';
+import GraphModelMigrationPlannedGraphOperation from './GraphModelMigrationPlannedGraphOperation.ts';
+import WarpError from '../errors/WarpError.ts';
+import type GraphModelMigrationContentSource from './GraphModelMigrationContentSource.ts';
+import type GraphModelMigrationPropertyMapping from './GraphModelMigrationPropertyMapping.ts';
+
+const MISSING_CONTENT_SOURCE_CODE = 'E_MISSING_CONTENT_SOURCE';
+const DRY_RUN_TARGET_BASIS_SUFFIX = ':v18-dry-run';
+const CONTENT_ATTACHMENT_PREFIX = 'content-attachment:';
+
+/** Pure domain planner for graph-model migration dry runs. */
+export default class DryRunGraphModelMigrationPlanner {
+  /** Creates a deterministic dry-run plan without reading or writing graph history. */
+  plan(request: DryRunGraphModelMigrationPlanRequest): DryRunGraphModelMigrationPlan {
+    return planForRequest(requireRequest(request));
+  }
+}
+
+/** Builds a plan from an already validated request. */
+function planForRequest(
+  request: DryRunGraphModelMigrationPlanRequest,
+): DryRunGraphModelMigrationPlan {
+  const { inventory } = request;
+  const { sourceBasis, fatalErrors: sourceFatalErrors, warnings } = inventory;
+  if (sourceBasis === null || sourceFatalErrors.length > 0) {
+    return failedPlan(warnings, sourceFatalErrors);
+  }
+  const contentMappings = plannedContentMappings(inventory.contentSources);
+  const fatalErrors = missingContentSourceErrors(request.requiredContentKeys, contentMappings);
+  if (fatalErrors.length > 0) {
+    return failedPlan(warnings, fatalErrors);
+  }
+  return successfulPlan(request, sourceBasis, contentMappings);
+}
+
+/** Builds a successful dry-run plan value. */
+function successfulPlan(
+  request: DryRunGraphModelMigrationPlanRequest,
+  sourceBasis: GraphModelMigrationBasis,
+  contentMappings: readonly GraphModelMigrationContentMapping[],
+): DryRunGraphModelMigrationPlan {
+  const manifest = new GraphModelMigrationManifest({
+    version: GraphModelMigrationManifestVersion.current(),
+    sourceBasis,
+    targetBasis: targetBasisFor(sourceBasis),
+    nodeMappings: request.nodeMappings,
+    edgeMappings: request.edgeMappings,
+    propertyMappings: request.propertyMappings,
+    contentMappings,
+    warnings: request.inventory.warnings,
+    fatalErrors: [],
+  });
+  return new DryRunGraphModelMigrationPlan({
+    manifest,
+    plannedOperations: plannedOperationsFor(request, contentMappings),
+    warnings: request.inventory.warnings,
+    fatalErrors: [],
+  });
+}
+
+/** Requires a planner request instance. */
+function requireRequest(request: DryRunGraphModelMigrationPlanRequest): DryRunGraphModelMigrationPlanRequest {
+  if (!(request instanceof DryRunGraphModelMigrationPlanRequest)) {
+    throw new WarpError('request must be a DryRunGraphModelMigrationPlanRequest', 'E_VALIDATION');
+  }
+  return request;
+}
+
+/** Builds a failed dry-run result value. */
+function failedPlan(
+  warnings: readonly GraphModelMigrationNotice[],
+  fatalErrors: readonly GraphModelMigrationNotice[],
+): DryRunGraphModelMigrationPlan {
+  return new DryRunGraphModelMigrationPlan({
+    manifest: null,
+    plannedOperations: [],
+    warnings,
+    fatalErrors,
+  });
+}
+
+/** Returns the deterministic dry-run target basis for a source basis. */
+function targetBasisFor(sourceBasis: GraphModelMigrationBasis): GraphModelMigrationBasis {
+  return new GraphModelMigrationBasis({
+    graphId: sourceBasis.graphId,
+    basisId: `${sourceBasis.basisId}${DRY_RUN_TARGET_BASIS_SUFFIX}`,
+  });
+}
+
+/** Plans content mappings from collected content source facts. */
+function plannedContentMappings(
+  contentSources: readonly GraphModelMigrationContentSource[],
+): readonly GraphModelMigrationContentMapping[] {
+  return Object.freeze([...contentSources]
+    .sort(compareContentSources)
+    .map((source) => new GraphModelMigrationContentMapping({
+      legacyContentKey: source.legacyContentKey,
+      targetAttachmentKey: targetAttachmentKeyFor(source.legacyContentKey),
+    })));
+}
+
+/** Creates missing-content fatal errors for required content sources. */
+function missingContentSourceErrors(
+  requiredContentKeys: readonly string[],
+  contentMappings: readonly GraphModelMigrationContentMapping[],
+): readonly GraphModelMigrationNotice[] {
+  const contentKeys = new Set(contentMappings.map((mapping) => mapping.legacyContentKey));
+  const fatalErrors: GraphModelMigrationNotice[] = [];
+  for (const requiredContentKey of requiredContentKeys) {
+    if (!contentKeys.has(requiredContentKey)) {
+      fatalErrors.push(GraphModelMigrationNotice.fatal(
+        MISSING_CONTENT_SOURCE_CODE,
+        `missing content source ${requiredContentKey}`,
+      ));
+    }
+  }
+  return Object.freeze(fatalErrors);
+}
+
+/** Builds planned graph operation facts from manifest mapping inputs. */
+function plannedOperationsFor(
+  request: DryRunGraphModelMigrationPlanRequest,
+  contentMappings: readonly GraphModelMigrationContentMapping[],
+): readonly GraphModelMigrationPlannedGraphOperation[] {
+  const operations: GraphModelMigrationPlannedGraphOperation[] = [];
+  for (const nodeMapping of request.nodeMappings) {
+    operations.push(GraphModelMigrationPlannedGraphOperation.nodeRecord(
+      nodeMapping.legacyNodeId,
+      nodeMapping.targetNodeId,
+    ));
+  }
+  for (const edgeMapping of request.edgeMappings) {
+    operations.push(GraphModelMigrationPlannedGraphOperation.edgeRecord(
+      edgeMapping.legacyEdgeId,
+      edgeMapping.targetEdgeId,
+    ));
+  }
+  for (const propertyMapping of request.propertyMappings) {
+    operations.push(plannedPropertyOperation(propertyMapping));
+  }
+  for (const contentMapping of contentMappings) {
+    operations.push(GraphModelMigrationPlannedGraphOperation.contentAttachment(
+      contentMapping.legacyContentKey,
+      contentMapping.targetAttachmentKey,
+    ));
+  }
+  return Object.freeze(operations.sort(comparePlannedOperations));
+}
+
+/** Builds a planned property operation fact. */
+function plannedPropertyOperation(
+  propertyMapping: GraphModelMigrationPropertyMapping,
+): GraphModelMigrationPlannedGraphOperation {
+  return GraphModelMigrationPlannedGraphOperation.property(
+    propertyMapping.legacyKey(),
+    `${propertyMapping.targetOwnerId}\0${propertyMapping.targetPropertyKey}`,
+  );
+}
+
+/** Returns the deterministic dry-run target attachment key. */
+function targetAttachmentKeyFor(legacyContentKey: string): string {
+  return `${CONTENT_ATTACHMENT_PREFIX}${legacyContentKey}`;
+}
+
+/** Compares content source facts deterministically. */
+function compareContentSources(
+  left: GraphModelMigrationContentSource,
+  right: GraphModelMigrationContentSource,
+): number {
+  return compareStrings(left.legacyContentKey, right.legacyContentKey);
+}
+
+/** Compares planned graph operation facts deterministically. */
+function comparePlannedOperations(
+  left: GraphModelMigrationPlannedGraphOperation,
+  right: GraphModelMigrationPlannedGraphOperation,
+): number {
+  return compareStrings(left.toKey(), right.toKey());
+}

--- a/src/domain/migrations/GraphModelMigrationBasis.ts
+++ b/src/domain/migrations/GraphModelMigrationBasis.ts
@@ -1,0 +1,42 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationBasisFields = {
+  readonly graphId: string;
+  readonly basisId: string;
+};
+
+/** Runtime-backed identity for one migration source or target basis. */
+export default class GraphModelMigrationBasis {
+  readonly graphId: string;
+  readonly basisId: string;
+
+  constructor(fields: GraphModelMigrationBasisFields) {
+    const checkedFields = requireFields(fields);
+    this.graphId = requireNonEmptyString(checkedFields.graphId, 'graphId');
+    this.basisId = requireNonEmptyString(checkedFields.basisId, 'basisId');
+    Object.freeze(this);
+  }
+
+  /** Returns a stable key for equality and map indexing. */
+  toKey(): string {
+    return `${this.graphId}\0${this.basisId}`;
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationBasisFields | null | undefined,
+): GraphModelMigrationBasisFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationBasis fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationContentMapping.ts
+++ b/src/domain/migrations/GraphModelMigrationContentMapping.ts
@@ -1,0 +1,37 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationContentMappingFields = {
+  readonly legacyContentKey: string;
+  readonly targetAttachmentKey: string;
+};
+
+/** Runtime-backed mapping from a legacy content property to a planned attachment fact. */
+export default class GraphModelMigrationContentMapping {
+  readonly legacyContentKey: string;
+  readonly targetAttachmentKey: string;
+
+  constructor(fields: GraphModelMigrationContentMappingFields) {
+    const checkedFields = requireFields(fields);
+    this.legacyContentKey = requireNonEmptyString(checkedFields.legacyContentKey, 'legacyContentKey');
+    this.targetAttachmentKey = requireNonEmptyString(checkedFields.targetAttachmentKey, 'targetAttachmentKey');
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationContentMappingFields | null | undefined,
+): GraphModelMigrationContentMappingFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationContentMapping fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationContentSource.ts
+++ b/src/domain/migrations/GraphModelMigrationContentSource.ts
@@ -1,0 +1,37 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationContentSourceFields = {
+  readonly legacyContentKey: string;
+  readonly contentOid: string;
+};
+
+/** Runtime-backed source blob fact needed by migration planning. */
+export default class GraphModelMigrationContentSource {
+  readonly legacyContentKey: string;
+  readonly contentOid: string;
+
+  constructor(fields: GraphModelMigrationContentSourceFields) {
+    const checkedFields = requireFields(fields);
+    this.legacyContentKey = requireNonEmptyString(checkedFields.legacyContentKey, 'legacyContentKey');
+    this.contentOid = requireNonEmptyString(checkedFields.contentOid, 'contentOid');
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationContentSourceFields | null | undefined,
+): GraphModelMigrationContentSourceFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationContentSource fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationEdgeMapping.ts
+++ b/src/domain/migrations/GraphModelMigrationEdgeMapping.ts
@@ -1,0 +1,37 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationEdgeMappingFields = {
+  readonly legacyEdgeId: string;
+  readonly targetEdgeId: string;
+};
+
+/** Runtime-backed mapping from a legacy edge id to the planned graph edge id. */
+export default class GraphModelMigrationEdgeMapping {
+  readonly legacyEdgeId: string;
+  readonly targetEdgeId: string;
+
+  constructor(fields: GraphModelMigrationEdgeMappingFields) {
+    const checkedFields = requireFields(fields);
+    this.legacyEdgeId = requireNonEmptyString(checkedFields.legacyEdgeId, 'legacyEdgeId');
+    this.targetEdgeId = requireNonEmptyString(checkedFields.targetEdgeId, 'targetEdgeId');
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationEdgeMappingFields | null | undefined,
+): GraphModelMigrationEdgeMappingFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationEdgeMapping fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationHistoryInput.ts
+++ b/src/domain/migrations/GraphModelMigrationHistoryInput.ts
@@ -1,0 +1,97 @@
+import { compareStrings } from '../utils/StringComparison.ts';
+import GraphModelMigrationHistorySegment from './GraphModelMigrationHistorySegment.ts';
+import WarpError from '../errors/WarpError.ts';
+import type GraphModelMigrationHistoryPatchInput from './GraphModelMigrationHistoryPatchInput.ts';
+
+export type GraphModelMigrationHistoryInputFields = {
+  readonly segments: readonly GraphModelMigrationHistorySegment[];
+};
+
+/** Runtime-backed ordered legacy history input for graph-model migration. */
+export default class GraphModelMigrationHistoryInput {
+  readonly segments: readonly GraphModelMigrationHistorySegment[];
+  readonly patches: readonly GraphModelMigrationHistoryPatchInput[];
+
+  constructor(fields: GraphModelMigrationHistoryInputFields) {
+    const checkedFields = requireFields(fields);
+    this.segments = freezeSegments(checkedFields.segments);
+    this.patches = freezeOrderedPatches(this.segments);
+    requireFrontierEvidence(this.patches);
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationHistoryInputFields | null | undefined,
+): GraphModelMigrationHistoryInputFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationHistoryInput fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates, sorts, and freezes writer history segments. */
+function freezeSegments(
+  segments: readonly GraphModelMigrationHistorySegment[],
+): readonly GraphModelMigrationHistorySegment[] {
+  const checked = requireArray(segments, 'segments').map(requireSegment);
+  requireUnique(checked.map((segment) => segment.writerId), 'writer segment');
+  return Object.freeze([...checked].sort(compareSegments));
+}
+
+/** Flattens and freezes all patches in deterministic segment order. */
+function freezeOrderedPatches(
+  segments: readonly GraphModelMigrationHistorySegment[],
+): readonly GraphModelMigrationHistoryPatchInput[] {
+  const patches = segments.flatMap((segment) => segment.patches);
+  requireUnique(patches.map((patch) => patch.patchId), 'patch id');
+  return Object.freeze(patches);
+}
+
+/** Requires frontier evidence for all equivalence-ready patch inputs. */
+function requireFrontierEvidence(
+  patches: readonly GraphModelMigrationHistoryPatchInput[],
+): void {
+  for (const patch of patches) {
+    if (patch.frontierEvidence === null) {
+      throw new WarpError(`patch ${patch.patchId} is missing frontier evidence`, 'E_VALIDATION');
+    }
+  }
+}
+
+/** Requires an array field. */
+function requireArray<T>(items: readonly T[] | null | undefined, label: string): readonly T[] {
+  if (items === null || items === undefined || !Array.isArray(items)) {
+    throw new WarpError(`GraphModelMigrationHistoryInput ${label} must be an array`, 'E_VALIDATION');
+  }
+  const checkedItems: readonly T[] = items;
+  return checkedItems;
+}
+
+/** Requires a history segment instance. */
+function requireSegment(segment: GraphModelMigrationHistorySegment): GraphModelMigrationHistorySegment {
+  if (!(segment instanceof GraphModelMigrationHistorySegment)) {
+    throw new WarpError('segments must contain history segments', 'E_VALIDATION');
+  }
+  return segment;
+}
+
+/** Requires no duplicate keys in history input. */
+function requireUnique(keys: readonly string[], label: string): void {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) {
+      throw new WarpError(`GraphModelMigrationHistoryInput duplicates ${label} ${key}`, 'E_VALIDATION');
+    }
+    seen.add(key);
+  }
+}
+
+/** Compares writer segments deterministically. */
+function compareSegments(
+  left: GraphModelMigrationHistorySegment,
+  right: GraphModelMigrationHistorySegment,
+): number {
+  return compareStrings(left.writerId, right.writerId);
+}

--- a/src/domain/migrations/GraphModelMigrationHistoryPatchInput.ts
+++ b/src/domain/migrations/GraphModelMigrationHistoryPatchInput.ts
@@ -1,0 +1,120 @@
+import GraphModelMigrationPatchFrontierEvidence from './GraphModelMigrationPatchFrontierEvidence.ts';
+import GraphModelMigrationPatchOperationFact from './GraphModelMigrationPatchOperationFact.ts';
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationHistoryPatchInputFields = {
+  readonly writerId: string;
+  readonly patchId: string;
+  readonly writerSequence: number;
+  readonly frontierEvidence: GraphModelMigrationPatchFrontierEvidence | null;
+  readonly operations: readonly GraphModelMigrationPatchOperationFact[];
+};
+
+/** Runtime-backed ordered legacy patch input for migration planning. */
+export default class GraphModelMigrationHistoryPatchInput {
+  readonly writerId: string;
+  readonly patchId: string;
+  readonly writerSequence: number;
+  readonly frontierEvidence: GraphModelMigrationPatchFrontierEvidence | null;
+  readonly operations: readonly GraphModelMigrationPatchOperationFact[];
+
+  constructor(fields: GraphModelMigrationHistoryPatchInputFields) {
+    const checkedFields = requireFields(fields);
+    this.writerId = requireNonEmptyString(checkedFields.writerId, 'writerId');
+    this.patchId = requireNonEmptyString(checkedFields.patchId, 'patchId');
+    this.writerSequence = requireWriterSequence(checkedFields.writerSequence);
+    this.frontierEvidence = requireOptionalFrontierEvidence(checkedFields.frontierEvidence);
+    this.operations = freezeOperations(checkedFields.operations);
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationHistoryPatchInputFields | null | undefined,
+): GraphModelMigrationHistoryPatchInputFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationHistoryPatchInput fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Validates a deterministic per-writer sequence number. */
+function requireWriterSequence(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new WarpError('writerSequence must be a non-negative safe integer', 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Requires frontier evidence when present. */
+function requireOptionalFrontierEvidence(
+  evidence: GraphModelMigrationPatchFrontierEvidence | null,
+): GraphModelMigrationPatchFrontierEvidence | null {
+  if (evidence !== null && !(evidence instanceof GraphModelMigrationPatchFrontierEvidence)) {
+    throw new WarpError('frontierEvidence must be a GraphModelMigrationPatchFrontierEvidence', 'E_VALIDATION');
+  }
+  return evidence;
+}
+
+/** Validates, sorts, and freezes patch operation facts. */
+function freezeOperations(
+  operations: readonly GraphModelMigrationPatchOperationFact[],
+): readonly GraphModelMigrationPatchOperationFact[] {
+  const checked = requireArray(operations, 'operations').map(requireOperationFact);
+  const sorted = [...checked].sort(compareOperations);
+  requireContiguousOperationIndexes(sorted);
+  return Object.freeze(sorted);
+}
+
+/** Requires an array field. */
+function requireArray<T>(items: readonly T[] | null | undefined, label: string): readonly T[] {
+  if (items === null || items === undefined || !Array.isArray(items)) {
+    throw new WarpError(`GraphModelMigrationHistoryPatchInput ${label} must be an array`, 'E_VALIDATION');
+  }
+  const checkedItems: readonly T[] = items;
+  return checkedItems;
+}
+
+/** Requires a patch operation fact instance. */
+function requireOperationFact(
+  operation: GraphModelMigrationPatchOperationFact,
+): GraphModelMigrationPatchOperationFact {
+  if (!(operation instanceof GraphModelMigrationPatchOperationFact)) {
+    throw new WarpError('operations must contain patch operation facts', 'E_VALIDATION');
+  }
+  return operation;
+}
+
+/** Requires operation indexes to be contiguous from zero. */
+function requireContiguousOperationIndexes(
+  operations: readonly GraphModelMigrationPatchOperationFact[],
+): void {
+  operations.forEach((operation, position) => {
+    if (operation.operationIndex !== position) {
+      throw new WarpError('operation indexes must be contiguous per patch', 'E_VALIDATION');
+    }
+  });
+}
+
+/** Compares patch operation facts by operation index. */
+function compareOperations(
+  left: GraphModelMigrationPatchOperationFact,
+  right: GraphModelMigrationPatchOperationFact,
+): number {
+  if (left.operationIndex < right.operationIndex) {
+    return -1;
+  }
+  if (left.operationIndex > right.operationIndex) {
+    return 1;
+  }
+  return 0;
+}

--- a/src/domain/migrations/GraphModelMigrationHistorySegment.ts
+++ b/src/domain/migrations/GraphModelMigrationHistorySegment.ts
@@ -1,0 +1,118 @@
+import GraphModelMigrationHistoryPatchInput from './GraphModelMigrationHistoryPatchInput.ts';
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationHistorySegmentFields = {
+  readonly writerId: string;
+  readonly patches: readonly GraphModelMigrationHistoryPatchInput[];
+};
+
+/** Runtime-backed ordered legacy history segment for one writer. */
+export default class GraphModelMigrationHistorySegment {
+  readonly writerId: string;
+  readonly patches: readonly GraphModelMigrationHistoryPatchInput[];
+
+  constructor(fields: GraphModelMigrationHistorySegmentFields) {
+    const checkedFields = requireFields(fields);
+    this.writerId = requireNonEmptyString(checkedFields.writerId, 'writerId');
+    this.patches = freezePatches(this.writerId, checkedFields.patches);
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationHistorySegmentFields | null | undefined,
+): GraphModelMigrationHistorySegmentFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationHistorySegment fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Validates, sorts, and freezes patches in writer-chain order. */
+function freezePatches(
+  writerId: string,
+  patches: readonly GraphModelMigrationHistoryPatchInput[],
+): readonly GraphModelMigrationHistoryPatchInput[] {
+  const checked = requireArray(patches, 'patches').map(requirePatchInput);
+  requireAllPatchesBelongToWriter(writerId, checked);
+  const sorted = [...checked].sort(comparePatches);
+  requireContiguousWriterSequence(sorted);
+  requireUnique(sorted.map((patch) => patch.patchId), 'patch id');
+  return Object.freeze(sorted);
+}
+
+/** Requires an array field. */
+function requireArray<T>(items: readonly T[] | null | undefined, label: string): readonly T[] {
+  if (items === null || items === undefined || !Array.isArray(items)) {
+    throw new WarpError(`GraphModelMigrationHistorySegment ${label} must be an array`, 'E_VALIDATION');
+  }
+  const checkedItems: readonly T[] = items;
+  return checkedItems;
+}
+
+/** Requires a history patch input instance. */
+function requirePatchInput(
+  patch: GraphModelMigrationHistoryPatchInput,
+): GraphModelMigrationHistoryPatchInput {
+  if (!(patch instanceof GraphModelMigrationHistoryPatchInput)) {
+    throw new WarpError('patches must contain history patch inputs', 'E_VALIDATION');
+  }
+  return patch;
+}
+
+/** Requires every patch in the segment to belong to the segment writer. */
+function requireAllPatchesBelongToWriter(
+  writerId: string,
+  patches: readonly GraphModelMigrationHistoryPatchInput[],
+): void {
+  for (const patch of patches) {
+    if (patch.writerId !== writerId) {
+      throw new WarpError(`patch ${patch.patchId} belongs to the wrong writer`, 'E_VALIDATION');
+    }
+  }
+}
+
+/** Requires writer sequences to be contiguous from zero. */
+function requireContiguousWriterSequence(
+  patches: readonly GraphModelMigrationHistoryPatchInput[],
+): void {
+  patches.forEach((patch, position) => {
+    if (patch.writerSequence !== position) {
+      throw new WarpError('writer patch order must be contiguous per writer', 'E_VALIDATION');
+    }
+  });
+}
+
+/** Requires no duplicate keys in a history segment. */
+function requireUnique(keys: readonly string[], label: string): void {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) {
+      throw new WarpError(`GraphModelMigrationHistorySegment duplicates ${label} ${key}`, 'E_VALIDATION');
+    }
+    seen.add(key);
+  }
+}
+
+/** Compares history patch inputs by writer sequence. */
+function comparePatches(
+  left: GraphModelMigrationHistoryPatchInput,
+  right: GraphModelMigrationHistoryPatchInput,
+): number {
+  if (left.writerSequence < right.writerSequence) {
+    return -1;
+  }
+  if (left.writerSequence > right.writerSequence) {
+    return 1;
+  }
+  return 0;
+}

--- a/src/domain/migrations/GraphModelMigrationManifest.ts
+++ b/src/domain/migrations/GraphModelMigrationManifest.ts
@@ -40,8 +40,8 @@ export default class GraphModelMigrationManifest {
     this.edgeMappings = freezeEdgeMappings(checkedFields.edgeMappings);
     this.propertyMappings = freezePropertyMappings(checkedFields.propertyMappings);
     this.contentMappings = freezeContentMappings(checkedFields.contentMappings);
-    this.warnings = freezeNotices(checkedFields.warnings, false, 'warnings');
-    this.fatalErrors = freezeNotices(checkedFields.fatalErrors, true, 'fatalErrors');
+    this.warnings = freezeWarningNotices(checkedFields.warnings);
+    this.fatalErrors = freezeFatalNotices(checkedFields.fatalErrors);
     Object.freeze(this);
   }
 
@@ -116,16 +116,27 @@ function freezeContentMappings(
   return Object.freeze(checked);
 }
 
-/** Validates and freezes warning or fatal notices. */
-function freezeNotices(
+/** Validates and freezes warning notices. */
+function freezeWarningNotices(
   notices: readonly GraphModelMigrationNotice[],
-  fatal: boolean,
-  label: string,
 ): readonly GraphModelMigrationNotice[] {
-  const checked = requireArray(notices, label).map(requireNotice);
+  const checked = requireArray(notices, 'warnings').map(requireNotice);
   for (const notice of checked) {
-    if (notice.isFatal() !== fatal) {
-      throw new WarpError(`${label} contains the wrong notice kind`, 'E_VALIDATION');
+    if (notice.isFatal()) {
+      throw new WarpError('warnings contains the wrong notice kind', 'E_VALIDATION');
+    }
+  }
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes fatal notices. */
+function freezeFatalNotices(
+  notices: readonly GraphModelMigrationNotice[],
+): readonly GraphModelMigrationNotice[] {
+  const checked = requireArray(notices, 'fatalErrors').map(requireNotice);
+  for (const notice of checked) {
+    if (!notice.isFatal()) {
+      throw new WarpError('fatalErrors contains the wrong notice kind', 'E_VALIDATION');
     }
   }
   return Object.freeze(checked);

--- a/src/domain/migrations/GraphModelMigrationManifest.ts
+++ b/src/domain/migrations/GraphModelMigrationManifest.ts
@@ -1,0 +1,196 @@
+import GraphModelMigrationBasis from './GraphModelMigrationBasis.ts';
+import GraphModelMigrationContentMapping from './GraphModelMigrationContentMapping.ts';
+import GraphModelMigrationEdgeMapping from './GraphModelMigrationEdgeMapping.ts';
+import GraphModelMigrationManifestVersion from './GraphModelMigrationManifestVersion.ts';
+import GraphModelMigrationNodeMapping from './GraphModelMigrationNodeMapping.ts';
+import GraphModelMigrationNotice from './GraphModelMigrationNotice.ts';
+import GraphModelMigrationPropertyMapping from './GraphModelMigrationPropertyMapping.ts';
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationManifestFields = {
+  readonly version: GraphModelMigrationManifestVersion;
+  readonly sourceBasis: GraphModelMigrationBasis;
+  readonly targetBasis: GraphModelMigrationBasis;
+  readonly nodeMappings: readonly GraphModelMigrationNodeMapping[];
+  readonly edgeMappings: readonly GraphModelMigrationEdgeMapping[];
+  readonly propertyMappings: readonly GraphModelMigrationPropertyMapping[];
+  readonly contentMappings: readonly GraphModelMigrationContentMapping[];
+  readonly warnings: readonly GraphModelMigrationNotice[];
+  readonly fatalErrors: readonly GraphModelMigrationNotice[];
+};
+
+/** Runtime-backed root manifest for a dry-run graph-model migration plan. */
+export default class GraphModelMigrationManifest {
+  readonly version: GraphModelMigrationManifestVersion;
+  readonly sourceBasis: GraphModelMigrationBasis;
+  readonly targetBasis: GraphModelMigrationBasis;
+  readonly nodeMappings: readonly GraphModelMigrationNodeMapping[];
+  readonly edgeMappings: readonly GraphModelMigrationEdgeMapping[];
+  readonly propertyMappings: readonly GraphModelMigrationPropertyMapping[];
+  readonly contentMappings: readonly GraphModelMigrationContentMapping[];
+  readonly warnings: readonly GraphModelMigrationNotice[];
+  readonly fatalErrors: readonly GraphModelMigrationNotice[];
+
+  constructor(fields: GraphModelMigrationManifestFields) {
+    const checkedFields = requireFields(fields);
+    this.version = requireVersion(checkedFields.version);
+    this.sourceBasis = requireBasis(checkedFields.sourceBasis, 'sourceBasis');
+    this.targetBasis = requireBasis(checkedFields.targetBasis, 'targetBasis');
+    this.nodeMappings = freezeNodeMappings(checkedFields.nodeMappings);
+    this.edgeMappings = freezeEdgeMappings(checkedFields.edgeMappings);
+    this.propertyMappings = freezePropertyMappings(checkedFields.propertyMappings);
+    this.contentMappings = freezeContentMappings(checkedFields.contentMappings);
+    this.warnings = freezeNotices(checkedFields.warnings, false, 'warnings');
+    this.fatalErrors = freezeNotices(checkedFields.fatalErrors, true, 'fatalErrors');
+    Object.freeze(this);
+  }
+
+  /** Returns true when the manifest contains fatal planning failures. */
+  hasFatalErrors(): boolean {
+    return this.fatalErrors.length > 0;
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationManifestFields | null | undefined,
+): GraphModelMigrationManifestFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationManifest fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Requires a runtime-backed manifest version. */
+function requireVersion(version: GraphModelMigrationManifestVersion): GraphModelMigrationManifestVersion {
+  if (!(version instanceof GraphModelMigrationManifestVersion)) {
+    throw new WarpError(
+      'GraphModelMigrationManifest version must be a GraphModelMigrationManifestVersion',
+      'E_VALIDATION',
+    );
+  }
+  return version;
+}
+
+/** Requires a runtime-backed migration basis. */
+function requireBasis(basis: GraphModelMigrationBasis, name: string): GraphModelMigrationBasis {
+  if (!(basis instanceof GraphModelMigrationBasis)) {
+    throw new WarpError(`${name} must be a GraphModelMigrationBasis`, 'E_VALIDATION');
+  }
+  return basis;
+}
+
+/** Validates and freezes node mappings. */
+function freezeNodeMappings(
+  mappings: readonly GraphModelMigrationNodeMapping[],
+): readonly GraphModelMigrationNodeMapping[] {
+  const checked = requireArray(mappings, 'nodeMappings').map(requireNodeMapping);
+  requireUnique(checked.map((mapping) => mapping.legacyNodeId), 'legacy node mapping');
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes edge mappings. */
+function freezeEdgeMappings(
+  mappings: readonly GraphModelMigrationEdgeMapping[],
+): readonly GraphModelMigrationEdgeMapping[] {
+  const checked = requireArray(mappings, 'edgeMappings').map(requireEdgeMapping);
+  requireUnique(checked.map((mapping) => mapping.legacyEdgeId), 'legacy edge mapping');
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes property mappings. */
+function freezePropertyMappings(
+  mappings: readonly GraphModelMigrationPropertyMapping[],
+): readonly GraphModelMigrationPropertyMapping[] {
+  const checked = requireArray(mappings, 'propertyMappings').map(requirePropertyMapping);
+  requireUnique(checked.map((mapping) => mapping.legacyKey()), 'legacy property mapping');
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes content mappings. */
+function freezeContentMappings(
+  mappings: readonly GraphModelMigrationContentMapping[],
+): readonly GraphModelMigrationContentMapping[] {
+  const checked = requireArray(mappings, 'contentMappings').map(requireContentMapping);
+  requireUnique(checked.map((mapping) => mapping.legacyContentKey), 'legacy content mapping');
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes warning or fatal notices. */
+function freezeNotices(
+  notices: readonly GraphModelMigrationNotice[],
+  fatal: boolean,
+  label: string,
+): readonly GraphModelMigrationNotice[] {
+  const checked = requireArray(notices, label).map(requireNotice);
+  for (const notice of checked) {
+    if (notice.isFatal() !== fatal) {
+      throw new WarpError(`${label} contains the wrong notice kind`, 'E_VALIDATION');
+    }
+  }
+  return Object.freeze(checked);
+}
+
+/** Requires an array field. */
+function requireArray<T>(items: readonly T[] | null | undefined, label: string): readonly T[] {
+  if (items === null || items === undefined || !Array.isArray(items)) {
+    throw new WarpError(`GraphModelMigrationManifest ${label} must be an array`, 'E_VALIDATION');
+  }
+  const checkedItems: readonly T[] = items;
+  return checkedItems;
+}
+
+/** Requires a node mapping instance. */
+function requireNodeMapping(mapping: GraphModelMigrationNodeMapping): GraphModelMigrationNodeMapping {
+  if (!(mapping instanceof GraphModelMigrationNodeMapping)) {
+    throw new WarpError('nodeMappings must contain node mappings', 'E_VALIDATION');
+  }
+  return mapping;
+}
+
+/** Requires an edge mapping instance. */
+function requireEdgeMapping(mapping: GraphModelMigrationEdgeMapping): GraphModelMigrationEdgeMapping {
+  if (!(mapping instanceof GraphModelMigrationEdgeMapping)) {
+    throw new WarpError('edgeMappings must contain edge mappings', 'E_VALIDATION');
+  }
+  return mapping;
+}
+
+/** Requires a property mapping instance. */
+function requirePropertyMapping(
+  mapping: GraphModelMigrationPropertyMapping,
+): GraphModelMigrationPropertyMapping {
+  if (!(mapping instanceof GraphModelMigrationPropertyMapping)) {
+    throw new WarpError('propertyMappings must contain property mappings', 'E_VALIDATION');
+  }
+  return mapping;
+}
+
+/** Requires a content mapping instance. */
+function requireContentMapping(
+  mapping: GraphModelMigrationContentMapping,
+): GraphModelMigrationContentMapping {
+  if (!(mapping instanceof GraphModelMigrationContentMapping)) {
+    throw new WarpError('contentMappings must contain content mappings', 'E_VALIDATION');
+  }
+  return mapping;
+}
+
+/** Requires a notice instance. */
+function requireNotice(notice: GraphModelMigrationNotice): GraphModelMigrationNotice {
+  if (!(notice instanceof GraphModelMigrationNotice)) {
+    throw new WarpError('migration notices must be GraphModelMigrationNotice instances', 'E_VALIDATION');
+  }
+  return notice;
+}
+
+/** Requires no duplicate keys in a manifest section. */
+function requireUnique(keys: readonly string[], label: string): void {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) {
+      throw new WarpError(`GraphModelMigrationManifest duplicates ${label} ${key}`, 'E_VALIDATION');
+    }
+    seen.add(key);
+  }
+}

--- a/src/domain/migrations/GraphModelMigrationManifestVersion.ts
+++ b/src/domain/migrations/GraphModelMigrationManifestVersion.ts
@@ -1,0 +1,29 @@
+import WarpError from '../errors/WarpError.ts';
+
+export const GRAPH_MODEL_MIGRATION_MANIFEST_VERSION = 1;
+
+/** Runtime-backed version for graph-model migration manifests. */
+export default class GraphModelMigrationManifestVersion {
+  readonly value: number;
+
+  constructor(value: number) {
+    this.value = requireManifestVersion(value);
+    Object.freeze(this);
+  }
+
+  /** Returns the current manifest version. */
+  static current(): GraphModelMigrationManifestVersion {
+    return new GraphModelMigrationManifestVersion(GRAPH_MODEL_MIGRATION_MANIFEST_VERSION);
+  }
+}
+
+/** Validates a manifest version number. */
+function requireManifestVersion(value: number): number {
+  if (value !== GRAPH_MODEL_MIGRATION_MANIFEST_VERSION) {
+    throw new WarpError(
+      `Graph-model migration manifest version must be ${GRAPH_MODEL_MIGRATION_MANIFEST_VERSION}`,
+      'E_VALIDATION',
+    );
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationNodeMapping.ts
+++ b/src/domain/migrations/GraphModelMigrationNodeMapping.ts
@@ -1,0 +1,37 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationNodeMappingFields = {
+  readonly legacyNodeId: string;
+  readonly targetNodeId: string;
+};
+
+/** Runtime-backed mapping from a legacy node id to the planned graph node id. */
+export default class GraphModelMigrationNodeMapping {
+  readonly legacyNodeId: string;
+  readonly targetNodeId: string;
+
+  constructor(fields: GraphModelMigrationNodeMappingFields) {
+    const checkedFields = requireFields(fields);
+    this.legacyNodeId = requireNonEmptyString(checkedFields.legacyNodeId, 'legacyNodeId');
+    this.targetNodeId = requireNonEmptyString(checkedFields.targetNodeId, 'targetNodeId');
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationNodeMappingFields | null | undefined,
+): GraphModelMigrationNodeMappingFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationNodeMapping fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationNotice.ts
+++ b/src/domain/migrations/GraphModelMigrationNotice.ts
@@ -1,0 +1,68 @@
+import WarpError from '../errors/WarpError.ts';
+
+const WARNING_NOTICE = 'warning';
+const FATAL_NOTICE = 'fatal';
+
+export type GraphModelMigrationNoticeKind = typeof WARNING_NOTICE | typeof FATAL_NOTICE;
+
+export type GraphModelMigrationNoticeFields = {
+  readonly kind: GraphModelMigrationNoticeKind;
+  readonly code: string;
+  readonly message: string;
+};
+
+/** Runtime-backed warning or fatal planning notice for graph-model migration. */
+export default class GraphModelMigrationNotice {
+  readonly kind: GraphModelMigrationNoticeKind;
+  readonly code: string;
+  readonly message: string;
+
+  constructor(fields: GraphModelMigrationNoticeFields) {
+    const checkedFields = requireFields(fields);
+    this.kind = requireKind(checkedFields.kind);
+    this.code = requireNonEmptyString(checkedFields.code, 'code');
+    this.message = requireNonEmptyString(checkedFields.message, 'message');
+    Object.freeze(this);
+  }
+
+  /** Builds a warning notice. */
+  static warning(code: string, message: string): GraphModelMigrationNotice {
+    return new GraphModelMigrationNotice({ kind: WARNING_NOTICE, code, message });
+  }
+
+  /** Builds a fatal planning notice. */
+  static fatal(code: string, message: string): GraphModelMigrationNotice {
+    return new GraphModelMigrationNotice({ kind: FATAL_NOTICE, code, message });
+  }
+
+  /** Returns true when this notice blocks planning. */
+  isFatal(): boolean {
+    return this.kind === FATAL_NOTICE;
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationNoticeFields | null | undefined,
+): GraphModelMigrationNoticeFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationNotice fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a notice kind. */
+function requireKind(kind: GraphModelMigrationNoticeKind): GraphModelMigrationNoticeKind {
+  if (kind !== WARNING_NOTICE && kind !== FATAL_NOTICE) {
+    throw new WarpError('GraphModelMigrationNotice kind must be warning or fatal', 'E_VALIDATION');
+  }
+  return kind;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationPatchDescriptor.ts
+++ b/src/domain/migrations/GraphModelMigrationPatchDescriptor.ts
@@ -1,0 +1,53 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationPatchDescriptorFields = {
+  readonly patchId: string;
+  readonly writerId: string;
+  readonly writerSequence: number;
+};
+
+/** Runtime-backed source patch descriptor for graph-model migration planning. */
+export default class GraphModelMigrationPatchDescriptor {
+  readonly patchId: string;
+  readonly writerId: string;
+  readonly writerSequence: number;
+
+  constructor(fields: GraphModelMigrationPatchDescriptorFields) {
+    const checkedFields = requireFields(fields);
+    this.patchId = requireNonEmptyString(checkedFields.patchId, 'patchId');
+    this.writerId = requireNonEmptyString(checkedFields.writerId, 'writerId');
+    this.writerSequence = requireWriterSequence(checkedFields.writerSequence);
+    Object.freeze(this);
+  }
+
+  /** Returns the per-writer sequence uniqueness key. */
+  writerSequenceKey(): string {
+    return `${this.writerId}\0${this.writerSequence}`;
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationPatchDescriptorFields | null | undefined,
+): GraphModelMigrationPatchDescriptorFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationPatchDescriptor fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Validates a deterministic per-writer sequence number. */
+function requireWriterSequence(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new WarpError('writerSequence must be a non-negative safe integer', 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationPatchFrontierEvidence.ts
+++ b/src/domain/migrations/GraphModelMigrationPatchFrontierEvidence.ts
@@ -1,0 +1,66 @@
+import { compareStrings } from '../utils/StringComparison.ts';
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationPatchFrontierEvidenceFields = {
+  readonly frontierKey: string;
+  readonly parentPatchIds: readonly string[];
+};
+
+/** Runtime-backed patch frontier evidence for later migration equivalence checks. */
+export default class GraphModelMigrationPatchFrontierEvidence {
+  readonly frontierKey: string;
+  readonly parentPatchIds: readonly string[];
+
+  constructor(fields: GraphModelMigrationPatchFrontierEvidenceFields) {
+    const checkedFields = requireFields(fields);
+    this.frontierKey = requireNonEmptyString(checkedFields.frontierKey, 'frontierKey');
+    this.parentPatchIds = freezeParentPatchIds(checkedFields.parentPatchIds);
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationPatchFrontierEvidenceFields | null | undefined,
+): GraphModelMigrationPatchFrontierEvidenceFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationPatchFrontierEvidence fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates and freezes parent patch ids as a deterministic set. */
+function freezeParentPatchIds(parentPatchIds: readonly string[]): readonly string[] {
+  const checked = requireArray(parentPatchIds, 'parentPatchIds')
+    .map((patchId) => requireNonEmptyString(patchId, 'parentPatchId'));
+  requireUnique(checked, 'parent patch id');
+  return Object.freeze([...checked].sort(compareStrings));
+}
+
+/** Requires an array field. */
+function requireArray<T>(items: readonly T[] | null | undefined, label: string): readonly T[] {
+  if (items === null || items === undefined || !Array.isArray(items)) {
+    throw new WarpError(`GraphModelMigrationPatchFrontierEvidence ${label} must be an array`, 'E_VALIDATION');
+  }
+  const checkedItems: readonly T[] = items;
+  return checkedItems;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Requires no duplicate keys in a frontier section. */
+function requireUnique(keys: readonly string[], label: string): void {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) {
+      throw new WarpError(`GraphModelMigrationPatchFrontierEvidence duplicates ${label} ${key}`, 'E_VALIDATION');
+    }
+    seen.add(key);
+  }
+}

--- a/src/domain/migrations/GraphModelMigrationPatchOperationFact.ts
+++ b/src/domain/migrations/GraphModelMigrationPatchOperationFact.ts
@@ -1,0 +1,48 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationPatchOperationFactFields = {
+  readonly operationIndex: number;
+  readonly operationKind: string;
+  readonly operationKey: string;
+};
+
+/** Runtime-backed legacy patch operation boundary for migration history input. */
+export default class GraphModelMigrationPatchOperationFact {
+  readonly operationIndex: number;
+  readonly operationKind: string;
+  readonly operationKey: string;
+
+  constructor(fields: GraphModelMigrationPatchOperationFactFields) {
+    const checkedFields = requireFields(fields);
+    this.operationIndex = requireOperationIndex(checkedFields.operationIndex);
+    this.operationKind = requireNonEmptyString(checkedFields.operationKind, 'operationKind');
+    this.operationKey = requireNonEmptyString(checkedFields.operationKey, 'operationKey');
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationPatchOperationFactFields | null | undefined,
+): GraphModelMigrationPatchOperationFactFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationPatchOperationFact fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a deterministic operation index. */
+function requireOperationIndex(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new WarpError('operationIndex must be a non-negative safe integer', 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationPlannedGraphOperation.ts
+++ b/src/domain/migrations/GraphModelMigrationPlannedGraphOperation.ts
@@ -1,0 +1,116 @@
+import WarpError from '../errors/WarpError.ts';
+
+const PLANNED_NODE_RECORD = 'node-record';
+const PLANNED_EDGE_RECORD = 'edge-record';
+const PLANNED_PROPERTY = 'property';
+const PLANNED_CONTENT_ATTACHMENT = 'content-attachment';
+
+export type GraphModelMigrationPlannedGraphOperationKind =
+  | typeof PLANNED_NODE_RECORD
+  | typeof PLANNED_EDGE_RECORD
+  | typeof PLANNED_PROPERTY
+  | typeof PLANNED_CONTENT_ATTACHMENT;
+
+export type GraphModelMigrationPlannedGraphOperationFields = {
+  readonly kind: GraphModelMigrationPlannedGraphOperationKind;
+  readonly sourceKey: string;
+  readonly targetKey: string;
+};
+
+/** Runtime-backed dry-run graph operation fact, not a write instruction. */
+export default class GraphModelMigrationPlannedGraphOperation {
+  readonly kind: GraphModelMigrationPlannedGraphOperationKind;
+  readonly sourceKey: string;
+  readonly targetKey: string;
+
+  constructor(fields: GraphModelMigrationPlannedGraphOperationFields) {
+    const checkedFields = requireFields(fields);
+    this.kind = requireKind(checkedFields.kind);
+    this.sourceKey = requireNonEmptyString(checkedFields.sourceKey, 'sourceKey');
+    this.targetKey = requireNonEmptyString(checkedFields.targetKey, 'targetKey');
+    Object.freeze(this);
+  }
+
+  /** Creates a planned node-record operation fact. */
+  static nodeRecord(sourceKey: string, targetKey: string): GraphModelMigrationPlannedGraphOperation {
+    return new GraphModelMigrationPlannedGraphOperation({
+      kind: PLANNED_NODE_RECORD,
+      sourceKey,
+      targetKey,
+    });
+  }
+
+  /** Creates a planned edge-record operation fact. */
+  static edgeRecord(sourceKey: string, targetKey: string): GraphModelMigrationPlannedGraphOperation {
+    return new GraphModelMigrationPlannedGraphOperation({
+      kind: PLANNED_EDGE_RECORD,
+      sourceKey,
+      targetKey,
+    });
+  }
+
+  /** Creates a planned property operation fact. */
+  static property(sourceKey: string, targetKey: string): GraphModelMigrationPlannedGraphOperation {
+    return new GraphModelMigrationPlannedGraphOperation({
+      kind: PLANNED_PROPERTY,
+      sourceKey,
+      targetKey,
+    });
+  }
+
+  /** Creates a planned content-attachment operation fact. */
+  static contentAttachment(
+    sourceKey: string,
+    targetKey: string,
+  ): GraphModelMigrationPlannedGraphOperation {
+    return new GraphModelMigrationPlannedGraphOperation({
+      kind: PLANNED_CONTENT_ATTACHMENT,
+      sourceKey,
+      targetKey,
+    });
+  }
+
+  /** Returns a deterministic operation key. */
+  toKey(): string {
+    return `${this.kind}\0${this.sourceKey}\0${this.targetKey}`;
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationPlannedGraphOperationFields | null | undefined,
+): GraphModelMigrationPlannedGraphOperationFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError(
+      'GraphModelMigrationPlannedGraphOperation fields must be provided',
+      'E_VALIDATION',
+    );
+  }
+  return fields;
+}
+
+/** Validates a planned operation kind. */
+function requireKind(
+  kind: GraphModelMigrationPlannedGraphOperationKind,
+): GraphModelMigrationPlannedGraphOperationKind {
+  if (
+    kind !== PLANNED_NODE_RECORD
+    && kind !== PLANNED_EDGE_RECORD
+    && kind !== PLANNED_PROPERTY
+    && kind !== PLANNED_CONTENT_ATTACHMENT
+  ) {
+    throw new WarpError(
+      'GraphModelMigrationPlannedGraphOperation kind is unsupported',
+      'E_VALIDATION',
+    );
+  }
+  return kind;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationPropertyMapping.ts
+++ b/src/domain/migrations/GraphModelMigrationPropertyMapping.ts
@@ -1,0 +1,48 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationPropertyMappingFields = {
+  readonly legacyOwnerId: string;
+  readonly legacyPropertyKey: string;
+  readonly targetOwnerId: string;
+  readonly targetPropertyKey: string;
+};
+
+/** Runtime-backed mapping from a legacy property fact to a planned target property fact. */
+export default class GraphModelMigrationPropertyMapping {
+  readonly legacyOwnerId: string;
+  readonly legacyPropertyKey: string;
+  readonly targetOwnerId: string;
+  readonly targetPropertyKey: string;
+
+  constructor(fields: GraphModelMigrationPropertyMappingFields) {
+    const checkedFields = requireFields(fields);
+    this.legacyOwnerId = requireNonEmptyString(checkedFields.legacyOwnerId, 'legacyOwnerId');
+    this.legacyPropertyKey = requireNonEmptyString(checkedFields.legacyPropertyKey, 'legacyPropertyKey');
+    this.targetOwnerId = requireNonEmptyString(checkedFields.targetOwnerId, 'targetOwnerId');
+    this.targetPropertyKey = requireNonEmptyString(checkedFields.targetPropertyKey, 'targetPropertyKey');
+    Object.freeze(this);
+  }
+
+  /** Returns the legacy uniqueness key. */
+  legacyKey(): string {
+    return `${this.legacyOwnerId}\0${this.legacyPropertyKey}`;
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationPropertyMappingFields | null | undefined,
+): GraphModelMigrationPropertyMappingFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationPropertyMapping fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationSourceInventory.ts
+++ b/src/domain/migrations/GraphModelMigrationSourceInventory.ts
@@ -255,7 +255,7 @@ function requireChainPatchDescriptors(
   chain.patchIds.forEach((patchId, position) => {
     const descriptor = patchesById.get(patchId);
     if (descriptor === undefined) {
-      throw new WarpError(`writer chain references unknown patch ${patchId}`, 'E_VALIDATION');
+      throw new WarpError(`writer chain references uncollected patch ${patchId}`, 'E_VALIDATION');
     }
     if (descriptor.writerId !== chain.writerId) {
       throw new WarpError(`patch descriptor ${patchId} belongs to the wrong writer`, 'E_VALIDATION');

--- a/src/domain/migrations/GraphModelMigrationSourceInventory.ts
+++ b/src/domain/migrations/GraphModelMigrationSourceInventory.ts
@@ -1,0 +1,289 @@
+import { compareStrings } from '../utils/StringComparison.ts';
+import GraphModelMigrationBasis from './GraphModelMigrationBasis.ts';
+import GraphModelMigrationContentSource from './GraphModelMigrationContentSource.ts';
+import GraphModelMigrationNotice from './GraphModelMigrationNotice.ts';
+import GraphModelMigrationPatchDescriptor from './GraphModelMigrationPatchDescriptor.ts';
+import GraphModelMigrationStateSnapshotReference from './GraphModelMigrationStateSnapshotReference.ts';
+import GraphModelMigrationWriterChainDescriptor from './GraphModelMigrationWriterChainDescriptor.ts';
+import WarpError from '../errors/WarpError.ts';
+
+const MISSING_SOURCE_BASIS_CODE = 'E_MISSING_SOURCE_BASIS';
+
+export type GraphModelMigrationSourceInventoryFields = {
+  readonly graphId: string;
+  readonly sourceBasis?: GraphModelMigrationBasis | null;
+  readonly writerChains: readonly GraphModelMigrationWriterChainDescriptor[];
+  readonly patchDescriptors: readonly GraphModelMigrationPatchDescriptor[];
+  readonly stateSnapshot?: GraphModelMigrationStateSnapshotReference | null;
+  readonly contentSources: readonly GraphModelMigrationContentSource[];
+  readonly warnings: readonly GraphModelMigrationNotice[];
+  readonly fatalErrors: readonly GraphModelMigrationNotice[];
+};
+
+/** Runtime-backed source fact inventory for dry-run graph-model migration. */
+export default class GraphModelMigrationSourceInventory {
+  readonly graphId: string;
+  readonly sourceBasis: GraphModelMigrationBasis | null;
+  readonly writerChains: readonly GraphModelMigrationWriterChainDescriptor[];
+  readonly patchDescriptors: readonly GraphModelMigrationPatchDescriptor[];
+  readonly stateSnapshot: GraphModelMigrationStateSnapshotReference | null;
+  readonly contentSources: readonly GraphModelMigrationContentSource[];
+  readonly warnings: readonly GraphModelMigrationNotice[];
+  readonly fatalErrors: readonly GraphModelMigrationNotice[];
+
+  constructor(fields: GraphModelMigrationSourceInventoryFields) {
+    const checkedFields = requireFields(fields);
+    this.graphId = requireNonEmptyString(checkedFields.graphId, 'graphId');
+    this.sourceBasis = requireOptionalBasis(checkedFields.sourceBasis ?? null);
+    this.writerChains = freezeWriterChains(checkedFields.writerChains);
+    this.patchDescriptors = freezePatchDescriptors(checkedFields.patchDescriptors);
+    this.stateSnapshot = requireOptionalStateSnapshot(checkedFields.stateSnapshot ?? null);
+    this.contentSources = freezeContentSources(checkedFields.contentSources);
+    this.warnings = freezeNotices(checkedFields.warnings, false, 'warnings');
+    this.fatalErrors = freezeFatalErrors(
+      checkedFields.fatalErrors,
+      this.sourceBasis === null,
+    );
+    requirePatchChainConsistency(this.writerChains, this.patchDescriptors);
+    Object.freeze(this);
+  }
+
+  /** Returns true when collection found planning-blocking source problems. */
+  hasFatalErrors(): boolean {
+    return this.fatalErrors.length > 0;
+  }
+
+  /** Returns true when the inventory can be used by a dry-run planner. */
+  isUsableForPlanning(): boolean {
+    return this.sourceBasis !== null && !this.hasFatalErrors();
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationSourceInventoryFields | null | undefined,
+): GraphModelMigrationSourceInventoryFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationSourceInventory fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Requires a basis when one has been collected. */
+function requireOptionalBasis(
+  basis: GraphModelMigrationBasis | null,
+): GraphModelMigrationBasis | null {
+  if (basis !== null && !(basis instanceof GraphModelMigrationBasis)) {
+    throw new WarpError('sourceBasis must be a GraphModelMigrationBasis', 'E_VALIDATION');
+  }
+  return basis;
+}
+
+/** Requires a state snapshot reference when one has been collected. */
+function requireOptionalStateSnapshot(
+  stateSnapshot: GraphModelMigrationStateSnapshotReference | null,
+): GraphModelMigrationStateSnapshotReference | null {
+  if (
+    stateSnapshot !== null
+    && !(stateSnapshot instanceof GraphModelMigrationStateSnapshotReference)
+  ) {
+    throw new WarpError('stateSnapshot must be a GraphModelMigrationStateSnapshotReference', 'E_VALIDATION');
+  }
+  return stateSnapshot;
+}
+
+/** Validates and freezes source writer chains. */
+function freezeWriterChains(
+  writerChains: readonly GraphModelMigrationWriterChainDescriptor[],
+): readonly GraphModelMigrationWriterChainDescriptor[] {
+  const checked = requireArray(writerChains, 'writerChains').map(requireWriterChain);
+  requireUnique(checked.map((chain) => chain.writerId), 'writer chain');
+  const patchIds = checked.flatMap((chain) => chain.patchIds);
+  requireUnique(patchIds, 'writer-chain patch identity');
+  return Object.freeze(checked);
+}
+
+/** Validates, sorts, and freezes source patch descriptors. */
+function freezePatchDescriptors(
+  patchDescriptors: readonly GraphModelMigrationPatchDescriptor[],
+): readonly GraphModelMigrationPatchDescriptor[] {
+  const checked = requireArray(patchDescriptors, 'patchDescriptors').map(requirePatchDescriptor);
+  requireUnique(checked.map((patch) => patch.patchId), 'patch identity');
+  requireUnique(checked.map((patch) => patch.writerSequenceKey()), 'writer sequence');
+  return Object.freeze([...checked].sort(comparePatchDescriptors));
+}
+
+/** Validates and freezes source content facts. */
+function freezeContentSources(
+  contentSources: readonly GraphModelMigrationContentSource[],
+): readonly GraphModelMigrationContentSource[] {
+  const checked = requireArray(contentSources, 'contentSources').map(requireContentSource);
+  requireUnique(checked.map((source) => source.legacyContentKey), 'content source');
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes warning notices. */
+function freezeNotices(
+  notices: readonly GraphModelMigrationNotice[],
+  fatal: boolean,
+  label: string,
+): readonly GraphModelMigrationNotice[] {
+  const checked = requireArray(notices, label).map(requireNotice);
+  for (const notice of checked) {
+    if (notice.isFatal() !== fatal) {
+      throw new WarpError(`${label} contains the wrong notice kind`, 'E_VALIDATION');
+    }
+  }
+  return Object.freeze(checked);
+}
+
+/** Validates fatal notices and adds collection-derived fatal conditions. */
+function freezeFatalErrors(
+  fatalErrors: readonly GraphModelMigrationNotice[],
+  missingSourceBasis: boolean,
+): readonly GraphModelMigrationNotice[] {
+  const checked = freezeNotices(fatalErrors, true, 'fatalErrors');
+  if (!missingSourceBasis) {
+    return checked;
+  }
+  return Object.freeze([
+    GraphModelMigrationNotice.fatal(
+      MISSING_SOURCE_BASIS_CODE,
+      'source basis was not collected',
+    ),
+    ...checked,
+  ]);
+}
+
+/** Requires an array field. */
+function requireArray<T>(items: readonly T[] | null | undefined, label: string): readonly T[] {
+  if (items === null || items === undefined || !Array.isArray(items)) {
+    throw new WarpError(`GraphModelMigrationSourceInventory ${label} must be an array`, 'E_VALIDATION');
+  }
+  const checkedItems: readonly T[] = items;
+  return checkedItems;
+}
+
+/** Requires a writer chain descriptor. */
+function requireWriterChain(
+  chain: GraphModelMigrationWriterChainDescriptor,
+): GraphModelMigrationWriterChainDescriptor {
+  if (!(chain instanceof GraphModelMigrationWriterChainDescriptor)) {
+    throw new WarpError('writerChains must contain writer chain descriptors', 'E_VALIDATION');
+  }
+  return chain;
+}
+
+/** Requires a patch descriptor. */
+function requirePatchDescriptor(
+  patch: GraphModelMigrationPatchDescriptor,
+): GraphModelMigrationPatchDescriptor {
+  if (!(patch instanceof GraphModelMigrationPatchDescriptor)) {
+    throw new WarpError('patchDescriptors must contain patch descriptors', 'E_VALIDATION');
+  }
+  return patch;
+}
+
+/** Requires a content source fact. */
+function requireContentSource(
+  source: GraphModelMigrationContentSource,
+): GraphModelMigrationContentSource {
+  if (!(source instanceof GraphModelMigrationContentSource)) {
+    throw new WarpError('contentSources must contain content source facts', 'E_VALIDATION');
+  }
+  return source;
+}
+
+/** Requires a migration notice. */
+function requireNotice(notice: GraphModelMigrationNotice): GraphModelMigrationNotice {
+  if (!(notice instanceof GraphModelMigrationNotice)) {
+    throw new WarpError('inventory notices must be GraphModelMigrationNotice instances', 'E_VALIDATION');
+  }
+  return notice;
+}
+
+/** Requires no duplicate keys in an inventory section. */
+function requireUnique(keys: readonly string[], label: string): void {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) {
+      throw new WarpError(`GraphModelMigrationSourceInventory duplicates ${label} ${key}`, 'E_VALIDATION');
+    }
+    seen.add(key);
+  }
+}
+
+/** Requires patch descriptors to match their owning writer chains. */
+function requirePatchChainConsistency(
+  writerChains: readonly GraphModelMigrationWriterChainDescriptor[],
+  patchDescriptors: readonly GraphModelMigrationPatchDescriptor[],
+): void {
+  const patchesById = new Map<string, GraphModelMigrationPatchDescriptor>();
+  for (const patch of patchDescriptors) {
+    patchesById.set(patch.patchId, patch);
+  }
+
+  const chainedPatchIds = new Set<string>();
+  for (const chain of writerChains) {
+    requireChainPatchDescriptors(chain, patchesById, chainedPatchIds);
+  }
+
+  for (const patch of patchDescriptors) {
+    if (!chainedPatchIds.has(patch.patchId)) {
+      throw new WarpError(
+        `patch descriptor ${patch.patchId} is missing from writer chains`,
+        'E_VALIDATION',
+      );
+    }
+  }
+}
+
+/** Requires every patch in a writer chain to have a matching descriptor. */
+function requireChainPatchDescriptors(
+  chain: GraphModelMigrationWriterChainDescriptor,
+  patchesById: ReadonlyMap<string, GraphModelMigrationPatchDescriptor>,
+  chainedPatchIds: Set<string>,
+): void {
+  chain.patchIds.forEach((patchId, position) => {
+    const descriptor = patchesById.get(patchId);
+    if (descriptor === undefined) {
+      throw new WarpError(`writer chain references unknown patch ${patchId}`, 'E_VALIDATION');
+    }
+    if (descriptor.writerId !== chain.writerId) {
+      throw new WarpError(`patch descriptor ${patchId} belongs to the wrong writer`, 'E_VALIDATION');
+    }
+    if (descriptor.writerSequence !== position) {
+      throw new WarpError(
+        `patch descriptor ${patchId} does not match writer chain position`,
+        'E_VALIDATION',
+      );
+    }
+    chainedPatchIds.add(patchId);
+  });
+}
+
+/** Compares patch descriptors deterministically by writer and sequence. */
+function comparePatchDescriptors(
+  left: GraphModelMigrationPatchDescriptor,
+  right: GraphModelMigrationPatchDescriptor,
+): number {
+  const writerOrder = compareStrings(left.writerId, right.writerId);
+  if (writerOrder !== 0) {
+    return writerOrder;
+  }
+  if (left.writerSequence < right.writerSequence) {
+    return -1;
+  }
+  if (left.writerSequence > right.writerSequence) {
+    return 1;
+  }
+  return compareStrings(left.patchId, right.patchId);
+}

--- a/src/domain/migrations/GraphModelMigrationSourceInventory.ts
+++ b/src/domain/migrations/GraphModelMigrationSourceInventory.ts
@@ -39,10 +39,10 @@ export default class GraphModelMigrationSourceInventory {
     this.patchDescriptors = freezePatchDescriptors(checkedFields.patchDescriptors);
     this.stateSnapshot = requireOptionalStateSnapshot(checkedFields.stateSnapshot ?? null);
     this.contentSources = freezeContentSources(checkedFields.contentSources);
-    this.warnings = freezeNotices(checkedFields.warnings, false, 'warnings');
-    this.fatalErrors = freezeFatalErrors(
+    this.warnings = freezeWarningNotices(checkedFields.warnings);
+    this.fatalErrors = freezeFatalErrorsForSourceBasis(
       checkedFields.fatalErrors,
-      this.sourceBasis === null,
+      this.sourceBasis,
     );
     requirePatchChainConsistency(this.writerChains, this.patchDescriptors);
     Object.freeze(this);
@@ -131,27 +131,38 @@ function freezeContentSources(
 }
 
 /** Validates and freezes warning notices. */
-function freezeNotices(
+function freezeWarningNotices(
   notices: readonly GraphModelMigrationNotice[],
-  fatal: boolean,
-  label: string,
 ): readonly GraphModelMigrationNotice[] {
-  const checked = requireArray(notices, label).map(requireNotice);
+  const checked = requireArray(notices, 'warnings').map(requireNotice);
   for (const notice of checked) {
-    if (notice.isFatal() !== fatal) {
-      throw new WarpError(`${label} contains the wrong notice kind`, 'E_VALIDATION');
+    if (notice.isFatal()) {
+      throw new WarpError('warnings contains the wrong notice kind', 'E_VALIDATION');
+    }
+  }
+  return Object.freeze(checked);
+}
+
+/** Validates and freezes fatal notices. */
+function freezeFatalNotices(
+  notices: readonly GraphModelMigrationNotice[],
+): readonly GraphModelMigrationNotice[] {
+  const checked = requireArray(notices, 'fatalErrors').map(requireNotice);
+  for (const notice of checked) {
+    if (!notice.isFatal()) {
+      throw new WarpError('fatalErrors contains the wrong notice kind', 'E_VALIDATION');
     }
   }
   return Object.freeze(checked);
 }
 
 /** Validates fatal notices and adds collection-derived fatal conditions. */
-function freezeFatalErrors(
+function freezeFatalErrorsForSourceBasis(
   fatalErrors: readonly GraphModelMigrationNotice[],
-  missingSourceBasis: boolean,
+  sourceBasis: GraphModelMigrationBasis | null,
 ): readonly GraphModelMigrationNotice[] {
-  const checked = freezeNotices(fatalErrors, true, 'fatalErrors');
-  if (!missingSourceBasis) {
+  const checked = freezeFatalNotices(fatalErrors);
+  if (sourceBasis !== null) {
     return checked;
   }
   return Object.freeze([

--- a/src/domain/migrations/GraphModelMigrationStateSnapshotReference.ts
+++ b/src/domain/migrations/GraphModelMigrationStateSnapshotReference.ts
@@ -1,0 +1,34 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationStateSnapshotReferenceFields = {
+  readonly snapshotId: string;
+};
+
+/** Runtime-backed reference to a collected visible-state snapshot. */
+export default class GraphModelMigrationStateSnapshotReference {
+  readonly snapshotId: string;
+
+  constructor(fields: GraphModelMigrationStateSnapshotReferenceFields) {
+    const checkedFields = requireFields(fields);
+    this.snapshotId = requireNonEmptyString(checkedFields.snapshotId, 'snapshotId');
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationStateSnapshotReferenceFields | null | undefined,
+): GraphModelMigrationStateSnapshotReferenceFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('GraphModelMigrationStateSnapshotReference fields must be provided', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}

--- a/src/domain/migrations/GraphModelMigrationWriterChainDescriptor.ts
+++ b/src/domain/migrations/GraphModelMigrationWriterChainDescriptor.ts
@@ -1,0 +1,67 @@
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphModelMigrationWriterChainDescriptorFields = {
+  readonly writerId: string;
+  readonly patchIds: readonly string[];
+};
+
+/** Runtime-backed source writer chain for graph-model migration planning. */
+export default class GraphModelMigrationWriterChainDescriptor {
+  readonly writerId: string;
+  readonly patchIds: readonly string[];
+
+  constructor(fields: GraphModelMigrationWriterChainDescriptorFields) {
+    const checkedFields = requireFields(fields);
+    this.writerId = requireNonEmptyString(checkedFields.writerId, 'writerId');
+    this.patchIds = freezePatchIds(checkedFields.patchIds);
+    Object.freeze(this);
+  }
+}
+
+/** Validates the constructor envelope. */
+function requireFields(
+  fields: GraphModelMigrationWriterChainDescriptorFields | null | undefined,
+): GraphModelMigrationWriterChainDescriptorFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError(
+      'GraphModelMigrationWriterChainDescriptor fields must be provided',
+      'E_VALIDATION',
+    );
+  }
+  return fields;
+}
+
+/** Validates and freezes patch ids. */
+function freezePatchIds(patchIds: readonly string[]): readonly string[] {
+  const checked = requireArray(patchIds, 'patchIds').map((patchId) => requireNonEmptyString(patchId, 'patchId'));
+  requireUnique(checked, 'writer chain patch id');
+  return Object.freeze(checked);
+}
+
+/** Requires an array field. */
+function requireArray<T>(items: readonly T[] | null | undefined, label: string): readonly T[] {
+  if (items === null || items === undefined || !Array.isArray(items)) {
+    throw new WarpError(`GraphModelMigrationWriterChainDescriptor ${label} must be an array`, 'E_VALIDATION');
+  }
+  const checkedItems: readonly T[] = items;
+  return checkedItems;
+}
+
+/** Validates a required non-empty string. */
+function requireNonEmptyString(value: string, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new WarpError(`${name} must be a non-empty string`, 'E_VALIDATION');
+  }
+  return value;
+}
+
+/** Requires no duplicate keys in a chain section. */
+function requireUnique(keys: readonly string[], label: string): void {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    if (seen.has(key)) {
+      throw new WarpError(`GraphModelMigrationWriterChainDescriptor duplicates ${label} ${key}`, 'E_VALIDATION');
+    }
+    seen.add(key);
+  }
+}

--- a/src/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.ts
+++ b/src/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.ts
@@ -1,0 +1,279 @@
+import GraphModelMigrationBasis from '../../domain/migrations/GraphModelMigrationBasis.ts';
+import GraphModelMigrationContentMapping from '../../domain/migrations/GraphModelMigrationContentMapping.ts';
+import GraphModelMigrationEdgeMapping from '../../domain/migrations/GraphModelMigrationEdgeMapping.ts';
+import GraphModelMigrationManifest from '../../domain/migrations/GraphModelMigrationManifest.ts';
+import GraphModelMigrationManifestVersion from '../../domain/migrations/GraphModelMigrationManifestVersion.ts';
+import GraphModelMigrationNodeMapping from '../../domain/migrations/GraphModelMigrationNodeMapping.ts';
+import GraphModelMigrationNotice, {
+  type GraphModelMigrationNoticeKind,
+} from '../../domain/migrations/GraphModelMigrationNotice.ts';
+import GraphModelMigrationPropertyMapping from '../../domain/migrations/GraphModelMigrationPropertyMapping.ts';
+import AdapterValidationError from '../../domain/errors/AdapterValidationError.ts';
+import type { JsonObject } from './JsonObject.ts';
+
+const MANIFEST_KEYS = Object.freeze([
+  'version',
+  'sourceBasis',
+  'targetBasis',
+  'nodeMappings',
+  'edgeMappings',
+  'propertyMappings',
+  'contentMappings',
+  'warnings',
+  'fatalErrors',
+]);
+
+/** Serializes a migration manifest as deterministic JSON text. */
+export function serializeGraphModelMigrationManifest(
+  manifest: GraphModelMigrationManifest,
+): string {
+  return `${JSON.stringify(manifestToJson(requireManifest(manifest)), null, 2)}\n`;
+}
+
+/** Parses migration manifest JSON into runtime-backed domain nouns. */
+export function parseGraphModelMigrationManifest(raw: string): GraphModelMigrationManifest {
+  return manifestFromJson(parseJson(raw));
+}
+
+/** Converts a manifest into its adapter-boundary JSON object. */
+function manifestToJson(manifest: GraphModelMigrationManifest): JsonObject {
+  return {
+    version: manifest.version.value,
+    sourceBasis: basisToJson(manifest.sourceBasis),
+    targetBasis: basisToJson(manifest.targetBasis),
+    nodeMappings: manifest.nodeMappings.map(nodeMappingToJson),
+    edgeMappings: manifest.edgeMappings.map(edgeMappingToJson),
+    propertyMappings: manifest.propertyMappings.map(propertyMappingToJson),
+    contentMappings: manifest.contentMappings.map(contentMappingToJson),
+    warnings: manifest.warnings.map(noticeToJson),
+    fatalErrors: manifest.fatalErrors.map(noticeToJson),
+  };
+}
+
+/** Converts parsed JSON into a migration manifest. */
+function manifestFromJson(value: unknown): GraphModelMigrationManifest {
+  const source = requireJsonObject(value, 'manifest');
+  rejectUnknownKeys(source, MANIFEST_KEYS, 'manifest');
+  return new GraphModelMigrationManifest({
+    version: new GraphModelMigrationManifestVersion(readRequiredNumber(source, 'version')),
+    sourceBasis: readBasis(source, 'sourceBasis'),
+    targetBasis: readBasis(source, 'targetBasis'),
+    nodeMappings: readNodeMappings(source),
+    edgeMappings: readEdgeMappings(source),
+    propertyMappings: readPropertyMappings(source),
+    contentMappings: readContentMappings(source),
+    warnings: readNotices(source, 'warnings'),
+    fatalErrors: readNotices(source, 'fatalErrors'),
+  });
+}
+
+/** Parses untrusted JSON text without leaking platform SyntaxError. */
+function parseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new AdapterValidationError('Graph model migration manifest JSON must be valid JSON');
+  }
+}
+
+/** Requires a manifest instance before serialization. */
+function requireManifest(manifest: GraphModelMigrationManifest): GraphModelMigrationManifest {
+  if (!(manifest instanceof GraphModelMigrationManifest)) {
+    throw new AdapterValidationError('Graph model migration manifest must be a manifest instance');
+  }
+  return manifest;
+}
+
+/** Serializes a basis value. */
+function basisToJson(basis: GraphModelMigrationBasis): JsonObject {
+  return {
+    graphId: basis.graphId,
+    basisId: basis.basisId,
+  };
+}
+
+/** Serializes a node mapping. */
+function nodeMappingToJson(mapping: GraphModelMigrationNodeMapping): JsonObject {
+  return {
+    legacyNodeId: mapping.legacyNodeId,
+    targetNodeId: mapping.targetNodeId,
+  };
+}
+
+/** Serializes an edge mapping. */
+function edgeMappingToJson(mapping: GraphModelMigrationEdgeMapping): JsonObject {
+  return {
+    legacyEdgeId: mapping.legacyEdgeId,
+    targetEdgeId: mapping.targetEdgeId,
+  };
+}
+
+/** Serializes a property mapping. */
+function propertyMappingToJson(mapping: GraphModelMigrationPropertyMapping): JsonObject {
+  return {
+    legacyOwnerId: mapping.legacyOwnerId,
+    legacyPropertyKey: mapping.legacyPropertyKey,
+    targetOwnerId: mapping.targetOwnerId,
+    targetPropertyKey: mapping.targetPropertyKey,
+  };
+}
+
+/** Serializes a content mapping. */
+function contentMappingToJson(mapping: GraphModelMigrationContentMapping): JsonObject {
+  return {
+    legacyContentKey: mapping.legacyContentKey,
+    targetAttachmentKey: mapping.targetAttachmentKey,
+  };
+}
+
+/** Serializes a migration notice. */
+function noticeToJson(notice: GraphModelMigrationNotice): JsonObject {
+  return {
+    kind: notice.kind,
+    code: notice.code,
+    message: notice.message,
+  };
+}
+
+/** Reads a basis object from the manifest envelope. */
+function readBasis(source: JsonObject, key: string): GraphModelMigrationBasis {
+  const basis = requireJsonObject(source[key], key);
+  rejectUnknownKeys(basis, ['graphId', 'basisId'], key);
+  return new GraphModelMigrationBasis({
+    graphId: readRequiredString(basis, `${key}.graphId`, 'graphId'),
+    basisId: readRequiredString(basis, `${key}.basisId`, 'basisId'),
+  });
+}
+
+/** Reads node mappings from the manifest envelope. */
+function readNodeMappings(source: JsonObject): readonly GraphModelMigrationNodeMapping[] {
+  return readObjectArray(source, 'nodeMappings').map((mapping, index) => {
+    const label = `nodeMappings[${index}]`;
+    rejectUnknownKeys(mapping, ['legacyNodeId', 'targetNodeId'], label);
+    return new GraphModelMigrationNodeMapping({
+      legacyNodeId: readRequiredString(mapping, `${label}.legacyNodeId`, 'legacyNodeId'),
+      targetNodeId: readRequiredString(mapping, `${label}.targetNodeId`, 'targetNodeId'),
+    });
+  });
+}
+
+/** Reads edge mappings from the manifest envelope. */
+function readEdgeMappings(source: JsonObject): readonly GraphModelMigrationEdgeMapping[] {
+  return readObjectArray(source, 'edgeMappings').map((mapping, index) => {
+    const label = `edgeMappings[${index}]`;
+    rejectUnknownKeys(mapping, ['legacyEdgeId', 'targetEdgeId'], label);
+    return new GraphModelMigrationEdgeMapping({
+      legacyEdgeId: readRequiredString(mapping, `${label}.legacyEdgeId`, 'legacyEdgeId'),
+      targetEdgeId: readRequiredString(mapping, `${label}.targetEdgeId`, 'targetEdgeId'),
+    });
+  });
+}
+
+/** Reads property mappings from the manifest envelope. */
+function readPropertyMappings(source: JsonObject): readonly GraphModelMigrationPropertyMapping[] {
+  return readObjectArray(source, 'propertyMappings').map((mapping, index) => {
+    const label = `propertyMappings[${index}]`;
+    rejectUnknownKeys(
+      mapping,
+      ['legacyOwnerId', 'legacyPropertyKey', 'targetOwnerId', 'targetPropertyKey'],
+      label,
+    );
+    return new GraphModelMigrationPropertyMapping({
+      legacyOwnerId: readRequiredString(mapping, `${label}.legacyOwnerId`, 'legacyOwnerId'),
+      legacyPropertyKey: readRequiredString(mapping, `${label}.legacyPropertyKey`, 'legacyPropertyKey'),
+      targetOwnerId: readRequiredString(mapping, `${label}.targetOwnerId`, 'targetOwnerId'),
+      targetPropertyKey: readRequiredString(mapping, `${label}.targetPropertyKey`, 'targetPropertyKey'),
+    });
+  });
+}
+
+/** Reads content mappings from the manifest envelope. */
+function readContentMappings(source: JsonObject): readonly GraphModelMigrationContentMapping[] {
+  return readObjectArray(source, 'contentMappings').map((mapping, index) => {
+    const label = `contentMappings[${index}]`;
+    rejectUnknownKeys(mapping, ['legacyContentKey', 'targetAttachmentKey'], label);
+    return new GraphModelMigrationContentMapping({
+      legacyContentKey: readRequiredString(mapping, `${label}.legacyContentKey`, 'legacyContentKey'),
+      targetAttachmentKey: readRequiredString(mapping, `${label}.targetAttachmentKey`, 'targetAttachmentKey'),
+    });
+  });
+}
+
+/** Reads notice arrays from the manifest envelope. */
+function readNotices(source: JsonObject, key: string): readonly GraphModelMigrationNotice[] {
+  return readObjectArray(source, key).map((notice, index) => {
+    const label = `${key}[${index}]`;
+    rejectUnknownKeys(notice, ['kind', 'code', 'message'], label);
+    return new GraphModelMigrationNotice({
+      kind: readNoticeKind(notice, `${label}.kind`, 'kind'),
+      code: readRequiredString(notice, `${label}.code`, 'code'),
+      message: readRequiredString(notice, `${label}.message`, 'message'),
+    });
+  });
+}
+
+/** Requires an object array field. */
+function readObjectArray(source: JsonObject, key: string): readonly JsonObject[] {
+  const value = source[key];
+  if (!Array.isArray(value)) {
+    throw new AdapterValidationError(`Graph model migration manifest field "${key}" must be an array`);
+  }
+  const objects: JsonObject[] = [];
+  value.forEach((entry, index) => {
+    objects.push(requireJsonObject(entry, `${key}[${index}]`));
+  });
+  return Object.freeze(objects);
+}
+
+/** Reads a required string field. */
+function readRequiredString(source: JsonObject, label: string, key: string): string {
+  const value = source[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new AdapterValidationError(`Graph model migration manifest field "${label}" must be a non-empty string`);
+  }
+  return value;
+}
+
+/** Reads a required finite number field. */
+function readRequiredNumber(source: JsonObject, key: string): number {
+  const value = source[key];
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new AdapterValidationError(`Graph model migration manifest field "${key}" must be a finite number`);
+  }
+  return value;
+}
+
+/** Reads a notice kind without string casts. */
+function readNoticeKind(source: JsonObject, label: string, key: string): GraphModelMigrationNoticeKind {
+  const value = source[key];
+  if (value === 'warning' || value === 'fatal') {
+    return value;
+  }
+  throw new AdapterValidationError(
+    `Graph model migration manifest field "${label}" must be warning or fatal`,
+  );
+}
+
+/** Requires a non-array JSON object. */
+function requireJsonObject(value: unknown, label: string): JsonObject {
+  if (!isJsonObject(value)) {
+    throw new AdapterValidationError(`Graph model migration manifest field "${label}" must be an object`);
+  }
+  return value;
+}
+
+/** Returns true for non-array JSON object values. */
+function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Rejects unexpected fields at the manifest JSON boundary. */
+function rejectUnknownKeys(source: JsonObject, allowed: readonly string[], label: string): void {
+  for (const key of Object.keys(source)) {
+    if (!allowed.includes(key)) {
+      throw new AdapterValidationError(
+        `Graph model migration manifest field "${label}.${key}" is not allowed`,
+      );
+    }
+  }
+}

--- a/test/unit/domain/migrations/DryRunGraphModelMigrationPlanner.test.ts
+++ b/test/unit/domain/migrations/DryRunGraphModelMigrationPlanner.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import DryRunGraphModelMigrationPlanRequest
+  from '../../../../src/domain/migrations/DryRunGraphModelMigrationPlanRequest.ts';
+import DryRunGraphModelMigrationPlanner
+  from '../../../../src/domain/migrations/DryRunGraphModelMigrationPlanner.ts';
+import GraphModelMigrationBasis from '../../../../src/domain/migrations/GraphModelMigrationBasis.ts';
+import GraphModelMigrationContentSource
+  from '../../../../src/domain/migrations/GraphModelMigrationContentSource.ts';
+import GraphModelMigrationNodeMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationNodeMapping.ts';
+import GraphModelMigrationPatchDescriptor
+  from '../../../../src/domain/migrations/GraphModelMigrationPatchDescriptor.ts';
+import GraphModelMigrationPropertyMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationPropertyMapping.ts';
+import GraphModelMigrationSourceInventory
+  from '../../../../src/domain/migrations/GraphModelMigrationSourceInventory.ts';
+import GraphModelMigrationStateSnapshotReference
+  from '../../../../src/domain/migrations/GraphModelMigrationStateSnapshotReference.ts';
+import GraphModelMigrationWriterChainDescriptor
+  from '../../../../src/domain/migrations/GraphModelMigrationWriterChainDescriptor.ts';
+
+describe('DryRunGraphModelMigrationPlanner', () => {
+  it('emits a manifest and planned graph-operation facts for complete inventory', () => {
+    const result = planner().plan(createRequest({
+      contentSources: [
+        contentSource('node:b\0_content', 'oid:b'),
+        contentSource('node:a\0_content', 'oid:a'),
+      ],
+      nodeMappings: [
+        new GraphModelMigrationNodeMapping({
+          legacyNodeId: 'node:a',
+          targetNodeId: 'node:a',
+        }),
+      ],
+      propertyMappings: [
+        new GraphModelMigrationPropertyMapping({
+          legacyOwnerId: 'node:a',
+          legacyPropertyKey: 'title',
+          targetOwnerId: 'node:a',
+          targetPropertyKey: 'title',
+        }),
+      ],
+      requiredContentKeys: ['node:a\0_content'],
+    }));
+
+    expect(result.hasFatalErrors()).toBe(false);
+    expect(result.manifest?.sourceBasis.basisId).toBe('basis:source');
+    expect(result.manifest?.targetBasis.basisId).toBe('basis:source:v18-dry-run');
+    expect(result.manifest?.contentMappings.map((mapping) => mapping.legacyContentKey)).toEqual([
+      'node:a\0_content',
+      'node:b\0_content',
+    ]);
+    expect(result.plannedOperations.map((operation) => operation.kind)).toEqual([
+      'content-attachment',
+      'content-attachment',
+      'node-record',
+      'property',
+    ]);
+  });
+
+  it('fails closed when source inventory is incomplete', () => {
+    const result = planner().plan(createRequest({ sourceBasis: null }));
+
+    expect(result.manifest).toBeNull();
+    expect(result.plannedOperations).toEqual([]);
+    expect(result.hasFatalErrors()).toBe(true);
+    expect(result.fatalErrors.map((notice) => notice.code)).toContain('E_MISSING_SOURCE_BASIS');
+  });
+
+  it('fails closed when required content sources are missing', () => {
+    const result = planner().plan(createRequest({
+      requiredContentKeys: ['node:missing\0_content'],
+    }));
+
+    expect(result.manifest).toBeNull();
+    expect(result.plannedOperations).toEqual([]);
+    expect(result.fatalErrors.map((notice) => notice.code)).toEqual(['E_MISSING_CONTENT_SOURCE']);
+  });
+
+  it('does not admit malformed property facts into planned output', () => {
+    expect(() => new DryRunGraphModelMigrationPlanRequest({
+      inventory: sourceInventory({}),
+      requiredContentKeys: [],
+      nodeMappings: [],
+      edgeMappings: [],
+      // @ts-expect-error exercising runtime validation
+      propertyMappings: [{ legacyOwnerId: 'node:a', legacyPropertyKey: 'title' }],
+    })).toThrow(/propertyMappings must contain property mappings/);
+  });
+
+  it('emits deterministic output across repeated runs', () => {
+    const request = createRequest({
+      contentSources: [
+        contentSource('node:b\0_content', 'oid:b'),
+        contentSource('node:a\0_content', 'oid:a'),
+      ],
+    });
+    const first = planner().plan(request);
+    const second = planner().plan(request);
+
+    expect(first.plannedOperations.map((operation) => operation.toKey())).toEqual(
+      second.plannedOperations.map((operation) => operation.toKey()),
+    );
+    expect(first.manifest?.contentMappings).toEqual(second.manifest?.contentMappings);
+  });
+});
+
+type RequestOverrides = {
+  readonly sourceBasis?: GraphModelMigrationBasis | null;
+  readonly contentSources?: readonly GraphModelMigrationContentSource[];
+  readonly requiredContentKeys?: readonly string[];
+  readonly nodeMappings?: readonly GraphModelMigrationNodeMapping[];
+  readonly propertyMappings?: readonly GraphModelMigrationPropertyMapping[];
+};
+
+function planner(): DryRunGraphModelMigrationPlanner {
+  return new DryRunGraphModelMigrationPlanner();
+}
+
+function createRequest(overrides: RequestOverrides): DryRunGraphModelMigrationPlanRequest {
+  return new DryRunGraphModelMigrationPlanRequest({
+    inventory: sourceInventory(overrides),
+    requiredContentKeys: overrides.requiredContentKeys ?? [],
+    nodeMappings: overrides.nodeMappings ?? [],
+    edgeMappings: [],
+    propertyMappings: overrides.propertyMappings ?? [],
+  });
+}
+
+function sourceInventory(overrides: RequestOverrides): GraphModelMigrationSourceInventory {
+  return new GraphModelMigrationSourceInventory({
+    graphId: 'graph:source',
+    sourceBasis: 'sourceBasis' in overrides ? overrides.sourceBasis : sourceBasis(),
+    writerChains: [
+      new GraphModelMigrationWriterChainDescriptor({
+        writerId: 'writer:a',
+        patchIds: ['patch:a:0'],
+      }),
+    ],
+    patchDescriptors: [
+      new GraphModelMigrationPatchDescriptor({
+        patchId: 'patch:a:0',
+        writerId: 'writer:a',
+        writerSequence: 0,
+      }),
+    ],
+    stateSnapshot: new GraphModelMigrationStateSnapshotReference({
+      snapshotId: 'snapshot:source',
+    }),
+    contentSources: overrides.contentSources ?? [],
+    warnings: [],
+    fatalErrors: [],
+  });
+}
+
+function sourceBasis(): GraphModelMigrationBasis {
+  return new GraphModelMigrationBasis({
+    graphId: 'graph:source',
+    basisId: 'basis:source',
+  });
+}
+
+function contentSource(
+  legacyContentKey: string,
+  contentOid: string,
+): GraphModelMigrationContentSource {
+  return new GraphModelMigrationContentSource({ legacyContentKey, contentOid });
+}

--- a/test/unit/domain/migrations/DryRunGraphModelMigrationPlanner.test.ts
+++ b/test/unit/domain/migrations/DryRunGraphModelMigrationPlanner.test.ts
@@ -57,6 +57,8 @@ describe('DryRunGraphModelMigrationPlanner', () => {
       'node-record',
       'property',
     ]);
+    const propertyOperation = result.plannedOperations.find((operation) => operation.kind === 'property');
+    expect(propertyOperation?.targetKey).toBe('property-target-key:length-prefixed-v1:6:node:a:5:title');
   });
 
   it('fails closed when source inventory is incomplete', () => {

--- a/test/unit/domain/migrations/GraphModelMigrationConstructorGuards.test.ts
+++ b/test/unit/domain/migrations/GraphModelMigrationConstructorGuards.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+
+import DryRunGraphModelMigrationPlan
+  from '../../../../src/domain/migrations/DryRunGraphModelMigrationPlan.ts';
+import DryRunGraphModelMigrationPlanRequest
+  from '../../../../src/domain/migrations/DryRunGraphModelMigrationPlanRequest.ts';
+import GraphModelMigrationBasis from '../../../../src/domain/migrations/GraphModelMigrationBasis.ts';
+import GraphModelMigrationContentMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationContentMapping.ts';
+import GraphModelMigrationContentSource
+  from '../../../../src/domain/migrations/GraphModelMigrationContentSource.ts';
+import GraphModelMigrationEdgeMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationEdgeMapping.ts';
+import GraphModelMigrationHistoryPatchInput
+  from '../../../../src/domain/migrations/GraphModelMigrationHistoryPatchInput.ts';
+import GraphModelMigrationHistorySegment
+  from '../../../../src/domain/migrations/GraphModelMigrationHistorySegment.ts';
+import GraphModelMigrationManifest
+  from '../../../../src/domain/migrations/GraphModelMigrationManifest.ts';
+import GraphModelMigrationManifestVersion
+  from '../../../../src/domain/migrations/GraphModelMigrationManifestVersion.ts';
+import GraphModelMigrationNodeMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationNodeMapping.ts';
+import GraphModelMigrationNotice from '../../../../src/domain/migrations/GraphModelMigrationNotice.ts';
+import GraphModelMigrationPatchDescriptor
+  from '../../../../src/domain/migrations/GraphModelMigrationPatchDescriptor.ts';
+import GraphModelMigrationPatchFrontierEvidence
+  from '../../../../src/domain/migrations/GraphModelMigrationPatchFrontierEvidence.ts';
+import GraphModelMigrationPatchOperationFact
+  from '../../../../src/domain/migrations/GraphModelMigrationPatchOperationFact.ts';
+import GraphModelMigrationPlannedGraphOperation
+  from '../../../../src/domain/migrations/GraphModelMigrationPlannedGraphOperation.ts';
+import GraphModelMigrationPropertyMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationPropertyMapping.ts';
+import GraphModelMigrationSourceInventory
+  from '../../../../src/domain/migrations/GraphModelMigrationSourceInventory.ts';
+import GraphModelMigrationStateSnapshotReference
+  from '../../../../src/domain/migrations/GraphModelMigrationStateSnapshotReference.ts';
+import GraphModelMigrationWriterChainDescriptor
+  from '../../../../src/domain/migrations/GraphModelMigrationWriterChainDescriptor.ts';
+
+describe('graph model migration constructor guards', () => {
+  it('rejects invalid scalar fields on leaf nouns', () => {
+    expect(() => new GraphModelMigrationBasis({
+      graphId: '',
+      basisId: 'basis:one',
+    })).toThrow(/graphId/);
+    expect(() => new GraphModelMigrationManifestVersion(2)).toThrow(/version/);
+    expect(() => new GraphModelMigrationNotice({
+      // @ts-expect-error exercising runtime validation
+      kind: 'info',
+      code: 'I_BAD_KIND',
+      message: 'bad kind',
+    })).toThrow(/kind/);
+    expect(() => new GraphModelMigrationPatchDescriptor({
+      patchId: 'patch:a',
+      writerId: 'writer:a',
+      writerSequence: -1,
+    })).toThrow(/writerSequence/);
+    expect(() => new GraphModelMigrationPatchOperationFact({
+      operationIndex: -1,
+      operationKind: 'node:set',
+      operationKey: 'node:a',
+    })).toThrow(/operationIndex/);
+  });
+
+  it('covers stable keys and factory constructors', () => {
+    expect(sourceBasis().toKey()).toBe('graph:source\0basis:source');
+    expect(GraphModelMigrationNotice.fatal('E_FATAL', 'fatal').isFatal()).toBe(true);
+    expect(GraphModelMigrationPlannedGraphOperation.edgeRecord('legacy:edge', 'edge:a').kind)
+      .toBe('edge-record');
+    expect(GraphModelMigrationPlannedGraphOperation.contentAttachment('legacy:content', 'attachment:a').kind)
+      .toBe('content-attachment');
+    expect(() => new GraphModelMigrationPlannedGraphOperation({
+      // @ts-expect-error exercising runtime validation
+      kind: 'write-now',
+      sourceKey: 'source',
+      targetKey: 'target',
+    })).toThrow(/kind/);
+  });
+
+  it('rejects invalid mapping and source fact envelopes', () => {
+    expect(() => new GraphModelMigrationNodeMapping({
+      legacyNodeId: '',
+      targetNodeId: 'node:a',
+    })).toThrow(/legacyNodeId/);
+    expect(() => new GraphModelMigrationEdgeMapping({
+      legacyEdgeId: 'edge:a',
+      targetEdgeId: '',
+    })).toThrow(/targetEdgeId/);
+    expect(() => new GraphModelMigrationPropertyMapping({
+      legacyOwnerId: 'node:a',
+      legacyPropertyKey: '',
+      targetOwnerId: 'node:a',
+      targetPropertyKey: 'title',
+    })).toThrow(/legacyPropertyKey/);
+    expect(() => new GraphModelMigrationContentMapping({
+      legacyContentKey: '',
+      targetAttachmentKey: 'content-attachment:a',
+    })).toThrow(/legacyContentKey/);
+    expect(() => new GraphModelMigrationContentSource({
+      legacyContentKey: 'node:a\0_content',
+      contentOid: '',
+    })).toThrow(/contentOid/);
+    expect(() => new GraphModelMigrationStateSnapshotReference({
+      snapshotId: '',
+    })).toThrow(/snapshotId/);
+  });
+
+  it('rejects ambiguous frontier and history ordering facts', () => {
+    expect(() => new GraphModelMigrationPatchFrontierEvidence({
+      frontierKey: 'frontier:a',
+      parentPatchIds: ['patch:a', 'patch:a'],
+    })).toThrow(/duplicates parent patch id/);
+    expect(new GraphModelMigrationPatchFrontierEvidence({
+      frontierKey: 'frontier:a',
+      parentPatchIds: ['patch:b', 'patch:a'],
+    }).parentPatchIds).toEqual(['patch:a', 'patch:b']);
+    expect(() => new GraphModelMigrationHistorySegment({
+      writerId: 'writer:a',
+      patches: [historyPatch('writer:b', 'patch:b', 0)],
+    })).toThrow(/wrong writer/);
+    expect(() => new GraphModelMigrationHistorySegment({
+      writerId: 'writer:a',
+      patches: [historyPatch('writer:a', 'patch:a:1', 1)],
+    })).toThrow(/contiguous per writer/);
+  });
+
+  it('rejects boolean-trap notice inversions through explicit helpers', () => {
+    expect(() => new DryRunGraphModelMigrationPlan({
+      manifest: null,
+      plannedOperations: [],
+      warnings: [GraphModelMigrationNotice.fatal('E_IN_WARNING', 'fatal in warning slot')],
+      fatalErrors: [GraphModelMigrationNotice.fatal('E_FATAL', 'fatal')],
+    })).toThrow(/warnings contains the wrong notice kind/);
+    expect(() => new DryRunGraphModelMigrationPlan({
+      manifest: null,
+      plannedOperations: [],
+      warnings: [],
+      fatalErrors: [GraphModelMigrationNotice.warning('W_IN_FATAL', 'warning in fatal slot')],
+    })).toThrow(/fatalErrors contains the wrong notice kind/);
+    expect(() => createInventory({
+      warnings: [GraphModelMigrationNotice.fatal('E_IN_WARNING', 'fatal in warning slot')],
+    })).toThrow(/warnings contains the wrong notice kind/);
+    expect(() => createInventory({
+      fatalErrors: [GraphModelMigrationNotice.warning('W_IN_FATAL', 'warning in fatal slot')],
+    })).toThrow(/fatalErrors contains the wrong notice kind/);
+  });
+
+  it('rejects cross-field plan invariants and request duplicates', () => {
+    expect(() => new DryRunGraphModelMigrationPlan({
+      manifest: null,
+      plannedOperations: [],
+      warnings: [],
+      fatalErrors: [],
+    })).toThrow(/successful dry-run plans/);
+    expect(() => new DryRunGraphModelMigrationPlan({
+      manifest: emptyManifest(),
+      plannedOperations: [],
+      warnings: [],
+      fatalErrors: [GraphModelMigrationNotice.fatal('E_FATAL', 'fatal')],
+    })).toThrow(/fatal dry-run plans/);
+    expect(() => new DryRunGraphModelMigrationPlanRequest({
+      inventory: createInventory({}),
+      requiredContentKeys: ['content:a', 'content:a'],
+      nodeMappings: [],
+      edgeMappings: [],
+      propertyMappings: [],
+    })).toThrow(/duplicates required content key/);
+  });
+});
+
+type InventoryOverrides = {
+  readonly warnings?: readonly GraphModelMigrationNotice[];
+  readonly fatalErrors?: readonly GraphModelMigrationNotice[];
+};
+
+function sourceBasis(): GraphModelMigrationBasis {
+  return new GraphModelMigrationBasis({
+    graphId: 'graph:source',
+    basisId: 'basis:source',
+  });
+}
+
+function targetBasis(): GraphModelMigrationBasis {
+  return new GraphModelMigrationBasis({
+    graphId: 'graph:target',
+    basisId: 'basis:target',
+  });
+}
+
+function emptyManifest(): GraphModelMigrationManifest {
+  return new GraphModelMigrationManifest({
+    version: GraphModelMigrationManifestVersion.current(),
+    sourceBasis: sourceBasis(),
+    targetBasis: targetBasis(),
+    nodeMappings: [],
+    edgeMappings: [],
+    propertyMappings: [],
+    contentMappings: [],
+    warnings: [],
+    fatalErrors: [],
+  });
+}
+
+function createInventory(overrides: InventoryOverrides): GraphModelMigrationSourceInventory {
+  return new GraphModelMigrationSourceInventory({
+    graphId: 'graph:source',
+    sourceBasis: sourceBasis(),
+    writerChains: [
+      new GraphModelMigrationWriterChainDescriptor({
+        writerId: 'writer:a',
+        patchIds: ['patch:a:0'],
+      }),
+    ],
+    patchDescriptors: [
+      new GraphModelMigrationPatchDescriptor({
+        patchId: 'patch:a:0',
+        writerId: 'writer:a',
+        writerSequence: 0,
+      }),
+    ],
+    stateSnapshot: new GraphModelMigrationStateSnapshotReference({
+      snapshotId: 'snapshot:source',
+    }),
+    contentSources: [],
+    warnings: overrides.warnings ?? [],
+    fatalErrors: overrides.fatalErrors ?? [],
+  });
+}
+
+function historyPatch(
+  writerId: string,
+  patchId: string,
+  writerSequence: number,
+): GraphModelMigrationHistoryPatchInput {
+  return new GraphModelMigrationHistoryPatchInput({
+    writerId,
+    patchId,
+    writerSequence,
+    frontierEvidence: new GraphModelMigrationPatchFrontierEvidence({
+      frontierKey: `${patchId}:frontier`,
+      parentPatchIds: [],
+    }),
+    operations: [
+      new GraphModelMigrationPatchOperationFact({
+        operationIndex: 0,
+        operationKind: 'node:set',
+        operationKey: `${patchId}:node`,
+      }),
+    ],
+  });
+}

--- a/test/unit/domain/migrations/GraphModelMigrationConstructorGuards.test.ts
+++ b/test/unit/domain/migrations/GraphModelMigrationConstructorGuards.test.ts
@@ -41,6 +41,10 @@ import GraphModelMigrationWriterChainDescriptor
 
 describe('graph model migration constructor guards', () => {
   it('rejects invalid scalar fields on leaf nouns', () => {
+    expect(() => {
+      // @ts-expect-error exercising runtime validation
+      new GraphModelMigrationBasis(null);
+    }).toThrow(/fields/);
     expect(() => new GraphModelMigrationBasis({
       graphId: '',
       basisId: 'basis:one',
@@ -62,6 +66,10 @@ describe('graph model migration constructor guards', () => {
       operationKind: 'node:set',
       operationKey: 'node:a',
     })).toThrow(/operationIndex/);
+    expect(() => new GraphModelMigrationWriterChainDescriptor({
+      writerId: 'writer:a',
+      patchIds: ['patch:a', 'patch:a'],
+    })).toThrow(/duplicates writer chain patch id/);
   });
 
   it('covers stable keys and factory constructors', () => {
@@ -80,6 +88,33 @@ describe('graph model migration constructor guards', () => {
   });
 
   it('rejects invalid mapping and source fact envelopes', () => {
+    expect(() => {
+      // @ts-expect-error exercising runtime validation
+      new GraphModelMigrationManifest(null);
+    }).toThrow(/fields/);
+    expect(() => new GraphModelMigrationManifest({
+      version: GraphModelMigrationManifestVersion.current(),
+      // @ts-expect-error exercising runtime validation
+      sourceBasis: { graphId: 'graph:source', basisId: 'basis:source' },
+      targetBasis: targetBasis(),
+      nodeMappings: [],
+      edgeMappings: [],
+      propertyMappings: [],
+      contentMappings: [],
+      warnings: [],
+      fatalErrors: [],
+    })).toThrow(/sourceBasis/);
+    expect(() => new GraphModelMigrationManifest({
+      version: GraphModelMigrationManifestVersion.current(),
+      sourceBasis: sourceBasis(),
+      targetBasis: targetBasis(),
+      nodeMappings: [],
+      edgeMappings: [],
+      propertyMappings: [],
+      contentMappings: [{ legacyContentKey: 'node:a', targetAttachmentKey: 'attachment:a' }],
+      warnings: [],
+      fatalErrors: [],
+    })).toThrow(/contentMappings/);
     expect(() => new GraphModelMigrationNodeMapping({
       legacyNodeId: '',
       targetNodeId: 'node:a',
@@ -108,6 +143,10 @@ describe('graph model migration constructor guards', () => {
   });
 
   it('rejects ambiguous frontier and history ordering facts', () => {
+    expect(() => {
+      // @ts-expect-error exercising runtime validation
+      new GraphModelMigrationPatchFrontierEvidence(null);
+    }).toThrow(/fields/);
     expect(() => new GraphModelMigrationPatchFrontierEvidence({
       frontierKey: 'frontier:a',
       parentPatchIds: ['patch:a', 'patch:a'],
@@ -124,6 +163,20 @@ describe('graph model migration constructor guards', () => {
       writerId: 'writer:a',
       patches: [historyPatch('writer:a', 'patch:a:1', 1)],
     })).toThrow(/contiguous per writer/);
+    expect(() => new GraphModelMigrationHistoryPatchInput({
+      writerId: 'writer:a',
+      patchId: 'patch:a',
+      writerSequence: 0,
+      frontierEvidence: { frontierKey: 'frontier:a', parentPatchIds: [] },
+      operations: [],
+    })).toThrow(/frontierEvidence/);
+    expect(() => new GraphModelMigrationHistoryPatchInput({
+      writerId: 'writer:a',
+      patchId: 'patch:a',
+      writerSequence: 0,
+      frontierEvidence: null,
+      operations: [{ operationIndex: 0, operationKind: 'node:set', operationKey: 'node:a' }],
+    })).toThrow(/operation facts/);
   });
 
   it('rejects boolean-trap notice inversions through explicit helpers', () => {
@@ -148,6 +201,24 @@ describe('graph model migration constructor guards', () => {
   });
 
   it('rejects cross-field plan invariants and request duplicates', () => {
+    expect(() => {
+      // @ts-expect-error exercising runtime validation
+      new DryRunGraphModelMigrationPlan(null);
+    }).toThrow(/fields/);
+    expect(() => new DryRunGraphModelMigrationPlan({
+      // @ts-expect-error exercising runtime validation
+      manifest: GraphModelMigrationNotice.warning('W_NOT_MANIFEST', 'not a manifest'),
+      plannedOperations: [],
+      warnings: [],
+      fatalErrors: [],
+    })).toThrow(/manifest/);
+    expect(() => new DryRunGraphModelMigrationPlan({
+      manifest: emptyManifest(),
+      // @ts-expect-error exercising runtime validation
+      plannedOperations: [{ kind: 'node-record', sourceKey: 'node:a', targetKey: 'node:a' }],
+      warnings: [],
+      fatalErrors: [],
+    })).toThrow(/planned graph operations/);
     expect(() => new DryRunGraphModelMigrationPlan({
       manifest: null,
       plannedOperations: [],
@@ -167,6 +238,65 @@ describe('graph model migration constructor guards', () => {
       edgeMappings: [],
       propertyMappings: [],
     })).toThrow(/duplicates required content key/);
+    expect(() => new DryRunGraphModelMigrationPlanRequest({
+      // @ts-expect-error exercising runtime validation
+      inventory: emptyManifest(),
+      requiredContentKeys: [],
+      nodeMappings: [],
+      edgeMappings: [],
+      propertyMappings: [],
+    })).toThrow(/inventory/);
+    expect(() => new DryRunGraphModelMigrationPlanRequest({
+      inventory: createInventory({}),
+      // @ts-expect-error exercising runtime validation
+      requiredContentKeys: [1],
+      nodeMappings: [],
+      edgeMappings: [],
+      propertyMappings: [],
+    })).toThrow(/contentKey/);
+  });
+
+  it('rejects invalid source inventory carrier shapes', () => {
+    expect(() => {
+      // @ts-expect-error exercising runtime validation
+      new GraphModelMigrationSourceInventory(null);
+    }).toThrow(/fields/);
+    expect(() => new GraphModelMigrationSourceInventory({
+      graphId: 'graph:source',
+      // @ts-expect-error exercising runtime validation
+      sourceBasis: { graphId: 'graph:source', basisId: 'basis:source' },
+      writerChains: [],
+      patchDescriptors: [],
+      stateSnapshot: null,
+      contentSources: [],
+      warnings: [],
+      fatalErrors: [],
+    })).toThrow(/sourceBasis/);
+    expect(() => new GraphModelMigrationSourceInventory({
+      graphId: 'graph:source',
+      sourceBasis: sourceBasis(),
+      writerChains: [{ writerId: 'writer:a', patchIds: [] }],
+      patchDescriptors: [],
+      stateSnapshot: null,
+      contentSources: [],
+      warnings: [],
+      fatalErrors: [],
+    })).toThrow(/writerChains/);
+    expect(() => new GraphModelMigrationSourceInventory({
+      graphId: 'graph:source',
+      sourceBasis: sourceBasis(),
+      writerChains: [
+        new GraphModelMigrationWriterChainDescriptor({
+          writerId: 'writer:a',
+          patchIds: ['patch:a'],
+        }),
+      ],
+      patchDescriptors: [],
+      stateSnapshot: null,
+      contentSources: [],
+      warnings: [],
+      fatalErrors: [],
+    })).toThrow(/uncollected patch/);
   });
 });
 

--- a/test/unit/domain/migrations/GraphModelMigrationHistoryInput.test.ts
+++ b/test/unit/domain/migrations/GraphModelMigrationHistoryInput.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import GraphModelMigrationHistoryInput
+  from '../../../../src/domain/migrations/GraphModelMigrationHistoryInput.ts';
+import GraphModelMigrationHistoryPatchInput
+  from '../../../../src/domain/migrations/GraphModelMigrationHistoryPatchInput.ts';
+import GraphModelMigrationHistorySegment
+  from '../../../../src/domain/migrations/GraphModelMigrationHistorySegment.ts';
+import GraphModelMigrationPatchFrontierEvidence
+  from '../../../../src/domain/migrations/GraphModelMigrationPatchFrontierEvidence.ts';
+import GraphModelMigrationPatchOperationFact
+  from '../../../../src/domain/migrations/GraphModelMigrationPatchOperationFact.ts';
+
+describe('GraphModelMigrationHistoryInput', () => {
+  it('rejects duplicate patch ids across writer history', () => {
+    expect(() => new GraphModelMigrationHistoryInput({
+      segments: [
+        historySegment('writer:a', [historyPatch('writer:a', 'patch:same', 0)]),
+        historySegment('writer:b', [historyPatch('writer:b', 'patch:same', 0)]),
+      ],
+    })).toThrow(/duplicates patch id/);
+  });
+
+  it('requires contiguous operation indexes per patch', () => {
+    expect(() => historyPatch('writer:a', 'patch:a:0', 0, {
+      operations: [
+        operationFact(0, 'node:set', 'node:a'),
+        operationFact(2, 'node:set', 'node:b'),
+      ],
+    })).toThrow(/operation indexes must be contiguous/);
+  });
+
+  it('orders writer history deterministically', () => {
+    const input = new GraphModelMigrationHistoryInput({
+      segments: [
+        historySegment('writer:b', [historyPatch('writer:b', 'patch:b:0', 0)]),
+        historySegment('writer:a', [
+          historyPatch('writer:a', 'patch:a:1', 1),
+          historyPatch('writer:a', 'patch:a:0', 0),
+        ]),
+      ],
+    });
+
+    expect(input.patches.map((patch) => patch.patchId)).toEqual([
+      'patch:a:0',
+      'patch:a:1',
+      'patch:b:0',
+    ]);
+  });
+
+  it('requires frontier evidence for equivalence-ready history input', () => {
+    expect(() => new GraphModelMigrationHistoryInput({
+      segments: [
+        historySegment('writer:a', [
+          historyPatch('writer:a', 'patch:a:0', 0, { frontierEvidence: null }),
+        ]),
+      ],
+    })).toThrow(/missing frontier evidence/);
+  });
+
+  it('freezes history input and patch operation boundaries', () => {
+    const input = new GraphModelMigrationHistoryInput({
+      segments: [
+        historySegment('writer:a', [historyPatch('writer:a', 'patch:a:0', 0)]),
+      ],
+    });
+
+    expect(Object.isFrozen(input)).toBe(true);
+    expect(Object.isFrozen(input.segments)).toBe(true);
+    expect(Object.isFrozen(input.patches)).toBe(true);
+    expect(Object.isFrozen(input.patches[0]?.operations)).toBe(true);
+  });
+});
+
+type HistoryPatchOverrides = {
+  readonly frontierEvidence?: GraphModelMigrationPatchFrontierEvidence | null;
+  readonly operations?: readonly GraphModelMigrationPatchOperationFact[];
+};
+
+function historySegment(
+  writerId: string,
+  patches: readonly GraphModelMigrationHistoryPatchInput[],
+): GraphModelMigrationHistorySegment {
+  return new GraphModelMigrationHistorySegment({ writerId, patches });
+}
+
+function historyPatch(
+  writerId: string,
+  patchId: string,
+  writerSequence: number,
+  overrides: HistoryPatchOverrides = {},
+): GraphModelMigrationHistoryPatchInput {
+  return new GraphModelMigrationHistoryPatchInput({
+    writerId,
+    patchId,
+    writerSequence,
+    frontierEvidence: 'frontierEvidence' in overrides
+      ? overrides.frontierEvidence
+      : frontierEvidence(patchId),
+    operations: overrides.operations ?? [operationFact(0, 'node:set', `${patchId}:node`)],
+  });
+}
+
+function frontierEvidence(patchId: string): GraphModelMigrationPatchFrontierEvidence {
+  return new GraphModelMigrationPatchFrontierEvidence({
+    frontierKey: `${patchId}:frontier`,
+    parentPatchIds: [],
+  });
+}
+
+function operationFact(
+  operationIndex: number,
+  operationKind: string,
+  operationKey: string,
+): GraphModelMigrationPatchOperationFact {
+  return new GraphModelMigrationPatchOperationFact({
+    operationIndex,
+    operationKind,
+    operationKey,
+  });
+}

--- a/test/unit/domain/migrations/GraphModelMigrationManifest.test.ts
+++ b/test/unit/domain/migrations/GraphModelMigrationManifest.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+
+import GraphModelMigrationBasis from '../../../../src/domain/migrations/GraphModelMigrationBasis.ts';
+import GraphModelMigrationContentMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationContentMapping.ts';
+import GraphModelMigrationEdgeMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationEdgeMapping.ts';
+import GraphModelMigrationManifest
+  from '../../../../src/domain/migrations/GraphModelMigrationManifest.ts';
+import GraphModelMigrationManifestVersion
+  from '../../../../src/domain/migrations/GraphModelMigrationManifestVersion.ts';
+import GraphModelMigrationNodeMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationNodeMapping.ts';
+import GraphModelMigrationNotice from '../../../../src/domain/migrations/GraphModelMigrationNotice.ts';
+import GraphModelMigrationPropertyMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationPropertyMapping.ts';
+
+describe('GraphModelMigrationManifest', () => {
+  it('requires explicit source and target basis', () => {
+    expect(() => {
+      new GraphModelMigrationManifest({
+        version: GraphModelMigrationManifestVersion.current(),
+        // @ts-expect-error exercising runtime validation
+        sourceBasis: null,
+        targetBasis: targetBasis(),
+        nodeMappings: [],
+        edgeMappings: [],
+        propertyMappings: [],
+        contentMappings: [],
+        warnings: [],
+        fatalErrors: [],
+      });
+    }).toThrow(/sourceBasis/);
+    expect(() => {
+      new GraphModelMigrationManifest({
+        version: GraphModelMigrationManifestVersion.current(),
+        sourceBasis: sourceBasis(),
+        // @ts-expect-error exercising runtime validation
+        targetBasis: undefined,
+        nodeMappings: [],
+        edgeMappings: [],
+        propertyMappings: [],
+        contentMappings: [],
+        warnings: [],
+        fatalErrors: [],
+      });
+    }).toThrow(/targetBasis/);
+  });
+
+  it('rejects duplicate legacy node mappings', () => {
+    expect(() => createManifest({
+      nodeMappings: [
+        new GraphModelMigrationNodeMapping({
+          legacyNodeId: 'node:a',
+          targetNodeId: 'node:a',
+        }),
+        new GraphModelMigrationNodeMapping({
+          legacyNodeId: 'node:a',
+          targetNodeId: 'node:a-copy',
+        }),
+      ],
+    })).toThrow(/duplicates legacy node mapping/);
+  });
+
+  it('rejects duplicate legacy edge mappings', () => {
+    expect(() => createManifest({
+      edgeMappings: [
+        new GraphModelMigrationEdgeMapping({
+          legacyEdgeId: 'node:a\0node:b\0knows',
+          targetEdgeId: 'edge:a',
+        }),
+        new GraphModelMigrationEdgeMapping({
+          legacyEdgeId: 'node:a\0node:b\0knows',
+          targetEdgeId: 'edge:b',
+        }),
+      ],
+    })).toThrow(/duplicates legacy edge mapping/);
+  });
+
+  it('keeps warnings and fatal errors distinct', () => {
+    const warning = GraphModelMigrationNotice.warning('W_CONTENT_ALIAS', 'legacy content alias retained');
+    const fatal = GraphModelMigrationNotice.fatal('E_MISSING_BASIS', 'source basis missing');
+    const manifest = createManifest({
+      warnings: [warning],
+      fatalErrors: [fatal],
+    });
+
+    expect(manifest.warnings).toEqual([warning]);
+    expect(manifest.fatalErrors).toEqual([fatal]);
+    expect(manifest.hasFatalErrors()).toBe(true);
+    expect(() => createManifest({ warnings: [fatal] })).toThrow(/wrong notice kind/);
+    expect(() => createManifest({ fatalErrors: [warning] })).toThrow(/wrong notice kind/);
+  });
+
+  it('freezes manifest entries after construction', () => {
+    const nodeMapping = new GraphModelMigrationNodeMapping({
+      legacyNodeId: 'node:a',
+      targetNodeId: 'node:a',
+    });
+    const manifest = createManifest({ nodeMappings: [nodeMapping] });
+
+    expect(Object.isFrozen(manifest)).toBe(true);
+    expect(Object.isFrozen(manifest.nodeMappings)).toBe(true);
+    expect(manifest.nodeMappings).toEqual([nodeMapping]);
+  });
+
+  it('records all migration mapping sections', () => {
+    const propertyMapping = new GraphModelMigrationPropertyMapping({
+      legacyOwnerId: 'node:a',
+      legacyPropertyKey: 'title',
+      targetOwnerId: 'node:a',
+      targetPropertyKey: 'title',
+    });
+    const contentMapping = new GraphModelMigrationContentMapping({
+      legacyContentKey: 'node:a\0_content',
+      targetAttachmentKey: 'node:a\0content',
+    });
+    const manifest = createManifest({
+      propertyMappings: [propertyMapping],
+      contentMappings: [contentMapping],
+    });
+
+    expect(manifest.propertyMappings).toEqual([propertyMapping]);
+    expect(manifest.contentMappings).toEqual([contentMapping]);
+  });
+});
+
+type ManifestOverrides = {
+  readonly sourceBasis?: GraphModelMigrationBasis;
+  readonly targetBasis?: GraphModelMigrationBasis;
+  readonly nodeMappings?: readonly GraphModelMigrationNodeMapping[];
+  readonly edgeMappings?: readonly GraphModelMigrationEdgeMapping[];
+  readonly propertyMappings?: readonly GraphModelMigrationPropertyMapping[];
+  readonly contentMappings?: readonly GraphModelMigrationContentMapping[];
+  readonly warnings?: readonly GraphModelMigrationNotice[];
+  readonly fatalErrors?: readonly GraphModelMigrationNotice[];
+};
+
+function createManifest(overrides: ManifestOverrides = {}): GraphModelMigrationManifest {
+  return new GraphModelMigrationManifest({
+    version: GraphModelMigrationManifestVersion.current(),
+    sourceBasis: overrides.sourceBasis ?? sourceBasis(),
+    targetBasis: overrides.targetBasis ?? targetBasis(),
+    nodeMappings: overrides.nodeMappings ?? [],
+    edgeMappings: overrides.edgeMappings ?? [],
+    propertyMappings: overrides.propertyMappings ?? [],
+    contentMappings: overrides.contentMappings ?? [],
+    warnings: overrides.warnings ?? [],
+    fatalErrors: overrides.fatalErrors ?? [],
+  });
+}
+
+function sourceBasis(): GraphModelMigrationBasis {
+  return new GraphModelMigrationBasis({
+    graphId: 'graph:source',
+    basisId: 'basis:source',
+  });
+}
+
+function targetBasis(): GraphModelMigrationBasis {
+  return new GraphModelMigrationBasis({
+    graphId: 'graph:target',
+    basisId: 'basis:target',
+  });
+}

--- a/test/unit/domain/migrations/GraphModelMigrationSourceInventory.test.ts
+++ b/test/unit/domain/migrations/GraphModelMigrationSourceInventory.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import GraphModelMigrationBasis from '../../../../src/domain/migrations/GraphModelMigrationBasis.ts';
+import GraphModelMigrationContentSource
+  from '../../../../src/domain/migrations/GraphModelMigrationContentSource.ts';
+import GraphModelMigrationNotice from '../../../../src/domain/migrations/GraphModelMigrationNotice.ts';
+import GraphModelMigrationPatchDescriptor
+  from '../../../../src/domain/migrations/GraphModelMigrationPatchDescriptor.ts';
+import GraphModelMigrationSourceInventory
+  from '../../../../src/domain/migrations/GraphModelMigrationSourceInventory.ts';
+import GraphModelMigrationStateSnapshotReference
+  from '../../../../src/domain/migrations/GraphModelMigrationStateSnapshotReference.ts';
+import GraphModelMigrationWriterChainDescriptor
+  from '../../../../src/domain/migrations/GraphModelMigrationWriterChainDescriptor.ts';
+
+describe('GraphModelMigrationSourceInventory', () => {
+  it('records a missing source basis as a fatal collection error', () => {
+    const inventory = createInventory({ sourceBasis: null });
+
+    expect(inventory.sourceBasis).toBeNull();
+    expect(inventory.hasFatalErrors()).toBe(true);
+    expect(inventory.isUsableForPlanning()).toBe(false);
+    expect(inventory.fatalErrors.map((notice) => notice.code)).toContain('E_MISSING_SOURCE_BASIS');
+  });
+
+  it('rejects duplicate patch identity', () => {
+    expect(() => createInventory({
+      patchDescriptors: [
+        patchDescriptor('patch:one', 'writer:a', 0),
+        patchDescriptor('patch:one', 'writer:a', 1),
+      ],
+      writerChains: [writerChain('writer:a', ['patch:one'])],
+    })).toThrow(/duplicates patch identity/);
+  });
+
+  it('orders patch descriptors deterministically by writer and sequence', () => {
+    const inventory = createInventory({
+      patchDescriptors: [
+        patchDescriptor('patch:a:1', 'writer:a', 1),
+        patchDescriptor('patch:b:0', 'writer:b', 0),
+        patchDescriptor('patch:a:0', 'writer:a', 0),
+      ],
+      writerChains: [
+        writerChain('writer:b', ['patch:b:0']),
+        writerChain('writer:a', ['patch:a:0', 'patch:a:1']),
+      ],
+    });
+
+    expect(inventory.patchDescriptors.map((patch) => patch.patchId)).toEqual([
+      'patch:a:0',
+      'patch:a:1',
+      'patch:b:0',
+    ]);
+  });
+
+  it('rejects patch descriptors that do not match writer chain order', () => {
+    expect(() => createInventory({
+      patchDescriptors: [
+        patchDescriptor('patch:a:0', 'writer:a', 1),
+        patchDescriptor('patch:a:1', 'writer:a', 0),
+      ],
+      writerChains: [writerChain('writer:a', ['patch:a:0', 'patch:a:1'])],
+    })).toThrow(/does not match writer chain position/);
+  });
+
+  it('keeps warnings usable for planning', () => {
+    const warning = GraphModelMigrationNotice.warning(
+      'W_CONTENT_SOURCE_EXTRA',
+      'extra content source was collected',
+    );
+    const inventory = createInventory({ warnings: [warning] });
+
+    expect(inventory.warnings).toEqual([warning]);
+    expect(inventory.hasFatalErrors()).toBe(false);
+    expect(inventory.isUsableForPlanning()).toBe(true);
+  });
+
+  it('keeps fatal collection errors from planner use', () => {
+    const fatal = GraphModelMigrationNotice.fatal(
+      'E_PATCH_JOURNAL_INCOMPLETE',
+      'patch journal collection stopped early',
+    );
+    const inventory = createInventory({ fatalErrors: [fatal] });
+
+    expect(inventory.fatalErrors).toEqual([fatal]);
+    expect(inventory.hasFatalErrors()).toBe(true);
+    expect(inventory.isUsableForPlanning()).toBe(false);
+  });
+
+  it('records state and content source facts immutably', () => {
+    const contentSource = new GraphModelMigrationContentSource({
+      legacyContentKey: 'node:a\0_content',
+      contentOid: 'oid:content:a',
+    });
+    const stateSnapshot = new GraphModelMigrationStateSnapshotReference({
+      snapshotId: 'snapshot:one',
+    });
+    const inventory = createInventory({
+      contentSources: [contentSource],
+      stateSnapshot,
+    });
+
+    expect(Object.isFrozen(inventory)).toBe(true);
+    expect(Object.isFrozen(inventory.contentSources)).toBe(true);
+    expect(inventory.contentSources).toEqual([contentSource]);
+    expect(inventory.stateSnapshot).toBe(stateSnapshot);
+  });
+});
+
+type InventoryOverrides = {
+  readonly sourceBasis?: GraphModelMigrationBasis | null;
+  readonly writerChains?: readonly GraphModelMigrationWriterChainDescriptor[];
+  readonly patchDescriptors?: readonly GraphModelMigrationPatchDescriptor[];
+  readonly stateSnapshot?: GraphModelMigrationStateSnapshotReference | null;
+  readonly contentSources?: readonly GraphModelMigrationContentSource[];
+  readonly warnings?: readonly GraphModelMigrationNotice[];
+  readonly fatalErrors?: readonly GraphModelMigrationNotice[];
+};
+
+function createInventory(overrides: InventoryOverrides = {}): GraphModelMigrationSourceInventory {
+  return new GraphModelMigrationSourceInventory({
+    graphId: 'graph:source',
+    sourceBasis: 'sourceBasis' in overrides ? overrides.sourceBasis : sourceBasis(),
+    writerChains: overrides.writerChains ?? [writerChain('writer:a', ['patch:a:0'])],
+    patchDescriptors: overrides.patchDescriptors ?? [patchDescriptor('patch:a:0', 'writer:a', 0)],
+    stateSnapshot: 'stateSnapshot' in overrides ? overrides.stateSnapshot : stateSnapshot(),
+    contentSources: overrides.contentSources ?? [],
+    warnings: overrides.warnings ?? [],
+    fatalErrors: overrides.fatalErrors ?? [],
+  });
+}
+
+function sourceBasis(): GraphModelMigrationBasis {
+  return new GraphModelMigrationBasis({
+    graphId: 'graph:source',
+    basisId: 'basis:source',
+  });
+}
+
+function stateSnapshot(): GraphModelMigrationStateSnapshotReference {
+  return new GraphModelMigrationStateSnapshotReference({
+    snapshotId: 'snapshot:default',
+  });
+}
+
+function writerChain(
+  writerId: string,
+  patchIds: readonly string[],
+): GraphModelMigrationWriterChainDescriptor {
+  return new GraphModelMigrationWriterChainDescriptor({ writerId, patchIds });
+}
+
+function patchDescriptor(
+  patchId: string,
+  writerId: string,
+  writerSequence: number,
+): GraphModelMigrationPatchDescriptor {
+  return new GraphModelMigrationPatchDescriptor({ patchId, writerId, writerSequence });
+}

--- a/test/unit/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.test.ts
@@ -44,6 +44,65 @@ describe('GraphModelMigrationManifestJsonAdapter', () => {
     }`)).toThrow(/version/);
   });
 
+  it('fails closed for invalid JSON and unexpected fields', () => {
+    expect(() => parseGraphModelMigrationManifest('{')).toThrow(/valid JSON/);
+    expect(() => parseGraphModelMigrationManifest(`{
+      "version": 1,
+      "sourceBasis": { "graphId": "graph:source", "basisId": "basis:source" },
+      "targetBasis": { "graphId": "graph:target", "basisId": "basis:target" },
+      "nodeMappings": [],
+      "edgeMappings": [],
+      "propertyMappings": [],
+      "contentMappings": [],
+      "warnings": [],
+      "fatalErrors": [],
+      "surprise": true
+    }`)).toThrow(/surprise/);
+  });
+
+  it('fails closed for malformed object arrays and notice kind fields', () => {
+    expect(() => parseGraphModelMigrationManifest(`{
+      "version": 1,
+      "sourceBasis": { "graphId": "graph:source", "basisId": "basis:source" },
+      "targetBasis": { "graphId": "graph:target", "basisId": "basis:target" },
+      "nodeMappings": "nope",
+      "edgeMappings": [],
+      "propertyMappings": [],
+      "contentMappings": [],
+      "warnings": [],
+      "fatalErrors": []
+    }`)).toThrow(/nodeMappings/);
+    expect(() => parseGraphModelMigrationManifest(`{
+      "version": 1,
+      "sourceBasis": { "graphId": "graph:source", "basisId": "basis:source" },
+      "targetBasis": { "graphId": "graph:target", "basisId": "basis:target" },
+      "nodeMappings": [null],
+      "edgeMappings": [],
+      "propertyMappings": [],
+      "contentMappings": [],
+      "warnings": [],
+      "fatalErrors": []
+    }`)).toThrow(/nodeMappings\[0\]/);
+    expect(() => parseGraphModelMigrationManifest(`{
+      "version": 1,
+      "sourceBasis": { "graphId": "graph:source", "basisId": "basis:source" },
+      "targetBasis": { "graphId": "graph:target", "basisId": "basis:target" },
+      "nodeMappings": [],
+      "edgeMappings": [],
+      "propertyMappings": [],
+      "contentMappings": [],
+      "warnings": [{ "kind": "info", "code": "I_BAD", "message": "bad" }],
+      "fatalErrors": []
+    }`)).toThrow(/warnings\[0\]\.kind/);
+  });
+
+  it('requires manifest instances for serialization', () => {
+    expect(() => {
+      // @ts-expect-error exercising runtime validation
+      serializeGraphModelMigrationManifest({ version: 1 });
+    }).toThrow(/manifest instance/);
+  });
+
   it('lets domain construction reject duplicate mapping entries', () => {
     const duplicatedNodeMapping = `{
       "version": 1,

--- a/test/unit/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import GraphModelMigrationBasis from '../../../../src/domain/migrations/GraphModelMigrationBasis.ts';
+import GraphModelMigrationContentMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationContentMapping.ts';
+import GraphModelMigrationEdgeMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationEdgeMapping.ts';
+import GraphModelMigrationManifest
+  from '../../../../src/domain/migrations/GraphModelMigrationManifest.ts';
+import GraphModelMigrationManifestVersion
+  from '../../../../src/domain/migrations/GraphModelMigrationManifestVersion.ts';
+import GraphModelMigrationNodeMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationNodeMapping.ts';
+import GraphModelMigrationNotice from '../../../../src/domain/migrations/GraphModelMigrationNotice.ts';
+import GraphModelMigrationPropertyMapping
+  from '../../../../src/domain/migrations/GraphModelMigrationPropertyMapping.ts';
+import {
+  parseGraphModelMigrationManifest,
+  serializeGraphModelMigrationManifest,
+} from '../../../../src/infrastructure/adapters/GraphModelMigrationManifestJsonAdapter.ts';
+
+describe('GraphModelMigrationManifestJsonAdapter', () => {
+  it('round-trips a valid manifest through JSON', () => {
+    const manifest = fixtureManifest();
+    const parsed = parseGraphModelMigrationManifest(serializeGraphModelMigrationManifest(manifest));
+
+    expect(parsed.version.value).toBe(1);
+    expect(parsed.sourceBasis.graphId).toBe('graph:source');
+    expect(parsed.nodeMappings[0]?.targetNodeId).toBe('node:a');
+    expect(parsed.warnings[0]?.code).toBe('W_DRY_RUN');
+  });
+
+  it('fails closed for malformed version fields', () => {
+    expect(() => parseGraphModelMigrationManifest(`{
+      "version": "1",
+      "sourceBasis": { "graphId": "graph:source", "basisId": "basis:source" },
+      "targetBasis": { "graphId": "graph:target", "basisId": "basis:target" },
+      "nodeMappings": [],
+      "edgeMappings": [],
+      "propertyMappings": [],
+      "contentMappings": [],
+      "warnings": [],
+      "fatalErrors": []
+    }`)).toThrow(/version/);
+  });
+
+  it('lets domain construction reject duplicate mapping entries', () => {
+    const duplicatedNodeMapping = `{
+      "version": 1,
+      "sourceBasis": { "graphId": "graph:source", "basisId": "basis:source" },
+      "targetBasis": { "graphId": "graph:target", "basisId": "basis:target" },
+      "nodeMappings": [
+        { "legacyNodeId": "node:a", "targetNodeId": "node:a" },
+        { "legacyNodeId": "node:a", "targetNodeId": "node:a-copy" }
+      ],
+      "edgeMappings": [],
+      "propertyMappings": [],
+      "contentMappings": [],
+      "warnings": [],
+      "fatalErrors": []
+    }`;
+
+    expect(() => parseGraphModelMigrationManifest(duplicatedNodeMapping))
+      .toThrow(/duplicates legacy node mapping/);
+  });
+
+  it('serializes deterministically for a fixture manifest', () => {
+    expect(serializeGraphModelMigrationManifest(fixtureManifest())).toBe(`{
+  "version": 1,
+  "sourceBasis": {
+    "graphId": "graph:source",
+    "basisId": "basis:source"
+  },
+  "targetBasis": {
+    "graphId": "graph:target",
+    "basisId": "basis:target"
+  },
+  "nodeMappings": [
+    {
+      "legacyNodeId": "node:a",
+      "targetNodeId": "node:a"
+    }
+  ],
+  "edgeMappings": [
+    {
+      "legacyEdgeId": "node:a\\u0000node:b\\u0000knows",
+      "targetEdgeId": "edge:a"
+    }
+  ],
+  "propertyMappings": [
+    {
+      "legacyOwnerId": "node:a",
+      "legacyPropertyKey": "title",
+      "targetOwnerId": "node:a",
+      "targetPropertyKey": "title"
+    }
+  ],
+  "contentMappings": [
+    {
+      "legacyContentKey": "node:a\\u0000_content",
+      "targetAttachmentKey": "content-attachment:node:a\\u0000_content"
+    }
+  ],
+  "warnings": [
+    {
+      "kind": "warning",
+      "code": "W_DRY_RUN",
+      "message": "dry-run only"
+    }
+  ],
+  "fatalErrors": []
+}
+`);
+  });
+
+  it('identifies the failing field for malformed mapping entries', () => {
+    const malformedNodeMapping = `{
+      "version": 1,
+      "sourceBasis": { "graphId": "graph:source", "basisId": "basis:source" },
+      "targetBasis": { "graphId": "graph:target", "basisId": "basis:target" },
+      "nodeMappings": [{ "targetNodeId": "node:a" }],
+      "edgeMappings": [],
+      "propertyMappings": [],
+      "contentMappings": [],
+      "warnings": [],
+      "fatalErrors": []
+    }`;
+
+    expect(() => parseGraphModelMigrationManifest(malformedNodeMapping))
+      .toThrow(/nodeMappings\[0\]\.legacyNodeId/);
+  });
+});
+
+function fixtureManifest(): GraphModelMigrationManifest {
+  return new GraphModelMigrationManifest({
+    version: GraphModelMigrationManifestVersion.current(),
+    sourceBasis: new GraphModelMigrationBasis({
+      graphId: 'graph:source',
+      basisId: 'basis:source',
+    }),
+    targetBasis: new GraphModelMigrationBasis({
+      graphId: 'graph:target',
+      basisId: 'basis:target',
+    }),
+    nodeMappings: [
+      new GraphModelMigrationNodeMapping({
+        legacyNodeId: 'node:a',
+        targetNodeId: 'node:a',
+      }),
+    ],
+    edgeMappings: [
+      new GraphModelMigrationEdgeMapping({
+        legacyEdgeId: 'node:a\0node:b\0knows',
+        targetEdgeId: 'edge:a',
+      }),
+    ],
+    propertyMappings: [
+      new GraphModelMigrationPropertyMapping({
+        legacyOwnerId: 'node:a',
+        legacyPropertyKey: 'title',
+        targetOwnerId: 'node:a',
+        targetPropertyKey: 'title',
+      }),
+    ],
+    contentMappings: [
+      new GraphModelMigrationContentMapping({
+        legacyContentKey: 'node:a\0_content',
+        targetAttachmentKey: 'content-attachment:node:a\0_content',
+      }),
+    ],
+    warnings: [GraphModelMigrationNotice.warning('W_DRY_RUN', 'dry-run only')],
+    fatalErrors: [],
+  });
+}


### PR DESCRIPTION
## Summary

- Reset BEARING for the v18 migration dry-run batch and completed slices 36 through 40.
- Add runtime-backed graph-model migration manifest, source inventory, dry-run planner, ordered history input, and planned graph-operation facts.
- Add infrastructure manifest JSON serialization with deterministic output and field-specific parse validation.

## Verification

- npm run test:local
- npm run lint
- npm run typecheck
- npm run lint:sludge
- npm run lint:semgrep
- GIT_WARP_QUARANTINE_BASE=origin/main npm run lint:quarantine-graduate
- npm run typecheck:surface
- npm run lint:contamination
- npx markdownlint-cli2 CHANGELOG.md docs/BEARING.md docs/design/0184-v18-graph-model-migration-manifest/v18-graph-model-migration-manifest.md docs/design/0185-v18-migration-source-inventory/v18-migration-source-inventory.md docs/design/0186-v18-dry-run-state-migration-planner/v18-dry-run-state-migration-planner.md docs/design/0187-v18-migration-history-input/v18-migration-history-input.md docs/design/0188-v18-migration-manifest-serialization/v18-migration-manifest-serialization.md
- git diff --check HEAD
- git push pre-push firewall: static gates and test:local passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added V18 graph-model migration dry-run tooling with runtime-backed migration manifests and planning capabilities
  * Dry-run planner enables previewing migrations and collecting actionable warnings and errors without writing history
  * Migration manifest JSON serialization for persistence and data interchange
  * Source inventory tracking for comprehensive migration visibility

* **Documentation**
  * Completed design documentation for migration manifest, source inventory, dry-run planner, history input, and manifest serialization

* **Tests**
  * Added comprehensive test coverage for migration planning, inventory management, manifest handling, and JSON serialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->