### PR TITLE
Fix #368: prove upgrade entrypoint contract

### DIFF
--- a/test/helpers/parseUpgradeCommandEntrypoint.ts
+++ b/test/helpers/parseUpgradeCommandEntrypoint.ts
@@ -1,0 +1,8 @@
+export function parseUpgradeCommandEntrypoint(command: string): string {
+  const stages = command.split(' && ');
+  const [, nodeCommand] = stages;
+  if (stages.length !== 2 || nodeCommand === undefined || !nodeCommand.startsWith('node ')) {
+    throw new Error(`Unexpected upgrade command shape: ${command}`);
+  }
+  return nodeCommand.slice('node '.length);
+}

--- a/test/unit/scripts/uniform-git-cas-closeout.test.ts
+++ b/test/unit/scripts/uniform-git-cas-closeout.test.ts
@@ -3,10 +3,22 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import packageJson from '../../../package.json' with { type: 'json' };
+import publishTsconfig from '../../../tsconfig.publish.json' with { type: 'json' };
+
 const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
 
 function readRepoFile(relativePath: string): string {
   return readFileSync(join(repoRoot, relativePath), 'utf8');
+}
+
+function upgradeCommandEntrypoint(): string {
+  const command = packageJson.scripts.upgrade;
+  const [, nodeCommand] = command.split(' && ');
+  if (nodeCommand === undefined || !nodeCommand.startsWith('node ')) {
+    throw new Error(`Unexpected upgrade command shape: ${command}`);
+  }
+  return nodeCommand.slice('node '.length);
 }
 
 describe('uniform git-cas closeout', () => {
@@ -79,19 +91,23 @@ describe('uniform git-cas closeout', () => {
   });
 
   it('keeps raw-substrate compatibility behind the upgrade command, not mainline policy', () => {
-    const packageJson = readRepoFile('package.json');
     const design = readRepoFile('docs/design/0092-close-uniform-git-cas.md');
     const releaseLedger = readRepoFile('docs/releases/v17.0.0/README.md');
     const upgradeTool = readRepoFile(
       'docs/archive/backlog/v17.0.0-residual-backlog/INFRA_substrate-upgrade-tool.md'
     );
-    const upgradeEntrypoint = readRepoFile('scripts/upgrade-v16-to-v17.ts');
-    const migrationHelper = readRepoFile('scripts/migrations/v17.0.0/migrate.ts');
 
-    expect(packageJson).toContain(
-      '"upgrade": "npm run build --silent && node dist/scripts/upgrade-v16-to-v17.js"'
+    const distEntrypoint = upgradeCommandEntrypoint();
+    const sourceEntrypoint = distEntrypoint.replace(/^dist\//u, '').replace(/\.js$/u, '.ts');
+
+    expect(packageJson.scripts.upgrade).toBe(
+      'npm run build --silent && node dist/scripts/upgrade-v16-to-v17.js',
     );
-    expect(packageJson).toContain('"dist"');
+    expect(distEntrypoint).toBe('dist/scripts/upgrade-v16-to-v17.js');
+    expect(sourceEntrypoint).toBe('scripts/upgrade-v16-to-v17.ts');
+    expect(existsSync(join(repoRoot, sourceEntrypoint))).toBe(true);
+    expect(publishTsconfig.include).toContain('scripts/**/*.ts');
+    expect(packageJson.files).toContain('dist');
     expect(design).not.toContain('legacy raw blobs may still be read');
     expect(releaseLedger).not.toContain('legacy raw reads');
     expect(releaseLedger).toContain(
@@ -100,9 +116,6 @@ describe('uniform git-cas closeout', () => {
     expect(upgradeTool).toContain('The package-level command is:');
     expect(upgradeTool).toContain('npm run upgrade -- --graph <name>');
     expect(upgradeTool).toContain('Mainline cleanup requirement');
-    expect(upgradeEntrypoint).toContain('Top-level v16 -> v17 graph substrate upgrade utility');
-    expect(upgradeEntrypoint).toContain('upgradeCheckpointSchema');
-    expect(migrationHelper).toContain('not in shipped runtime code under src/');
   });
 
   it('tracks broader adapter parity as a split successor', () => {

--- a/test/unit/scripts/uniform-git-cas-closeout.test.ts
+++ b/test/unit/scripts/uniform-git-cas-closeout.test.ts
@@ -5,20 +5,12 @@ import { describe, expect, it } from 'vitest';
 
 import packageJson from '../../../package.json' with { type: 'json' };
 import publishTsconfig from '../../../tsconfig.publish.json' with { type: 'json' };
+import { parseUpgradeCommandEntrypoint } from '../../helpers/parseUpgradeCommandEntrypoint.ts';
 
 const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
 
 function readRepoFile(relativePath: string): string {
   return readFileSync(join(repoRoot, relativePath), 'utf8');
-}
-
-function upgradeCommandEntrypoint(): string {
-  const command = packageJson.scripts.upgrade;
-  const [, nodeCommand] = command.split(' && ');
-  if (nodeCommand === undefined || !nodeCommand.startsWith('node ')) {
-    throw new Error(`Unexpected upgrade command shape: ${command}`);
-  }
-  return nodeCommand.slice('node '.length);
 }
 
 describe('uniform git-cas closeout', () => {
@@ -97,7 +89,7 @@ describe('uniform git-cas closeout', () => {
       'docs/archive/backlog/v17.0.0-residual-backlog/INFRA_substrate-upgrade-tool.md'
     );
 
-    const distEntrypoint = upgradeCommandEntrypoint();
+    const distEntrypoint = parseUpgradeCommandEntrypoint(packageJson.scripts.upgrade);
     const sourceEntrypoint = distEntrypoint.replace(/^dist\//u, '').replace(/\.js$/u, '.ts');
 
     expect(packageJson.scripts.upgrade).toBe(

--- a/test/unit/scripts/v16-to-v17-upgrade.test.ts
+++ b/test/unit/scripts/v16-to-v17-upgrade.test.ts
@@ -11,18 +11,10 @@ import {
   parseArgs,
   upgradeV16ToV17,
 } from '../../../scripts/upgrade-v16-to-v17.ts';
+import { parseUpgradeCommandEntrypoint } from '../../helpers/parseUpgradeCommandEntrypoint.ts';
 
 function oid(hex: string): string {
   return hex.repeat(40).slice(0, 40);
-}
-
-function upgradeCommandEntrypoint(): string {
-  const command = packageJson.scripts.upgrade;
-  const [, nodeCommand] = command.split(' && ');
-  if (nodeCommand === undefined || !nodeCommand.startsWith('node ')) {
-    throw new Error(`Unexpected upgrade command shape: ${command}`);
-  }
-  return nodeCommand.slice('node '.length);
 }
 
 describe('v16 to v17 top-level upgrade utility', () => {
@@ -100,7 +92,7 @@ describe('v16 to v17 top-level upgrade utility', () => {
   });
 
   it('wires npm run upgrade through the top-level operator script', () => {
-    expect(upgradeCommandEntrypoint()).toBe('dist/scripts/upgrade-v16-to-v17.js');
+    expect(parseUpgradeCommandEntrypoint(packageJson.scripts.upgrade)).toBe('dist/scripts/upgrade-v16-to-v17.js');
     expect(publishTsconfig.include).toContain('scripts/**/*.ts');
     expect(packageJson.files).toContain('dist');
   });

--- a/test/unit/scripts/v16-to-v17-upgrade.test.ts
+++ b/test/unit/scripts/v16-to-v17-upgrade.test.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import packageJson from '../../../package.json' with { type: 'json' };
+import publishTsconfig from '../../../tsconfig.publish.json' with { type: 'json' };
 import { createEmptyState } from '../../../src/domain/services/JoinReducer.ts';
 import { createFrontier } from '../../../src/domain/services/Frontier.ts';
 import { createCheckpointEnvelope } from '../../../src/domain/services/state/checkpointCreate.ts';
@@ -12,14 +12,17 @@ import {
   upgradeV16ToV17,
 } from '../../../scripts/upgrade-v16-to-v17.ts';
 
-const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
-
-function readRepoFile(relativePath: string): string {
-  return readFileSync(`${repoRoot}${relativePath}`, 'utf8');
-}
-
 function oid(hex: string): string {
   return hex.repeat(40).slice(0, 40);
+}
+
+function upgradeCommandEntrypoint(): string {
+  const command = packageJson.scripts.upgrade;
+  const [, nodeCommand] = command.split(' && ');
+  if (nodeCommand === undefined || !nodeCommand.startsWith('node ')) {
+    throw new Error(`Unexpected upgrade command shape: ${command}`);
+  }
+  return nodeCommand.slice('node '.length);
 }
 
 describe('v16 to v17 top-level upgrade utility', () => {
@@ -97,10 +100,8 @@ describe('v16 to v17 top-level upgrade utility', () => {
   });
 
   it('wires npm run upgrade through the top-level operator script', () => {
-    const pkg = readRepoFile('package.json');
-    const publishConfig = readRepoFile('tsconfig.publish.json');
-
-    expect(pkg).toContain('node dist/scripts/upgrade-v16-to-v17.js');
-    expect(publishConfig).toContain('"scripts/**/*.ts"');
+    expect(upgradeCommandEntrypoint()).toBe('dist/scripts/upgrade-v16-to-v17.js');
+    expect(publishTsconfig.include).toContain('scripts/**/*.ts');
+    expect(packageJson.files).toContain('dist');
   });
 });


### PR DESCRIPTION
## Summary

- replace raw package/tsconfig source-text checks with structured package and publish-config imports
- derive the built upgrade entrypoint from `scripts.upgrade` and verify its source is included by the publish build
- update the top-level v16-to-v17 upgrade test to use the same structured package contract

Closes #368

## Validation

- `npm exec vitest run test/unit/scripts/uniform-git-cas-closeout.test.ts test/unit/scripts/v16-to-v17-upgrade.test.ts`
- `npm run typecheck:test`
- pre-push IRONCLAD gates 0-7 passed with `WARP_QUICK_PUSH=1`
