### PR TITLE
Plan post-v18 release handoff and next goalpost

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -27,9 +27,10 @@ Continuum remains translated git-warp evidence.
 
 ## Where Are We
 
-`git-warp` has shipped `v17.0.0` and the `v17.0.1` release repair. The
-active major direction is `v18.0.0`: Continuum/WARP Optic compatibility for
-git-warp as an independent Continuum participant.
+`git-warp` has a public `v17.0.0` package/tag line, with `v17.0.1` repair
+work recorded in source docs but not present as public package/tag evidence.
+The active major direction is `v18.0.0`: Continuum/WARP Optic compatibility
+for git-warp as an independent Continuum participant.
 
 The long-term compatibility target is the WARP Optic shape described in
 `~/git/blog/aion-paper-07/dist/aion-paper-07.txt`, plus the Continuum
@@ -43,8 +44,10 @@ Current branch state at this boundary:
 - Base branch: `main`
 - Current `origin/main`: `fdcb5da9`
 - Latest merged PR: #107, v18 release-prep metadata and final gates
-- Latest released package line: `17.0.1` until the `v18.0.0` tag and publish
+- Latest released package line: `17.0.0` until the `v18.0.0` tag and publish
   complete
+- Latest recorded repair entry: `17.0.1` exists in source docs/changelog
+  without public npm/tag evidence
 - Release-prep package metadata: `18.0.0`, merged to `main`, not tagged or
   published yet
 - Latest completed implementation cycle:

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -39,19 +39,23 @@ of handwritten adapter folklore.
 
 Current branch state at this boundary:
 
-- Current branch: `v18-release-prep-slices-97-102`
+- Current branch: `v18-release-prep-slices-103-112`
 - Base branch: `main`
-- Current `origin/main`: `023c7d75`
-- Latest merged PR: #106, v18 release-candidate evidence and review cleanup
-- Latest released package line: `17.0.1`
-- Release-prep package metadata: `18.0.0`, not tagged or published yet
+- Current `origin/main`: `fdcb5da9`
+- Latest merged PR: #107, v18 release-prep metadata and final gates
+- Latest released package line: `17.0.1` until the `v18.0.0` tag and publish
+  complete
+- Release-prep package metadata: `18.0.0`, merged to `main`, not tagged or
+  published yet
 - Latest completed implementation cycle:
-  `0250-v18-final-release-prep-replan`
-- Current work: release-prep PR review for `v18.0.0`; local release preflight
-  is green for `18.0.0` metadata, and the remaining public-release gates are
-  PR review, GitHub CI, merge to `main`, tag, and publish.
-- Cleanup checkpoint: PR #106 is merged to `main`; this branch starts from that
-  merge and must not widen the v18 promise while preparing the public tag.
+  `0260-next-goalpost-replan-after-v18-merge`
+- Current work: post-merge release handoff and next-goalpost planning. PR
+  review, GitHub CI, and merge are complete for the release-prep branch. The
+  remaining public-release operation is to tag and publish `v18.0.0` from
+  aligned `main`.
+- Cleanup checkpoint: PR #107 is merged to `main`; this branch starts from
+  that merge and must not widen the v18 promise while setting the next
+  engineering goalpost.
 
 The current v18 graph-model posture is:
 
@@ -155,15 +159,16 @@ The current v18 graph-model posture is:
   command-owned readings, emits the command report, and permits live-ref
   finalization only through a reviewed JSON request that matches observed
   runtime evidence.
-- V18 release-candidate blockers are now explicit: GitHub CI, PR review,
-  post-merge tag/publish work, and the accepted residual raw content/property
-  risk.
+- V18 release-candidate blockers are now narrowed: PR review, GitHub CI, and
+  merge are complete; post-merge tag/publish work remains, with accepted
+  residual raw content/property risk and the full-graph-streaming non-claim
+  preserved.
 
 That is useful progress, not a finish line. The repo now has migration safety,
 wet-run proof, guarded finalization, generated Continuum contract tie-back,
-release-candidate docs, `18.0.0` package metadata, and a green local release
-preflight. Public v18 still needs PR review, GitHub CI, merge to `main`, tag,
-and publish.
+release-candidate docs, `18.0.0` package metadata on `main`, a green local
+release preflight from the release-prep branch, and green GitHub CI on PR
+#107. Public v18 still needs tag and publish work from aligned `main`.
 
 ## What Just Shipped
 
@@ -229,6 +234,16 @@ PR #106 landed v18 slices 66 through 96:
 - backlog reconciliation after the release-candidate evidence;
 - review follow-up that tightened runtime replay validation, finalization JSON
   evidence binding, fixture coverage, and migration script structure.
+
+PR #107 landed v18 slices 97 through 102:
+
+- release-prep baseline and gate evidence;
+- residual raw content/property storage risk decision;
+- public operator release notes and v18 non-goals;
+- `18.0.0` package, JSR, lockfile, workspace, changelog, and release-policy
+  metadata alignment;
+- final release-prep replan before PR review;
+- technical teardown publication and review follow-up.
 
 Slice 36 is complete on this branch. The migration manifest root now exists
 as a frozen domain noun, with runtime-backed basis, mapping, warning, and
