### PR TITLE
Fix #270: update package module example

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,28 @@
  * First-use application code should open a named worldline with
  * `openWarpWorldline()`. `WarpApp`, `WarpCore`, and `openWarpGraph()` remain
  * supported compatibility and diagnostic surfaces for graph-first code.
+ *
+ * @example
+ * ```typescript
+ * import { GitGraphAdapter, openWarpWorldline } from '@git-stunts/git-warp';
+ * import GitPlumbing from '@git-stunts/plumbing';
+ *
+ * const persistence = new GitGraphAdapter({
+ *   plumbing: new GitPlumbing({ cwd: '.' }),
+ * });
+ *
+ * const events = await openWarpWorldline({
+ *   persistence,
+ *   worldlineName: 'events',
+ *   writerId: 'agent-1',
+ * });
+ *
+ * await events.commit((patch) => {
+ *   patch.addNode('user:alice');
+ * });
+ *
+ * const props = await events.live().getNodeProps('user:alice');
+ * ```
  */
 
 import GitGraphAdapter from './src/infrastructure/adapters/GitGraphAdapter.ts';

--- a/test/unit/scripts/v18-package-surface-audit.test.ts
+++ b/test/unit/scripts/v18-package-surface-audit.test.ts
@@ -12,7 +12,16 @@ function readText(relativePath: string): string {
 const packageJson = readText('package.json');
 const jsrJson = readText('jsr.json');
 const indexSource = readText('index.ts');
-const moduleDoc = indexSource.slice(0, indexSource.indexOf("import GitGraphAdapter"));
+
+function packageModuleDoc(): string {
+  const terminator = indexSource.indexOf('*/');
+  if (terminator === -1) {
+    throw new Error('index.ts is missing its package module JSDoc block');
+  }
+  return indexSource.slice(0, terminator + '*/'.length);
+}
+
+const moduleDoc = packageModuleDoc();
 
 describe('v18 package surface audit', () => {
   it('positions the registry package around the Worldline-first API', () => {

--- a/test/unit/scripts/v18-package-surface-audit.test.ts
+++ b/test/unit/scripts/v18-package-surface-audit.test.ts
@@ -12,6 +12,7 @@ function readText(relativePath: string): string {
 const packageJson = readText('package.json');
 const jsrJson = readText('jsr.json');
 const indexSource = readText('index.ts');
+const moduleDoc = indexSource.slice(0, indexSource.indexOf("import GitGraphAdapter"));
 
 describe('v18 package surface audit', () => {
   it('positions the registry package around the Worldline-first API', () => {
@@ -36,6 +37,16 @@ describe('v18 package surface audit', () => {
     expect(indexSource).toContain('WarpWorldline,');
     expect(indexSource).toContain('WarpWorldlineOpenOptions,');
     expect(indexSource).toContain('WarpWorldlinePatchBuild,');
+  });
+
+  it('keeps package hover docs on the Worldline-first example', () => {
+    expect(moduleDoc).toContain('@example');
+    expect(moduleDoc).toContain('openWarpWorldline');
+    expect(moduleDoc).toContain("events.commit((patch) =>");
+    expect(moduleDoc).toContain('events.live().getNodeProps');
+    expect(moduleDoc).not.toContain('WarpApp.open(');
+    expect(moduleDoc).not.toContain('app.createPatch(');
+    expect(moduleDoc).not.toContain('app.materialize(');
   });
 
   it('keeps default export compatibility explicit', () => {


### PR DESCRIPTION
## Summary

- add a Worldline-first package module example to the root barrel docs
- add a package surface guard that keeps stale `WarpApp.open()` examples out of the module hover docs

Closes #270

## Validation

- `npm exec vitest run test/unit/scripts/v18-package-surface-audit.test.ts`
- pre-push IRONCLAD gates 0-7 passed with `WARP_QUICK_PUSH=1`
