### PR TITLE
Fix #267: prove GC failure handling

### DIFF
--- a/src/domain/services/controllers/CheckpointController.ts
+++ b/src/domain/services/controllers/CheckpointController.ts
@@ -457,9 +457,26 @@ export default class CheckpointController {
       }
     } catch (err) {
       if (h._logger) {
+        let error = 'non-Error thrown value';
+        if (err instanceof Error) {
+          error = err.message;
+        } else if (err === null) {
+          error = 'null';
+        } else if (err === undefined) {
+          error = 'undefined';
+        } else if (typeof err === 'string') {
+          error = err;
+        } else if (
+          typeof err === 'number'
+          || typeof err === 'boolean'
+          || typeof err === 'bigint'
+          || typeof err === 'symbol'
+        ) {
+          error = String(err);
+        }
         h._logger.warn(
           'Auto-GC failed; materialize will continue.',
-          { error: err instanceof Error ? err.message : String(err) },
+          { error },
         );
       }
       // GC failure never breaks materialize

--- a/src/domain/services/controllers/CheckpointController.ts
+++ b/src/domain/services/controllers/CheckpointController.ts
@@ -455,7 +455,13 @@ export default class CheckpointController {
           { reasons },
         );
       }
-    } catch {
+    } catch (err) {
+      if (h._logger) {
+        h._logger.warn(
+          'Auto-GC failed; materialize will continue.',
+          { error: err instanceof Error ? err.message : String(err) },
+        );
+      }
       // GC failure never breaks materialize
     }
   }

--- a/test/unit/domain/WarpGraph.autoGC.test.ts
+++ b/test/unit/domain/WarpGraph.autoGC.test.ts
@@ -141,13 +141,53 @@ describe('WarpCore auto-GC after materialize (GK/GC/1)', () => {
     await graph.materialize();
 
     // Create a broken state that will cause GC to throw
-    const badState = ({ nodeAlive: null, edgeAlive: null } as any);
+    const badState = createHighTombstoneState();
+    Object.defineProperty(badState, 'nodeAlive', { value: null });
+    Object.defineProperty(badState, 'edgeAlive', { value: null });
 
     // Should not throw despite internal error
     expect(() => (graph)._maybeRunGC(badState)).not.toThrow();
     expect(logger.warn).toHaveBeenCalledWith(
       'Auto-GC failed; materialize will continue.',
       expect.objectContaining({ error: expect.any(String) }),
+    );
+  });
+
+  it('GC throws a null-prototype value → materialize still succeeds', async () => {
+    const logger = createMockLogger();
+    const graph = await openRuntimeHostProduct({
+      persistence,
+      graphName: 'test',
+      writerId: 'writer-1',
+      logger,
+      gcPolicy: {
+        enabled: true,
+        tombstoneRatioThreshold: 0.01,
+        minPatchesSinceCompaction: 0,
+        maxTicksSinceCompaction: 0,
+        entryCountThreshold: 0,
+      },
+    });
+
+    const badState = createHighTombstoneState();
+    Object.defineProperty(badState, 'nodeAlive', {
+      value: {
+        countEntries() {
+          throw Object.create(null);
+        },
+        countTombstones() {
+          return 0;
+        },
+        countLiveDots() {
+          return 0;
+        },
+      },
+    });
+
+    expect(() => (graph)._maybeRunGC(badState)).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Auto-GC failed; materialize will continue.',
+      expect.objectContaining({ error: 'non-Error thrown value' }),
     );
   });
 

--- a/test/unit/domain/WarpGraph.autoGC.test.ts
+++ b/test/unit/domain/WarpGraph.autoGC.test.ts
@@ -145,6 +145,10 @@ describe('WarpCore auto-GC after materialize (GK/GC/1)', () => {
 
     // Should not throw despite internal error
     expect(() => (graph)._maybeRunGC(badState)).not.toThrow();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Auto-GC failed; materialize will continue.',
+      expect.objectContaining({ error: expect.any(String) }),
+    );
   });
 
   it('_lastGCLamport and _patchesSinceGC reset after GC', async () => {
@@ -172,12 +176,13 @@ describe('WarpCore auto-GC after materialize (GK/GC/1)', () => {
     expect((graph)._lastGCLamport).toBeGreaterThanOrEqual(0);
   });
 
-  it('no logger provided → no crash', async () => {
+  it('no logger provided → enabled GC still executes', async () => {
     const graph = await openRuntimeHostProduct({
       persistence,
       graphName: 'test',
       writerId: 'writer-1',
       gcPolicy: {
+        enabled: true,
         tombstoneRatioThreshold: 0.01,
         minPatchesSinceCompaction: 0,
         maxTicksSinceCompaction: 0,
@@ -186,8 +191,10 @@ describe('WarpCore auto-GC after materialize (GK/GC/1)', () => {
     });
 
     await graph.materialize();
+    (graph)._patchesSinceGC = 999;
 
-    // No logger → should still work without crashing
-    expect(() => (graph)._maybeRunGC(createHighTombstoneState())).not.toThrow();
+    (graph)._maybeRunGC(createHighTombstoneState());
+
+    expect((graph)._patchesSinceGC).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- log caught auto-GC failures instead of silently swallowing them
- make the GC failure test prove the failure was caught and reported
- replace the no-logger no-crash assertion with a no-logger enabled-GC execution proof

Closes #267

## Validation

- `npm exec vitest run test/unit/domain/WarpGraph.autoGC.test.ts`
- `npm run typecheck:src`
- `npm run typecheck:test`
- pre-push IRONCLAD gates 0-7 passed with `WARP_QUICK_PUSH=1`