@@ -387,13 +402,14 @@ and wet-run fixture harnessing.
   map because historical replay tests carry pre-codec inline fixture classes
   that are not `PropValue`-honest enough for `LegacyPropertyValue`.
 - The v18 migration tool now replays migrated scratch operations through the
-  production graph runtime write/materialization path during wet runs, but
-  public release still needs the full release-prep gate set on the eventual
-  release branch.
+  production graph runtime write/materialization path during wet runs, and the
+  release-prep PR has merged. Public release now needs tag and publish
+  evidence from aligned `main`.
 - Legacy readings from the v17 golden fixture now have restored public-read
   construction, but broader non-fixture replay coverage remains future work.
 - The command wrapper can finalize through a reviewed JSON request, but the
-  public tag still needs CI and release-preflight validation.
+  public tag still needs aligned-main release preflight, tag evidence, and
+  registry publish evidence.
 - Continuum/WARP Optic release claims now have generated contract evidence for
   runtime-boundary graph-model migration, but native Continuum witnesshood is
   still not claimed.
@@ -405,21 +421,17 @@ and wet-run fixture harnessing.
 
 ## Where We Are Heading
 
-The remaining runway is no longer a five-slice tail. The next realistic plan
-is thirty slices. Some slices may collapse when evidence is in hand, but the
-release plan should assume the proof work is hard until it is proven easy.
+The release-prep branch has merged. The next move is no longer adding v18
+features. It is one of three explicitly separated actions:
 
-The first thirty slices converted operation-derived confidence into
-production-runtime confidence, restored the v17 golden fixture, drove the
-canonical wet-run report to zero public-read mismatches, guarded live
-finalization, tied graph-model migration to generated runtime-boundary
-contracts, and added the first `warp-ttd` generated-family smoke. The next
-goalpost is release-prep hardening rather than new feature expansion.
+1. cut and publish `v18.0.0` from aligned `main`;
+2. retire one more raw content/property compatibility boundary;
+3. start the v19 observer/admission witnesshood runway.
 
-Slice 96 reconciled the backlog ledger with that evidence. The next practical
-goalpost is a release-prep branch that runs the full gate set, freezes package
-and release notes, and decides whether remaining raw content/property storage
-retirement blocks the public tag or ships as explicit residual risk.
+Those should not be blended. Tag/publish is release operation. Storage
+retirement is substrate-debt reduction. V19 starts a new semantic runway.
+
+Slices 103 through 112 record that split and keep the next goalpost honest.
 
 ### Release-Prep Checklist
 
@@ -435,6 +447,29 @@ retirement blocks the public tag or ships as explicit residual risk.
   [0249](design/0249-v18-version-tag-readiness/v18-version-tag-readiness.md).
 - [x] 102. Replan from final release-prep evidence before PR review:
   [0250](design/0250-v18-final-release-prep-replan/v18-final-release-prep-replan.md).
+
+### Post-Merge Goalpost Checklist
+
+- [x] 103. Record the v18 post-merge release handoff:
+  [0251](design/0251-v18-post-merge-release-handoff/v18-post-merge-release-handoff.md).
+- [x] 104. Define the v18 tag and publish gate:
+  [0252](design/0252-v18-tag-publish-gate/v18-tag-publish-gate.md).
+- [x] 105. Define the v18 release evidence archive:
+  [0253](design/0253-v18-release-evidence-archive/v18-release-evidence-archive.md).
+- [x] 106. Frame the post-v18 storage retirement decision:
+  [0254](design/0254-post-v18-storage-retirement-decision/post-v18-storage-retirement-decision.md).
+- [x] 107. Frame the v19 native Continuum witnesshood runway:
+  [0255](design/0255-v19-native-continuum-witnesshood-runway/v19-native-continuum-witnesshood-runway.md).
+- [x] 108. Scope end-to-end graph streaming reads and writes to v20:
+  [0256](design/0256-v20-streaming-reads-writes-scope/v20-streaming-reads-writes-scope.md).
+- [x] 109. Define the post-v18 public doc honesty audit:
+  [0257](design/0257-post-v18-public-doc-honesty-audit/post-v18-public-doc-honesty-audit.md).
+- [x] 110. Define the next residual boundary retirement decision:
+  [0258](design/0258-v18-residual-boundary-next-retirement/v18-residual-boundary-next-retirement.md).
+- [x] 111. Plan backlog lane cleanup after v18:
+  [0259](design/0259-backlog-lane-cleanup-after-v18/backlog-lane-cleanup-after-v18.md).
+- [x] 112. Replan the next goalpost after the v18 release-prep merge:
+  [0260](design/0260-next-goalpost-replan-after-v18-merge/next-goalpost-replan-after-v18-merge.md).
 
 ### Next Thirty-Slice Checklist
 
@@ -799,3 +834,23 @@ and concrete checks live in `docs/invariants/`.
   [0249](design/0249-v18-version-tag-readiness/v18-version-tag-readiness.md).
 - [x] 102. Replan from final release-prep evidence before PR review:
   [0250](design/0250-v18-final-release-prep-replan/v18-final-release-prep-replan.md).
