### PR TITLE
Fix #381: Invalidate GC-derived caches

### DIFF
--- a/src/domain/services/controllers/CheckpointController.ts
+++ b/src/domain/services/controllers/CheckpointController.ts
@@ -57,6 +57,9 @@ type CheckpointHost = {
   _checkpointStore: CheckpointStorePort | null;
   _stateHashService: StateHashService | null;
   _provenanceIndex: ProvenanceIndex | null;
+  _materializedGraph?: object | null;
+  _logicalIndex?: object | null;
+  _propertyReader?: object | null;
   _cachedIndexTree: Record<string, Uint8Array> | null;
   _codec: CodecPort;
   _commitMessageCodec: CommitMessageCodecPort;
@@ -443,7 +446,7 @@ export default class CheckpointController {
           return;
         }
 
-        h._cachedState = clonedState;
+        this._installCompactedState(clonedState);
         h._lastGCLamport = h._maxObservedLamport;
         h._patchesSinceGC = 0;
         if (h._logger) {
@@ -508,11 +511,21 @@ export default class CheckpointController {
       );
     }
 
-    h._cachedState = clonedState;
+    this._installCompactedState(clonedState);
     h._lastGCLamport = h._maxObservedLamport;
     h._patchesSinceGC = 0;
 
     return result;
+  }
+
+  private _installCompactedState(state: WarpState): void {
+    const h = this._host;
+    h._cachedState = state;
+    h._materializedGraph = null;
+    h._logicalIndex = null;
+    h._propertyReader = null;
+    h._cachedIndexTree = null;
+    h._cachedViewHash = null;
   }
 
   getGCMetrics(): {

--- a/test/unit/domain/services/controllers/CheckpointController.test.ts
+++ b/test/unit/domain/services/controllers/CheckpointController.test.ts
@@ -170,6 +170,9 @@ function createMockHost(overrides = {}) {
     _lastFrontier: null,
     _cachedViewHash: null,
     _cachedIndexTree: null,
+    _materializedGraph: null,
+    _logicalIndex: null,
+    _propertyReader: null,
     discoverWriters: vi.fn().mockResolvedValue([]),
     materialize: vi.fn().mockResolvedValue(stubState()),
     _loadWriterPatches: vi.fn().mockResolvedValue([]),
@@ -473,6 +476,11 @@ describe('CheckpointController', () => {
     it('runs GC on cached state and returns result', () => {
       const state = stubState();
       host['_cachedState'] = state;
+      host['_materializedGraph'] = { stale: 'graph' };
+      host['_logicalIndex'] = { stale: 'index' };
+      host['_propertyReader'] = { stale: 'reader' };
+      host['_cachedIndexTree'] = { 'stale.cbor': new Uint8Array([1]) };
+      host['_cachedViewHash'] = 'stale-hash';
       const gcResult = stubGCResult();
       executeGCMock.mockReturnValue(gcResult);
 
@@ -482,6 +490,11 @@ describe('CheckpointController', () => {
       expect(cloneStateMock).toHaveBeenCalledWith(state);
       expect(computeAppliedVVMock).toHaveBeenCalled();
       expect(host['_patchesSinceGC']).toBe(0);
+      expect(host['_materializedGraph']).toBeNull();
+      expect(host['_logicalIndex']).toBeNull();
+      expect(host['_propertyReader']).toBeNull();
+      expect(host['_cachedIndexTree']).toBeNull();
+      expect(host['_cachedViewHash']).toBeNull();
     });
 
     it('throws E_NO_STATE when no cached state exists', () => {
@@ -589,12 +602,22 @@ describe('CheckpointController', () => {
     it('runs GC when enabled and thresholds met', () => {
       host['_gcPolicy'] = strictPolicy(true);
       host['_cachedState'] = null;
+      host['_materializedGraph'] = { stale: 'graph' };
+      host['_logicalIndex'] = { stale: 'index' };
+      host['_propertyReader'] = { stale: 'reader' };
+      host['_cachedIndexTree'] = { 'stale.cbor': new Uint8Array([1]) };
+      host['_cachedViewHash'] = 'stale-hash';
 
       const state = stubState();
       ctrl._maybeRunGC(state);
 
       expect(executeGCMock).toHaveBeenCalled();
       expect(host['_patchesSinceGC']).toBe(0);
+      expect(host['_materializedGraph']).toBeNull();
+      expect(host['_logicalIndex']).toBeNull();
+      expect(host['_propertyReader']).toBeNull();
+      expect(host['_cachedIndexTree']).toBeNull();
+      expect(host['_cachedViewHash']).toBeNull();
     });
 
     it('logs warning when GC disabled but thresholds met', () => {


### PR DESCRIPTION
## What changed

Routed manual and auto GC through a shared compacted-state install path that clears derived materialized graph, logical index, property reader, index tree, and view-hash caches.

## Why

GC previously swapped `_cachedState` directly, leaving derived read/index caches pointing at pre-compaction objects. The cache state is now invalidated consistently after compaction.

Closes #381

## Validation

- `npx vitest run test/unit/domain/services/controllers/CheckpointController.test.ts`
- `npm run typecheck:src -- --pretty false`
- `npm run typecheck:test -- --pretty false`
