### PR TITLE
Fix #279: add standard doc root pointers

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Code Of Conduct
+
+The repository code of conduct lives in
+[.github/CODE_OF_CONDUCT.md](.github/CODE_OF_CONDUCT.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Code Of Conduct
+# Code of Conduct
 
 The repository code of conduct lives in
 [.github/CODE_OF_CONDUCT.md](.github/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+Repository contribution guidance lives in
+[.github/CONTRIBUTING.md](.github/CONTRIBUTING.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Security
+
+Repository security and vulnerability reporting guidance lives in
+[.github/SECURITY.md](.github/SECURITY.md).

--- a/test/unit/scripts/repository-standard-docs.test.ts
+++ b/test/unit/scripts/repository-standard-docs.test.ts
@@ -14,21 +14,26 @@ describe('repository standard docs', () => {
       {
         rootPath: 'CODE_OF_CONDUCT.md',
         githubPath: '.github/CODE_OF_CONDUCT.md',
+        heading: 'Code of Conduct',
       },
       {
         rootPath: 'CONTRIBUTING.md',
         githubPath: '.github/CONTRIBUTING.md',
+        heading: 'Contributing',
       },
       {
         rootPath: 'SECURITY.md',
         githubPath: '.github/SECURITY.md',
+        heading: 'Security',
       },
     ];
 
     for (const pointer of pointers) {
       expect(existsSync(`${repoRoot}${pointer.rootPath}`)).toBe(true);
       expect(existsSync(`${repoRoot}${pointer.githubPath}`)).toBe(true);
-      expect(readRepoFile(pointer.rootPath)).toContain(`[${pointer.githubPath}](${pointer.githubPath})`);
+      const rootPointer = readRepoFile(pointer.rootPath);
+      expect(rootPointer).toContain(`[${pointer.githubPath}](${pointer.githubPath})`);
+      expect(rootPointer).toContain(`# ${pointer.heading}\n\n`);
     }
   });
 });

--- a/test/unit/scripts/repository-standard-docs.test.ts
+++ b/test/unit/scripts/repository-standard-docs.test.ts
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(`${repoRoot}${relativePath}`, 'utf8');
+}
+
+describe('repository standard docs', () => {
+  it('keeps root pointers to the canonical GitHub standard docs', () => {
+    const pointers = [
+      {
+        rootPath: 'CODE_OF_CONDUCT.md',
+        githubPath: '.github/CODE_OF_CONDUCT.md',
+      },
+      {
+        rootPath: 'CONTRIBUTING.md',
+        githubPath: '.github/CONTRIBUTING.md',
+      },
+      {
+        rootPath: 'SECURITY.md',
+        githubPath: '.github/SECURITY.md',
+      },
+    ];
+
+    for (const pointer of pointers) {
+      expect(existsSync(`${repoRoot}${pointer.rootPath}`)).toBe(true);
+      expect(existsSync(`${repoRoot}${pointer.githubPath}`)).toBe(true);
+      expect(readRepoFile(pointer.rootPath)).toContain(`[${pointer.githubPath}](${pointer.githubPath})`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add root-level pointers for the repository code of conduct, contributing guide, and security policy
- keep the canonical full documents under `.github/`
- add a repository docs guard that verifies each root pointer and canonical target exist

Closes #279

## Validation

- `npm exec vitest run test/unit/scripts/repository-standard-docs.test.ts`
- `npm exec markdownlint CODE_OF_CONDUCT.md CONTRIBUTING.md SECURITY.md`
- pre-push IRONCLAD gates 0-7 passed with `WARP_QUICK_PUSH=1`