+- [x] 103. Record the v18 post-merge release handoff:
+  [0251](design/0251-v18-post-merge-release-handoff/v18-post-merge-release-handoff.md).
+- [x] 104. Define the v18 tag and publish gate:
+  [0252](design/0252-v18-tag-publish-gate/v18-tag-publish-gate.md).
+- [x] 105. Define the v18 release evidence archive:
+  [0253](design/0253-v18-release-evidence-archive/v18-release-evidence-archive.md).
+- [x] 106. Frame the post-v18 storage retirement decision:
+  [0254](design/0254-post-v18-storage-retirement-decision/post-v18-storage-retirement-decision.md).
+- [x] 107. Frame the v19 native Continuum witnesshood runway:
+  [0255](design/0255-v19-native-continuum-witnesshood-runway/v19-native-continuum-witnesshood-runway.md).
+- [x] 108. Scope end-to-end graph streaming reads and writes to v20:
+  [0256](design/0256-v20-streaming-reads-writes-scope/v20-streaming-reads-writes-scope.md).
+- [x] 109. Define the post-v18 public doc honesty audit:
+  [0257](design/0257-post-v18-public-doc-honesty-audit/post-v18-public-doc-honesty-audit.md).
+- [x] 110. Define the next residual boundary retirement decision:
+  [0258](design/0258-v18-residual-boundary-next-retirement/v18-residual-boundary-next-retirement.md).
+- [x] 111. Plan backlog lane cleanup after v18:
+  [0259](design/0259-backlog-lane-cleanup-after-v18/backlog-lane-cleanup-after-v18.md).
+- [x] 112. Replan the next goalpost after the v18 release-prep merge:
+  [0260](design/0260-next-goalpost-replan-after-v18-merge/next-goalpost-replan-after-v18-merge.md).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,9 +4,9 @@
 > See METHOD for the current process.
 > Completed items remain in `docs/ROADMAP/COMPLETED.md`. This file is kept for reference only.
 
-> **Current release on `main`:** v17.0.1
+> **Current public package/tag release:** v17.0.0
 > **Next intended release:** v18.0.0
-> **Last reconciled:** 2026-05-22 (v17.0.1 patch. Recursive tree OID reads use one path-preserving Git command; v17.0.0 release delivered readings/worldlines, TypeScript source, and the generated npm type surface.)
+> **Last reconciled:** 2026-05-22 (v17.0.1 repair work is recorded in source docs/changelog without public npm/tag evidence. Recursive tree OID reads use one path-preserving Git command; v17.0.0 release delivered readings/worldlines, TypeScript source, and the generated npm type surface.)
 > **Completed milestones:** [docs/ROADMAP/COMPLETED.md](ROADMAP/COMPLETED.md)
 
 ---

--- a/docs/design/0251-v18-post-merge-release-handoff/v18-post-merge-release-handoff.md
+++ b/docs/design/0251-v18-post-merge-release-handoff/v18-post-merge-release-handoff.md
@@ -1,0 +1,46 @@
+# V18 Post-Merge Release Handoff
+
+## Hill
+
+Record the state after the release-prep PR merged and make the remaining
+`v18.0.0` release work explicit: tag and publish from `main`, with no new
+runtime promise added on a follow-up branch.
+
+## Context
+
+PR #107 merged the `18.0.0` metadata, release notes, release-prep evidence,
+and technical teardown to `main`. The package line is release-ready in source,
+but the public release is not complete until the tag and publish artifacts are
+cut from merged `main`.
+
+The follow-up branch exists to cleanly bookkeep that handoff and set the next
+engineering goalpost. It must not blur three different states:
+
+- `18.0.0` metadata merged to `main`;
+- `v18.0.0` tag created from `main`;
+- npm and JSR artifacts published from that release path.
+
+## User Stories
+
+- As a release manager, I can tell whether the source tree, the Git tag, and
+  the package registries all agree on `18.0.0`.
+- As a maintainer, I can see that the release-prep PR has merged without
+  accidentally treating that as a completed public release.
+- As a downstream operator, I can inspect release notes that describe actual
+  `v18` guarantees without inheriting hidden branch-state assumptions.
+
+## Acceptance Criteria
+
+- `docs/BEARING.md` names PR #107 as merged and `origin/main` as the source
+  of truth for the current branch.
+- The v18 blocker ledger treats PR review, CI, and merge as complete.
+- Tag and publish remain explicitly open until registry evidence exists.
+- No follow-up doc claims that end-to-end graph streaming is part of v18.
+
+## Test Plan
+
+- `git status --short --branch`
+- `git rev-parse --short origin/main`
+- `gh pr view 107 --json state,mergedAt,mergeCommit`
+- `npx markdownlint` on edited Markdown files
+- `git diff --check`

