### PR TITLE
Fix #315: prove graph composition root posture

### DIFF
--- a/src/domain/WarpGraph.ts
+++ b/src/domain/WarpGraph.ts
@@ -169,38 +169,6 @@ export interface WarpGraphDeps {
 // Factory
 // ---------------------------------------------------------------------------
 
-/**
- * Opens a WARP multi-writer graph and returns a frozen capability bag.
- *
- * This remains the advanced composition root for the admission architecture.
- * Application workflows should prefer openWarpWorldline(), which opens the
- * named causal worldline and keeps materialization and graph-wide diagnostics
- * off the first-use surface.
- *
- * @deprecated For application workflows, use openWarpWorldline(). This
- * advanced capability bag remains supported for compatibility, tooling, and
- * substrate diagnostics.
- *
- * @example
- * ```ts
- * import { openWarpGraph } from '@git-stunts/git-warp';
- *
- * const graph = await openWarpGraph({
- *   persistence,
- *   graphName: 'events',
- *   writerId: 'node-1',
- *   trust: { mode: 'enforce' },
- * });
- *
- * // Commitment: create a patch
- * const patch = await graph.patches.createPatch();
- * patch.addNode('user:alice');
- * await patch.commit();
- *
- * // Revelation: read through the bounded query surface
- * const props = await graph.query.getNodeProps('user:alice');
- * ```
- */
 type SyncCapabilitySurface = Pick<
   SyncCapability,
   'getFrontier' |
@@ -373,6 +341,16 @@ function bindSubscriptionCapability(runtime: WarpGraphRuntimeSurface): Subscript
   });
 }
 
+/**
+ * Opens a WARP multi-writer graph compatibility capability bag.
+ *
+ * Application workflows should use openWarpWorldline(), which opens a named
+ * causal worldline and keeps reads on explicit worldline, coordinate, observer,
+ * or optic bases instead of graph-wide materialization.
+ *
+ * @deprecated For application workflows, use openWarpWorldline(). This advanced
+ * compatibility bag remains supported for tooling and substrate diagnostics.
+ */
 export async function openWarpGraph(deps: WarpGraphDeps): Promise<WarpGraph> {
   const runtime = await openWarpGraphRuntime(deps);
 

--- a/test/unit/scripts/openwarpgraph-composition-root.test.ts
+++ b/test/unit/scripts/openwarpgraph-composition-root.test.ts
@@ -1,61 +1,209 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
+import { openWarpGraph } from '../../../index.ts';
+import { createInMemoryRepo } from '../../helpers/warpGraphTestUtils.ts';
 
-const warpGraphBridgeSource = readFileSync(
-  fileURLToPath(new URL('../../../src/domain/warp/WarpGraphRuntimeBridge.ts', import.meta.url)),
-  'utf8',
-);
+type SourcePaths = {
+  readonly warpGraph: string;
+  readonly warpGraphBridge: string;
+  readonly warpCore: string;
+  readonly warpCoreProduct: string;
+  readonly runtimeHostProduct: string;
+  readonly runtimeHost: string;
+  readonly runtimeHostBoot: string;
+};
 
-const warpCoreSource = readFileSync(
-  fileURLToPath(new URL('../../../src/domain/WarpCore.ts', import.meta.url)),
-  'utf8',
-);
+const sourcePaths: SourcePaths = Object.freeze({
+  warpGraph: sourcePath('../../../src/domain/WarpGraph.ts'),
+  warpGraphBridge: sourcePath('../../../src/domain/warp/WarpGraphRuntimeBridge.ts'),
+  warpCore: sourcePath('../../../src/domain/WarpCore.ts'),
+  warpCoreProduct: sourcePath('../../../src/domain/warp/WarpCoreRuntimeProduct.ts'),
+  runtimeHostProduct: sourcePath('../../../src/domain/warp/RuntimeHostProduct.ts'),
+  runtimeHost: sourcePath('../../../src/domain/RuntimeHost.ts'),
+  runtimeHostBoot: sourcePath('../../../src/domain/warp/RuntimeHostBoot.ts'),
+});
 
-const warpCoreProductSource = readFileSync(
-  fileURLToPath(new URL('../../../src/domain/warp/WarpCoreRuntimeProduct.ts', import.meta.url)),
-  'utf8',
-);
+function sourcePath(relativeUrl: string): string {
+  return fileURLToPath(new URL(relativeUrl, import.meta.url));
+}
 
-const runtimeHostProductSource = readFileSync(
-  fileURLToPath(new URL('../../../src/domain/warp/RuntimeHostProduct.ts', import.meta.url)),
-  'utf8',
-);
+function parseSource(sourceFilePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    sourceFilePath,
+    readFileSync(sourceFilePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+}
 
-const runtimeHostSource = readFileSync(
-  fileURLToPath(new URL('../../../src/domain/RuntimeHost.ts', import.meta.url)),
-  'utf8',
-);
+function moduleImports(sourceFile: ts.SourceFile): Set<string> {
+  const modules = new Set<string>();
+  sourceFile.forEachChild((node) => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      modules.add(node.moduleSpecifier.text);
+    }
+  });
+  return modules;
+}
 
