### PR TITLE
Docs: lock runtime truth standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ DTO and stop there**. Do not hallucinate fake domain models.
   boundary reader modules. Core behavior branches on validated domain
   objects, not raw decoded shapes.
 - Prefer `instanceof` dispatch over tag switching.
-- No `any`. No `unknown` outside parser functions. No `as` assertions. No `enum`.
+- No `any`. No `unknown` outside adapters. No `as` assertions. No `enum`.
 - `interface` is for ports only. Domain concepts are classes.
 - No boolean trap parameters. Use named option objects or separate methods.
 - No magic strings or numbers when a named constant should exist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@ The policy is binding:
 - **Decisions:** [`docs/ANTI_SLUDGE_DECISIONS.md`](docs/ANTI_SLUDGE_DECISIONS.md)
 - **Foundations:** [`docs/SYSTEMS_STYLE_TYPESCRIPT.md`](docs/SYSTEMS_STYLE_TYPESCRIPT.md)
 
+Rule 0 is binding: **Runtime Truth Wins**. If runtime behavior, types,
+tests, and docs disagree, fix the runtime model first and then update the
+evidence. Type annotations and docs support runtime truth; they do not
+override it.
+
 ### Automatic rejection list
 
 A patch must be rejected on sight if it introduces any of the
@@ -63,6 +68,9 @@ Generate only:
   constructors, `Object.freeze`, `instanceof` dispatch)
 - runtime-honest TypeScript (types document reality; parsers gate
   untrusted input)
+- constructor-injected ports for external capabilities
+- domain object construction in core only when it establishes validated
+  runtime truth
 - boring adapters and sharp core logic
 - discriminated unions and explicit result types instead of
   boolean-flag bags
@@ -73,6 +81,8 @@ Do **not** generate:
 - clever sludge
 - "good enough" sludge
 - compile-time theater
+- construction of infrastructure adapters, host APIs, persistence
+  implementations, wall clocks, or entropy sources inside core
 - puddle-assembly object construction (`thing.a = ...; if (...) thing.b = ...`)
 - `utils.ts`, `helpers.ts`, `misc.ts`, `common.ts` — name the concept
 
@@ -146,6 +156,12 @@ DTO and stop there**. Do not hallucinate fake domain models.
 - Prefer one file per class, type, or object. If a file accumulates peer concepts, split it.
 - Runtime truth wins. If something has invariants, identity, or behavior, it should exist as a runtime-backed type.
 - Validate at boundaries and constructors. Constructors establish invariants and do no I/O.
+- Dependency injection is mandatory for external capabilities. Core may
+  construct domain objects, but not adapters, host services, persistence
+  implementations, wall clocks, or entropy sources.
+- Encoding and decoding stay in adapters, codec ports, or explicitly named
+  boundary reader modules. Core behavior branches on validated domain
+  objects, not raw decoded shapes.
 - Prefer `instanceof` dispatch over tag switching.
 - No `any`. No `unknown` outside parser functions. No `as` assertions. No `enum`.
 - `interface` is for ports only. Domain concepts are classes.

--- a/docs/ANTI_SLUDGE_DECISIONS.md
+++ b/docs/ANTI_SLUDGE_DECISIONS.md
@@ -28,7 +28,7 @@ caps, missing raw-Error discipline).
 This document records the binding decisions for how we adopt the
 bundle's enforcement and how we repay the pre-existing contamination.
 
-## 2. The five binding decisions
+## 2. The six binding decisions
 
 ### Decision 1 — Hot adoption, not ratchet
 
@@ -119,6 +119,32 @@ then boundary leakage (root cause of most casts), then fake naming
 (decorative symptoms), then wall tightening (structural fix that
 stabilizes the above).
 
