### PR TITLE
Fix #316: prove runtime bridge closeout behavior

### DIFF
--- a/test/unit/scripts/openwarpruntime-bridge-closeout.test.ts
+++ b/test/unit/scripts/openwarpruntime-bridge-closeout.test.ts
@@ -1,15 +1,62 @@
-import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { openWarpGraphRuntime } from '../../../src/domain/warp/WarpGraphRuntimeBridge.ts';
+import { createInMemoryRepo } from '../../helpers/warpGraphTestUtils.ts';
 
-const bridgeSource = readFileSync(
-  fileURLToPath(new URL('../../../src/domain/warp/WarpGraphRuntimeBridge.ts', import.meta.url)),
-  'utf8',
+const bridgePath = fileURLToPath(
+  new URL('../../../src/domain/warp/WarpGraphRuntimeBridge.ts', import.meta.url),
 );
 
+function collectRetiredRuntimeReferences(sourcePath: string): string[] {
+  const sourceText = readFileSync(sourcePath, 'utf8');
+  const sourceFile = ts.createSourceFile(sourcePath, sourceText, ts.ScriptTarget.Latest, true);
+  const references: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const moduleSpecifier = node.moduleSpecifier.text;
+      if (moduleSpecifier === '../WarpRuntime.ts') {
+        references.push(`${sourcePath}: imports retired WarpRuntime module`);
+      }
+    }
+
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      if (node.expression.text === 'openWarpRuntime') {
+        references.push(`${sourcePath}: calls retired runtime opener`);
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return references;
+}
+
 describe('openWarpRuntime bridge closeout', () => {
-  it('keeps WarpGraphRuntimeBridge off WarpRuntime imports and openWarpRuntime calls', () => {
-    expect(bridgeSource).not.toContain("from '../WarpRuntime.ts'");
-    expect(bridgeSource).not.toContain('openWarpRuntime(');
+  it('keeps WarpGraphRuntimeBridge off retired WarpRuntime bridge wiring', () => {
+    expect(collectRetiredRuntimeReferences(bridgePath)).toEqual([]);
+  });
+
+  it('constructs the graph runtime bridge through the supported host product', async () => {
+    const repo = createInMemoryRepo();
+
+    try {
+      const runtime = await openWarpGraphRuntime({
+        persistence: repo.persistence,
+        graphName: 'bridge-closeout',
+        writerId: 'alice',
+      });
+
+      expect(runtime.graphName).toBe('bridge-closeout');
+      expect(runtime.writerId).toBe('alice');
+      expect(typeof runtime.hasNode).toBe('function');
+      expect(typeof runtime.createPatch).toBe('function');
+      expect(Object.isFrozen(runtime)).toBe(true);
+    } finally {
+      await repo.cleanup();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- replace brittle openWarpRuntime bridge source string checks with TypeScript AST import/call policy
- add an in-memory openWarpGraphRuntime construction witness through the supported host product
- keep the runtime surface frozen/structural behavior under test

## Validation
- npm exec vitest run test/unit/scripts/openwarpruntime-bridge-closeout.test.ts
- npm run typecheck:test
- npm run lint -- test/unit/scripts/openwarpruntime-bridge-closeout.test.ts
- git diff --check
- WARP_QUICK_PUSH=1 git push -u origin fix-316-runtime-bridge-policy

Closes #316