### PR TITLE
Fix #378: Share git-cas store factory

### DIFF
--- a/src/infrastructure/adapters/CasBlobAdapter.ts
+++ b/src/infrastructure/adapters/CasBlobAdapter.ts
@@ -15,8 +15,7 @@
 import BlobStoragePort from '../../ports/BlobStoragePort.ts';
 import PersistenceError from '../../domain/errors/PersistenceError.ts';
 import { createLazyCas } from './lazyCasInit.ts';
-import { loadGitCasConstructors } from './gitCasModule.ts';
-import LoggerObservabilityBridge from './LoggerObservabilityBridge.ts';
+import { createCdcCasStore } from './CasStoreFactory.ts';
 import type LoggerPort from '../../ports/LoggerPort.ts';
 import { Readable } from 'node:stream';
 
@@ -31,14 +30,6 @@ interface CasStore {
   store(opts: { source: unknown; slug: string; filename: string; encryptionKey?: Uint8Array }): Promise<CasManifest>;
   createTree(opts: { manifest: CasManifest }): Promise<string>;
 }
-
-type CasCodecInstance = object;
-type CasStoreOptions = {
-  plumbing: unknown;
-  codec: CasCodecInstance;
-  chunking: { strategy: string };
-  observability?: unknown;
-};
 
 export interface BlobPersistence {
   readBlob(oid: string): Promise<Uint8Array | null | undefined>;
@@ -100,20 +91,10 @@ export default class CasBlobAdapter extends BlobStoragePort {
   }
 
   private async _initCas(): Promise<CasStore> {
-    const { ContentAddressableStore, CborCodecCtor } = await loadGitCasConstructors<
-      CasStoreOptions,
-      CasStore,
-      CasCodecInstance
-    >();
-    const opts: CasStoreOptions = {
+    return await createCdcCasStore<CasStore>({
       plumbing: this._plumbing,
-      codec: new CborCodecCtor(),
-      chunking: { strategy: 'cdc' },
-    };
-    if (this._logger) {
-      opts.observability = new LoggerObservabilityBridge(this._logger);
-    }
-    return new ContentAddressableStore(opts);
+      logger: this._logger,
+    });
   }
 
   override async store(content: Uint8Array | string, options?: { slug?: string; mime?: string | null; size?: number | null }): Promise<string> {

--- a/src/infrastructure/adapters/CasSeekCacheAdapter.ts
+++ b/src/infrastructure/adapters/CasSeekCacheAdapter.ts
@@ -19,8 +19,7 @@
 import SeekCachePort, { type SeekCacheEntry, type SeekCacheSetOptions } from '../../ports/SeekCachePort.ts';
 import { buildSeekCacheRef } from '../../domain/utils/RefLayout.ts';
 import { createLazyCas } from './lazyCasInit.ts';
-import { loadGitCasConstructors } from './gitCasModule.ts';
-import LoggerObservabilityBridge from './LoggerObservabilityBridge.ts';
+import { createCdcCasStore } from './CasStoreFactory.ts';
 import CacheError from '../../domain/errors/CacheError.ts';
 import { textEncode, textDecode, concatBytes } from '../../domain/utils/bytes.ts';
 import type LoggerPort from '../../ports/LoggerPort.ts';
@@ -33,14 +32,6 @@ interface CasStore {
   store(opts: { source: Readable; slug: string; filename: string; encryptionKey?: Uint8Array }): Promise<unknown>;
   createTree(opts: { manifest: unknown }): Promise<string>;
 }
-
-type CasCodecInstance = object;
-type CasStoreOptions = {
-  plumbing: unknown;
-  codec: CasCodecInstance;
-  chunking: { strategy: string };
-  observability?: unknown;
-};
 
 interface CachePersistence {
   readRef(ref: string): Promise<string | null>;
@@ -115,20 +106,10 @@ export default class CasSeekCacheAdapter extends SeekCachePort {
   }
 
   private async _initCas(): Promise<CasStore> {
-    const { ContentAddressableStore, CborCodecCtor } = await loadGitCasConstructors<
-      CasStoreOptions,
-      CasStore,
-      CasCodecInstance
-    >();
-    const opts: CasStoreOptions = {
+    return await createCdcCasStore<CasStore>({
       plumbing: this._plumbing,
-      codec: new CborCodecCtor(),
-      chunking: { strategy: 'cdc' },
-    };
-    if (this._logger !== null && this._logger !== undefined) {
-      opts.observability = new LoggerObservabilityBridge(this._logger);
-    }
-    return new ContentAddressableStore(opts);
+      logger: this._logger,
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/infrastructure/adapters/CasStoreFactory.ts
+++ b/src/infrastructure/adapters/CasStoreFactory.ts
@@ -1,0 +1,37 @@
+import type LoggerPort from '../../ports/LoggerPort.ts';
+import { loadGitCasConstructors } from './gitCasModule.ts';
+import LoggerObservabilityBridge from './LoggerObservabilityBridge.ts';
+
+type CasCodecInstance = object;
+type CasStoreOptions = {
+  plumbing: unknown;
+  codec: CasCodecInstance;
+  chunking: { strategy: string };
+  observability?: unknown;
+};
+
+/**
+ * Builds the standard CDC-backed git-cas store used by runtime adapters.
+ */
+export async function createCdcCasStore<CasStore>({
+  plumbing,
+  logger,
+}: {
+  plumbing: unknown;
+  logger: LoggerPort | undefined;
+}): Promise<CasStore> {
+  const { ContentAddressableStore, CborCodecCtor } = await loadGitCasConstructors<
+    CasStoreOptions,
+    CasStore,
+    CasCodecInstance
+  >();
+  const opts: CasStoreOptions = {
+    plumbing,
+    codec: new CborCodecCtor(),
+    chunking: { strategy: 'cdc' },
+  };
+  if (logger !== undefined) {
+    opts.observability = new LoggerObservabilityBridge(logger);
+  }
+  return new ContentAddressableStore(opts);
+}


### PR DESCRIPTION
## What changed

Added `CasStoreFactory` and routed `CasBlobAdapter` plus `CasSeekCacheAdapter` through the shared CDC git-cas construction recipe.

## Why

Both adapters previously duplicated dynamic git-cas loading, CBOR codec construction, chunking setup, and logger observability wiring. The adapters still own their lazy caching behavior, but the construction recipe now has one owner.

Closes #378

## Validation

- `npx vitest run test/unit/infrastructure/adapters/CasBlobAdapter.test.ts test/unit/infrastructure/adapters/CasSeekCacheAdapter.test.ts`
- `npm run typecheck:src -- --pretty false`
- `npx eslint src/infrastructure/adapters/CasStoreFactory.ts src/infrastructure/adapters/CasBlobAdapter.ts src/infrastructure/adapters/CasSeekCacheAdapter.ts`