+### Decision 6 — Runtime truth standard, adapted for git-warp
+
+Adopt the Runtime Truth standard as binding doctrine for git-warp,
+with these repository-specific interpretations:
+
+- Runtime behavior is the source of authority. Types, tests, docs,
+  schemas, and generated artifacts are evidence about runtime truth.
+- Hexagonal architecture remains mandatory.
+- Dependency injection is mandatory for external capabilities.
+- Core may construct domain objects. Core must not construct concrete
+  infrastructure, host, persistence, wall-clock, entropy, or adapter
+  implementations.
+- Encoding and decoding stay in adapters, codec ports, or explicitly named
+  boundary reader modules.
+- Decoded transport values must be validated into runtime-backed domain
+  objects before behavioral domain logic branches on them.
+- `unknown` remains boundary-only rather than globally impossible because
+  parser and adapter code need a way to name untrusted input before
+  validation.
+- Current complexity limits stay stricter than the reference standard:
+  complexity 5, depth 3, 30 lines per function, and 3 parameters unless a
+  documented carve-out applies.
+
+This decision adopts the standard's substance without weakening git-warp's
+existing stricter gates.
+
 ## 3. Rules added from the bundle
 
 | Rule | Enforcement | Source |
@@ -183,5 +209,6 @@ stabilizes the above).
 
 | Date | Change |
 |---|---|
-| 2026-04-16 | Initial adoption. Decisions 1–5 locked. |
+| 2026-04-16 | Initial adoption. Decisions 1-5 locked. |
 | 2026-04-23 | Activated `consistent-type-imports` and `restrict-template-expressions` as quarantine-backed hygiene rules. |
+| 2026-06-06 | Locked Runtime Truth standard into SSTS and anti-sludge policy as Decision 6. |

--- a/docs/ANTI_SLUDGE_DECISIONS.md
+++ b/docs/ANTI_SLUDGE_DECISIONS.md
@@ -135,8 +135,8 @@ with these repository-specific interpretations:
   boundary reader modules.
 - Decoded transport values must be validated into runtime-backed domain
   objects before behavioral domain logic branches on them.
-- `unknown` remains boundary-only rather than globally impossible because
-  parser and adapter code need a way to name untrusted input before
+- `unknown` remains adapter-boundary-only rather than globally impossible
+  because adapter parser code needs a way to name untrusted input before
   validation.
 - Current complexity limits stay stricter than the reference standard:
   complexity 5, depth 3, 30 lines per function, and 3 parameters unless a

--- a/docs/ANTI_SLUDGE_POLICY.md
+++ b/docs/ANTI_SLUDGE_POLICY.md
@@ -24,6 +24,11 @@ to express **real domain concepts**, **explicit boundaries**, and
 
 If the code compiles but violates this policy, the code is wrong.
 
+Runtime truth is the source of authority. When runtime behavior,
+types, tests, and docs disagree, repair the runtime model first.
+Type annotations, schemas, generated declarations, tests, and docs are
+evidence about the runtime. They do not outrank it.
+
 Cycle 0023 made the cost of shape-trust legible: we introduced an
 abstract class (`ORSetLike`) with exactly one implementation, named
 after a vague shape. It violated SSTS and was reverted within one
@@ -59,6 +64,27 @@ Dependencies point inward only.
 - `domain` and `ports` must **never** import from `infrastructure`.
 - `domain` and `ports` must **never** import Node platform APIs or
   framework libraries.
+
+### Dependency injection rule
+
+External capabilities enter core through constructors or explicit method
+parameters. Core must not reach sideways for globals, service locators,
+singletons, ambient process state, host APIs, or concrete adapter instances.
+
+This does not ban constructing domain objects in core. Domain code may create
+runtime-backed values, entities, outcomes, errors, cursors, coordinates, CRDT
+records, and other domain model objects. Those constructions establish
+runtime truth.
+
+The ban is on constructing concrete host capabilities in core:
+
+- infrastructure adapters
+- filesystem, network, process, or environment implementations
+- wall-clock or entropy sources
+- persistence implementations
+- codecs with host-specific side effects
+
+Those are ports. Core receives the port; adapters implement it.
 
 ### External effects belong in adapters
 
@@ -217,6 +243,10 @@ This is a hard rule.
 - operate only on already-decoded values
 - never parse raw transport data
 - never inspect ad-hoc object shapes from external systems