--- a/docs/design/0252-v18-tag-publish-gate/v18-tag-publish-gate.md
+++ b/docs/design/0252-v18-tag-publish-gate/v18-tag-publish-gate.md
@@ -1,0 +1,43 @@
+# V18 Tag And Publish Gate
+
+## Hill
+
+Define the final public-release gate for `v18.0.0` without performing it on a
+feature branch.
+
+## Context
+
+`package.json`, `jsr.json`, workspace package manifests, lockfile metadata,
+and the changelog now agree on `18.0.0`. The release-prep branch passed local
+preflight before merge, and GitHub CI passed before PR #107 merged.
+
+That is necessary but not sufficient. The public release must still be cut
+from merged `main`, and publish evidence must agree with the tag target.
+
+## User Stories
+
+- As a release manager, I can run a short gate before tagging and know which
+  evidence must be attached to the release record.
+- As a package consumer, I can trust that the npm artifact, JSR artifact, and
+  Git tag describe the same source tree.
+- As a maintainer, I do not have to infer whether a feature branch is allowed
+  to publish.
+
+## Acceptance Criteria
+
+- The release gate requires `main` to match `origin/main`.
+- The gate requires `npm run release:preflight` on `main` before tagging.
+- The gate requires the tag target, npm dry-run, JSR dry-run, and published
+  artifacts to agree on `18.0.0`.
+- The gate does not create a tag from a feature branch.
+- The gate preserves the v18 non-claim around full graph streaming reads and
+  writes.
+
+## Test Plan
+
+- `git checkout main`
+- `git pull --ff-only origin main`
+- `npm run release:preflight`
+- `git tag --list v18.0.0`
+- `npm view @git-stunts/git-warp version`
+- JSR package version inspection after publish

--- a/docs/design/0253-v18-release-evidence-archive/v18-release-evidence-archive.md
+++ b/docs/design/0253-v18-release-evidence-archive/v18-release-evidence-archive.md
@@ -1,0 +1,49 @@
+# V18 Release Evidence Archive
+
+## Hill
+
+Name the evidence that should survive after the public `v18.0.0` release,
+instead of leaving it scattered across PR comments, CI logs, and local command
+output.
+
+## Context
+
+The v18 path accumulated several classes of release evidence:
+
+- migration wet-run reports;
+- generated Continuum contract conformance;
+- `warp-ttd` generated-family smoke evidence;
+- closeout audit evidence for raw content/property compatibility boundaries;
+- release preflight output;
+- GitHub CI checks;
+- npm and JSR publish output.
+
+PR comments and CI logs are useful, but they are not a durable release ledger
+by themselves. A release evidence archive should summarize the final public
+facts and point back to inspectable sources.
+
+## User Stories
+
+- As a maintainer, I can answer "what exactly shipped in v18?" without
+  replaying the whole PR history.
+- As a downstream integrator, I can find the migration proof and generated
+  contract evidence that justify the release claim.
+- As a future release agent, I can compare v19 or v20 release evidence against
+  a stable v18 pattern.
+
+## Acceptance Criteria
+
+- A future release archive names the tag, commit, package versions, publish
+  timestamps, and registry artifacts.
+- The archive links to the release-prep PR, CI run, release notes, and local
+  gate evidence.
+- The archive records residual raw content/property compatibility risk as an
+  accepted v18 risk, not an omitted blocker.
+- The archive records that full graph streaming is a later-major goal.
+
+## Test Plan
+
+- Markdown lint the archive.
+- Link-check repository-local release evidence links.
+- Compare archived package versions against `package.json` and `jsr.json`.
+- Verify the archived tag SHA matches the release commit.

--- a/docs/design/0254-post-v18-storage-retirement-decision/post-v18-storage-retirement-decision.md
+++ b/docs/design/0254-post-v18-storage-retirement-decision/post-v18-storage-retirement-decision.md
@@ -1,0 +1,43 @@
+# Post-V18 Storage Retirement Decision
+
+## Hill
+
+Decide whether the next engineering goalpost should continue raw
+content/property storage retirement before starting v19 runtime doctrine work.
+
+## Context
+
+V18 deliberately accepts residual raw content/property compatibility
+boundaries. That is honest, but it is still debt. The closeout audit now
+guards drift, yet the repo still carries legacy compatibility spelling in
+named boundaries.
+
+The competing pressure is v19: observation, admission, and doctrine
+convergence. Starting v19 while storage-plane debt remains visible may be
+reasonable, but only if the debt is boxed and ratcheted tightly enough.
+
+## User Stories
+
+- As a maintainer, I can decide whether storage debt is a release-line risk or
+  a manageable ratcheted backlog item.
+- As a migration operator, I can trust that remaining legacy compatibility
+  boundaries are named and tested.
+- As a v19 planner, I can start observer/admission work without inheriting
+  ambiguous v18 substrate claims.
+
+## Acceptance Criteria
+
+- The decision distinguishes total storage retirement from bounded residual
+  compatibility.
+- The decision identifies the next single raw boundary to retire if retirement
+  continues first.
+- The decision explains why v19 can or cannot start before full storage
+  retirement.
+- The closeout audit remains the executable guard for any deferred boundary.
+
+## Test Plan
+
+- Run the content/property closeout audit.
+- Inspect each allowlisted boundary for ownership and reason.
+- Verify release docs do not claim total raw storage retirement.
+- Update the relevant backlog lane after the decision.

