### PR TITLE
Fix #266: dedupe relaxed ESLint overrides

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -363,31 +363,18 @@ export default tseslint.config(
   {
     files: [
       "src/domain/WarpGraph.ts",
-      "src/domain/services/controllers/QueryController.ts",
-      "src/domain/services/controllers/SubscriptionController.ts",
-      "src/domain/services/controllers/ProvenanceController.ts",
-      "src/domain/services/controllers/ForkController.ts",
       "src/domain/services/controllers/PatchController.ts",
       "src/domain/services/controllers/PatchDiscovery.ts",
-      "src/domain/services/controllers/CheckpointController.ts",
       "src/domain/services/controllers/MaterializeController.ts",
-      "src/domain/services/dag/CommitDagTraversalService.ts",
       "src/domain/services/state/checkpointHelpers.ts",
       "src/domain/services/state/checkpointCreate.ts",
       "src/domain/services/state/checkpointLoad.ts",
-      "src/domain/services/query/QueryBuilder.ts",
       "src/domain/services/codec/WarpMessageCodec.ts",
       "src/domain/services/codec/PatchMessageCodec.ts",
       "src/domain/services/codec/CheckpointMessageCodec.ts",
       "src/domain/services/codec/AnchorMessageCodec.ts",
       "src/domain/services/codec/MessageSchemaDetector.ts",
-      "src/domain/services/controllers/SyncController.ts",
       "src/domain/services/controllers/syncHelpers.ts",
-      "src/domain/services/controllers/SyncServerLauncher.ts",
-      "src/domain/services/sync/syncPatchLoader.ts",
-      "src/domain/services/sync/syncDelta.ts",
-      "src/domain/services/sync/syncRequestResponse.ts",
-      "src/domain/services/query/LogicalTraversal.ts",
       // Domain services — algorithm-heavy
       "src/domain/services/BisectService.ts",
       "src/domain/services/Frontier.ts",
@@ -485,7 +472,6 @@ export default tseslint.config(
       "src/infrastructure/adapters/gitErrorClassification.ts",
       "src/infrastructure/adapters/inMemoryHashing.ts",
       // CLI
-      "bin/warp-graph.ts",
       "bin/warp-graph.ts",
       "bin/cli/infrastructure.ts",
       "bin/cli/shared.ts",
@@ -726,7 +712,7 @@ export default tseslint.config(
 
   // ── JoinReducer: the algorithm from hell ───────────────────────────────────
   {
-    files: ["src/domain/services/JoinReducer.ts", "src/domain/services/JoinReducer.ts"],
+    files: ["src/domain/services/JoinReducer.ts"],
     rules: {
       "complexity": ["error", 35],
       "max-lines-per-function": ["error", 200],

--- a/test/unit/scripts/eslint-override-files-shape.test.ts
+++ b/test/unit/scripts/eslint-override-files-shape.test.ts
@@ -42,9 +42,12 @@ function collectFilesArrays(source: string): string[][] {
       && ts.isArrayLiteralExpression(node.initializer)
     ) {
       filesArrays.push(
-        node.initializer.elements
-          .filter(ts.isStringLiteral)
-          .map((element) => element.text),
+        node.initializer.elements.map((element) => {
+          if (!ts.isStringLiteral(element)) {
+            throw new Error('Unsupported nonliteral files entry in eslint.config.ts');
+          }
+          return element.text;
+        }),
       );
     }
     ts.forEachChild(node, visit);
@@ -54,7 +57,13 @@ function collectFilesArrays(source: string): string[][] {
   return filesArrays;
 }
 
-describe('ESLint relaxed complexity shape', () => {
+describe('ESLint override files shape', () => {
+  it('rejects nonliteral files entries instead of silently skipping them', () => {
+    expect(() => collectFilesArrays('export default [{ files: [dynamicPattern] }];')).toThrow(
+      'Unsupported nonliteral files entry in eslint.config.ts',
+    );
+  });
+
   it('does not list the same file twice inside one override block', () => {
     const source = readFileSync(eslintConfigPath, 'utf8');
     const duplicateEntries = collectFilesArrays(source)

--- a/test/unit/scripts/eslint-relaxed-complexity-shape.test.ts
+++ b/test/unit/scripts/eslint-relaxed-complexity-shape.test.ts
@@ -1,6 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
-import eslintConfig from '../../../eslint.config.ts';
+const eslintConfigPath = fileURLToPath(new URL('../../../eslint.config.ts', import.meta.url));
 
 function duplicateFiles(files: readonly string[]): string[] {
   const seen = new Set<string>();
@@ -15,23 +18,48 @@ function duplicateFiles(files: readonly string[]): string[] {
   return [...duplicates].sort();
 }
 
+function propertyNameText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
+    return name.text;
+  }
+  return null;
+}
+
+function collectFilesArrays(source: string): string[][] {
+  const sourceFile = ts.createSourceFile(
+    eslintConfigPath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const filesArrays: string[][] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isPropertyAssignment(node)
+      && propertyNameText(node.name) === 'files'
+      && ts.isArrayLiteralExpression(node.initializer)
+    ) {
+      filesArrays.push(
+        node.initializer.elements
+          .filter(ts.isStringLiteral)
+          .map((element) => element.text),
+      );
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return filesArrays;
+}
+
 describe('ESLint relaxed complexity shape', () => {
   it('does not list the same file twice inside one override block', () => {
-    const duplicateEntries = [];
-
-    for (const entry of eslintConfig) {
-      if (!Array.isArray(entry.files)) {
-        continue;
-      }
-      const duplicates = duplicateFiles(entry.files);
-      if (duplicates.length === 0) {
-        continue;
-      }
-      duplicateEntries.push({
-        files: entry.files,
-        duplicates,
-      });
-    }
+    const source = readFileSync(eslintConfigPath, 'utf8');
+    const duplicateEntries = collectFilesArrays(source)
+      .map((files) => ({ files, duplicates: duplicateFiles(files) }))
+      .filter((entry) => entry.duplicates.length > 0);
 
     expect(duplicateEntries).toEqual([]);
   });

--- a/test/unit/scripts/eslint-relaxed-complexity-shape.test.ts
+++ b/test/unit/scripts/eslint-relaxed-complexity-shape.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import eslintConfig from '../../../eslint.config.ts';
+
+function duplicateFiles(files: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const file of files) {
+    if (seen.has(file)) {
+      duplicates.add(file);
+      continue;
+    }
+    seen.add(file);
+  }
+  return [...duplicates].sort();
+}
+
+describe('ESLint relaxed complexity shape', () => {
+  it('does not list the same file twice inside one override block', () => {
+    const duplicateEntries = [];
+
+    for (const entry of eslintConfig) {
+      if (!Array.isArray(entry.files)) {
+        continue;
+      }
+      const duplicates = duplicateFiles(entry.files);
+      if (duplicates.length === 0) {
+        continue;
+      }
+      duplicateEntries.push({
+        files: entry.files,
+        duplicates,
+      });
+    }
+
+    expect(duplicateEntries).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- remove duplicate file entries from relaxed ESLint complexity override blocks
- add a TypeScript-AST config-shape guard that rejects duplicate file globs inside one override block
- keep the relaxed override behavior intact while preventing stale duplicate entries from returning

Closes #266

## Validation

- `npm exec vitest run test/unit/scripts/eslint-relaxed-complexity-shape.test.ts`
- `npm run lint`
- `npm run typecheck:test`
- pre-push IRONCLAD gates 0-7 passed with `WARP_QUICK_PUSH=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated ESLint configuration file allowlist to improve module categorization and removed a duplicate entry.

* **Tests**
  * Added validation test to prevent duplicate file entries in ESLint configuration, improving code quality consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->