-const runtimeHostBootSource = readFileSync(
-  fileURLToPath(new URL('../../../src/domain/warp/RuntimeHostBoot.ts', import.meta.url)),
-  'utf8',
-);
+function hasIdentifierCall(sourceFile: ts.SourceFile, identifier: string): boolean {
+  let found = false;
 
-describe('openWarpGraph composition root', () => {
-  it('keeps the public graph bridge off direct WarpRuntime imports and static open calls', () => {
-    expect(warpGraphBridgeSource).not.toContain("import WarpRuntime");
-    expect(warpGraphBridgeSource).not.toContain("import type WarpRuntime");
-    expect(warpGraphBridgeSource).not.toContain('WarpRuntime.open(');
+  function visit(node: ts.Node): void {
+    if (found) {
+      return;
+    }
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+      found = node.expression.text === identifier;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
+function hasPropertyCall(sourceFile: ts.SourceFile, objectName: string, propertyName: string): boolean {
+  let found = false;
+
+  function visit(node: ts.Node): void {
+    if (found) {
+      return;
+    }
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const callTarget = node.expression;
+      found = ts.isIdentifier(callTarget.expression) &&
+        callTarget.expression.text === objectName &&
+        callTarget.name.text === propertyName;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return found;
+}
+
+function exportedFunctionNames(sourceFile: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+
+  sourceFile.forEachChild((node) => {
+    if (!ts.isFunctionDeclaration(node) || node.name === undefined) {
+      return;
+    }
+    const isExported = node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+    if (isExported) {
+      names.add(node.name.text);
+    }
   });
 
-  it('keeps WarpCore off the deleted runtime bridge and static open calls', () => {
-    expect(warpCoreSource).not.toContain('./warp/WarpCoreRuntimeBridge.ts');
-    expect(warpCoreSource).not.toContain('WarpRuntime.open(');
-    expect(warpCoreProductSource).not.toContain('WarpRuntime.open(');
+  return names;
+}
+
+function exportedFunction(sourceFile: ts.SourceFile, functionName: string): ts.FunctionDeclaration | null {
+  let match: ts.FunctionDeclaration | null = null;
+
+  sourceFile.forEachChild((node) => {
+    if (match !== null || !ts.isFunctionDeclaration(node) || node.name === undefined) {
+      return;
+    }
+    const isExported = node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+    if (isExported && node.name.text === functionName) {
+      match = node;
+    }
   });
 
-  it('routes source-side runtime product boot through the shared host seam', () => {
-    expect(warpGraphBridgeSource).not.toContain("from '../WarpRuntime.ts'");
-    expect(warpCoreProductSource).not.toContain("from '../WarpRuntime.ts'");
-    expect(runtimeHostProductSource).toContain("from '../RuntimeHost.ts'");
-    expect(runtimeHostProductSource).toContain('return await openRuntimeHost(options)');
+  return match;
+}
+
+function hasJSDocTag(node: ts.Node, tagName: string): boolean {
+  return ts.getJSDocTags(node).some((tag) => tag.tagName.text === tagName);
+}
+
+function collectCompositionRootViolations(): string[] {
+  const violations: string[] = [];
+  const warpGraph = parseSource(sourcePaths.warpGraph);
+  const graphBridge = parseSource(sourcePaths.warpGraphBridge);
+  const core = parseSource(sourcePaths.warpCore);
+  const coreProduct = parseSource(sourcePaths.warpCoreProduct);
+  const runtimeHostProduct = parseSource(sourcePaths.runtimeHostProduct);
+  const runtimeHost = parseSource(sourcePaths.runtimeHost);
+  const runtimeHostBoot = parseSource(sourcePaths.runtimeHostBoot);
+
+  if (moduleImports(graphBridge).has('../WarpRuntime.ts')) {
+    violations.push('WarpGraphRuntimeBridge imports the retired runtime class module');
+  }
+  if (hasPropertyCall(graphBridge, 'WarpRuntime', 'open')) {
+    violations.push('WarpGraphRuntimeBridge calls the retired runtime class opener');
+  }
+  if (moduleImports(core).has('./warp/WarpCoreRuntimeBridge.ts')) {
+    violations.push('WarpCore imports the deleted runtime bridge');
+  }
+  if (hasPropertyCall(core, 'WarpRuntime', 'open')) {
+    violations.push('WarpCore calls the retired runtime class opener');
+  }
+  if (moduleImports(coreProduct).has('../WarpRuntime.ts')) {
+    violations.push('WarpCoreRuntimeProduct imports the retired runtime class module');
+  }
+  if (hasPropertyCall(coreProduct, 'WarpRuntime', 'open')) {
+    violations.push('WarpCoreRuntimeProduct calls the retired runtime class opener');
+  }
+  if (!moduleImports(runtimeHostProduct).has('../RuntimeHost.ts')) {
+    violations.push('RuntimeHostProduct no longer imports the shared runtime host seam');
+  }
+  if (!hasIdentifierCall(runtimeHostProduct, 'openRuntimeHost')) {
+    violations.push('RuntimeHostProduct no longer opens through the shared runtime host seam');
+  }
+  if (!moduleImports(runtimeHost).has('./warp/RuntimeHostBoot.ts')) {
+    violations.push('RuntimeHost no longer imports the dedicated boot module');
+  }
+  if (!hasIdentifierCall(runtimeHost, 'resolveRuntimeHostConstructionOptions')) {
+    violations.push('RuntimeHost no longer delegates option resolution to the dedicated boot module');
+  }
+  if (!exportedFunctionNames(runtimeHostBoot).has('resolveRuntimeHostConstructionOptions')) {
+    violations.push('RuntimeHostBoot no longer exports the construction-option resolver');
+  }
+  const openWarpGraphDeclaration = exportedFunction(warpGraph, 'openWarpGraph');
+  if (openWarpGraphDeclaration === null || !hasJSDocTag(openWarpGraphDeclaration, 'deprecated')) {
+    violations.push('openWarpGraph is no longer documented as a deprecated compatibility surface');
+  }
+
+  return violations;
+}
+
+describe('openWarpGraph compatibility composition root', () => {
+  it('keeps the deprecated compatibility factory from exposing runtime or implicit reads', async () => {
+    const repo = createInMemoryRepo();
+
+    try {
+      const graph = await openWarpGraph({
+        persistence: repo.persistence,
+        graphName: 'compatibility-composition-root',
+        writerId: 'alice',
+      });
+
+      expect(graph.graphName).toBe('compatibility-composition-root');
+      expect(graph.writerId).toBe('alice');
+      expect(Object.isFrozen(graph)).toBe(true);
+      expect(Object.isFrozen(graph.commitment)).toBe(true);
+      expect(Object.isFrozen(graph.revelation)).toBe(true);
+      expect(graph.commitment.patches).toBe(graph.patches);
+      expect(graph.revelation.query).toBe(graph.query);
+      expect(Object.prototype.hasOwnProperty.call(graph, '_runtime')).toBe(false);
+      expect('_runtime' in graph).toBe(false);
+
+      await (await graph.patches.createPatch()).addNode('node:compatibility-composition-root').commit();
+
+      await expect(graph.query.hasNode('node:compatibility-composition-root')).rejects.toMatchObject({
+        code: 'E_NO_STATE',
+      });
+    } finally {
+      await repo.cleanup();
+    }
   });
 
-  it('routes boot orchestration through the dedicated runtime boot module', () => {
-    expect(runtimeHostSource).toContain("from './warp/RuntimeHostBoot.ts'");
-    expect(runtimeHostSource).toContain('resolveRuntimeHostConstructionOptions');
-    expect(runtimeHostSource).toContain('return await openRuntimeHost(options);');
-    expect(runtimeHostBootSource).toContain('export async function resolveRuntimeHostConstructionOptions(');
+  it('keeps source composition routed through the shared runtime host seam', () => {
+    expect(collectCompositionRootViolations()).toEqual([]);
   });
 });

--- a/test/unit/scripts/worldline-api-deprecation.test.ts
+++ b/test/unit/scripts/worldline-api-deprecation.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
@@ -8,12 +9,62 @@ function readRepoFile(relativePath: string): string {
   return readFileSync(`${repoRoot}${relativePath}`, 'utf8');
 }
 
+function parseRepoFile(relativePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    relativePath,
+    readRepoFile(relativePath),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+}
+
+function exportedFunction(sourceFile: ts.SourceFile, functionName: string): ts.FunctionDeclaration | null {
+  let match: ts.FunctionDeclaration | null = null;
+
+  sourceFile.forEachChild((node) => {
+    if (match !== null || !ts.isFunctionDeclaration(node) || node.name === undefined) {
+      return;
+    }
+    const exported = node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+    if (exported && node.name.text === functionName) {
+      match = node;
+    }
+  });
+
+  return match;
+}
+
+function jsDocTagComment(tag: ts.JSDocTag): string {
+  const comment = tag.comment;
+  if (typeof comment === 'string') {
+    return comment;
+  }
+  if (comment === undefined) {
+    return '';
+  }
+  return comment.map((part) => part.getText()).join('');
+}
+
+function deprecationTextForExportedFunction(relativePath: string, functionName: string): string {
+  const declaration = exportedFunction(parseRepoFile(relativePath), functionName);
+  if (declaration === null) {
+    return '';
+  }
+  const deprecatedTag = ts.getJSDocTags(declaration)
+    .find((tag) => tag.tagName.text === 'deprecated');
+  if (deprecatedTag === undefined) {
+    return '';
+  }
+  return jsDocTagComment(deprecatedTag);
+}
+
 describe('Worldline-first legacy API deprecation posture', () => {
   it('marks openWarpGraph as an advanced compatibility surface', () => {
-    const source = readRepoFile('src/domain/WarpGraph.ts');
+    const deprecation = deprecationTextForExportedFunction('src/domain/WarpGraph.ts', 'openWarpGraph');
 
-    expect(source).toContain('@deprecated For application workflows, use openWarpWorldline().');
-    expect(source).toContain('advanced capability bag remains supported');
+    expect(deprecation).toContain('For application workflows, use openWarpWorldline().');
+    expect(deprecation).toContain('compatibility bag remains supported');
+    expect(deprecation).toContain('tooling and substrate diagnostics');
   });
 
   it('marks WarpApp as a compatibility facade for graph-first migrations', () => {


### PR DESCRIPTION
## Summary
- replace brittle openWarpGraph composition-root source string checks with TypeScript AST policy checks
- prove the deprecated compatibility factory stays frozen, hides the internal runtime, and does not create an implicit live reading basis after writes
- move the openWarpGraph deprecation documentation onto the actual exported function and remove the stale read-after-write example

## Follow-up
- filed #613 to remove or hard-gate graph-wide materializing APIs from the v18 public surface

## Validation
- npm exec vitest run test/unit/scripts/openwarpgraph-composition-root.test.ts
- npm run typecheck:test
- npm run lint -- src/domain/WarpGraph.ts test/unit/scripts/openwarpgraph-composition-root.test.ts
- git diff --check
- WARP_QUICK_PUSH=1 git push -u origin fix-315-openwarpgraph-composition-behavior

Closes #315