### PR TITLE
Close materialization boundary proof

### DIFF
--- a/test/conformance/fixtures/V17MaterializationFallbackTrap.ts
+++ b/test/conformance/fixtures/V17MaterializationFallbackTrap.ts
@@ -2,16 +2,41 @@ import { expect, vi } from 'vitest';
 import type { OpticFixtureGraph } from './V17CheckpointTailOpticGraphFixture.ts';
 import V17CheckpointTailOpticFixtureError from './V17CheckpointTailOpticFixtureError.ts';
 
+type ForbiddenMaterializationMethodName =
+  | 'materialize'
+  | '_materializeGraph'
+  | 'getNodes'
+  | 'getEdges';
+
+type ForbiddenMaterializationSpy = {
+  readonly methodName: ForbiddenMaterializationMethodName;
+  readonly spy: ReturnType<typeof vi.spyOn>;
+};
+
+const FORBIDDEN_MATERIALIZATION_METHODS: readonly ForbiddenMaterializationMethodName[] = Object.freeze([
+  'materialize',
+  '_materializeGraph',
+  'getNodes',
+  'getEdges',
+]);
+
 export default class V17MaterializationFallbackTrap {
-  private readonly materializeGraph: ReturnType<typeof vi.spyOn>;
+  private readonly forbiddenSpies: readonly ForbiddenMaterializationSpy[];
 
   constructor(graph: OpticFixtureGraph, message: string) {
-    this.materializeGraph = vi.spyOn(graph, '_materializeGraph');
-    this.materializeGraph.mockRejectedValue(new V17CheckpointTailOpticFixtureError(message));
+    this.forbiddenSpies = Object.freeze(
+      FORBIDDEN_MATERIALIZATION_METHODS.map((methodName) => {
+        const spy = vi.spyOn(graph, methodName);
+        spy.mockRejectedValue(new V17CheckpointTailOpticFixtureError(`${message}: ${methodName}`));
+        return Object.freeze({ methodName, spy });
+      }),
+    );
     Object.freeze(this);
   }
 
   expectUnused(): void {
-    expect(this.materializeGraph).not.toHaveBeenCalled();
+    for (const forbiddenSpy of this.forbiddenSpies) {
+      expect(forbiddenSpy.spy, forbiddenSpy.methodName).not.toHaveBeenCalled();
+    }
   }
 }

--- a/test/conformance/queryReadModelSeam.test.ts
+++ b/test/conformance/queryReadModelSeam.test.ts
@@ -130,16 +130,18 @@ describe('query read model seam', () => {
     const queryBuilderSource = readRepoFile(QUERY_BUILDER_PATH);
     const observerSource = readRepoFile(OBSERVER_PATH);
     const queryControllerSource = readRepoFile(QUERY_CONTROLLER_PATH);
-    const querySeamSource = [
+    const queryModelConstructionSource = [
       queryRunnerSource,
       queryBuilderSource,
-      observerSource,
       queryControllerSource,
     ].join('\n');
 
     for (const pattern of FULL_GRAPH_QUERY_MODEL_PATTERNS) {
-      expect(querySeamSource).not.toMatch(pattern);
+      expect(queryModelConstructionSource).not.toMatch(pattern);
     }
+
+    expect(observerSource).toContain('QueryReadModelProvider');
+    expect(observerSource).toContain('openQueryReadModel');
   });
 
   it('requires a streaming or cursor-shaped query read model contract', () => {


### PR DESCRIPTION
Refs #628

## Summary
- expand the materialization fallback trap used by checkpoint-tail optic conformance tests to reject `materialize()`, `_materializeGraph()`, `getNodes()`, and `getEdges()`
- keep the query read-model seam guard focused on provider construction while preserving explicit Observer read-model contract assertions

## Deterministic evidence
- Canonical fixture: `test/conformance/fixtures/V17MaterializationFallbackTrap.ts`
- Behavior witness: `test/conformance/v17CheckpointTailOpticReadBasis.test.ts`
- Source-shape witness: `test/conformance/queryReadModelSeam.test.ts`

## Validation
- `npm exec vitest run test/conformance/v17CheckpointTailOpticReadBasis.test.ts`
- `npm exec vitest run test/conformance/v17CheckpointTailOpticReadBasis.test.ts test/conformance/v18FirstUseOpticsHonesty.test.ts test/conformance/queryReadModelSeam.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet test/conformance/fixtures/V17MaterializationFallbackTrap.ts test/conformance/queryReadModelSeam.test.ts`
- `bash scripts/check-anti-sludge.sh test/conformance/fixtures/V17MaterializationFallbackTrap.ts test/conformance/queryReadModelSeam.test.ts`
- `npm run test:local`
- pre-push firewall: link check, lint, markdown gates, source/test/consumer/surface typechecks, policy check, unit tests

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] This PR does not touch persisted op formats; no ADR 3 readiness issue is required
- [x] This PR does not touch wire compatibility; canonical-only wire-op rejection is unchanged
- [x] This PR does not touch schema constants; patch and checkpoint namespaces are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced conformance test infrastructure to validate a broader range of materialization-related methods, improving test coverage and validation accuracy.
  * Refined query read model conformance testing to provide more granular assertions on query pattern validation.

<!-- end of auto-generated comment -->