+- construct validated runtime-backed domain objects
+- use named boundary reader modules only when the module is explicitly
+  responsible for turning serialized checkpoint or index data into domain
+  values
 
 There must be a visible place where the raw world becomes the
 typed world. No invisible shape drift. No inline property poking
@@ -396,6 +426,8 @@ TypeScript does not validate runtime data. Therefore:
 - External data must be decoded at runtime.
 - Internal logic must assume decoded inputs.
 - Compile-time types must correspond to actual runtime guarantees.
+- If runtime behavior contradicts a type, the type is wrong.
+- If a document contradicts runtime behavior, the document is wrong.
 
 A cast is not validation. It is a costume.
 
@@ -403,7 +435,9 @@ A cast is not validation. It is a costume.
 
 ## 13. Preferred patterns
 
-- pure domain functions
+- runtime-backed domain classes with constructor validation
+- pure domain functions where the concept truly has no identity,
+  invariant, or behavior
 - explicit ports and adapters
 - discriminated unions and sealed class hierarchies
 - exact named types (SSTS P1: runtime-backed forms)

--- a/docs/SYSTEMS_STYLE_TYPESCRIPT.md
+++ b/docs/SYSTEMS_STYLE_TYPESCRIPT.md
@@ -16,6 +16,11 @@ Trusted domain values must be created through runtime construction, parsing, or 
 
 This rule outranks type annotations, build steps, editor hints, compile-time tooling, team folklore, and "but the compiler said it was fine."
 
+Rule 0 is not inspirational prose. It is a merge standard. If runtime
+behavior, tests, types, and docs disagree, fix the runtime model first and
+then repair the witnesses around it. Types, tests, and docs are supporting
+evidence. They are not the source of truth.
+
 ### What This Means in Practice
 
 Infrastructure cannot afford fake contracts:
@@ -155,9 +160,48 @@ class NodeFsStorageAdapter implements StoragePort {
 }
 ```
 
+#### Dependency Injection Is Mandatory
+
+Core dependencies enter through constructors or explicit method parameters.
+No domain object may reach sideways for a global service, singleton,
+service locator, ambient process state, host API, or concrete adapter.
+
+This rule does **not** ban `new` in core. Core may construct domain value
+objects, entities, outcomes, errors, cursors, coordinates, CRDT records, and
+other runtime model objects. That is how runtime truth is established.
+
+What core may not construct is a concrete host capability:
+
+- no infrastructure adapters
+- no filesystem, network, process, or environment implementation
+- no ambient clock or entropy source
+- no concrete persistence implementation
+- no codec with host side effects
+
+Those capabilities are ports. Adapters implement the ports. Core receives the
+ports and owns only the domain behavior.
+
+#### Encoding and Decoding Stay at Boundaries
+
+Serialization, deserialization, and codec work happen in adapters, codec
+ports, or named boundary reader modules. After decoding, values must be
+validated and converted into runtime-backed domain objects before behavioral
+domain logic branches on them.
+
+Decoded DTOs may cross a boundary only as transport shapes. They do not get to
+masquerade as domain concepts. A parser or boundary reader has one job: turn
+untrusted bytes and shapes into validated runtime values, or fail with a typed
+error.
+
 ### The Object Model
 
 Systems-style TypeScript organizes code around four categories of **runtime-backed** objects:
+
+Prefer classes with constructors for domain concepts. The lighter
+`Interface + Factory + Brand` pattern is discouraged for domain modeling
+because it leaves too much trust in erased structural types. It is allowed
+only for pure transport DTOs, deliberately hot-path primitives, or cases where
+structural typing is itself the intended contract.
 
 **Value Objects** — Meaningful domain values with invariants
 
@@ -418,11 +462,16 @@ Most bad TypeScript infrastructure stems from weak modeling. The discipline is:
 
 Before merging, ask:
 
+- What is actually true at runtime, and which runtime object proves it?
+- Does this follow hexagonal architecture?
+- Are concrete dependencies injected rather than constructed in core?
+- Is encoding or decoding restricted to adapters, codec ports, or named
+  boundary readers?
 - Is this a real domain concept? Where is its runtime-backed class?
 - Are there any `any`, `unknown`, or `as` in the diff?
 - Does construction establish trust?
 - Does behavior live on the type that owns it?
-- Is anyone parsing `err.message` like a raccoon in a dumpster?
+- Is anyone parsing `err.message` instead of branching on typed errors?
 - Are there magic numbers or strings?
 - Could this logic run in a browser?
 - Is there an `interface` that should be a `class`?

--- a/docs/SYSTEMS_STYLE_TYPESCRIPT.md
+++ b/docs/SYSTEMS_STYLE_TYPESCRIPT.md
@@ -75,12 +75,12 @@ Every type annotation must reflect a runtime reality. If a class validates its c
 
 **No `any`. Ever.** Not in source, not in tests, not in type assertions, not hidden behind generics. `any` is a hole in the type system that propagates silently. It is banned without exception.
 
-**No `unknown` outside boundary parser implementations.** At raw system
-boundaries (JSON.parse, external APIs, wire protocols), untrusted data enters
-through a **parser** that produces a concrete type or fails with a typed error.
-The parser is the boundary. `unknown` is allowed only long enough for an
-adapter, parser, or explicitly named boundary reader to prove the concrete
-transport or domain type. It never reaches core behavior or public APIs.
+**No `unknown` outside adapter-owned boundary parser implementations.** At raw
+system boundaries (JSON.parse, external APIs, wire protocols), untrusted data
+enters through an adapter parser that produces a concrete type or fails with a
+typed error. The parser is the boundary. `unknown` is allowed only long enough
+for adapter-local parser code to prove the concrete transport or domain type.
+It never reaches core behavior, named boundary readers, or public APIs.
 
 ```typescript
 // The boundary parser. This is the ONLY place raw data is touched.
