### PR TITLE
Fix #599: wrap mock codec with structured codec

### DIFF
--- a/test/helpers/mockPorts.ts
+++ b/test/helpers/mockPorts.ts
@@ -7,6 +7,8 @@
  */
 import { vi, type Mock } from 'vitest';
 import WarpStream from '../../src/domain/stream/WarpStream.ts';
+import type CodecValue from '../../src/domain/types/codec/CodecValue.ts';
+import defaultCodec from '../../src/domain/utils/defaultCodec.ts';
 
 // ---------------------------------------------------------------------------
 // Mock Persistence (GraphPersistencePort surface)
@@ -87,14 +89,14 @@ export function createMockPersistence(overrides: Partial<MockPersistence> = {}):
 // ---------------------------------------------------------------------------
 
 export interface MockCodec {
-  encode: Mock;
-  decode: Mock;
+  encode: Mock<(value: CodecValue) => Uint8Array>;
+  decode: Mock<(bytes: Uint8Array) => CodecValue>;
 }
 
 export function createMockCodec(overrides: Partial<MockCodec> = {}): MockCodec {
   return {
-    encode: vi.fn((value: unknown) => new Uint8Array(JSON.stringify(value).split('').map(c => c.charCodeAt(0)))),
-    decode: vi.fn((bytes: Uint8Array) => JSON.parse(String.fromCharCode(...bytes))),
+    encode: vi.fn((value: CodecValue): Uint8Array => defaultCodec.encode(value)),
+    decode: vi.fn((bytes: Uint8Array): CodecValue => defaultCodec.decode(bytes)),
     ...overrides,
   };
 }
@@ -103,7 +105,7 @@ export function createMockCodec(overrides: Partial<MockCodec> = {}): MockCodec {
 export function createStubCodec(): MockCodec {
   return {
     encode: vi.fn(() => new Uint8Array([1])),
-    decode: vi.fn(() => ({})),
+    decode: vi.fn((_bytes: Uint8Array): CodecValue => ({})),
   };
 }
 

--- a/test/unit/helpers/mockPorts.test.ts
+++ b/test/unit/helpers/mockPorts.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, it } from 'vitest';
 
-import { createMockPersistence } from '../../helpers/mockPorts.ts';
+import type CodecValue from '../../../src/domain/types/codec/CodecValue.ts';
+import { createMockCodec, createMockPersistence } from '../../helpers/mockPorts.ts';
+
+type CodecRecord = { readonly [key: string]: CodecValue };
+
+function isCodecRecord(value: CodecValue): value is CodecRecord {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && !(value instanceof Uint8Array)
+    && !(value instanceof Date)
+  );
+}
+
+function bytesFromDecodedPayload(value: CodecValue): Uint8Array {
+  if (isCodecRecord(value)) {
+    const bytes = value['bytes'];
+    if (bytes instanceof Uint8Array) {
+      return bytes;
+    }
+  }
+  throw new Error('expected decoded payload bytes');
+}
 
 describe('mockPorts createMockPersistence', () => {
   it('rejects compareAndSwapRef when expected oid does not match current ref', async () => {
@@ -24,5 +47,19 @@ describe('mockPorts createMockPersistence', () => {
 
     expect(treeOids).toEqual({});
     expect(Array.isArray(treeOids)).toBe(false);
+  });
+});
+
+describe('mockPorts createMockCodec', () => {
+  it('wraps the structured codec boundary instead of JSON stringifying values', () => {
+    const codec = createMockCodec();
+    const payload = { bytes: new Uint8Array([1, 2, 3]) };
+
+    const encoded = codec.encode(payload);
+    const decodedBytes = bytesFromDecodedPayload(codec.decode(encoded));
+
+    expect(codec.encode).toHaveBeenCalledWith(payload);
+    expect(decodedBytes).toBeInstanceOf(Uint8Array);
+    expect([...decodedBytes]).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
Closes #599.

## Summary

- replaces the JSON stringify/parse mock codec with a spy wrapper around `defaultCodec`
- gives `MockCodec` a concrete `CodecValue` transport contract
- adds a regression proving `Uint8Array` survives the mock codec boundary

## Validation

- `npm exec vitest run test/unit/helpers/mockPorts.test.ts`
- `npm run typecheck:test`
- `npm run lint -- test/helpers/mockPorts.ts test/unit/helpers/mockPorts.test.ts`
- `git diff --check`
- `WARP_QUICK_PUSH=1 git push -u origin fix-599-mock-codec-real-boundary`
