### PR TITLE
Fix #310: Parse markdownlint config policy

### DIFF
--- a/test/unit/scripts/markdownlint-config.test.ts
+++ b/test/unit/scripts/markdownlint-config.test.ts
@@ -1,18 +1,62 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-const config = readFileSync(
-  fileURLToPath(new URL('../../../.markdownlint.jsonc', import.meta.url)),
-  'utf8',
-);
+const configPath = fileURLToPath(new URL('../../../.markdownlint.jsonc', import.meta.url));
+const configSource = readFileSync(configPath, 'utf8');
+const config = ts.parseJsonText(configPath, configSource);
+
+function configObjectExpression(): ts.ObjectLiteralExpression | null {
+  const statement = config.statements[0];
+  const expression = statement?.expression;
+  if (!expression || !ts.isObjectLiteralExpression(expression)) {
+    return null;
+  }
+  return expression;
+}
+
+function propertyNameText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+function booleanPropertyValue(propertyName: string): boolean | null {
+  const expression = configObjectExpression();
+  if (!expression) {
+    return null;
+  }
+
+  for (const property of expression.properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      continue;
+    }
+    if (propertyNameText(property.name) !== propertyName) {
+      continue;
+    }
+    if (property.initializer.kind === ts.SyntaxKind.TrueKeyword) {
+      return true;
+    }
+    if (property.initializer.kind === ts.SyntaxKind.FalseKeyword) {
+      return false;
+    }
+  }
+
+  return null;
+}
 
 describe('markdownlint config policy', () => {
+  it('parses as a JSONC object config', () => {
+    expect(configObjectExpression()).not.toBeNull();
+  });
+
   it('disables line-length wrapping explicitly', () => {
-    expect(config).toMatch(/"MD013"\s*:\s*false/);
+    expect(booleanPropertyValue('MD013')).toBe(false);
   });
 
   it('keeps fenced code block language enforcement enabled', () => {
-    expect(config).toMatch(/"MD040"\s*:\s*true/);
+    expect(booleanPropertyValue('MD040')).toBe(true);
   });
 });


### PR DESCRIPTION
## What changed

Replaced raw regex assertions against `.markdownlint.jsonc` with a parser-backed JSONC config test.

## Why

The old test matched source text rather than the config contract. This keeps the markdownlint policy check focused on parsed rule values.

Closes #310

## Validation

- `npx vitest run test/unit/scripts/markdownlint-config.test.ts`
- `npm run typecheck:test -- --pretty false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced internal test validation for markdown linting configuration using improved parsing techniques.

---

**Note:** This is an internal testing improvement with no direct end-user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->