### PR TITLE
Fix #286: prove BTR signing bytes ownership

### DIFF
--- a/test/conformance/btrSigningBytesOwnership.test.ts
+++ b/test/conformance/btrSigningBytesOwnership.test.ts
@@ -1,111 +1,160 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+import {
+  createBTR,
+  NodeCryptoAdapter,
+  ProvenancePayload,
+  verifyBTR,
+} from '../../index.ts';
+import BtrCodecAdapter from '../../src/infrastructure/adapters/BtrCodecAdapter.ts';
+import BtrSigningBytes from '../../src/domain/services/provenance/BtrSigningBytes.ts';
+import type BtrSigningEnvelope from '../../src/domain/services/provenance/BtrSigningEnvelope.ts';
+import CryptoPort from '../../src/ports/CryptoPort.ts';
+import { createEmptyState, createSamplePatches } from '../helpers/warpGraphTestUtils.ts';
 
-const DESIGN_PATH = 'docs/design/0098-btr-signing-bytes-layer-ownership.md';
-const GUIDE_PATH = 'docs/method/refactoring-guides/anti-sludge-refactoring-guide.md';
-const SLUDGE_MAP_PATH = 'policy/sludge/sludge-map.json';
+const key = 'btr-signing-bytes-ownership-test-key';
+const timestamp = '2026-04-14T00:00:00.000Z';
+const btrCodec = new BtrCodecAdapter();
+const crypto = new NodeCryptoAdapter();
 
