### PR TITLE
Fix #321: prove aperture consumer contract

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -207,6 +207,7 @@ import SnapshotORSet from './src/domain/services/snapshot/SnapshotORSet.ts';
 import SnapshotVersionVector from './src/domain/services/snapshot/SnapshotVersionVector.ts';
 import SnapshotWarpState from './src/domain/services/snapshot/SnapshotWarpState.ts';
 import type { PropValue } from './src/domain/types/PropValue.ts';
+import type { Aperture, ObserverConfig } from './src/domain/types/Aperture.ts';
 import type { SnapshotPropValue } from './src/domain/services/snapshot/SnapshotPropValue.ts';
 import type { SyncRateLimitConfig } from './src/domain/services/sync/SyncRateLimiter.ts';
 import type {
@@ -478,6 +479,8 @@ export {
 };
 
 export type {
+  Aperture,
+  ObserverConfig,
   PropValue,
   SnapshotPropValue,
   SyncRateLimitConfig,

--- a/test/type-check/consumer.ts
+++ b/test/type-check/consumer.ts
@@ -125,6 +125,8 @@ import WarpAppDefault, {
   NoOpEffectSink,
   ConsoleEffectSink,
   ChunkEffectSink,
+  type Aperture,
+  type ObserverConfig,
   type PropValue,
   type SnapshotPropValue,
   type SyncRateLimitConfig,
@@ -336,6 +338,12 @@ const warpWorldline: WarpWorldline = await openWarpWorldline(worldlineOptions);
 const worldlinePatchBuild: WarpWorldlinePatchBuild = (patch) => {
   patch.addNode('worldline-node');
 };
+const publicUsersAperture: Aperture = {
+  match: 'user:*',
+  expose: ['name'],
+  redact: ['secret'],
+};
+const publicUsersObserverConfig: ObserverConfig = publicUsersAperture;
 const worldlinePatchSha: string = await warpWorldline.commit(worldlinePatchBuild);
 const worldlineOpticBasis: WarpWorldlineOpticBasis = await warpWorldline.prepareOpticBasis();
 const worldlineCoordinate: WarpWorldlineCoordinate = await warpWorldline.coordinate();
@@ -344,6 +352,8 @@ const worldlineHistorical: Worldline = await warpWorldline.seek({
   source: { kind: 'live', ceiling: 1 },
 });
 const worldlineObserver: Observer = await warpWorldline.observer({ match: '*' });
+const namedApertureObserver: Observer = await warpWorldline.observer('public-users', publicUsersAperture);
+const aliasApertureObserver: Observer = await warpWorldline.observer(publicUsersObserverConfig);
 const coordinateFrontierEntries: readonly WarpWorldlineCoordinateFrontierEntry[] =
   worldlineCoordinate.frontierEntries;
 const coordinateSource = worldlineCoordinate.source();
@@ -358,6 +368,8 @@ void coordinateOpticAlive;
 void worldlineLive;
 void worldlineHistorical;
 void worldlineObserver;
+void namedApertureObserver;
+void aliasApertureObserver;
 
 const materialized: SnapshotWarpState = await graph.materialize();
 const materializedWithReceipts: { state: SnapshotWarpState; receipts: readonly ReturnType<typeof createTickReceipt>[] } =

--- a/test/unit/scripts/public-api-aperture-noun.test.ts
+++ b/test/unit/scripts/public-api-aperture-noun.test.ts
@@ -1,37 +1,34 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import {
+  Observer,
+  computeTranslationCost,
+} from '../../../index.ts';
+import type {
+  Aperture,
+  ObserverConfig,
+} from '../../../index.ts';
 
-// repoRoot removed — unused after readDoc refactor
-
-function readDoc(relativePath: string): string {
-  return readFileSync(fileURLToPath(new URL(`../../../${relativePath}`, import.meta.url)), 'utf8');
+function acceptAperture(config: Aperture): ObserverConfig {
+  return config;
 }
 
-const barrel = readDoc('index.ts');
-const apertureSource = readDoc('src/domain/types/Aperture.ts');
-const readme = readDoc('README.md');
-const guide = readDoc('docs/GUIDE.md');
-
 describe('Aperture is a first-class public noun', () => {
-  it('exports Aperture and keeps ObserverConfig as a compatibility alias', () => {
-    expect(apertureSource).toContain('export interface Aperture {');
-    expect(apertureSource).toContain('export type ObserverConfig = Aperture;');
+  it('exports runtime observer surfaces used by Aperture consumers', () => {
+    expect(Observer).toBeDefined();
+    expect(typeof computeTranslationCost).toBe('function');
   });
 
-  it('re-exports observer and translationCost through the barrel with Aperture-typed signatures', () => {
-    expect(barrel).toContain('Observer,');
-    expect(barrel).toContain('computeTranslationCost,');
-  });
+  it('exports Aperture and keeps ObserverConfig assignable as a compatibility alias', () => {
+    const aperture = {
+      match: 'user:*',
+      expose: ['name'],
+      redact: ['secret'],
+    } satisfies Aperture;
 
-  it('teaches Aperture in the README glossary and observer example', () => {
-    expect(readme).toContain('| **Aperture** | The boundary that shapes what an observer can see. |');
-    expect(readme).toContain('| **Observer** | Filtered read-only projection through an aperture. |');
-  });
+    const observerConfig: ObserverConfig = acceptAperture(aperture);
 
-  it('uses Aperture language in the guide observer walkthrough', () => {
-    expect(guide).toContain('- An `Aperture` defines what is visible.');
-    expect(guide).toContain('const userAperture = {');
-    expect(guide).toContain("worldline.observer('public-users', userAperture)");
+    expect(observerConfig.match).toBe('user:*');
+    expect(observerConfig.expose).toEqual(['name']);
+    expect(observerConfig.redact).toEqual(['secret']);
   });
 });


### PR DESCRIPTION
## Summary
- export Aperture and the ObserverConfig compatibility alias from the package root
- replace README/guide source-text assertions with runtime import and type assignability proof
- extend the consumer compile-only test so WarpWorldline.observer accepts Aperture and ObserverConfig from the public package root

## Validation
- npm exec vitest run test/unit/scripts/public-api-aperture-noun.test.ts
- npm run typecheck:test
- npm run typecheck:consumer
- npm run lint -- test/unit/scripts/public-api-aperture-noun.test.ts
- npm run lint
- git diff --check
- WARP_QUICK_PUSH=1 git push -u origin fix-321-aperture-consumer-contract

Closes #321