### PR TITLE
Guard fresh live observer materialization

### DIFF
--- a/src/domain/services/controllers/QueryController.ts
+++ b/src/domain/services/controllers/QueryController.ts
@@ -55,7 +55,13 @@ type QueryObserverFactoryHost = {
   observer(name: string, config: ObserverConfig, options?: ObserverOptions): Promise<Observer>;
 };
 
-type MaterializableHost = QueryReadHost & QueryContentHost & QueryObserverFactoryHost & Pick<QueryCapability, 'hasNode' | 'getNodes' | 'getNodeProps' | 'getEdges'> & Partial<CheckpointTailOpticSource>;
+type LiveFrontierHost = {
+  _lastFrontier: Map<string, string> | null;
+  _stateDirty: boolean;
+  getFrontier(): Promise<Map<string, string>>;
+};
+
+type MaterializableHost = QueryReadHost & QueryContentHost & QueryObserverFactoryHost & Pick<QueryCapability, 'hasNode' | 'getNodes' | 'getNodeProps' | 'getEdges'> & Partial<CheckpointTailOpticSource> & Partial<LiveFrontierHost>;
 
 type QueryStateHasher = (state: WarpState) => Promise<string>;
 
@@ -78,6 +84,36 @@ async function snapshotCurrent(deps: QueryControllerDeps): Promise<QuerySnapshot
     throw new QueryError(E_NO_STATE_MSG, { code: 'E_NO_STATE' });
   }
   return { state: cloneState(state), stateHash: await deps.hashState(state) };
+}
+
+function hasLiveFrontierHost(graph: MaterializableHost): graph is MaterializableHost & LiveFrontierHost {
+  return graph._lastFrontier instanceof Map
+    && typeof graph._stateDirty === 'boolean'
+    && typeof graph.getFrontier === 'function';
+}
+
+function frontiersEqual(left: Map<string, string>, right: Map<string, string>): boolean {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const [writerId, tipSha] of left.entries()) {
+    if (right.get(writerId) !== tipSha) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function hasFreshCachedLiveSnapshot(deps: QueryControllerDeps): Promise<boolean> {
+  const graph = deps.hostGraph;
+  if (graph._cachedState === null || !hasLiveFrontierHost(graph) || graph._stateDirty) {
+    return false;
+  }
+  const lastFrontier = graph._lastFrontier;
+  if (lastFrontier === null) {
+    return false;
+  }
+  return frontiersEqual(await graph.getFrontier(), lastFrontier);
 }
 
 // ── Observer snapshot resolution ────────────────────────────────────
@@ -124,6 +160,9 @@ async function resolveLiveSnapshot(
   deps: QueryControllerDeps,
   source: LiveSelector,
 ): Promise<QuerySnapshot> {
+  if (source.ceiling === null && await hasFreshCachedLiveSnapshot(deps)) {
+    return await snapshotCurrent(deps);
+  }
   const detached = await openDetachedObserverGraph(deps);
   const materialized = await detached._materializeGraph({ ceiling: source.ceiling ?? null });
   return {

--- a/test/unit/domain/services/controllers/QueryController.test.ts
+++ b/test/unit/domain/services/controllers/QueryController.test.ts
@@ -103,9 +103,13 @@ function buildState(spec = {}) {
  * @returns {*}
  */
 function createHost(state, overrides = {}) {
+  const frontier = new Map([['w', 'tip']]);
   return {
     _cachedState: state,
     _autoMaterialize: true,
+    _lastFrontier: frontier,
+    _stateDirty: false,
+    getFrontier: vi.fn().mockResolvedValue(new Map(frontier)),
     _ensureFreshState: vi.fn().mockResolvedValue(undefined),
     _persistence: {
       readBlob: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
@@ -542,6 +546,46 @@ describe('QueryController', () => {
       const props = await observer.getNodeProps('alice');
 
       expect(host._materializeGraph).not.toHaveBeenCalled();
+      expect(props).toEqual({ age: 30, name: 'Alice' });
+    });
+
+    it('creates explicit live-source observers without detached full graph materialization', async () => {
+      host._materializeGraph = vi.fn().mockRejectedValue(new Error('live observer must not materialize'));
+
+      const observer = await ctrl.observer('people', { match: 'alice' }, { source: { kind: 'live' } });
+      const props = await observer.getNodeProps('alice');
+
+      expect(host.getFrontier).toHaveBeenCalled();
+      expect(host._materializeGraph).not.toHaveBeenCalled();
+      expect(props).toEqual({ age: 30, name: 'Alice' });
+    });
+
+    it('uses detached live materialization when the cached frontier is stale', async () => {
+      const detachedState = buildState({
+        nodes: ['alice'],
+        props: [
+          { nodeId: 'alice', key: 'name', value: 'Detached Alice' },
+        ],
+      });
+      host._lastFrontier = new Map([['w', 'old-tip']]);
+      host.getFrontier = vi.fn().mockResolvedValue(new Map([['w', 'new-tip']]));
+      host._materializeGraph = vi.fn().mockResolvedValue({ state: detachedState, stateHash: 'detached-state-hash' });
+
+      const observer = await ctrl.observer('people', { match: 'alice' }, { source: { kind: 'live' } });
+      const props = await observer.getNodeProps('alice');
+
+      expect(host.getFrontier).toHaveBeenCalled();
+      expect(host._materializeGraph).toHaveBeenCalledWith({ ceiling: null });
+      expect(props).toEqual({ name: 'Detached Alice' });
+    });
+
+    it('keeps ceiling-scoped live observers on the detached materialization path', async () => {
+      host._materializeGraph = vi.fn().mockResolvedValue({ state, stateHash: 'ceiling-hash' });
+
+      const observer = await ctrl.observer('people', { match: 'alice' }, { source: { kind: 'live', ceiling: 7 } });
+      const props = await observer.getNodeProps('alice');
+
+      expect(host._materializeGraph).toHaveBeenCalledWith({ ceiling: 7 });
       expect(props).toEqual({ age: 30, name: 'Alice' });
     });
   });


### PR DESCRIPTION
Refs #628

## Summary
- reuse cached live observer snapshots only when the host has a fresh cached live frontier
- preserve detached live materialization for stale caller caches and ceiling-scoped live observers
- add focused regressions for fresh, stale, and ceiling live-source observer paths

## Validation
- npm exec vitest run test/unit/domain/services/controllers/QueryController.test.ts -- -t "live-source observers|stale|ceiling-scoped live observers"
- npm exec vitest run test/unit/domain/WarpGraph.worldline.test.ts test/unit/domain/WarpGraph.observerBoundary.test.ts
- npm exec vitest run test/unit/domain/services/controllers/QueryController.test.ts test/unit/domain/services/Observer.test.ts test/unit/domain/WarpWorldline.test.ts test/unit/domain/WarpGraph.worldline.test.ts test/unit/domain/WarpGraph.observerBoundary.test.ts
- npm run lint
- npm run typecheck
- npm run test:local
- git push pre-push firewall: link check, lint, markdown gates, source/test/consumer/surface typechecks, policy check, unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced live snapshot caching to efficiently return fresh cached snapshots without unnecessary graph materialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->