### PR TITLE
Fix #344: Exercise hygiene rules with ESLint fixtures

### DIFF
--- a/test/unit/scripts/type-import-hygiene-shape.test.ts
+++ b/test/unit/scripts/type-import-hygiene-shape.test.ts
@@ -1,44 +1,138 @@
-import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { ESLint } from 'eslint';
+import ts from 'typescript';
+import { afterEach, describe, expect, it } from 'vitest';
 
-function readUtf8(path: string): string {
-  return readFileSync(path, 'utf8');
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+
+const HYGIENE_CONSISTENT_TYPE_IMPORTS = '@typescript-eslint/consistent-type-imports';
+const HYGIENE_RESTRICT_TEMPLATE_EXPRESSIONS = '@typescript-eslint/restrict-template-expressions';
+const fixturePaths: string[] = [];
+
+afterEach(() => {
+  while (fixturePaths.length > 0) {
+    const fixturePath = fixturePaths.pop();
+    if (fixturePath !== undefined) {
+      rmSync(fixturePath, { force: true });
+    }
+  }
+});
+
+function presentRuleId(ruleId: string | null): ruleId is string {
+  return ruleId !== null;
+}
+
+async function lintRuleIds(relativePath: string, source: string): Promise<string[]> {
+  const fixturePath = `${repoRoot}${relativePath}`;
+  writeFileSync(fixturePath, source, 'utf8');
+  fixturePaths.push(fixturePath);
+
+  const eslint = new ESLint({ cwd: repoRoot });
+  const [result] = await eslint.lintFiles([relativePath]);
+  if (!result) {
+    return [];
+  }
+  return result.messages.map((message) => message.ruleId).filter(presentRuleId);
+}
+
+function manifestObject(manifestName: string): ts.ObjectLiteralExpression | null {
+  const path = `${repoRoot}policy/quarantines/${manifestName}.json`;
+  const sourceFile = ts.parseJsonText(path, readFileSync(path, 'utf8'));
+  const statement = sourceFile.statements[0];
+  const expression = statement?.expression;
+  if (!expression || !ts.isObjectLiteralExpression(expression)) {
+    return null;
+  }
+  return expression;
+}
+
+function propertyNameText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+function propertyAssignment(
+  objectExpression: ts.ObjectLiteralExpression,
+  propertyName: string,
+): ts.PropertyAssignment | null {
+  for (const property of objectExpression.properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      continue;
+    }
+    if (propertyNameText(property.name) === propertyName) {
+      return property;
+    }
+  }
+  return null;
+}
+
+function stringProperty(manifestName: string, propertyName: string): string | null {
+  const objectExpression = manifestObject(manifestName);
+  if (!objectExpression) {
+    return null;
+  }
+  const property = propertyAssignment(objectExpression, propertyName);
+  if (!property || !ts.isStringLiteral(property.initializer)) {
+    return null;
+  }
+  return property.initializer.text;
+}
+
+function arrayPropertyLength(manifestName: string, propertyName: string): number | null {
+  const objectExpression = manifestObject(manifestName);
+  if (!objectExpression) {
+    return null;
+  }
+  const property = propertyAssignment(objectExpression, propertyName);
+  if (!property || !ts.isArrayLiteralExpression(property.initializer)) {
+    return null;
+  }
+  return property.initializer.elements.length;
 }
 
 describe('type-import/template-expression hygiene posture', () => {
-  it('enables both hygiene rules in eslint config', () => {
-    const eslintConfig = readUtf8('eslint.config.ts');
+  it('rejects value imports that are only used as types through ESLint', async () => {
+    const ruleIds = await lintRuleIds(
+      'src/domain/type-import-hygiene-fixture.ts',
+      [
+        "import WarpError from './errors/WarpError.ts';",
+        '',
+        'type Box = { readonly error: WarpError | null };',
+        'const box: Box = { error: null };',
+        'void box;',
+        '',
+      ].join('\n'),
+    );
 
-    expect(eslintConfig).toContain('"@typescript-eslint/consistent-type-imports": ["error"');
-    expect(eslintConfig).toContain('prefer: "type-imports"');
-    expect(eslintConfig).toContain('fixStyle: "inline-type-imports"');
-
-    expect(eslintConfig).toContain('"@typescript-eslint/restrict-template-expressions": ["error"');
-    expect(eslintConfig).toContain('allowAny: false');
-    expect(eslintConfig).toContain('allowBoolean: false');
-    expect(eslintConfig).toContain('allowNever: false');
-    expect(eslintConfig).toContain('allowNullish: false');
-    expect(eslintConfig).toContain('allowNumber: true');
-    expect(eslintConfig).toContain('allowRegExp: false');
-    expect(eslintConfig).toContain('HYGIENE-consistent-type-imports');
-    expect(eslintConfig).toContain('HYGIENE-restrict-template-expressions');
+    expect(ruleIds).toContain(HYGIENE_CONSISTENT_TYPE_IMPORTS);
   });
 
-  it('records the rules as active rather than deferred in the decisions doc', () => {
-    const decisions = readUtf8('docs/ANTI_SLUDGE_DECISIONS.md');
+  it('rejects boolean template interpolation through ESLint', async () => {
+    const ruleIds = await lintRuleIds(
+      'src/domain/template-expression-hygiene-fixture.ts',
+      [
+        'const enabled = true;',
+        'const message = `enabled: ${enabled}`;',
+        'void message;',
+        '',
+      ].join('\n'),
+    );
 
-    expect(decisions).toContain('`@typescript-eslint/consistent-type-imports` | ESLint (active hygiene rule; quarantine-backed paydown) | bundle |');
-    expect(decisions).toContain('`@typescript-eslint/restrict-template-expressions` | ESLint (active hygiene rule; quarantine-backed paydown) | bundle |');
+    expect(ruleIds).toContain(HYGIENE_RESTRICT_TEMPLATE_EXPRESSIONS);
   });
 
-  it('keeps the hygiene quarantine manifests explicit and legible', () => {
-    const consistentManifest = readUtf8('policy/quarantines/HYGIENE-consistent-type-imports.json');
-    const templateManifest = readUtf8('policy/quarantines/HYGIENE-restrict-template-expressions.json');
+  it('keeps the hygiene quarantine manifests active and empty', () => {
+    expect(stringProperty('HYGIENE-consistent-type-imports', 'rule_id')).toBe(
+      HYGIENE_CONSISTENT_TYPE_IMPORTS,
+    );
+    expect(arrayPropertyLength('HYGIENE-consistent-type-imports', 'files')).toBe(0);
 
-    expect(consistentManifest).toContain('"rule_id": "@typescript-eslint/consistent-type-imports"');
-    expect(consistentManifest).toMatch(/"files"\s*:\s*\[\s*\]/u);
-
-    expect(templateManifest).toContain('"rule_id": "@typescript-eslint/restrict-template-expressions"');
-    expect(templateManifest).toMatch(/"files"\s*:\s*\[\s*\]/u);
+    expect(stringProperty('HYGIENE-restrict-template-expressions', 'rule_id')).toBe(
+      HYGIENE_RESTRICT_TEMPLATE_EXPRESSIONS,
+    );
+    expect(arrayPropertyLength('HYGIENE-restrict-template-expressions', 'files')).toBe(0);
   });
 });


### PR DESCRIPTION
## What changed

Replaced config/doc string assertions with ESLint fixture execution and parser-backed quarantine manifest checks.

## Why

The old test proved exact source text in config, docs, and manifests. The new test proves the hygiene rules actually fire and that their quarantine manifests remain active and empty.

Closes #344

## Validation

- `npx vitest run test/unit/scripts/type-import-hygiene-shape.test.ts`
- `npm run typecheck:test -- --pretty false`
