### PR TITLE
Fix #323: prove public facade split

### DIFF
--- a/test/unit/scripts/public-api-facade-split.test.ts
+++ b/test/unit/scripts/public-api-facade-split.test.ts
@@ -1,36 +1,46 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import WarpAppDefault, {
+  InMemoryGraphAdapter,
+  WarpApp,
+  WarpCore,
+} from '../../../index.ts';
+import * as publicApi from '../../../index.ts';
 
-const barrel = readFileSync(
-  fileURLToPath(new URL('../../../index.ts', import.meta.url)),
-  'utf8',
-);
-
-const warpAppSource = readFileSync(
-  fileURLToPath(new URL('../../../src/domain/WarpApp.ts', import.meta.url)),
-  'utf8',
-);
+function openOptions(graphName: string, writerId: string): Parameters<typeof WarpCore.open>[0] {
+  return {
+    persistence: new InMemoryGraphAdapter(),
+    graphName,
+    writerId,
+  };
+}
 
 describe('public facade split', () => {
-  it('exports WarpApp as the default product-facing entrypoint', async () => {
-    const pkg = /** @type {{ default?: unknown; WarpApp?: unknown }} */ (await import('../../../index.ts'));
-    expect(pkg.default).toBe(pkg.WarpApp);
-    expect(barrel).toContain('export default WarpApp;');
+  it('exports WarpApp as the default compatibility facade without WarpRuntime', () => {
+    expect(WarpAppDefault).toBe(WarpApp);
+    expect(publicApi.WarpApp).toBe(WarpApp);
+    expect(publicApi.WarpCore).toBe(WarpCore);
+    expect(Object.prototype.hasOwnProperty.call(publicApi, 'WarpRuntime')).toBe(false);
   });
 
-  it('exposes WarpCore and does not export WarpRuntime anymore', async () => {
-    const pkg = /** @type {{ WarpCore?: unknown; WarpRuntime?: unknown }} */ (await import('../../../index.ts'));
-    expect(pkg.WarpCore).toBeDefined();
-    expect((pkg as any).WarpRuntime).toBeUndefined();
-    expect(barrel).not.toContain('WarpCore as WarpRuntime,');
+  it('opens WarpApp as a curated facade with an explicit WarpCore escape hatch', async () => {
+    const app = await WarpApp.open(openOptions('facade-app', 'writer-app'));
+
+    expect(app).toBeInstanceOf(WarpApp);
+    expect(app.graphName).toBe('facade-app');
+    expect(app.writerId).toBe('writer-app');
+    expect(app.core()).toBeInstanceOf(WarpCore);
+    expect('materialize' in app).toBe(false);
+    expect('getNodes' in app).toBe(false);
+    expect('query' in app).toBe(false);
   });
 
-  it('declares WarpApp as a curated surface with an explicit core escape hatch', () => {
-    expect(warpAppSource).toContain('export default class WarpApp {');
-    expect(warpAppSource).toMatch(/core\(\): WarpCore/);
-    expect(warpAppSource).not.toMatch(/\n\s+materialize\(/);
-    expect(warpAppSource).not.toMatch(/\n\s+getNodes\(\): Promise<string\[]>/);
-    expect(warpAppSource).not.toMatch(/\n\s+query\(\): QueryBuilder/);
+  it('opens WarpCore as the explicit compatibility escape hatch', async () => {
+    const core = await WarpCore.open(openOptions('facade-core', 'writer-core'));
+
+    expect(core).toBeInstanceOf(WarpCore);
+    expect(core.graphName).toBe('facade-core');
+    expect(core.writerId).toBe('writer-core');
+    expect(typeof core.createPatch).toBe('function');
+    expect(typeof core.materialize).toBe('function');
   });
 });


### PR DESCRIPTION
## Summary
- replace public facade source/doc string assertions with direct package runtime imports
- prove the default export is the WarpApp compatibility facade and WarpRuntime is absent from the package namespace
- open WarpApp and WarpCore through the public entrypoint and verify the facade/core split by behavior

## Validation
- npm exec vitest run test/unit/scripts/public-api-facade-split.test.ts
- npm run typecheck:test
- npm run lint -- test/unit/scripts/public-api-facade-split.test.ts
- git diff --check
- WARP_QUICK_PUSH=1 git push -u origin fix-323-public-facade-consumer-contract

Closes #323