-const BTR_SIGNING_BYTES = 'BtrSigningBytes';
+class CapturingCryptoPort extends CryptoPort {
+  readonly #delegate = new NodeCryptoAdapter();
+  readonly #hmacInputs: Uint8Array[] = [];
 
-type ProposedNoun = {
-  readonly name?: string;
-  readonly constructs?: string;
-  readonly consumes?: string;
-  readonly layer?: string;
-};
+  hmacInputs(): readonly Uint8Array[] {
+    return this.#hmacInputs.map((bytes) => new Uint8Array(bytes));
+  }
 
-type SludgeFinding = {
-  readonly proposed_nouns?: readonly ProposedNoun[];
-};
+  override async hash(algorithm: string, data: string | Uint8Array): Promise<string> {
+    return await this.#delegate.hash(algorithm, data);
+  }
 
-type SludgeFamily = {
-  readonly findings?: readonly SludgeFinding[];
-};
+  override async hmac(
+    algorithm: string,
+    hmacKey: string | Uint8Array,
+    data: string | Uint8Array,
+  ): Promise<Uint8Array> {
+    this.#hmacInputs.push(copyData(data));
+    return await this.#delegate.hmac(algorithm, hmacKey, data);
+  }
 
-type SludgeMap = {
-  readonly families?: readonly SludgeFamily[];
-};
-
-function readRepoFile(path: string): string {
-  return readFileSync(join(REPO_ROOT, path), 'utf8');
+  override timingSafeEqual(left: Uint8Array, right: Uint8Array): boolean {
+    return this.#delegate.timingSafeEqual(left, right);
+  }
 }
 
-function readSludgeMap(): SludgeMap {
-  return JSON.parse(readRepoFile(SLUDGE_MAP_PATH)) as SludgeMap;
-}
-
-function allProposedNouns(sludgeMap: SludgeMap): readonly ProposedNoun[] {
-  return (sludgeMap.families ?? [])
-    .flatMap((family) => family.findings ?? [])
-    .flatMap((finding) => finding.proposed_nouns ?? []);
-}
-
-function btrSigningBytesNouns(): readonly ProposedNoun[] {
-  return allProposedNouns(readSludgeMap())
-    .filter((noun) => noun.name === BTR_SIGNING_BYTES);
-}
-
-function normalized(value: string | undefined): string {
-  return value?.toLowerCase() ?? '';
-}
-
-describe('BTR signing-byte ownership doctrine', () => {
-  it('records the ownership decision in the 0098 design doc', () => {
-    const design = readRepoFile(DESIGN_PATH);
-
-    expect(design).toContain('`BtrSigningEnvelope` is owned by `domain`.');
-    expect(design).toContain('`BtrSigningBytes` is owned by `domain`.');
-    expect(design).toMatch(/`BoundaryTransitionRecordCodecPort` is a\s+port capability/);
-    expect(design).toContain('Canonical BTR signing encoding happens in the adapter implementing');
-    expect(design).toContain('The crypto/HMAC use-case consumes `BtrSigningBytes`.');
-    expect(design).toContain('Ports define capabilities');
-    expect(design).toContain('A port does not own the values that cross');
-  });
-
-  it('requires BtrSigningBytes to exist as a proposed sludge-map noun', () => {
-    expect(btrSigningBytesNouns().length).toBeGreaterThan(0);
-  });
-
-  it('requires BtrSigningBytes to be a domain value, not a ports noun', () => {
-    for (const noun of btrSigningBytesNouns()) {
-      expect(noun.layer).toBe('domain');
-      expect(noun.layer).not.toBe('ports');
-    }
-  });
-
-  it('requires the construction proof to name the codec port and adapter', () => {
-    for (const noun of btrSigningBytesNouns()) {
-      const constructs = normalized(noun.constructs);
-
-      expect(noun.constructs).toContain('BoundaryTransitionRecordCodecPort');
-      expect(constructs).toContain('adapter');
-    }
-  });
-
-  it('requires the consumption proof to name HMAC and CryptoPort', () => {
-    for (const noun of btrSigningBytesNouns()) {
-      const consumes = normalized(noun.consumes);
-
-      expect(consumes).toContain('hmac');
-      expect(noun.consumes).toContain('CryptoPort');
-    }
-  });
-
-  it('teaches that ports define capabilities but do not own returned values', () => {
-    const guide = readRepoFile(GUIDE_PATH);
-
-    expect(guide).toContain('Ports define capabilities; they do not own the values they return.');
-  });
-
-  it('guards against canonical-byte cosplay from arbitrary raw bytes', () => {
-    const design = readRepoFile(DESIGN_PATH);
-
-    expect(design).toContain(
-      'BtrSigningBytes must not be constructible from arbitrary raw bytes outside the canonical BTR signing encoder path.',
+class AlteredSigningBytesCodec extends BtrCodecAdapter {
+  override signingBytes(envelope: BtrSigningEnvelope): BtrSigningBytes {
+    return BtrSigningBytes.fromCanonicalBtrSigningEncoder(
+      appendZero(super.signingBytes(envelope).copyBytes()),
     );
+  }
+}
+
+function samplePayload(): ProvenancePayload {
+  const { patchA, patchB } = createSamplePatches();
+  return new ProvenancePayload([patchA, patchB]);
+}
+
+function copyData(data: string | Uint8Array): Uint8Array {
+  if (typeof data === 'string') {
+    return new TextEncoder().encode(data);
+  }
+  return new Uint8Array(data);
+}
+
+function appendZero(bytes: Uint8Array): Uint8Array {
+  const altered = new Uint8Array(bytes.byteLength + 1);
+  altered.set(bytes);
+  altered[bytes.byteLength] = 0;
+  return altered;
+}
+
+function firstByte(bytes: Uint8Array): number {
+  const byte = bytes[0];
+  if (byte === undefined) {
+    throw new Error('Expected non-empty signing bytes');
+  }
+  return byte;
+}
+
+function runtimeSigningBytesConstructor(): Function {
+  const sample = BtrSigningBytes.fromCanonicalBtrSigningEncoder(new Uint8Array([1]));
+  const prototype = Reflect.getPrototypeOf(sample);
+  if (prototype === null || typeof prototype.constructor !== 'function') {
+    throw new Error('Missing BtrSigningBytes runtime constructor');
+  }
+  return prototype.constructor;
+}
+
+describe('BTR signing-byte ownership behavior', () => {
+  it('returns runtime-backed BtrSigningBytes from the BTR codec port', async () => {
+    const record = await createBTR(createEmptyState(), samplePayload(), {
+      key,
+      timestamp,
+      crypto,
+      btrCodec,
+    });
+    const signingBytes = btrCodec.signingBytes(record.envelope);
+
+    expect(signingBytes).toBeInstanceOf(BtrSigningBytes);
+    expect(signingBytes.copyBytes().byteLength).toBeGreaterThan(0);
+  });
+
+  it('defensively copies canonical signing bytes', async () => {
+    const record = await createBTR(createEmptyState(), samplePayload(), {
+      key,
+      timestamp,
+      crypto,
+      btrCodec,
+    });
+    const signingBytes = btrCodec.signingBytes(record.envelope);
+    const exposed = signingBytes.copyBytes();
+    const originalFirstByte = firstByte(exposed);
+
+    exposed[0] = originalFirstByte ^ 0xff;
+
+    expect(firstByte(signingBytes.copyBytes())).toBe(originalFirstByte);
+  });
+
+  it('feeds the HMAC consumer with canonical BtrSigningBytes from the codec port', async () => {
+    const capturingCrypto = new CapturingCryptoPort();
+    const record = await createBTR(createEmptyState(), samplePayload(), {
+      key,
+      timestamp,
+      crypto: capturingCrypto,
+      btrCodec,
+    });
+    const hmacInputs = capturingCrypto.hmacInputs();
+    const hmacInput = hmacInputs[0];
+    if (hmacInput === undefined) {
+      throw new Error('Expected createBTR to call CryptoPort.hmac');
+    }
+
+    expect(hmacInputs).toHaveLength(1);
+    expect(hmacInput).toEqual(btrCodec.signingBytes(record.envelope).copyBytes());
+  });
+
+  it('rejects verification when the codec port returns different signing bytes', async () => {
+    const record = await createBTR(createEmptyState(), samplePayload(), {
+      key,
+      timestamp,
+      crypto,
+      btrCodec,
+    });
+    const verification = await verifyBTR(record, key, {
+      crypto,
+      btrCodec: new AlteredSigningBytesCodec(),
+    });
+
+    expect(verification.valid).toBe(false);
+    expect(verification.reason).toBe('Authentication tag mismatch');
+  });
+
+  it('rejects raw runtime construction outside the canonical encoder path', () => {
+    expect(() => Reflect.construct(
+      runtimeSigningBytesConstructor(),
+      [new Uint8Array([1]), Symbol('raw-signing-bytes')],
+    )).toThrow('BtrSigningBytes must be created by the canonical BTR signing encoder');
   });
 });


### PR DESCRIPTION
## Summary
- replaces BTR signing-byte doctrine/source/sludge-map text checks with runtime behavior
- proves BtrCodecAdapter returns runtime-backed BtrSigningBytes and defensive copies canonical bytes
- verifies HMAC input comes from codec-produced signing bytes, altered signing bytes fail verification, and raw runtime construction is rejected

## Validation
- npm exec vitest run test/conformance/btrSigningBytesOwnership.test.ts
- npm run typecheck:test
- npm run lint -- test/conformance/btrSigningBytesOwnership.test.ts
- git diff --check
- WARP_QUICK_PUSH=1 git push -u origin fix-286-btr-signing-bytes-contract

Closes #286