--- a/docs/design/0255-v19-native-continuum-witnesshood-runway/v19-native-continuum-witnesshood-runway.md
+++ b/docs/design/0255-v19-native-continuum-witnesshood-runway/v19-native-continuum-witnesshood-runway.md
@@ -1,0 +1,41 @@
+# V19 Native Continuum Witnesshood Runway
+
+## Hill
+
+Frame the first v19 runway without pretending that generated Continuum-shaped
+evidence in v18 is already native Continuum witnesshood.
+
+## Context
+
+V18 made graph-model evidence compatible with generated contract families and
+proved a `warp-ttd` smoke over translated-substrate facts. That is useful
+compatibility evidence, not the full v19 claim.
+
+V19 should make observer, admission, suffix, and receipt surfaces runtime-real
+enough that git-warp can produce native witness records where today it produces
+translated git-warp evidence shaped for Continuum.
+
+## User Stories
+
+- As a Continuum integrator, I can distinguish translated v18 evidence from
+  native v19 witnesshood.
+- As a `warp-ttd` consumer, I can receive witness records whose authority and
+  basis semantics are not adapter folklore.
+- As a maintainer, I can start v19 work from the current v18 evidence rather
+  than rearguing the graph substrate.
+
+## Acceptance Criteria
+
+- The v19 runway starts from generated contract evidence, not handwritten
+  shape claims.
+- The first v19 backlog items name observer-readable receipts, reading
+  envelopes, and witnessed suffix admission as separate concerns.
+- The runway does not pull v20 full graph streaming into v19.
+- The runway keeps Echo and git-warp as sibling Continuum participants.
+
+## Test Plan
+
+- Inspect `docs/method/backlog/v19.0.0/README.md`.
+- Inspect generated contract fixture ingestion and conformance tests.
+- Verify docs avoid claiming native witnesshood before v19 work proves it.
+- Keep `warp-ttd` smoke evidence tied to generated-family facts.

--- a/docs/design/0256-v20-streaming-reads-writes-scope/v20-streaming-reads-writes-scope.md
+++ b/docs/design/0256-v20-streaming-reads-writes-scope/v20-streaming-reads-writes-scope.md
@@ -1,0 +1,42 @@
+# V20 Streaming Reads And Writes Scope
+
+## Hill
+
+Keep end-to-end graph streaming reads and writes in the v20 runtime-realization
+lane, and define what v19 must prove before that claim becomes executable.
+
+## Context
+
+The repo already has stream-shaped utilities and stream-capable lower-level
+ideas, but it does not fully support graph reads and writes without
+materializing broad state in memory. V18 release notes now say this explicitly.
+
+The next risk is planning drift: calling a later branch "streaming" because
+one surface returns an async iterator while the runtime still materializes the
+whole graph or patch set underneath.
+
+## User Stories
+
+- As a large-graph user, I can tell whether an API is truly bounded, paged,
+  streamed, or merely stream-shaped after full materialization.
+- As a v19 implementer, I know which support and index contracts v20 depends
+  on.
+- As a reviewer, I can reject premature streaming claims with a concrete
+  standard.
+
+## Acceptance Criteria
+
+- The v20 backlog keeps end-to-end graph streaming as a runtime-realization
+  goal.
+- V19 prerequisites include bounded support rules, causal indexes, and
+  support-scoped fragments.
+- Public docs distinguish content-byte streaming from graph-level streaming.
+- Any future streaming claim names the storage boundary, reducer path, read
+  path, and public API surface it covers.
+
+## Test Plan
+
+- Inspect `docs/method/backlog/v20.0.0/PERF_end-to-end-graph-streaming.md`.
+- Add or preserve docs-shape tests that forbid v18 streaming overclaims.
+- For implementation slices, require memory witnesses and anti-collect
+  regressions before accepting a streaming label.

--- a/docs/design/0257-post-v18-public-doc-honesty-audit/post-v18-public-doc-honesty-audit.md
+++ b/docs/design/0257-post-v18-public-doc-honesty-audit/post-v18-public-doc-honesty-audit.md
@@ -1,0 +1,44 @@
+# Post-V18 Public Doc Honesty Audit
+
+## Hill
+
+Define a post-release public-doc audit that keeps README, VISION, BEARING,
+release notes, and technical teardown aligned with what v18 actually shipped.
+
+## Context
+
+V18 touched the public story heavily. It added release notes, a technical
+teardown, generated contract evidence, migration proof, and explicit non-goals.
+Those docs are now high-value surfaces and therefore high-risk drift points.
+
+The audit should focus on claims that can mislead users:
+
+- v18 is graph-model convergence, not full native Continuum witnesshood;
+- v18 carries accepted residual content/property compatibility risk;
+- v18 does not provide end-to-end graph streaming reads and writes;
+- Echo and git-warp are sibling Continuum participants;
+- tag/publish state is separate from source metadata.
+
+## User Stories
+
+- As a new reader, I can learn what git-warp is without receiving stale v17 or
+  overbroad v18 claims.
+- As a release reviewer, I can catch documentation overclaims before tagging.
+- As a future maintainer, I can keep VISION stable while BEARING changes at
+  cycle boundaries.
+
+## Acceptance Criteria
+
+- Public docs agree on the current package line and release status.
+- Public docs use the canonical WARP expansion.
+- Public docs preserve the v18 non-claims around streaming and native
+  witnesshood.
+- Public docs keep git-warp positioned as an independent Continuum
+  participant.
+
+## Test Plan
+
+- `rg -n "Recursive Witnessed Admission over Git|cold runtime|cold substrate"`
+- `rg -n "streaming|witnesshood|18.0.0|17.0.1" README.md docs`
+- `npx markdownlint` on edited docs.
+- Link check public documentation paths.

--- a/docs/design/0257-post-v18-public-doc-honesty-audit/post-v18-public-doc-honesty-audit.md
+++ b/docs/design/0257-post-v18-public-doc-honesty-audit/post-v18-public-doc-honesty-audit.md
@@ -40,5 +40,5 @@ The audit should focus on claims that can mislead users:
 
 - `rg -n "Recursive Witnessed Admission over Git|cold runtime|cold substrate"`
 - `rg -n "streaming|witnesshood|18.0.0|17.0.1" README.md docs`