@@ -366,24 +366,17 @@ The runtime model is the source. TypeScript types reflect it. Tests prove it. Do
 **P7: Runtime Dispatch Over Tag Switching**
 Inside a coherent runtime, `instanceof` is the correct dispatch mechanism.
 
-**Cross-realm note:** `instanceof` breaks across realm boundaries (iframes, web workers, multiple module instances). When values cross realms, use branding:
-
-```typescript
-class EventId {
-  static readonly brand = Symbol.for('flyingrobots.EventId');
-  get [EventId.brand](): true { return true; }
-  static is(v: unknown): v is EventId {
-    return v != null && (v as Record<symbol, unknown>)[EventId.brand] === true;
-  }
-}
-```
+**Cross-realm note:** `instanceof` breaks across realm boundaries (iframes,
+web workers, multiple module instances). When values cross realms, normalize
+them at an adapter or boundary reader and construct validated domain objects in
+the current realm before core logic uses them.
 
 ### Practices
 
 These are concrete coding disciplines. Most are linter-enforceable. Violations should fail CI.
 
 - **`any` is banished.** No exceptions. No `as any`. No generic defaults to `any`. No `Function` type. If you cannot type it, you haven't understood it yet.
-- **`unknown` is banished.** Raw data enters through parsers that return concrete types or throw. The parser is the boundary, not the call site.
+- **`unknown` is adapter-boundary-only.** Adapter parsers may use it as a temporary name for raw input. They must return concrete types or typed failures. It does not cross into core.
 - **`as` is banished.** Type assertions bypass the compiler. Use runtime guards, discriminated classes, or parser functions instead. The compiler should follow your runtime logic, not be overridden by your wishes.
 - **`interface` is for ports only.** Ports (abstract contracts between layers) use `interface`. Domain concepts use `class`. If it has invariants, identity, or behavior, it is a class.
 - **Trusted values must preserve integrity** — Use `Object.freeze()`, `readonly`, or `private` fields to protect invariants after construction.
@@ -403,17 +396,13 @@ await replayer.replaySegment(segment, policy);
 - **Magic numbers and strings are banished** — Give semantic numbers a named constant.
 - **Boolean trap parameters are banished** — Use named parameter objects or separate methods.
 - **One thing per file.** "Where is Foo?" → open `Foo.ts` → find Foo. Done. Every class, every domain type, every meaningful export lives in a file named after it. Re-export shims that forward from a monolith are not splits — they are lies about where code lives. If the file is named after the class, the class definition must be in that file.
