### PR TITLE
Fix #277: type readTreeOids mock contract

### DIFF
--- a/test/helpers/WarpGraphMockPersistence.ts
+++ b/test/helpers/WarpGraphMockPersistence.ts
@@ -35,7 +35,7 @@ class WarpGraphMockPersistence {
   readonly writeBlob = vi.fn();
   readonly writeTree = vi.fn();
   readonly readBlob = vi.fn();
-  readonly readTreeOids = vi.fn().mockResolvedValue({});
+  readonly readTreeOids = vi.fn(async (_treeOid: string): Promise<Record<string, string>> => ({}));
   readonly commitNode = vi.fn();
   readonly commitNodeWithTree = vi.fn();
   readonly updateRef = vi.fn(async (ref: string, sha: string) => {

--- a/test/helpers/mockPorts.ts
+++ b/test/helpers/mockPorts.ts
@@ -21,7 +21,7 @@ export interface MockPersistence {
   readBlob: Mock;
   writeBlob: Mock;
   readTree: Mock;
-  readTreeOids: Mock;
+  readTreeOids: Mock<(treeOid: string) => Promise<Record<string, string>>>;
   writeTree: Mock;
   commitNode: Mock;
   commitNodeWithTree: Mock;
@@ -62,7 +62,7 @@ export function createMockPersistence(overrides: Partial<MockPersistence> = {}):
     readBlob: vi.fn().mockResolvedValue(new Uint8Array(0)),
     writeBlob: vi.fn().mockResolvedValue(MOCK_OID),
     readTree: vi.fn().mockResolvedValue({}),
-    readTreeOids: vi.fn().mockResolvedValue({}),
+    readTreeOids: vi.fn(async (_treeOid: string): Promise<Record<string, string>> => ({})),
     writeTree: vi.fn().mockResolvedValue(MOCK_OID),
     commitNode: vi.fn().mockResolvedValue(MOCK_OID),
     commitNodeWithTree: vi.fn().mockResolvedValue(MOCK_OID),

--- a/test/unit/helpers/WarpGraphMockPersistence.test.ts
+++ b/test/unit/helpers/WarpGraphMockPersistence.test.ts
@@ -14,4 +14,15 @@ describe('WarpGraphMockPersistence', () => {
     await expect(persistence.compareAndSwapRef(ref, nextOid, null)).rejects.toThrow('CAS mismatch');
     await expect(persistence.readRef(ref)).resolves.toBe(currentOid);
   });
+
+  it('types readTreeOids as a tree path to object-map contract', async () => {
+    const persistence = createMockPersistence();
+    const readTreeOids: (treeOid: string) => Promise<Record<string, string>> =
+      persistence.readTreeOids;
+
+    const treeOids = await readTreeOids('tree-oid');
+
+    expect(treeOids).toEqual({});
+    expect(Array.isArray(treeOids)).toBe(false);
+  });
 });

--- a/test/unit/helpers/WarpGraphMockPersistence.test.ts
+++ b/test/unit/helpers/WarpGraphMockPersistence.test.ts
@@ -15,7 +15,7 @@ describe('WarpGraphMockPersistence', () => {
     await expect(persistence.readRef(ref)).resolves.toBe(currentOid);
   });
 
-  it('types readTreeOids as a tree path to object-map contract', async () => {
+  it('types readTreeOids as a tree object id to object-map contract', async () => {
     const persistence = createMockPersistence();
     const readTreeOids: (treeOid: string) => Promise<Record<string, string>> =
       persistence.readTreeOids;

--- a/test/unit/helpers/mockPorts.test.ts
+++ b/test/unit/helpers/mockPorts.test.ts
@@ -14,4 +14,15 @@ describe('mockPorts createMockPersistence', () => {
     await expect(persistence.compareAndSwapRef(ref, nextOid, null)).rejects.toThrow('CAS mismatch');
     await expect(persistence.readRef(ref)).resolves.toBe(currentOid);
   });
+
+  it('types readTreeOids as a tree path to object-map contract', async () => {
+    const persistence = createMockPersistence();
+    const readTreeOids: (treeOid: string) => Promise<Record<string, string>> =
+      persistence.readTreeOids;
+
+    const treeOids = await readTreeOids('tree-oid');
+
+    expect(treeOids).toEqual({});
+    expect(Array.isArray(treeOids)).toBe(false);
+  });
 });

--- a/test/unit/helpers/mockPorts.test.ts
+++ b/test/unit/helpers/mockPorts.test.ts
@@ -15,7 +15,7 @@ describe('mockPorts createMockPersistence', () => {
     await expect(persistence.readRef(ref)).resolves.toBe(currentOid);
   });
 
-  it('types readTreeOids as a tree path to object-map contract', async () => {
+  it('types readTreeOids as a tree object id to object-map contract', async () => {
     const persistence = createMockPersistence();
     const readTreeOids: (treeOid: string) => Promise<Record<string, string>> =
       persistence.readTreeOids;


### PR DESCRIPTION
## Summary

- type shared mock `readTreeOids` helpers as `Promise<Record<string, string>>`
- default both mock persistence factories to async object-map implementations
- add focused tests that compile against and assert the object-map contract

Closes #277

## Validation

- `npm exec vitest run test/unit/helpers/mockPorts.test.ts test/unit/helpers/WarpGraphMockPersistence.test.ts`
- `npm run typecheck:test`
- pre-push IRONCLAD gates 0-7 passed with `WARP_QUICK_PUSH=1`