-- `npx markdownlint` on edited docs.
+- `npm run lint:md` on edited docs.
 - Link check public documentation paths.

--- a/docs/design/0258-v18-residual-boundary-next-retirement/v18-residual-boundary-next-retirement.md
+++ b/docs/design/0258-v18-residual-boundary-next-retirement/v18-residual-boundary-next-retirement.md
@@ -1,0 +1,40 @@
+# V18 Residual Boundary Next Retirement
+
+## Hill
+
+Pick the next raw content/property compatibility boundary to retire after v18,
+using the executable closeout audit as the source of truth.
+
+## Context
+
+The closeout audit already prevents unreviewed drift. It also gives the next
+retirement slice a concrete starting point: reduce the allowlist or narrow one
+remaining exception.
+
+The highest-value next boundary is not necessarily the largest file. The right
+choice is the boundary whose retirement reduces future migration, projection,
+or public-read risk without destabilizing the release line.
+
+## User Stories
+
+- As a maintainer, I can choose the next retirement target from evidence
+  instead of frustration.
+- As a reviewer, I can see that a retirement slice reduces the audit surface.
+- As a migration operator, I can trust that legacy compatibility remains
+  backward-compatible while the internal raw boundary shrinks.
+
+## Acceptance Criteria
+
+- The next retirement candidate is named with file paths and current audit
+  reason.
+- The slice defines whether it retires a whole file, a pattern family, or a
+  narrower inline exception.
+- The audit is tightened in the same slice that retires the boundary.
+- Regression tests prove public read/write behavior remains compatible.
+
+## Test Plan
+
+- Run `npm exec vitest run test/unit/scripts/v18-content-property-closeout-audit.test.ts`.
+- Inspect the current audit allowlist before choosing a boundary.
+- Add targeted tests for the retired boundary.
+- Run `npm run test:local` or the relevant focused suite after the cut.

--- a/docs/design/0259-backlog-lane-cleanup-after-v18/backlog-lane-cleanup-after-v18.md
+++ b/docs/design/0259-backlog-lane-cleanup-after-v18/backlog-lane-cleanup-after-v18.md
@@ -1,0 +1,39 @@
+# Backlog Lane Cleanup After V18
+
+## Hill
+
+Cleanly separate shipped v18 work, deferred storage debt, v19 doctrine work,
+v20 streaming/runtime work, and v21 distributed/plural admission work.
+
+## Context
+
+The backlog already has release lanes for v18 through v21. After the v18
+release-prep merge, the remaining risk is not lack of backlog files. The risk
+is stale status: a reader may not know which items are shipped, deferred,
+promoted, blocked, or intentionally later-major.
+
+The cleanup should be surgical. Do not reorganize the whole backlog mid-cycle.
+Make the few labels and lane summaries that prevent planning mistakes.
+
+## User Stories
+
+- As a planner, I can inspect backlog lanes and know which release owns the
+  next work.
+- As a reviewer, I can see that v18 residual risk has not vanished.
+- As a maintainer, I can avoid dragging v20 streaming or v21 braid semantics
+  into v19 by accident.
+
+## Acceptance Criteria
+
+- `v18.0.0` backlog marks implementation blockers complete and public release
+  tag/publish as the remaining release action.
+- `v19.0.0` backlog is framed as observer/admission doctrine convergence.
+- `v20.0.0` backlog keeps graph streaming and slice-first runtime realization.
+- `v21.0.0` backlog keeps plural/distributed admission semantics.
+- No stale doc suggests v18 is blocked on v19, v20, or v21 work.
+
+## Test Plan
+
+- Inspect release lane READMEs for contradictory status.
+- `rg -n "blocked|tag|publish|streaming|witnesshood" docs/method/backlog`.
+- Markdown lint edited lane files.

--- a/docs/design/0260-next-goalpost-replan-after-v18-merge/next-goalpost-replan-after-v18-merge.md
+++ b/docs/design/0260-next-goalpost-replan-after-v18-merge/next-goalpost-replan-after-v18-merge.md
@@ -1,0 +1,46 @@
+# Next Goalpost Replan After V18 Merge
+
+## Hill
+
+Set the next engineering goalpost after the v18 release-prep merge: finish the
+public release mechanics from `main`, then choose between storage retirement
+and the first v19 witnesshood runway with evidence in hand.
+
+## Context
+
+The repo has crossed an important boundary. The source tree on `main` now
+contains the v18 release metadata and public release notes. The next work
+should not keep adding v18 features on a release branch.
+
+There are three honest next moves:
+
+1. cut and publish `v18.0.0` from `main`;
+2. retire one more raw content/property compatibility boundary;
+3. start v19 observer/admission witnesshood work.
+
+Those moves have different risk profiles. Publishing is release operations.
+Storage retirement is local substrate debt reduction. V19 starts a new
+semantic runway. They should not be smuggled into one ambiguous branch.
+
+## User Stories
+
+- As a release manager, I can finish v18 without new scope.
+- As a maintainer, I can choose the next implementation slice based on risk,
+  not momentum.
+- As a future agent, I can read BEARING and know whether the repo is in
+  release mode, debt-retirement mode, or v19 feature mode.
+
+## Acceptance Criteria
+
+- BEARING marks slices 103 through 112 as a post-merge planning chunk.
+- The next goalpost is explicit and does not widen v18.
+- The branch leaves tag/publish work as an operation to run from `main`.
+- The branch gives storage retirement and v19 kickoff separate decision
+  surfaces.
+
+## Test Plan
+
+- Markdown lint all new design docs.
+- `git diff --check`
+- Review `docs/BEARING.md` for stale branch, PR, and release status.
+- Verify backlog lane summaries still point to the correct major releases.