-- **No `enum`.** TypeScript enums are runtime objects with surprising behavior. Use `as const` objects or class hierarchies.
+- **No `enum`.** TypeScript enums are runtime objects with surprising behavior. Use runtime token classes or class hierarchies.
 
 ```typescript
 // WRONG — TypeScript enum (reverse mapping, numeric default, surprising equality)
 enum OpType { NodeAdd, NodeRemove }
 
-// RIGHT — const object
-const OP_TYPE = { NODE_ADD: 'NodeAdd', NODE_REMOVE: 'NodeRemove' } as const;
-type OpType = typeof OP_TYPE[keyof typeof OP_TYPE];
-
-// BEST — class hierarchy (when behavior differs per variant)
+// RIGHT — class hierarchy
 abstract class Op { abstract apply(state: State): State; }
 class NodeAdd extends Op { /* ... */ }
 class NodeRemove extends Op { /* ... */ }

--- a/docs/SYSTEMS_STYLE_TYPESCRIPT.md
+++ b/docs/SYSTEMS_STYLE_TYPESCRIPT.md
@@ -75,7 +75,12 @@ Every type annotation must reflect a runtime reality. If a class validates its c
 
 **No `any`. Ever.** Not in source, not in tests, not in type assertions, not hidden behind generics. `any` is a hole in the type system that propagates silently. It is banned without exception.
 
-**No `unknown`.** Not as a parameter type, not as a return type, not as a field type. At raw system boundaries (JSON.parse, external APIs, wire protocols), untrusted data enters through a **parser** that produces a concrete type or throws. The parser is the boundary. `unknown` never escapes it.
+**No `unknown` outside boundary parser implementations.** At raw system
+boundaries (JSON.parse, external APIs, wire protocols), untrusted data enters
+through a **parser** that produces a concrete type or fails with a typed error.
+The parser is the boundary. `unknown` is allowed only long enough for an
+adapter, parser, or explicitly named boundary reader to prove the concrete
+transport or domain type. It never reaches core behavior or public APIs.
 
 ```typescript
 // The boundary parser. This is the ONLY place raw data is touched.
@@ -95,7 +100,7 @@ function applyPatch(patch: PatchV2): PatchResult { /* ... */ }
 const id = value as string;
 
 // RIGHT — prove it at runtime, compiler follows
-if (typeof value !== 'string') { throw new TypeError('expected string'); }
+if (typeof value !== 'string') { throw new InvalidBoundaryValue('expected string'); }
 const id = value; // compiler knows it's string
 ```
 
@@ -290,7 +295,7 @@ class InvalidObjectId extends DomainError {
 if (err instanceof InvalidObjectId) { /* ... */ }
 
 // NEVER parse messages
-if (err.message.includes('invalid')) { /* raccoon-in-a-dumpster energy */ }
+if (err.message.includes('invalid')) { /* message parsing is not a contract */ }
 ```
 
 ### Principles


### PR DESCRIPTION
## Summary

- Make Runtime Truth a binding source-of-authority rule in the TypeScript/system policy docs.
- Lock mandatory dependency injection and boundary-only encoding/decoding into AGENTS and anti-sludge guidance.
- Record the git-warp-specific adaptation as Decision 6.

## Issue

Refs #555

## Test plan

- npm run lint:md
- npm run lint:md:code
- git diff --check
- commit hook: IRONCLAD M9 type policy gate
- pre-push hook: IRONCLAD M9 static gates
- pre-push hook: npm run test:local, 544 files / 7151 tests passed

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] If this PR touches persisted op formats, I linked the ADR 3 readiness issue. Not applicable: docs-only standards update.
- [x] If this PR touches wire compatibility, I confirmed canonical-only ops are still rejected on the wire pre-cutover. Not applicable: docs-only standards update.
- [x] If this PR touches schema constants, I confirmed patch and checkpoint namespaces remain distinct. Not applicable: docs-only standards update.
