### PR TITLE
Fix #263: prove Deno close rejection behavior

### DIFF
--- a/test/unit/infrastructure/adapters/DenoHttpAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/DenoHttpAdapter.test.ts
@@ -347,8 +347,8 @@ describe('DenoHttpAdapter', () => {
 
       await new Promise((r) => setTimeout(r, 0));
 
-      // If we get here without an unhandled rejection, the test passes
-      expect(true).toBe(true);
+      expect(mockServer.shutdown).toHaveBeenCalledTimes(1);
+      expect(server.address()).toBeNull();
     });
 
     it('nullifies state.server after shutdown rejection', async () => {


### PR DESCRIPTION
## Summary

- replace the tautological Deno close rejection assertion with observable shutdown proof
- keep the no-unhandled-rejection coverage while proving the server handle is cleared

Closes #263

## Validation

- `npm exec vitest run test/unit/infrastructure/adapters/DenoHttpAdapter.test.ts`
- pre-push IRONCLAD gates 0-7 passed with `WARP_QUICK_PUSH=1`