--- a/docs/method/backlog/README.md
+++ b/docs/method/backlog/README.md
@@ -139,7 +139,7 @@ lanes.
 | `inbox/` | `B0` | Anything here is blocked on triage, not implementation. |
 | backlog root | `B1` | These notes are real work, but still need lane assignment or an explicit pull decision. When `feature:` is present, treat that as the subsystem home while release-home remains undecided. |
 | `bad-code/` | `B2` | Invariant debt can block `v17.0.0`, `v18.0.0`, and `up-next`. |
-| `v17.0.0/` | `B3` | This is shipped release residual work after `v17.0.0` and `v17.0.1`; rehome notes before treating them as blockers. |
+| `v17.0.0/` | `B3` | This is shipped release residual work after the public `v17.0.0` package/tag line and source-recorded `17.0.1` repair work; rehome notes before treating them as blockers. |
 | `v18.0.0/` | `B4` | This is the next-major graph-model convergence lane. |
 | `up-next/` | `B4` | Feature-overflow queue behind the active release and next-major graph-model work unless explicitly promoted into a numbered lane. |
 | `v19.0.0/` | `B5` | Doctrine, observer, and admission convergence after the substrate cut. |
@@ -278,7 +278,8 @@ Invariant counts:
 Dependency posture:
 
 - explicit frontmatter edges override lane inheritance
-- `v17.0.0` and `v17.0.1` have shipped
+- public `v17.0.0` has shipped; `17.0.1` repair work is recorded in source
+  docs/changelog without public npm/tag evidence
 - notes in this lane need archive, rehome, or explicit pull decisions before
   they block later release work
 

--- a/docs/method/backlog/v18.0.0/README.md
+++ b/docs/method/backlog/v18.0.0/README.md
@@ -77,7 +77,8 @@ graph model. Change the envelope only if replay honesty requires it.
 
 ## Current Evidence
 
-After v18 slice 95, the migration path has release-candidate evidence:
+After PR #107 merged, the migration path has release-candidate evidence on
+`main`:
 
 - dry-run planning, source inventory, operation lowering, scratch writing,
   equivalence gating, and optional finalization are wired as command stages;
@@ -94,15 +95,15 @@ After v18 slice 95, the migration path has release-candidate evidence:
   boundaries and has a retired-boundary ratchet for the coordinate fact export
   cut;
 - release-candidate evidence now names candidate scope, go/no-go gates,
-  public-tag gates, and residual risks.
+  public-tag gates, and residual risks;
+- `18.0.0` package, JSR, workspace, lockfile, changelog, release notes, and
+  technical teardown updates are merged to `main`.
 
-The remaining public v18 work is release hygiene and residual-risk review:
+The remaining public v18 work is release operation:
 
-- full local release-prep gates and GitHub CI on the final release branch;
-- package/version/tag work for the public release;
-- operator release notes that distinguish graph-model convergence from later
-  Continuum admission shells;
-- explicit release notes that accept remaining raw content/property storage
-  compatibility as residual v18 risk;
-- an explicit non-claim that v18 does not provide end-to-end graph streaming
-  reads and writes.
+- align local `main` with `origin/main`;
+- rerun release preflight from `main`;
+- tag `v18.0.0` from the merged release commit;
+- publish npm and JSR artifacts from the release path;
+- preserve the explicit non-claim that v18 does not provide end-to-end graph
+  streaming reads and writes.

--- a/docs/method/backlog/v18.0.0/RELEASE_v18-public-release-blockers.md
+++ b/docs/method/backlog/v18.0.0/RELEASE_v18-public-release-blockers.md
@@ -43,14 +43,20 @@ migration safety than the repository can prove.
 | Operator release notes | Complete in `docs/releases/v18.0.0/README.md`. |
 | Version metadata | Root package, private workspaces, lockfile, JSR metadata, and changelog now point at `18.0.0`. |
 | Local release preflight | `npm run release:preflight` passes for `18.0.0` metadata on the release-prep branch. |
+| PR review, GitHub CI, and merge | Complete in PR #107. |
 
 ## Current Public-Release Blockers
 
 | Blocker | Why it still blocks public release | Required evidence |
 |---------|------------------------------------|-------------------|
