### PR TITLE
Fix hygiene fixture race

### DIFF
--- a/test/unit/scripts/type-import-hygiene-shape.test.ts
+++ b/test/unit/scripts/type-import-hygiene-shape.test.ts
@@ -1,35 +1,32 @@
-import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { ESLint } from 'eslint';
 import ts from 'typescript';
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
 
 const HYGIENE_CONSISTENT_TYPE_IMPORTS = '@typescript-eslint/consistent-type-imports';
 const HYGIENE_RESTRICT_TEMPLATE_EXPRESSIONS = '@typescript-eslint/restrict-template-expressions';
-const fixturePaths: string[] = [];
-
-afterEach(() => {
-  while (fixturePaths.length > 0) {
-    const fixturePath = fixturePaths.pop();
-    if (fixturePath !== undefined) {
-      rmSync(fixturePath, { force: true });
-    }
-  }
-});
+const SOURCE_TREE_HYGIENE_FIXTURES = Object.freeze([
+  'src/domain/type-import-hygiene-fixture.ts',
+  'src/domain/template-expression-hygiene-fixture.ts',
+]);
+const DOMAIN_LINT_TEXT_FILE = 'src/domain/errors/index.ts';
 
 function presentRuleId(ruleId: string | null): ruleId is string {
   return ruleId !== null;
 }
 
-async function lintRuleIds(relativePath: string, source: string): Promise<string[]> {
-  const fixturePath = `${repoRoot}${relativePath}`;
-  writeFileSync(fixturePath, source, 'utf8');
-  fixturePaths.push(fixturePath);
+function expectNoSourceTreeHygieneFixtures(): void {
+  for (const fixturePath of SOURCE_TREE_HYGIENE_FIXTURES) {
+    expect(existsSync(`${repoRoot}${fixturePath}`)).toBe(false);
+  }
+}
 
+async function lintRuleIds(relativePath: string, source: string): Promise<string[]> {
   const eslint = new ESLint({ cwd: repoRoot });
-  const [result] = await eslint.lintFiles([relativePath]);
+  const [result] = await eslint.lintText(source, { filePath: relativePath });
   if (!result) {
     return [];
   }
@@ -96,23 +93,24 @@ function arrayPropertyLength(manifestName: string, propertyName: string): number
 describe('type-import/template-expression hygiene posture', () => {
   it('rejects value imports that are only used as types through ESLint', async () => {
     const ruleIds = await lintRuleIds(
-      'src/domain/type-import-hygiene-fixture.ts',
+      DOMAIN_LINT_TEXT_FILE,
       [
-        "import WarpError from './errors/WarpError.ts';",
+        "import WarpError from './WarpError.ts';",
         '',
-        'type Box = { readonly error: WarpError | null };',
-        'const box: Box = { error: null };',
+        'type Box = { readonly error: WarpError };',
+        'declare const box: Box;',
         'void box;',
         '',
       ].join('\n'),
     );
 
     expect(ruleIds).toContain(HYGIENE_CONSISTENT_TYPE_IMPORTS);
+    expectNoSourceTreeHygieneFixtures();
   });
 
   it('rejects boolean template interpolation through ESLint', async () => {
     const ruleIds = await lintRuleIds(
-      'src/domain/template-expression-hygiene-fixture.ts',
+      DOMAIN_LINT_TEXT_FILE,
       [
         'const enabled = true;',
         'const message = `enabled: ${enabled}`;',
@@ -122,6 +120,7 @@ describe('type-import/template-expression hygiene posture', () => {
     );
 
     expect(ruleIds).toContain(HYGIENE_RESTRICT_TEMPLATE_EXPRESSIONS);
+    expectNoSourceTreeHygieneFixtures();
   });
 
   it('keeps the hygiene quarantine manifests active and empty', () => {


### PR DESCRIPTION
Closes #637.

## Summary

- Stop `type-import-hygiene-shape.test.ts` from writing transient fixtures under `src/domain`.
- Use `ESLint.lintText` with an existing domain source file as the TypeScript project-service anchor, preserving typed ESLint coverage without creating files matched by broad repo gates.
- Add regression assertions that the former source-tree hygiene fixture paths do not exist after the lint probes.

## Validation

- RED: `npm exec vitest run test/unit/scripts/type-import-hygiene-shape.test.ts` failed before the helper change because source-tree fixtures existed during the test.
- GREEN: `npm exec vitest run test/unit/scripts/type-import-hygiene-shape.test.ts`
- Concurrent proof: `npm run lint`, `npm run typecheck`, and `npm run test:local` run at the same time all passed.
- `git diff --check`
- Pre-push IRONCLAD M9 passed, including static gates and `npm run test:local` with 537 files / 7117 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored unit tests to improve reliability and maintainability through streamlined test execution methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->