### PR TITLE
Fix #376: Assert BitmapNeighborProvider backend invariant

### DIFF
--- a/src/domain/services/index/BitmapNeighborProvider.ts
+++ b/src/domain/services/index/BitmapNeighborProvider.ts
@@ -92,7 +92,10 @@ export default class BitmapNeighborProvider extends NeighborProviderPort {
       const id = await this._reader.lookupId(nodeId);
       return id !== undefined;
     }
-    return false;
+    throw new IndexError(
+      'BitmapNeighborProvider readiness check passed without an active backend',
+      { code: 'E_NEIGHBOR_PROVIDER_INVALID_BACKEND' },
+    );
   }
 
   override get latencyClass(): 'async-local' {

--- a/test/unit/domain/services/BitmapNeighborProvider.test.ts
+++ b/test/unit/domain/services/BitmapNeighborProvider.test.ts
@@ -108,6 +108,15 @@ describe('BitmapNeighborProvider', () => {
     );
   });
 
+  it('throws an explicit invariant error when readiness passes without a backend', async () => {
+    const empty = new BitmapNeighborProvider({});
+    Object.defineProperty(empty, '_assertReady', { value: () => undefined });
+
+    await expect(empty.hasNode('node:a')).rejects.toMatchObject({
+      code: 'E_NEIGHBOR_PROVIDER_INVALID_BACKEND',
+    });
+  });
+
   describe('logical index mode', () => {
         let logicalIndex;
         let logicalProvider;


### PR DESCRIPTION
## What changed

Replaced the unreachable `hasNode()` fallback `false` with an explicit `IndexError` invariant guard and added focused coverage for that impossible route.

## Why

The old tail branch made an invalid backend state indistinguishable from a real missing node. The provider now fails closed if readiness says a backend exists but routing cannot find one.

Closes #376

## Validation

- `npx vitest run test/unit/domain/services/BitmapNeighborProvider.test.ts`
- `npm run typecheck:src -- --pretty false`
- `npm run typecheck:test -- --pretty false`
