### PR TITLE
Fix #283: structure backlog release-home checks

### DIFF
--- a/test/unit/scripts/backlog-debt-release-home.test.ts
+++ b/test/unit/scripts/backlog-debt-release-home.test.ts
@@ -16,7 +16,28 @@ const badCodePaths = readdirSync(`${repoRoot}${badCodeRoot}`)
   .filter((name) => name !== 'RELEASE_TRIAGE.md')
   .map((name) => `${badCodeRoot}${name}`);
 
-const expectedReleaseHomes = new Set(['v17.0.0', 'v18.0.0', 'v19.0.0', 'v20.0.0', 'v21.0.0']);
+const expectedReleaseHomes = new Set([
+  'v17.0.0',
+  'v18.0.0',
+  'v19.0.0',
+  'v20.0.0',
+  'v21.0.0',
+]);
+
+type ReleaseHomeCount = {
+  readonly releaseHome: string;
+  readonly count: number;
+};
+
+type MarkdownTable = {
+  readonly header: readonly string[];
+  readonly rows: readonly (readonly string[])[];
+};
+
+type MarkdownLink = {
+  readonly label: string;
+  readonly href: string;
+};
 
 function readFrontmatter(path: string): string {
   const text = readFileSync(`${repoRoot}${path}`, 'utf8');
@@ -36,7 +57,7 @@ function readScalar(frontmatter: string, key: string): string | null {
   return null;
 }
 
-function countReleaseHomes(): Map<string, number> {
+function countReleaseHomes(): readonly ReleaseHomeCount[] {
   const counts = new Map<string, number>();
 
   for (const path of badCodePaths) {
@@ -50,13 +71,137 @@ function countReleaseHomes(): Map<string, number> {
     counts.set(releaseHome, previousCount === undefined ? 1 : previousCount + 1);
   }
 
-  return counts;
+  return Array.from(counts.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([releaseHome, count]) => ({ releaseHome, count }));
+}
+
+function sectionLines(markdown: string, headingText: string): readonly string[] {
+  const lines = markdown.split('\n');
+  const headingIndex = lines.findIndex((line) => {
+    const match = /^(#{1,6}) (.+)$/u.exec(line);
+    return match?.[2] === headingText;
+  });
+  expect(headingIndex, `Missing heading ${headingText}`).toBeGreaterThanOrEqual(0);
+
+  const headingLine = lines[headingIndex];
+  if (headingLine === undefined) {
+    throw new Error(`Missing heading line for ${headingText}`);
+  }
+  const headingMatch = /^(#{1,6}) /u.exec(headingLine);
+  const headingMarker = headingMatch?.[1];
+  if (headingMarker === undefined) {
+    throw new Error(`Malformed heading line for ${headingText}`);
+  }
+
+  const section: string[] = [];
+  for (const line of lines.slice(headingIndex + 1)) {
+    const nextHeadingMatch = /^(#{1,6}) /u.exec(line);
+    const nextHeadingMarker = nextHeadingMatch?.[1];
+    if (nextHeadingMarker !== undefined && nextHeadingMarker.length <= headingMarker.length) {
+      break;
+    }
+    section.push(line);
+  }
+
+  return section;
+}
+
+function parseMarkdownTable(markdown: string, headingText: string): MarkdownTable {
+  const lines = sectionLines(markdown, headingText);
+  const tableStart = lines.findIndex((line) => line.trim().startsWith('|'));
+  expect(tableStart, `Missing table under ${headingText}`).toBeGreaterThanOrEqual(0);
+
+  const headerLine = lines[tableStart];
+  const separatorLine = lines[tableStart + 1];
+  if (headerLine === undefined || separatorLine === undefined) {
+    throw new Error(`Incomplete table under ${headingText}`);
+  }
+
+  const header = markdownTableCells(headerLine);
+  const separator = markdownTableCells(separatorLine);
+  expect(separator).toHaveLength(header.length);
+  expect(separator.every((cell) => /^-+:?$/u.test(cell))).toBe(true);
+
+  const rows: string[][] = [];
+  for (const line of lines.slice(tableStart + 2)) {
+    if (!line.trim().startsWith('|')) {
+      break;
+    }
+    const cells = markdownTableCells(line);
+    expect(cells).toHaveLength(header.length);
+    rows.push(cells);
+  }
+
+  return { header, rows };
+}
+
+function markdownTableCells(line: string): string[] {
+  const trimmed = line.trim();
+  expect(trimmed.startsWith('|')).toBe(true);
+  expect(trimmed.endsWith('|')).toBe(true);
+  return trimmed.slice(1, -1).split('|').map((cell) => cell.trim());
+}
+
+function releaseHomeCountsFromTable(table: MarkdownTable): readonly ReleaseHomeCount[] {
+  const releaseHomeColumn = table.header.indexOf('Release Home');
+  const countColumn = table.header.indexOf('Count');
+  expect(releaseHomeColumn).toBeGreaterThanOrEqual(0);
+  expect(countColumn).toBeGreaterThanOrEqual(0);
+
+  return table.rows
+    .map((row) => {
+      const releaseHomeCell = row[releaseHomeColumn];
+      const countCell = row[countColumn];
+      if (releaseHomeCell === undefined || countCell === undefined) {
+        throw new Error('Release-home table row is missing required cells');
+      }
+      return {
+        releaseHome: unquoteCodeCell(releaseHomeCell),
+        count: parseCountCell(countCell),
+      };
+    })
+    .sort((left, right) => left.releaseHome.localeCompare(right.releaseHome));
+}
+
+function unquoteCodeCell(cell: string): string {
+  const match = /^`([^`]+)`$/u.exec(cell);
+  if (match === null) {
+    return cell;
+  }
+  const value = match[1];
+  if (value === undefined) {
+    throw new Error(`Malformed code cell ${cell}`);
+  }
+  return value;
+}
+
+function parseCountCell(cell: string): number {
+  expect(cell).toMatch(/^\d+$/u);
+  const count = Number(cell);
+  expect(Number.isSafeInteger(count)).toBe(true);
+  return count;
+}
+
+function linksInSection(markdown: string, headingText: string): readonly MarkdownLink[] {
+  return sectionLines(markdown, headingText).flatMap((line) => {
+    const match = /^- \[([^\]]+)\]\(([^)]+)\)$/u.exec(line);
+    if (match === null) {
+      return [];
+    }
+    const label = match[1];
+    const href = match[2];
+    if (label === undefined || href === undefined) {
+      return [];
+    }
+    return [{ label, href }];
+  });
 }
 
 describe('bad-code release homes', () => {
   it('requires every bad-code note to declare release_home', () => {
     const missingReleaseHome = badCodePaths.filter(
-      (path) => !readFrontmatter(path).includes('\nrelease_home: ')
+      (path) => readScalar(readFrontmatter(path), 'release_home') === null,
     );
 
     expect(missingReleaseHome).toEqual([]);
@@ -82,24 +227,35 @@ describe('bad-code release homes', () => {
     expect(invalidReleaseHomes).toEqual([]);
   });
 
-  it('documents the debt release-home law in the backlog readmes', () => {
-    expect(backlogReadme).toContain('GitHub Issues are now the live Method work tracker');
-    expect(backlogReadme).toContain('bad-code lane');
+  it('publishes computed release-home counts as structured tables', () => {
+    const computedCounts = countReleaseHomes();
 
-    expect(badCodeReadme).toContain('## Release Homes');
-    expect(badCodeReadme).toContain('`bad-code/` remains the debt ledger');
-    expect(badCodeReleaseTriage).toContain('## Current Metadata Snapshot');
-    expect(badCodeReleaseTriage).toContain(
-      'There should be no remaining `release_home: v20.0.0+` values.'
-    );
+    expect(releaseHomeCountsFromTable(
+      parseMarkdownTable(badCodeReadme, 'Release Homes'),
+    )).toEqual(computedCounts);
+    expect(releaseHomeCountsFromTable(
+      parseMarkdownTable(badCodeReleaseTriage, 'Current Metadata Snapshot'),
+    )).toEqual(computedCounts);
+  });
 
-    for (const [releaseHome, count] of countReleaseHomes()) {
-      const countRow = `| \`${releaseHome}\` | ${count} |`;
-
-      expect(badCodeReadme).toContain(countRow);
-      expect(badCodeReleaseTriage).toContain(countRow);
-    }
-
-    expect(badCodeReadme).not.toContain('`v20.0.0+`');
+  it('points live backlog lane links at GitHub issue queries', () => {
+    expect(linksInSection(backlogReadme, 'Current Tracker')).toEqual([
+      {
+        label: 'all open issues',
+        href: 'https://github.com/git-stunts/git-warp/issues',
+      },
+      {
+        label: 'v18 lane',
+        href: 'https://github.com/git-stunts/git-warp/issues?q=is%3Aissue%20is%3Aopen%20label%3Alane%3Av18.0.0',
+      },
+      {
+        label: 'bad-code lane',
+        href: 'https://github.com/git-stunts/git-warp/issues?q=is%3Aissue%20is%3Aopen%20label%3Alane%3Abad-code',
+      },
+      {
+        label: 'inbox lane',
+        href: 'https://github.com/git-stunts/git-warp/issues?q=is%3Aissue%20is%3Aopen%20label%3Alane%3Ainbox',
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- replaces backlog release-home prose and literal row checks with structured Markdown table parsing
- computes archived bad-code release-home counts from frontmatter and compares table data
- validates live backlog tracker links as structured Markdown links

## Validation
- npm exec vitest run test/unit/scripts/backlog-debt-release-home.test.ts
- npm run typecheck:test
- npm run lint -- test/unit/scripts/backlog-debt-release-home.test.ts
- git diff --check
- WARP_QUICK_PUSH=1 git push -u origin fix-283-backlog-release-home-contract

Closes #283