### PR TITLE
Fix #382: remove incremental props rewrap branch

### DIFF
--- a/src/domain/services/index/IncrementalIndexUpdater.ts
+++ b/src/domain/services/index/IncrementalIndexUpdater.ts
@@ -244,10 +244,6 @@ export default class IncrementalIndexUpdater {
         const fresh: Record<string, unknown> = createNullProto(); // nosemgrep: ts-no-record-string-unknown-outside-adapters -- 0025B; nosemgrep: ts-no-unknown-outside-adapters -- 0025B
         nodeProps = fresh;
         shard.set(prop.nodeId, fresh);
-      } else if (Object.getPrototypeOf(nodeProps) !== null) {
-        const safeProps = mergeIntoNullProto(nodeProps);
-        shard.set(prop.nodeId, safeProps);
-        nodeProps = safeProps;
       }
       nodeProps[prop.key] = prop.value;
     }

--- a/test/unit/domain/services/IncrementalIndexUpdater.test.ts
+++ b/test/unit/domain/services/IncrementalIndexUpdater.test.ts
@@ -69,14 +69,6 @@ function decodeProps(tree, shardKey) {
   return map;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object';
-}
-
-function isPropEntry(value: unknown): value is [string, Record<string, unknown>] {
-  return Array.isArray(value) && typeof value[0] === 'string' && isRecord(value[1]);
-}
-
 describe('IncrementalIndexUpdater', () => {
   describe('NodeAdd', () => {
     it('adds node to correct meta shard and sets alive bit', () => {
@@ -723,12 +715,14 @@ describe('IncrementalIndexUpdater', () => {
       const tree1 = buildTree(state);
       const shardKey = computeShardKey('A');
       tree1[`props_${shardKey}.cbor`] = defaultCodec.encode([['A', { name: 'Alice' }]]).slice();
-      const capturedPropBags: Array<Record<string, unknown>> = [];
+      const capturedPropBags: object[] = [];
       const codec = {
         encode<TEncoded>(data: TEncoded): Uint8Array {
-          if (Array.isArray(data) && data.every(isPropEntry)) {
-            for (const [, props] of data) {
-              capturedPropBags.push(props);
+          if (Array.isArray(data)) {
+            for (const entry of data) {
+              if (Array.isArray(entry) && typeof entry[0] === 'string' && typeof entry[1] === 'object' && entry[1] !== null) {
+                capturedPropBags.push(entry[1]);
+              }
             }
           }
           return defaultCodec.encode(data).slice();
@@ -758,8 +752,8 @@ describe('IncrementalIndexUpdater', () => {
         throw new Error('expected one captured prop bag');
       }
       expect(Object.getPrototypeOf(capturedPropBag)).toBe(null);
-      expect(capturedPropBag['name']).toBe('Alice');
-      expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+      expect(Reflect.get(capturedPropBag, 'name')).toBe('Alice');
+      expect(Reflect.get({}, 'polluted')).toBeUndefined();
     });
   });
 

--- a/test/unit/domain/services/IncrementalIndexUpdater.test.ts
+++ b/test/unit/domain/services/IncrementalIndexUpdater.test.ts
@@ -69,6 +69,14 @@ function decodeProps(tree, shardKey) {
   return map;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function isPropEntry(value: unknown): value is [string, Record<string, unknown>] {
+  return Array.isArray(value) && typeof value[0] === 'string' && isRecord(value[1]);
+}
+
 describe('IncrementalIndexUpdater', () => {
   describe('NodeAdd', () => {
     it('adds node to correct meta shard and sets alive bit', () => {
@@ -703,6 +711,54 @@ describe('IncrementalIndexUpdater', () => {
 
       expect(aProps['name']).toBe('Alice');
       expect(Reflect.get(Object.getPrototypeOf(aProps), 'polluted')).toBeUndefined();
+      expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    });
+
+    it('writes loaded prop bags only after null-prototype normalization', () => {
+      const state = buildState({
+        nodes: ['A'],
+        edges: [],
+        props: [{ nodeId: 'A', key: 'name', value: 'Alice' }],
+      });
+      const tree1 = buildTree(state);
+      const shardKey = computeShardKey('A');
+      tree1[`props_${shardKey}.cbor`] = defaultCodec.encode([['A', { name: 'Alice' }]]).slice();
+      const capturedPropBags: Array<Record<string, unknown>> = [];
+      const codec = {
+        encode<TEncoded>(data: TEncoded): Uint8Array {
+          if (Array.isArray(data) && data.every(isPropEntry)) {
+            for (const [, props] of data) {
+              capturedPropBags.push(props);
+            }
+          }
+          return defaultCodec.encode(data).slice();
+        },
+        decode<TDecoded>(bytes: Uint8Array): TDecoded {
+          return defaultCodec.decode<TDecoded>(bytes);
+        },
+      };
+      const diff = {
+        nodesAdded: [],
+        nodesRemoved: [],
+        edgesAdded: [],
+        edgesRemoved: [],
+        propsChanged: [{ nodeId: 'A', key: '__proto__', value: { polluted: true }, prevValue: undefined }],
+      };
+
+      const updater = new IncrementalIndexUpdater({ codec });
+      updater.computeDirtyShards({
+        diff,
+        state,
+        loadShard: (path) => tree1[path],
+      });
+
+      expect(capturedPropBags).toHaveLength(1);
+      const [capturedPropBag] = capturedPropBags;
+      if (capturedPropBag === undefined) {
+        throw new Error('expected one captured prop bag');
+      }
+      expect(Object.getPrototypeOf(capturedPropBag)).toBe(null);
+      expect(capturedPropBag['name']).toBe('Alice');
       expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Summary

- remove the unreachable `_handleProps()` prop-bag rewrap branch
- add a codec-boundary regression test proving loaded legacy prop bags are normalized before save-time mutation
- preserve the existing proto-pollution safety coverage

Closes #382

## Validation

- `npm exec vitest run test/unit/domain/services/IncrementalIndexUpdater.test.ts`
- `npm run typecheck:test`
- pre-push IRONCLAD gates 0-7 passed with `WARP_QUICK_PUSH=1`