-| GitHub CI and PR review | Local preflight is green, but release evidence is not a merged public branch. | PR review resolves all comments and GitHub CI is green on the final branch tip. |
-| Post-merge tag and publish work | Package metadata now points at `18.0.0`, but the tag and publish artifacts must be cut from merged `main`. | Signed or annotated tag, pushed tag, npm pack/publish evidence, and JSR publish evidence agree on `18.0.0`. |
-| Streaming overclaim guard | Release notes now state the non-claim, but CI/PR review must still preserve it. | Public docs state that full graph streaming reads and writes are a v20 goal, not a v18 claim. |
+| Post-merge tag and publish work | Package metadata now points at `18.0.0` on merged `main`, but the tag and publish artifacts do not exist yet. | Signed or annotated tag, pushed tag, npm pack/publish evidence, and JSR publish evidence agree on `18.0.0`. |
+
+## Public-Release Watch Items
+
+| Watch item | Guard |
+|------------|-------|
+| Streaming overclaim guard | Public docs must keep stating that full graph streaming reads and writes are a v20 goal, not a v18 claim. |
+| Native Continuum witnesshood overclaim guard | Public docs must keep distinguishing translated v18 git-warp evidence from native Continuum witnesshood work planned for v19+. |
 
 ## Accepted Residual Risk
 
@@ -66,7 +72,7 @@ remaining raw compatibility files and fails on unreviewed boundary drift.
 
 ## Next pull candidates
 
-- Open the release-prep PR and preserve the local preflight evidence through
-  review.
-- Cut the public tag and publish artifacts only after this branch merges and
-  the final gates pass on `main`.
+- Cut the public tag and publish artifacts only from aligned `main`.
+- Decide whether the next implementation branch retires one raw
+  content/property boundary or starts the v19 observer/admission witnesshood
+  runway.

--- a/docs/method/backlog/v19.0.0/README.md
+++ b/docs/method/backlog/v19.0.0/README.md
@@ -44,6 +44,14 @@ operational instead of decorative:
 - `v20` owns operational slice-first runtime realization
 - `v21` owns plural/distributed semantics such as common-basis braid and fuller admission reality
 
+## Post-v18 entry condition
+
+The v18 release-prep PR has merged to `main`, but the public `v18.0.0` tag and
+publish work should complete before v19 implementation widens the runtime
+promise. Planning may continue on a branch as long as it preserves the
+distinction between translated v18 git-warp evidence and native Continuum
+witnesshood.
+
 ## Practical rule
 
 Do not drag these doctrine and protocol tasks back into `v18.0.0`

--- a/docs/method/backlog/v20.0.0/README.md
+++ b/docs/method/backlog/v20.0.0/README.md
@@ -26,5 +26,7 @@ Rule:
   instead of doctrine-only language
 - end-to-end graph streaming reads and writes are a `v20` runtime-realization
   goal, not a `v18` graph-substrate release claim
+- v19 must settle bounded support, causal-index, and support-fragment
+  contracts before v20 can honestly claim end-to-end graph streaming
 - keep distributed/plural semantics that still require a settled slice-first
   runtime in `v21.0.0/`

--- a/test/unit/scripts/release-policy-shape.test.ts
+++ b/test/unit/scripts/release-policy-shape.test.ts
@@ -51,10 +51,12 @@ describe('release policy shape', () => {
     expect(releaseDoc).toContain('Merge to `main` after review and green CI.');
   });
 
-  it('keeps the roadmap header honest about the current release and correction patch', () => {
-    expect(roadmap).toContain('**Current release on `main`:** v17.0.1');
+  it('keeps the roadmap header honest about the public release and repair entry', () => {
+    expect(roadmap).toContain('**Current public package/tag release:** v17.0.0');
     expect(roadmap).toContain('**Next intended release:** v18.0.0');
-    expect(roadmap).toContain('v17.0.1 patch');
+    expect(roadmap).toContain(
+      'v17.0.1 repair work is recorded in source docs/changelog without public npm/tag evidence',
+    );
   });
 
   it('keeps publish artifacts slim instead of shipping the full repo corpus', () => {


### PR DESCRIPTION
## Summary

This PR records the post-merge handoff after the v18 release-prep branch landed on `main`, then sets the next goalpost without widening the `v18.0.0` release promise.

It adds design records for slices 103 through 112 covering:

- post-merge `v18.0.0` release handoff;
- tag and publish gates from aligned `main`;
- release evidence archive expectations;
- post-v18 storage retirement decision surface;
- v19 native Continuum witnesshood runway;
- v20 end-to-end graph streaming scope;
- post-v18 public documentation honesty audit;
- next raw content/property residual-boundary retirement decision;
- backlog lane cleanup after v18;
- next-goalpost replan after the v18 release-prep merge.

It also updates `docs/BEARING.md` and backlog lane summaries to reflect that PR #107 is merged, `18.0.0` metadata is on `main`, and the remaining public v18 operation is tag/publish from aligned `main`.

## Verification

- `npx markdownlint $(git diff --name-only origin/main...HEAD -- '*.md')`
- `git diff --check origin/main...HEAD`
- Pre-push IRONCLAD M9 static gates
- Pre-push unit suite: 521 test files, 7,126 tests

## Notes

This branch does not tag or publish `v18.0.0`. It keeps that as a release operation from aligned `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated v18 release-prep and post-merge handoff docs; added tag/publish gate, release-evidence archive, post-release audit, and retirement/replan design docs
  * Revised BEARING, ROADMAP, and backlog READMEs; expanded release checklists and blocker/watch items; clarified v19/v20 planning and next-goalpost guidance
* **Tests**
  * Adjusted unit test asserting updated roadmap/release-status wording

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/git-stunts/git-warp/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->