### PR TITLE
Fix #377: Signal bitmap shard corruption

### DIFF
--- a/src/domain/services/index/BitmapIndexReader.ts
+++ b/src/domain/services/index/BitmapIndexReader.ts
@@ -145,7 +145,14 @@ export default class BitmapIndexReader {
     for (const actualPath of this._resolveShardPaths(shardPath)) {
       const shard = await this._getOrLoadShard(actualPath) as Record<string, Uint8Array>;
       const bitmapBytes = shard[sha];
-      if (!bitmapBytes || !(bitmapBytes instanceof Uint8Array) || bitmapBytes.length === 0) {
+      if (bitmapBytes === undefined || bitmapBytes === null) {
+        continue;
+      }
+      if (!(bitmapBytes instanceof Uint8Array)) {
+        this._handleInvalidBitmapValue(actualPath, sha);
+        continue;
+      }
+      if (bitmapBytes.length === 0) {
         continue;
       }
       const ids = this._deserializeBitmapIds(bitmapBytes, actualPath);
@@ -246,6 +253,9 @@ export default class BitmapIndexReader {
   private _decodeAndCacheShard(buffer: Uint8Array, path: string, oid: string): LoadedShard {
     try {
       const data = this._codec.decode<LoadedShard>(buffer);
+      if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+        return this._handleInvalidShardShape(path, oid, 'shard_not_object');
+      }
       this.loadedShards.set(path, data);
       return data;
     } catch (err) {
@@ -269,6 +279,45 @@ export default class BitmapIndexReader {
       oid,
     });
     return {};
+  }
+
+  private _handleInvalidShardShape(path: string, oid: string, reason: string): LoadedShard {
+    const corruptionError = new ShardCorruptionError('Invalid shard shape', {
+      shardPath: path,
+      oid,
+      reason,
+    });
+    if (this.strict) {
+      throw corruptionError;
+    }
+    this.logger.warn('Shard shape invalid', {
+      operation: 'loadShard',
+      shardPath: path,
+      oid,
+      reason,
+    });
+    return {};
+  }
+
+  private _handleInvalidBitmapValue(path: string, sha: string): void {
+    const oid = this.shardOids.get(path);
+    const shardOid = isNonEmptyString(oid) ? oid : path;
+    const corruptionError = new ShardCorruptionError('Invalid bitmap value', {
+      shardPath: path,
+      oid: shardOid,
+      reason: 'bitmap_value_not_bytes',
+      context: { sha },
+    });
+    if (this.strict) {
+      throw corruptionError;
+    }
+    this.logger.warn('Bitmap value invalid', {
+      operation: 'deserializeBitmap',
+      shardPath: path,
+      oid: shardOid,
+      reason: 'bitmap_value_not_bytes',
+      sha,
+    });
   }
 
   private async _loadShardBuffer(path: string, oid: string): Promise<Uint8Array> {

--- a/src/domain/services/index/BitmapIndexReader.ts
+++ b/src/domain/services/index/BitmapIndexReader.ts
@@ -19,6 +19,14 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }
 
+function isPlainLoadedShard(value: LoadedShard | null | undefined): value is LoadedShard {
+  return value !== null
+    && value !== undefined
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
 function isMetaShardPath(path: string): boolean {
   return /^meta_[0-9a-f]{2}(?:\.chunk-\d{6})?\.cbor$/.test(path);
 }
@@ -253,7 +261,7 @@ export default class BitmapIndexReader {
   private _decodeAndCacheShard(buffer: Uint8Array, path: string, oid: string): LoadedShard {
     try {
       const data = this._codec.decode<LoadedShard>(buffer);
-      if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+      if (!isPlainLoadedShard(data)) {
         return this._handleInvalidShardShape(path, oid, 'shard_not_object');
       }
       this.loadedShards.set(path, data);

--- a/test/unit/domain/services/BitmapIndexReader.test.ts
+++ b/test/unit/domain/services/BitmapIndexReader.test.ts
@@ -32,6 +32,18 @@ const _makeBitmapBytes = (ids) => {
 };
 void _makeBitmapBytes;
 
+function createMockLogger() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
 describe('BitmapIndexReader', () => {
     let mockStorage;
     let reader;
@@ -204,14 +216,7 @@ describe('BitmapIndexReader', () => {
     });
 
     it('returns empty array with warning when shard contains wrong data type (non-strict)', async () => {
-      const mockLogger = {
-        debug: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        child: vi.fn(),
-      };
-      mockLogger.child.mockReturnValue(mockLogger);
+      const mockLogger = createMockLogger();
       const lenient = new BitmapIndexReader({
         storage: mockStorage,
         strict: false,
@@ -229,6 +234,32 @@ describe('BitmapIndexReader', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith('Shard shape invalid', expect.objectContaining({
         operation: 'loadShard',
         shardPath: 'shards_rev_ab.cbor',
+        reason: 'shard_not_object',
+      }));
+    });
+
+    it('rejects top-level byte-string shards before caching them (non-strict)', async () => {
+      const sha = 'abcd123400000000000000000000000000000000';
+      const shardPath = 'shards_rev_ab.cbor';
+      const mockLogger = createMockLogger();
+      const lenient = new BitmapIndexReader({
+        storage: mockStorage,
+        strict: false,
+        logger: mockLogger,
+      });
+      mockStorage.readBlob.mockResolvedValue(defaultCodec.encode(new Uint8Array([1, 2, 3])));
+
+      lenient.setup({
+        [shardPath]: 'fff6aaa100000000000000000000000000000000',
+      });
+
+      await expect(lenient.getParents(sha)).resolves.toEqual([]);
+      await expect(lenient.getParents(sha)).resolves.toEqual([]);
+      expect(mockStorage.readBlob).toHaveBeenCalledTimes(2);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+      expect(mockLogger.warn).toHaveBeenCalledWith('Shard shape invalid', expect.objectContaining({
+        operation: 'loadShard',
+        shardPath,
         reason: 'shard_not_object',
       }));
     });
@@ -303,14 +334,7 @@ describe('BitmapIndexReader', () => {
       // and requires values to be Uint8Array bitmap bytes.
       const sha = 'abcd123400000000000000000000000000000000';
       const corruptBitmapData = defaultCodec.encode({ [sha]: 'not-a-bitmap' });
-      const mockLogger = {
-        debug: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        child: vi.fn(),
-      };
-      mockLogger.child.mockReturnValue(mockLogger);
+      const mockLogger = createMockLogger();
 
       // Non-strict reader
       const nonStrictReader = new BitmapIndexReader({

--- a/test/unit/domain/services/BitmapIndexReader.test.ts
+++ b/test/unit/domain/services/BitmapIndexReader.test.ts
@@ -209,12 +209,14 @@ describe('BitmapIndexReader', () => {
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
+        child: vi.fn(),
       };
-      const lenient = new BitmapIndexReader(({
+      mockLogger.child.mockReturnValue(mockLogger);
+      const lenient = new BitmapIndexReader({
         storage: mockStorage,
         strict: false,
         logger: mockLogger,
-      } as any));
+      });
       // Valid CBOR but wrong structure (array instead of object)
       mockStorage.readBlob.mockResolvedValue(defaultCodec.encode([1, 2, 3]));
 
@@ -306,14 +308,16 @@ describe('BitmapIndexReader', () => {
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
+        child: vi.fn(),
       };
+      mockLogger.child.mockReturnValue(mockLogger);
 
       // Non-strict reader
-      const nonStrictReader = new BitmapIndexReader(({
+      const nonStrictReader = new BitmapIndexReader({
         storage: mockStorage,
         strict: false,
         logger: mockLogger,
-      } as any));
+      });
       mockStorage.readBlob.mockResolvedValue(corruptBitmapData);
       nonStrictReader.setup({ 'shards_rev_ab.cbor': 'eee5fff600000000000000000000000000000000' });
 

--- a/test/unit/domain/services/BitmapIndexReader.test.ts
+++ b/test/unit/domain/services/BitmapIndexReader.test.ts
@@ -203,8 +203,18 @@ describe('BitmapIndexReader', () => {
       expect(parents).toEqual([]);
     });
 
-    it('returns empty array when shard contains wrong data type (non-strict)', async () => {
-      const lenient = new BitmapIndexReader(({ storage: mockStorage, strict: false } as any));
+    it('returns empty array with warning when shard contains wrong data type (non-strict)', async () => {
+      const mockLogger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      const lenient = new BitmapIndexReader(({
+        storage: mockStorage,
+        strict: false,
+        logger: mockLogger,
+      } as any));
       // Valid CBOR but wrong structure (array instead of object)
       mockStorage.readBlob.mockResolvedValue(defaultCodec.encode([1, 2, 3]));
 
@@ -214,6 +224,11 @@ describe('BitmapIndexReader', () => {
 
       const parents = await lenient.getParents('abcd123400000000000000000000000000000000');
       expect(parents).toEqual([]);
+      expect(mockLogger.warn).toHaveBeenCalledWith('Shard shape invalid', expect.objectContaining({
+        operation: 'loadShard',
+        shardPath: 'shards_rev_ab.cbor',
+        reason: 'shard_not_object',
+      }));
     });
 
     it('throws ShardLoadError on storage failure but continues after', async () => {
@@ -283,27 +298,40 @@ describe('BitmapIndexReader', () => {
 
     it('non-strict mode returns empty but strict mode throws for same corruption', async () => {
       // Valid CBOR encoding of a plain object — but reader treats it as a bitmap shard
-      // and tries to deserialize values as Uint8Array bitmaps. Since the values are not
-      // Uint8Array, _deserializeBitmapIds will fail in strict mode.
+      // and requires values to be Uint8Array bitmap bytes.
       const sha = 'abcd123400000000000000000000000000000000';
       const corruptBitmapData = defaultCodec.encode({ [sha]: 'not-a-bitmap' });
+      const mockLogger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
 
       // Non-strict reader
-      const nonStrictReader = new BitmapIndexReader(({ storage: mockStorage, strict: false } as any));
+      const nonStrictReader = new BitmapIndexReader(({
+        storage: mockStorage,
+        strict: false,
+        logger: mockLogger,
+      } as any));
       mockStorage.readBlob.mockResolvedValue(corruptBitmapData);
       nonStrictReader.setup({ 'shards_rev_ab.cbor': 'eee5fff600000000000000000000000000000000' });
 
       const nonStrictResult = await nonStrictReader.getParents(sha);
       expect(nonStrictResult).toEqual([]); // Graceful degradation
 
-      // Strict reader gets same data but the bitmap value is not a Uint8Array
-      // so _getEdges returns [] for missing/empty bitmapBytes without throwing
-      // (the check is `!(bitmapBytes instanceof Uint8Array)`)
+      expect(mockLogger.warn).toHaveBeenCalledWith('Bitmap value invalid', expect.objectContaining({
+        operation: 'deserializeBitmap',
+        shardPath: 'shards_rev_ab.cbor',
+        reason: 'bitmap_value_not_bytes',
+        sha,
+      }));
+
+      // Strict reader gets same data and rejects the non-byte bitmap value.
       const strictReader = new BitmapIndexReader(({ storage: mockStorage, strict: true } as any));
       strictReader.setup({ 'shards_rev_ab.cbor': 'eee5fff600000000000000000000000000000000' });
 
-      const strictResult = await strictReader.getParents(sha);
-      expect(strictResult).toEqual([]);
+      await expect(strictReader.getParents(sha)).rejects.toThrow(ShardCorruptionError);
     });
 
     it('logs a warning on each CBOR decode error (no caching on failure)', async () => {


### PR DESCRIPTION
## What changed

Added explicit corruption handling for malformed bitmap shard shapes and non-byte bitmap values.

## Why

In non-strict mode, corrupted shards still return an empty result, but now emit warnings so callers and tests can distinguish corruption from a real no-neighbor result. In strict mode, invalid bitmap values now throw `ShardCorruptionError`.

Closes #377

## Validation

- `npx vitest run test/unit/domain/services/BitmapIndexReader.test.ts`
- `npm run typecheck:src -- --pretty false`
- `npm run typecheck:test -- --pretty false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and validation when loading and processing data to enhance system reliability and data integrity checks.

* **Tests**
  * Expanded test coverage for error handling scenarios to ensure proper behavior in edge cases and data corruption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->