### PR TITLE
Reconcile V18 closeout docs

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -81,12 +81,15 @@ Current release-blocking issues:
 
 - [#549 Bounded-memory large-graph product gate](https://github.com/git-stunts/git-warp/issues/549)
 - [#547 Optics public API closeout](https://github.com/git-stunts/git-warp/issues/547)
+- [#550 Content attachment-plane cutover](https://github.com/git-stunts/git-warp/issues/550)
 - [#552 v18 public release blockers](https://github.com/git-stunts/git-warp/issues/552)
 
 Completed gate evidence:
 
 - [#546 No full materialization in first-use Optics](https://github.com/git-stunts/git-warp/issues/546)
   closed on 2026-06-02 through PR #574.
+- V18-GP4 Holographic slicing and checkpoint basis closed on 2026-06-06
+  through PR #643 plus tracker closeout for issues #629 through #632.
 
 ## Where Are We
 

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -81,7 +81,6 @@ Current release-blocking issues:
 
 - [#549 Bounded-memory large-graph product gate](https://github.com/git-stunts/git-warp/issues/549)
 - [#547 Optics public API closeout](https://github.com/git-stunts/git-warp/issues/547)
-- [#550 Content attachment-plane cutover](https://github.com/git-stunts/git-warp/issues/550)
 - [#552 v18 public release blockers](https://github.com/git-stunts/git-warp/issues/552)
 
 Completed gate evidence:
@@ -90,6 +89,8 @@ Completed gate evidence:
   closed on 2026-06-02 through PR #574.
 - V18-GP4 Holographic slicing and checkpoint basis closed on 2026-06-06
   through PR #643 plus tracker closeout for issues #629 through #632.
+- V18-GP3 Content attachment-plane honesty closed on 2026-06-06 by naming the
+  v18 residual risk and carrying full storage-plane retirement to #646.
 
 ## Where Are We
 

--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -80,7 +80,6 @@ as evidence. The migration map is
 Current release-blocking issues:
 
 - [#549 Bounded-memory large-graph product gate](https://github.com/git-stunts/git-warp/issues/549)
-- [#547 Optics public API closeout](https://github.com/git-stunts/git-warp/issues/547)
 - [#552 v18 public release blockers](https://github.com/git-stunts/git-warp/issues/552)
 
 Completed gate evidence:
@@ -91,6 +90,9 @@ Completed gate evidence:
   through PR #643 plus tracker closeout for issues #629 through #632.
 - V18-GP3 Content attachment-plane honesty closed on 2026-06-06 by naming the
   v18 residual risk and carrying full storage-plane retirement to #646.
+- V18-GP1 Optics public API closeout closed on 2026-06-06 with public
+  coordinate node/property read, first-use honesty, recovery, docs, and
+  consumer type evidence.
 
 ## Where Are We
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,7 +29,7 @@ goalpost.
 | Release status | `active` |
 | Current public release | `v17.0.0` |
 | Goalposts | `5` |
-| Landed goalposts | `2` |
+| Landed goalposts | `3` |
 | Total planned slice budget | `53` |
 | Target lane | `lane:v18.0.0` |
 | Release evidence packet | `docs/releases/v18.0.0/README.md` |
@@ -42,7 +42,7 @@ and placeholder-free, and `npm run release:preflight` passes from aligned
 
 | Goalpost | Status | Slice budget | Umbrella or tracker issue | Goalpost doc | Release gate |
 | --- | --- | ---: | --- | --- | --- |
-| V18-GP1 Optics Public API Closeout | active | 20 | [#547](https://github.com/git-stunts/git-warp/issues/547) | [v18-gp1-optics-public-api-closeout.md](method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md) | First-use Optics must be usable and honest without hidden full materialization. |
+| V18-GP1 Optics Public API Closeout | landed | 20 | [#547](https://github.com/git-stunts/git-warp/issues/547) | [v18-gp1-optics-public-api-closeout.md](method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md) | First-use Optics are usable and honest without hidden full materialization. |
 | V18-GP2 Bounded-Memory Large-Graph Product Gate | active | 15 | [#549](https://github.com/git-stunts/git-warp/issues/549) | [v18-gp2-bounded-memory-large-graph-gate.md](method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md) | Normal public reads, writes, content lookup, and sync must honor an explicit memory budget. |
 | V18-GP3 Content Attachment Plane Honesty | landed | 4 | [#550](https://github.com/git-stunts/git-warp/issues/550) | [v18-gp3-content-attachment-plane-honesty.md](method/roadmap/v18.0.0/v18-gp3-content-attachment-plane-honesty.md) | Release claims now distinguish typed attachment-plane progress from accepted legacy storage residuals. |
 | V18-GP4 Holographic Slicing And Checkpoint Basis | landed | 8 | [#626](https://github.com/git-stunts/git-warp/issues/626), [#628](https://github.com/git-stunts/git-warp/issues/628)-[#635](https://github.com/git-stunts/git-warp/issues/635) | [v18-gp4-holographic-slicing-checkpoint-basis.md](method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md) | Normal public graph-shaped reads now have bounded, witnessed slices over declared basis. |
@@ -58,30 +58,28 @@ V18-GP4 Holographic slicing basis
   -> V18-GP5 Release operation evidence
 ```
 
-V18-GP4 is landed. The next release-blocking target is V18-GP1
-[#547](https://github.com/git-stunts/git-warp/issues/547), with V18-GP2
-[#549](https://github.com/git-stunts/git-warp/issues/549) still owning the
-broader bounded-memory release gate that may keep GP1 from closing as
-release-complete.
+V18-GP1, V18-GP3, and V18-GP4 are landed. The next release-blocking target is
+V18-GP2 [#549](https://github.com/git-stunts/git-warp/issues/549), which owns
+the broader bounded-memory public-path product gate.
 
 Release progress should be reported as:
 
 ```text
-v18.0.0 goalposts: 2/5 landed
-v18.0.0 slices: 12/53 landed
-next goalpost: V18-GP1 Optics Public API Closeout
-next slice: reconcile #547 against landed Optics evidence and #549 dependency
+v18.0.0 goalposts: 3/5 landed
+v18.0.0 slices: 32/53 landed
+next goalpost: V18-GP2 Bounded-Memory Large-Graph Product Gate
+next slice: reconcile #549 against landed holographic slicing evidence
 ```
 
 ## Snapshot
 
 | Metric | Count |
 | --- | ---: |
-| Open GitHub issues indexed | 408 |
+| Open GitHub issues indexed | 407 |
 | `lane:bad-code` maintenance issues | 214 |
 | `lane:cool-ideas` enhancement issues | 95 |
-| `lane:release` issues | 21 |
-| Blocked issues | 40 |
+| `lane:release` issues | 20 |
+| Blocked issues | 39 |
 | Unlabeled issues | 1 |
 
 ## Release Assignment Rules
@@ -97,7 +95,7 @@ next slice: reconcile #547 against landed Optics evidence and #549 dependency
 
 | Release Slot | Count | Planning Intent |
 | --- | ---: | --- |
-| v18.0.0 | 3 | Ship only after first-use Optics, bounded-memory public paths, and release operation evidence are coherent. |
+| v18.0.0 | 2 | Ship only after bounded-memory public paths and release operation evidence are coherent. |
 | v18.0.1 | 50 | Repair public docs, examples, release tooling, and review guardrails that make the v18 line usable without expanding the runtime ontology. |
 | v18.0.2 | 50 | Finish the remaining release-tooling spillover, then start the testing-quality cleanup wave with behavior-backed proofs instead of brittle text checks. |
 | v18.0.3 | 50 | Continue static-text and fixture-quality paydown while keeping the release train small enough to review as one coherent patch wave. |
@@ -125,8 +123,8 @@ next slice: reconcile #547 against landed Optics evidence and #549 dependency
 | lane:cool-ideas | 95 |
 | lane:up-next | 43 |
 | lane:backlog-root | 30 |
-| lane:release | 21 |
-| lane:v18.0.0 | 3 |
+| lane:release | 20 |
+| lane:v18.0.0 | 2 |
 | lane:v19.0.0 | 11 |
 | lane:inbox | 4 |
 | lane:v21.0.0 | 4 |
@@ -137,7 +135,7 @@ next slice: reconcile #547 against landed Optics evidence and #549 dependency
 | Label | Count |
 | --- | ---: |
 | type:maintenance | 214 |
-| type:enhancement | 201 |
+| type:enhancement | 192 |
 
 ### Release Home Labels
 
@@ -163,7 +161,7 @@ next slice: reconcile #547 against landed Optics evidence and #549 dependency
 | feature:observer-admission-runtime | 27 |
 | feature:tooling-release | 27 |
 | feature:trie-state-storage | 16 |
-| feature:graph-model-substrate | 4 |
+| feature:graph-model-substrate | 3 |
 | feature:btr-provenance-boundary | 1 |
 | feature:materialization-snapshotting | 1 |
 | feature:materialized-index | 1 |
@@ -176,11 +174,10 @@ Each issue appears once in the proposed release tables below. `Status` is derive
 
 ### v18.0.0 - Public Release Gate
 
-Ship only after first-use Optics, bounded-memory public paths, and release operation evidence are coherent.
+Ship only after bounded-memory public paths and release operation evidence are coherent.
 
 | Issue | Title | Status | Type | Lane | Feature | Release Home | Flags |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| [#547](https://github.com/git-stunts/git-warp/issues/547) | Optics public API closeout | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
 | [#549](https://github.com/git-stunts/git-warp/issues/549) | Bounded-memory large-graph product gate | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
 | [#552](https://github.com/git-stunts/git-warp/issues/552) | v18 public release blockers | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
 
@@ -705,8 +702,8 @@ Issues without enough signal for a release slot. They stay visible here until la
 
 | Check | Count |
 | --- | ---: |
-| Open issues pulled from GitHub | 408 |
-| Issues assigned to roadmap tables | 408 |
+| Open issues pulled from GitHub | 407 |
+| Issues assigned to roadmap tables | 407 |
 | Largest release slot | 50 |
 | Release slots over 50 issues | 0 |
 | Unassigned gap | 0 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # ROADMAP - @git-stunts/git-warp
 
-Last reconciled: 2026-06-04
+Last reconciled: 2026-06-06
 
 **Current public package/tag release:** v17.0.0
 **Next intended release:** v18.0.0
@@ -29,7 +29,7 @@ goalpost.
 | Release status | `active` |
 | Current public release | `v17.0.0` |
 | Goalposts | `5` |
-| Landed goalposts | `0` |
+| Landed goalposts | `1` |
 | Total planned slice budget | `53` |
 | Target lane | `lane:v18.0.0` |
 | Release evidence packet | `docs/releases/v18.0.0/README.md` |
@@ -45,7 +45,7 @@ and placeholder-free, and `npm run release:preflight` passes from aligned
 | V18-GP1 Optics Public API Closeout | active | 20 | [#547](https://github.com/git-stunts/git-warp/issues/547) | [v18-gp1-optics-public-api-closeout.md](method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md) | First-use Optics must be usable and honest without hidden full materialization. |
 | V18-GP2 Bounded-Memory Large-Graph Product Gate | active | 15 | [#549](https://github.com/git-stunts/git-warp/issues/549) | [v18-gp2-bounded-memory-large-graph-gate.md](method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md) | Normal public reads, writes, content lookup, and sync must honor an explicit memory budget. |
 | V18-GP3 Content Attachment Plane Honesty | active | 4 | [#550](https://github.com/git-stunts/git-warp/issues/550) | [v18-gp3-content-attachment-plane-honesty.md](method/roadmap/v18.0.0/v18-gp3-content-attachment-plane-honesty.md) | Release claims must distinguish typed attachment-plane progress from accepted legacy storage residuals. |
-| V18-GP4 Holographic Slicing And Checkpoint Basis | active | 8 | [#626](https://github.com/git-stunts/git-warp/issues/626), [#628](https://github.com/git-stunts/git-warp/issues/628)-[#635](https://github.com/git-stunts/git-warp/issues/635) | [v18-gp4-holographic-slicing-checkpoint-basis.md](method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md) | Normal public graph-shaped reads must move toward bounded, witnessed slices over declared basis. |
+| V18-GP4 Holographic Slicing And Checkpoint Basis | landed | 8 | [#626](https://github.com/git-stunts/git-warp/issues/626), [#628](https://github.com/git-stunts/git-warp/issues/628)-[#635](https://github.com/git-stunts/git-warp/issues/635) | [v18-gp4-holographic-slicing-checkpoint-basis.md](method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md) | Normal public graph-shaped reads now have bounded, witnessed slices over declared basis. |
 | V18-GP5 Release Operation Evidence | active | 6 | [#552](https://github.com/git-stunts/git-warp/issues/552) | [v18-gp5-release-operation-evidence.md](method/roadmap/v18.0.0/v18-gp5-release-operation-evidence.md) | Tagging and publishing must satisfy the release policy and record deterministic evidence. |
 
 Sequencing:
@@ -58,30 +58,26 @@ V18-GP4 Holographic slicing basis
   -> V18-GP5 Release operation evidence
 ```
 
-The next execution target is V18-GP4 slice 2, issue
-[#629](https://github.com/git-stunts/git-warp/issues/629), after issue
-[#628](https://github.com/git-stunts/git-warp/issues/628) is either closed from
-its landed implementation evidence or moved out of the v18 lane with explicit
-carry-forward disposition. The closed design umbrella issue
-[#626](https://github.com/git-stunts/git-warp/issues/626) does not by itself
-prove the goalpost landed; the implementation proof stories
-[#628](https://github.com/git-stunts/git-warp/issues/628) through
-[#635](https://github.com/git-stunts/git-warp/issues/635) own that proof.
+V18-GP4 is landed. The next release-blocking target is V18-GP1
+[#547](https://github.com/git-stunts/git-warp/issues/547), with V18-GP2
+[#549](https://github.com/git-stunts/git-warp/issues/549) still owning the
+broader bounded-memory release gate that may keep GP1 from closing as
+release-complete.
 
 Release progress should be reported as:
 
 ```text
-v18.0.0 goalposts: 0/5 landed
-v18.0.0 slices: 0/53 landed
-next goalpost: V18-GP4 Holographic Slicing And Checkpoint Basis
-next slice: #629 Checkpoint basis manifest contract
+v18.0.0 goalposts: 1/5 landed
+v18.0.0 slices: 8/53 landed
+next goalpost: V18-GP1 Optics Public API Closeout
+next slice: reconcile #547 against landed Optics evidence and #549 dependency
 ```
 
 ## Snapshot
 
 | Metric | Count |
 | --- | ---: |
-| Open GitHub issues indexed | 416 |
+| Open GitHub issues indexed | 408 |
 | `lane:bad-code` maintenance issues | 214 |
 | `lane:cool-ideas` enhancement issues | 95 |
 | `lane:release` issues | 22 |
@@ -101,7 +97,7 @@ next slice: #629 Checkpoint basis manifest contract
 
 | Release Slot | Count | Planning Intent |
 | --- | ---: | --- |
-| v18.0.0 | 12 | Ship only after first-use Optics, bounded-memory public paths, content cutover truth, holographic slicing posture, and release operation evidence are coherent. |
+| v18.0.0 | 4 | Ship only after first-use Optics, bounded-memory public paths, content cutover truth, and release operation evidence are coherent. |
 | v18.0.1 | 50 | Repair public docs, examples, release tooling, and review guardrails that make the v18 line usable without expanding the runtime ontology. |
 | v18.0.2 | 50 | Finish the remaining release-tooling spillover, then start the testing-quality cleanup wave with behavior-backed proofs instead of brittle text checks. |
 | v18.0.3 | 50 | Continue static-text and fixture-quality paydown while keeping the release train small enough to review as one coherent patch wave. |
@@ -130,7 +126,7 @@ next slice: #629 Checkpoint basis manifest contract
 | lane:up-next | 42 |
 | lane:backlog-root | 30 |
 | lane:release | 22 |
-| lane:v18.0.0 | 12 |
+| lane:v18.0.0 | 4 |
 | lane:v19.0.0 | 11 |
 | lane:inbox | 4 |
 | lane:v21.0.0 | 4 |
@@ -162,7 +158,7 @@ next slice: #629 Checkpoint basis manifest contract
 | feature:runtime-boundaries | 36 |
 | feature:api-capabilities | 35 |
 | feature:docs-dx | 34 |
-| feature:materialization-query-index | 34 |
+| feature:materialization-query-index | 26 |
 | feature:sync-trust-security | 30 |
 | feature:observer-admission-runtime | 27 |
 | feature:tooling-release | 27 |
@@ -180,7 +176,7 @@ Each issue appears once in the proposed release tables below. `Status` is derive
 
 ### v18.0.0 - Public Release Gate
 
-Ship only after first-use Optics, bounded-memory public paths, content cutover truth, holographic slicing posture, and release operation evidence are coherent.
+Ship only after first-use Optics, bounded-memory public paths, content cutover truth, and release operation evidence are coherent.
 
 | Issue | Title | Status | Type | Lane | Feature | Release Home | Flags |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -188,14 +184,6 @@ Ship only after first-use Optics, bounded-memory public paths, content cutover t
 | [#549](https://github.com/git-stunts/git-warp/issues/549) | Bounded-memory large-graph product gate | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
 | [#550](https://github.com/git-stunts/git-warp/issues/550) | Content attachment-plane cutover | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, release |
 | [#552](https://github.com/git-stunts/git-warp/issues/552) | v18 public release blockers | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
-| [#628](https://github.com/git-stunts/git-warp/issues/628) | PROTO-0271A - Materialization boundary guard | Open | enhancement | v18.0.0 | materialization-query-index | - | - |
-| [#629](https://github.com/git-stunts/git-warp/issues/629) | PROTO-0271B - Checkpoint basis manifest contract | Open | enhancement | v18.0.0 | materialization-query-index | - | - |
-| [#630](https://github.com/git-stunts/git-warp/issues/630) | PROTO-0271C - Streaming checkpoint basis builder | Open | enhancement | v18.0.0 | materialization-query-index | - | - |
-| [#631](https://github.com/git-stunts/git-warp/issues/631) | PROTO-0271D - Checkpoint patch-to-fact stream | Open | enhancement | v18.0.0 | materialization-query-index | - | - |
-| [#632](https://github.com/git-stunts/git-warp/issues/632) | PROTO-0271E - Node and property optics on streamed basis | Open | enhancement | v18.0.0 | materialization-query-index | - | - |
-| [#633](https://github.com/git-stunts/git-warp/issues/633) | PROTO-0271F - NeighborhoodOptic adjacency slices | Open | enhancement | v18.0.0 | materialization-query-index | - | - |
-| [#634](https://github.com/git-stunts/git-warp/issues/634) | PROTO-0271G - TraversalOptic cursorized traversal | Open | enhancement | v18.0.0 | materialization-query-index | - | - |
-| [#635](https://github.com/git-stunts/git-warp/issues/635) | PROTO-0271H - Holographic CLI/operator witness playback | Open | enhancement | v18.0.0 | materialization-query-index | - | - |
 
 ### v18.0.1 - Public Docs And Release Tooling Repair
 
@@ -717,8 +705,8 @@ Issues without enough signal for a release slot. They stay visible here until la
 
 | Check | Count |
 | --- | ---: |
-| Open issues pulled from GitHub | 416 |
-| Issues assigned to roadmap tables | 416 |
+| Open issues pulled from GitHub | 408 |
+| Issues assigned to roadmap tables | 408 |
 | Largest release slot | 50 |
 | Release slots over 50 issues | 0 |
 | Unassigned gap | 0 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,7 +29,7 @@ goalpost.
 | Release status | `active` |
 | Current public release | `v17.0.0` |
 | Goalposts | `5` |
-| Landed goalposts | `1` |
+| Landed goalposts | `2` |
 | Total planned slice budget | `53` |
 | Target lane | `lane:v18.0.0` |
 | Release evidence packet | `docs/releases/v18.0.0/README.md` |
@@ -44,7 +44,7 @@ and placeholder-free, and `npm run release:preflight` passes from aligned
 | --- | --- | ---: | --- | --- | --- |
 | V18-GP1 Optics Public API Closeout | active | 20 | [#547](https://github.com/git-stunts/git-warp/issues/547) | [v18-gp1-optics-public-api-closeout.md](method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md) | First-use Optics must be usable and honest without hidden full materialization. |
 | V18-GP2 Bounded-Memory Large-Graph Product Gate | active | 15 | [#549](https://github.com/git-stunts/git-warp/issues/549) | [v18-gp2-bounded-memory-large-graph-gate.md](method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md) | Normal public reads, writes, content lookup, and sync must honor an explicit memory budget. |
-| V18-GP3 Content Attachment Plane Honesty | active | 4 | [#550](https://github.com/git-stunts/git-warp/issues/550) | [v18-gp3-content-attachment-plane-honesty.md](method/roadmap/v18.0.0/v18-gp3-content-attachment-plane-honesty.md) | Release claims must distinguish typed attachment-plane progress from accepted legacy storage residuals. |
+| V18-GP3 Content Attachment Plane Honesty | landed | 4 | [#550](https://github.com/git-stunts/git-warp/issues/550) | [v18-gp3-content-attachment-plane-honesty.md](method/roadmap/v18.0.0/v18-gp3-content-attachment-plane-honesty.md) | Release claims now distinguish typed attachment-plane progress from accepted legacy storage residuals. |
 | V18-GP4 Holographic Slicing And Checkpoint Basis | landed | 8 | [#626](https://github.com/git-stunts/git-warp/issues/626), [#628](https://github.com/git-stunts/git-warp/issues/628)-[#635](https://github.com/git-stunts/git-warp/issues/635) | [v18-gp4-holographic-slicing-checkpoint-basis.md](method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md) | Normal public graph-shaped reads now have bounded, witnessed slices over declared basis. |
 | V18-GP5 Release Operation Evidence | active | 6 | [#552](https://github.com/git-stunts/git-warp/issues/552) | [v18-gp5-release-operation-evidence.md](method/roadmap/v18.0.0/v18-gp5-release-operation-evidence.md) | Tagging and publishing must satisfy the release policy and record deterministic evidence. |
 
@@ -67,8 +67,8 @@ release-complete.
 Release progress should be reported as:
 
 ```text
-v18.0.0 goalposts: 1/5 landed
-v18.0.0 slices: 8/53 landed
+v18.0.0 goalposts: 2/5 landed
+v18.0.0 slices: 12/53 landed
 next goalpost: V18-GP1 Optics Public API Closeout
 next slice: reconcile #547 against landed Optics evidence and #549 dependency
 ```
@@ -80,8 +80,8 @@ next slice: reconcile #547 against landed Optics evidence and #549 dependency
 | Open GitHub issues indexed | 408 |
 | `lane:bad-code` maintenance issues | 214 |
 | `lane:cool-ideas` enhancement issues | 95 |
-| `lane:release` issues | 22 |
-| Blocked issues | 41 |
+| `lane:release` issues | 21 |
+| Blocked issues | 40 |
 | Unlabeled issues | 1 |
 
 ## Release Assignment Rules
@@ -97,7 +97,7 @@ next slice: reconcile #547 against landed Optics evidence and #549 dependency
 
 | Release Slot | Count | Planning Intent |
 | --- | ---: | --- |
-| v18.0.0 | 4 | Ship only after first-use Optics, bounded-memory public paths, content cutover truth, and release operation evidence are coherent. |
+| v18.0.0 | 3 | Ship only after first-use Optics, bounded-memory public paths, and release operation evidence are coherent. |
 | v18.0.1 | 50 | Repair public docs, examples, release tooling, and review guardrails that make the v18 line usable without expanding the runtime ontology. |
 | v18.0.2 | 50 | Finish the remaining release-tooling spillover, then start the testing-quality cleanup wave with behavior-backed proofs instead of brittle text checks. |
 | v18.0.3 | 50 | Continue static-text and fixture-quality paydown while keeping the release train small enough to review as one coherent patch wave. |
@@ -109,7 +109,7 @@ next slice: reconcile #547 against landed Optics evidence and #549 dependency
 | v19.0.0 | 30 | Make observer doctrine runtime-real beyond the v18 bounded public-path gate: observer-readable receipts, support rules, plans, envelopes, fragments, and witnessed suffix shells. |
 | v19.1.0 | 30 | Advance trust/security contracts, sync authentication, protocol alignment, and policy surfaces once observer boundaries are stable enough to protect. |
 | v19.2.0 | 6 | Package extraction, multi-package release, MCP, and integration architecture that should follow the v19 observer model rather than constrain it prematurely. |
-| v20.0.0 | 18 | Make slice-first, bounded, streaming read/write execution ordinary runtime behavior rather than special-case gate evidence. |
+| v20.0.0 | 19 | Make slice-first, bounded, streaming read/write execution ordinary runtime behavior rather than special-case gate evidence. |
 | v20.1.0 | 23 | Reshape indexes, materialization controllers, async traversal, and diagnostics around bounded support instead of full-state residency. |
 | v21.0.0 | 36 | Make distributed/plural admission semantics runtime-real: merge classifiers, braid collapse, local sites, and strand/worldline merge nouns. |
 | v21.1.0 | 1 | Stabilize WESLEY and Continuum contract surfaces after the merge runtime nouns are no longer speculative. |
@@ -123,10 +123,10 @@ next slice: reconcile #547 against landed Optics evidence and #549 dependency
 | --- | ---: |
 | lane:bad-code | 214 |
 | lane:cool-ideas | 95 |
-| lane:up-next | 42 |
+| lane:up-next | 43 |
 | lane:backlog-root | 30 |
-| lane:release | 22 |
-| lane:v18.0.0 | 4 |
+| lane:release | 21 |
+| lane:v18.0.0 | 3 |
 | lane:v19.0.0 | 11 |
 | lane:inbox | 4 |
 | lane:v21.0.0 | 4 |
@@ -145,7 +145,7 @@ next slice: reconcile #547 against landed Optics evidence and #549 dependency
 | --- | ---: |
 | release-home:v17.0.0 | 162 |
 | release-home:v18.0.0 | 22 |
-| release-home:v20.0.0 | 14 |
+| release-home:v20.0.0 | 15 |
 | release-home:v19.0.0 | 13 |
 | release-home:v21.0.0 | 7 |
 
@@ -176,13 +176,12 @@ Each issue appears once in the proposed release tables below. `Status` is derive
 
 ### v18.0.0 - Public Release Gate
 
-Ship only after first-use Optics, bounded-memory public paths, content cutover truth, and release operation evidence are coherent.
+Ship only after first-use Optics, bounded-memory public paths, and release operation evidence are coherent.
 
 | Issue | Title | Status | Type | Lane | Feature | Release Home | Flags |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | [#547](https://github.com/git-stunts/git-warp/issues/547) | Optics public API closeout | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
 | [#549](https://github.com/git-stunts/git-warp/issues/549) | Bounded-memory large-graph product gate | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
-| [#550](https://github.com/git-stunts/git-warp/issues/550) | Content attachment-plane cutover | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, release |
 | [#552](https://github.com/git-stunts/git-warp/issues/552) | v18 public release blockers | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
 
 ### v18.0.1 - Public Docs And Release Tooling Repair
@@ -608,6 +607,7 @@ Make slice-first, bounded, streaming read/write execution ordinary runtime behav
 | [#565](https://github.com/git-stunts/git-warp/issues/565) | End-To-End Graph Streaming Reads And Writes | Blocked | enhancement | release, v20.0.0 | materialization-query-index | - | blocked, release |
 | [#566](https://github.com/git-stunts/git-warp/issues/566) | Align Playback-Head And TTD Consumers After Read Nouns Stabilize | Blocked | enhancement | release, v20.0.0 | merge-strands-worldlines | - | blocked, release |
 | [#567](https://github.com/git-stunts/git-warp/issues/567) | Strand Collapse Optic For Causal Slicing | Blocked | enhancement | release, v20.0.0 | merge-strands-worldlines | - | blocked, release |
+| [#646](https://github.com/git-stunts/git-warp/issues/646) | Retire legacy content attachment storage-plane boundaries | Open | enhancement | up-next | graph-model-substrate | v20.0.0 | - |
 
 ### v20.1.0 - Materialization, Index, And Diagnostic Model
 

--- a/docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md
+++ b/docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md
@@ -10,7 +10,7 @@
 | Goalpost doc | `docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md` |
 | Design cycle | `docs/design/0265-v18-optics-public-api-closeout/v18-optics-public-api-closeout.md` |
 | Slice budget | `20` |
-| Status | `active` |
+| Status | `landed` |
 | Sponsor human | `James` |
 | Sponsor agent | `Codex` |
 
@@ -22,10 +22,12 @@ without falling back to whole-graph materialization.
 
 ## Current Truth
 
-Issue [#547](https://github.com/git-stunts/git-warp/issues/547) is open in
-`lane:v18.0.0` and blocks the public v18 tag. Its issue body records the
-existing 20-slice PRD shape and states that branch-local public API evidence is
-not enough while first-use setup still depends on full materialization.
+Issue [#547](https://github.com/git-stunts/git-warp/issues/547) is closed as
+the public Optics closeout goalpost. The landed evidence proves
+`openWarpWorldline(...).prepareOpticBasis()`, `coordinate()`, and
+`coordinate.optic()` for public node/property reads without hidden full
+materialization. The broader memory-budget product gate remains open in
+[#549](https://github.com/git-stunts/git-warp/issues/549).
 
 ## Scope
 
@@ -53,41 +55,43 @@ not enough while first-use setup still depends on full materialization.
 
 | Slice | Status | Description | Expected proof |
 | ---: | --- | --- | --- |
-| 1 | open | Reconcile public Optics PRD against current runtime and release blockers. | docUpdate |
-| 2 | open | Define first-use basis setup success fixture. | fixture |
-| 3 | open | Add materialization trap for first-use Optics setup. | test |
-| 4 | open | Implement or verify Worldline-first basis setup path. | runtimeBehavior |
-| 5 | open | Implement or verify coordinate capture path. | runtimeBehavior |
-| 6 | open | Prove node read success from the public chain. | test |
-| 7 | open | Prove property read success from the public chain. | test |
-| 8 | open | Prove coordinate coherence while the live worldline advances. | test |
-| 9 | open | Prove missing bounded basis reports typed recovery guidance. | test |
-| 10 | open | Prove tail-budget failure reports bounded-budget error. | test |
-| 11 | open | Decide exported versus opaque public Optics result nouns. | docUpdate |
-| 12 | open | Add consumer type proof for the intended public chain. | test |
-| 13 | open | Update public docs for setup and recovery. | docUpdate |
-| 14 | open | Update public API cost labels for Optics paths. | docUpdate |
-| 15 | open | Add package-surface evidence for public Optics nouns. | test |
-| 16 | open | Add deterministic witness for successful first-use Optics playback. | witness |
-| 17 | open | Add deterministic witness for failure recovery. | witness |
-| 18 | open | Remove or classify stale materializing Optics docs. | docUpdate |
-| 19 | open | Update release evidence with Optics proof rows. | docUpdate |
-| 20 | open | Close or disposition #547 with landed proof. | issueUpdate |
+| 1 | complete | Reconcile public Optics PRD against current runtime and release blockers. | docUpdate |
+| 2 | complete | Define first-use basis setup success fixture. | fixture |
+| 3 | complete | Add materialization trap for first-use Optics setup. | test |
+| 4 | complete | Implement or verify Worldline-first basis setup path. | runtimeBehavior |
+| 5 | complete | Implement or verify coordinate capture path. | runtimeBehavior |
+| 6 | complete | Prove node read success from the public chain. | test |
+| 7 | complete | Prove property read success from the public chain. | test |
+| 8 | complete | Prove coordinate coherence while the live worldline advances. | test |
+| 9 | complete | Prove missing bounded basis reports typed recovery guidance. | test |
+| 10 | complete | Prove tail-budget failure reports bounded-budget error. | test |
+| 11 | complete | Decide exported versus opaque public Optics result nouns. | docUpdate |
+| 12 | complete | Add consumer type proof for the intended public chain. | test |
+| 13 | complete | Update public docs for setup and recovery. | docUpdate |
+| 14 | complete | Update public API cost labels for Optics paths. | docUpdate |
+| 15 | complete | Add package-surface evidence for public Optics nouns. | test |
+| 16 | complete | Add deterministic witness for successful first-use Optics playback. | witness |
+| 17 | complete | Add deterministic witness for failure recovery. | witness |
+| 18 | complete | Remove or classify stale materializing Optics docs. | docUpdate |
+| 19 | complete | Update release evidence with Optics proof rows. | docUpdate |
+| 20 | complete | Close or disposition #547 with landed proof. | issueUpdate |
 
 ## Acceptance Criteria
 
-- [ ] Public first-use Optics path succeeds without hidden full materialization.
-- [ ] Node and property read fixtures prove the public chain.
-- [ ] Missing basis and tail-budget failures have typed recovery guidance.
-- [ ] Consumer type checks cover the public chain.
-- [ ] Public docs and release evidence match the proven behavior.
+- [x] Public first-use Optics path succeeds without hidden full materialization.
+- [x] Node and property read fixtures prove the public chain.
+- [x] Missing basis and tail-budget failures have typed recovery guidance.
+- [x] Consumer type checks cover the public chain.
+- [x] Public docs and release evidence match the proven behavior.
 
 ## Deterministic Evidence
 
 | Claim | Canonical fixture or input | Witness | Replay command | Expected deterministic result |
 | --- | --- | --- | --- | --- |
-| Public Optics setup avoids full materialization. | First-use Optics fixture committed with the implementation slice. | Focused materialization trap test output. | `npm test -- --run <first-use-optics-test>` | Test fails if setup calls materializing APIs. |
-| Public node and property Optics read through a bounded basis. | Public-path coordinate fixture committed with the implementation slice. | Focused node/property Optics test output. | `npm test -- --run <coordinate-optics-test>` | Node and property reads succeed through the public chain. |
+| Public Optics setup avoids full materialization. | `test/conformance/v18FirstUseOpticsHonesty.test.ts`. | Focused materialization trap test output. | `npx vitest run test/conformance/v18FirstUseOpticsHonesty.test.ts` | Test fails if setup calls materializing APIs or full tree-map reads. |
+| Public node and property Optics read through a bounded basis. | `test/conformance/v18CoordinateOpticPublicPath.test.ts`. | Focused node/property Optics test output. | `npx vitest run test/conformance/v18CoordinateOpticPublicPath.test.ts` | Node and property reads succeed through the public chain with read identity evidence. |
+| Failure recovery remains typed. | Coordinate and checkpoint-tail failure fixtures. | Focused recovery test output. | `npx vitest run test/conformance/v18CoordinateOpticPublicPath.test.ts test/conformance/v17CheckpointTailOpticReadBasis.test.ts` | Missing basis, tail-budget, missing shard, and invalid shard failures fail closed without materialization. |
+| Public docs and cost labels are honest. | `docs/READINGS_AND_OPTICS.md`, `docs/public-api-cost-inventory.tsv`, and v18 release docs. | Documentation guard tests. | `npx vitest run test/unit/scripts/public-api-cost-inventory.test.ts test/unit/scripts/v18-worldline-api-doc-guard.test.ts test/unit/scripts/v18-package-surface-audit.test.ts` | Docs teach the coordinate chain, classify cost honestly, and keep materializing docs out of the first-use path. |
 | Consumer type surface is honest. | Tag commit source tree. | Consumer typecheck output. | `npm run typecheck:consumer` | Public chain typechecks without internal imports. |
 
 ## Observer Geometry
@@ -106,19 +110,19 @@ npm run release:prep
 
 ## Release Gate Impact
 
-This goalpost removes the v18 public Optics overclaim risk. Until it lands,
-`v18.0.0` must not be tagged because public docs would imply a bounded first-use
-Optics path that the repo has not proved.
+This landed goalpost removes the v18 public Optics overclaim risk. `v18.0.0`
+still waits on V18-GP2 bounded-memory product evidence and V18-GP5 release
+operation evidence before tagging.
 
 ## Residual Risks
 
 | Risk | Rationale | Owner | Follow-up issue |
 | --- | --- | --- | --- |
-| Neighborhood and traversal reads remain future work until V18-GP4. | GP1 proves node/property first-use Optics only. | `@git-stunts` | [#632](https://github.com/git-stunts/git-warp/issues/632)-[#635](https://github.com/git-stunts/git-warp/issues/635) |
+| Broader bounded-memory public-path product gate remains open. | GP1 proves the public Optics chain and first-use honesty, not every normal public read/write/content/sync path under memory budget. | `@git-stunts` | [#549](https://github.com/git-stunts/git-warp/issues/549) |
 
 ## Closeout
 
-- [ ] Slices complete or honestly dispositioned.
-- [ ] Proof matrix replayed.
-- [ ] Goalpost issue updated.
-- [ ] Release evidence updated.
+- [x] Slices complete or honestly dispositioned.
+- [x] Proof matrix replayed.
+- [x] Goalpost issue updated.
+- [x] Release evidence updated.

--- a/docs/method/roadmap/v18.0.0/v18-gp3-content-attachment-plane-honesty.md
+++ b/docs/method/roadmap/v18.0.0/v18-gp3-content-attachment-plane-honesty.md
@@ -10,7 +10,7 @@
 | Goalpost doc | `docs/method/roadmap/v18.0.0/v18-gp3-content-attachment-plane-honesty.md` |
 | Design cycle | `docs/specs/CONTENT_ATTACHMENT.md` |
 | Slice budget | `4` |
-| Status | `active` |
+| Status | `landed` |
 | Sponsor human | `James` |
 | Sponsor agent | `Codex` |
 
@@ -23,10 +23,11 @@ claim total storage-plane retirement.
 
 ## Current Truth
 
-Issue [#550](https://github.com/git-stunts/git-warp/issues/550) is open in
-`lane:v18.0.0`. Its issue body records completed content payload and projection
-progress, then states that content persistence still has named legacy
-`_content*` compatibility boundaries.
+Issue [#550](https://github.com/git-stunts/git-warp/issues/550) is closed as a
+v18 honesty gate, not as total storage-plane retirement. Its evidence records
+completed content payload and projection progress, names the remaining legacy
+`_content*` compatibility boundaries, and carries full storage-plane retirement
+forward to [#646](https://github.com/git-stunts/git-warp/issues/646).
 
 ## Scope
 
@@ -51,24 +52,25 @@ progress, then states that content persistence still has named legacy
 
 | Slice | Status | Description | Expected proof |
 | ---: | --- | --- | --- |
-| 1 | open | Re-audit content attachment progress against current source and specs. | docUpdate |
-| 2 | open | Replay or add content attachment equivalence evidence. | test |
-| 3 | open | Update release docs to name accepted legacy boundaries precisely. | docUpdate |
-| 4 | open | Close or carry forward #550 with storage-plane follow-up issue. | issueUpdate |
+| 1 | complete | Re-audit content attachment progress against current source and specs. | docUpdate |
+| 2 | complete | Replay or add content attachment equivalence evidence. | test |
+| 3 | complete | Update release docs to name accepted legacy boundaries precisely. | docUpdate |
+| 4 | complete | Close or carry forward #550 with storage-plane follow-up issue. | issueUpdate |
 
 ## Acceptance Criteria
 
-- [ ] Content attachment docs cite current runtime evidence.
-- [ ] Legacy `_content*` compatibility boundaries are named.
-- [ ] Public release notes do not claim total storage-plane retirement.
-- [ ] Follow-up ownership exists for any post-v18 storage cutover.
+- [x] Content attachment docs cite current runtime evidence.
+- [x] Legacy `_content*` compatibility boundaries are named.
+- [x] Public release notes do not claim total storage-plane retirement.
+- [x] Follow-up ownership exists for any post-v18 storage cutover.
 
 ## Deterministic Evidence
 
 | Claim | Canonical fixture or input | Witness | Replay command | Expected deterministic result |
 | --- | --- | --- | --- | --- |
-| Attachment-plane evidence still matches runtime behavior. | Existing content attachment fixtures or v18 release fixture. | Focused content attachment test output. | `npm test -- --run <content-attachment-test>` | Content attachment evidence matches runtime ids and projection behavior. |
-| Residual legacy boundaries are explicit. | Tag commit source tree. | Release evidence doc row. | `npm run release:prep` | Release evidence names accepted residual risk instead of hiding it. |
+| Attachment-plane evidence still matches runtime behavior. | `test/unit/domain/services/ContentAttachmentProjection.test.ts` and v18 fixture witnesses. | Focused content attachment test output. | `npx vitest run test/unit/domain/services/ContentAttachmentProjection.test.ts test/unit/scripts/v18-v17-public-read-legacy-reading-builder.test.ts test/unit/scripts/v18-scratch-public-read-builder.test.ts` | Content attachment evidence matches runtime ids and projection behavior. |
+| Residual legacy boundaries are explicit. | `docs/releases/v18.0.0/README.md` and `test/unit/scripts/v18-content-property-closeout-audit.test.ts`. | Release evidence doc row and raw-boundary audit output. | `npx vitest run test/unit/scripts/v18-content-property-closeout-audit.test.ts test/unit/scripts/v18-release-story-shape.test.ts test/unit/scripts/v18-worldline-api-doc-guard.test.ts` | Release evidence names accepted residual risk instead of hiding it, and public docs do not overclaim retirement. |
+| Post-v18 storage cutover has an owner. | GitHub issue [#646](https://github.com/git-stunts/git-warp/issues/646). | Issue tracker. | `gh issue view 646 --repo git-stunts/git-warp` | Full legacy `_content*` storage-plane retirement is carried outside `lane:v18.0.0`. |
 
 ## Observer Geometry
 
@@ -85,20 +87,19 @@ npm run release:prep
 
 ## Release Gate Impact
 
-This goalpost prevents v18 release notes from claiming more than the content
-attachment evidence proves. It can land by either completing the remaining v18
-content attachment work or by recording a precise accepted residual risk with a
-post-v18 follow-up.
+This landed goalpost prevents v18 release notes from claiming more than the
+content attachment evidence proves. The remaining full storage-plane retirement
+work is now tracked outside `lane:v18.0.0` by #646.
 
 ## Residual Risks
 
 | Risk | Rationale | Owner | Follow-up issue |
 | --- | --- | --- | --- |
-| Legacy content storage boundaries may remain after v18. | Issue #550 already records this as named residual risk, not hidden completeness debt. | `@git-stunts` | [#550](https://github.com/git-stunts/git-warp/issues/550) |
+| Legacy content storage boundaries remain after v18. | This is named residual risk, not hidden completeness debt; #646 owns later full retirement. | `@git-stunts` | [#646](https://github.com/git-stunts/git-warp/issues/646) |
 
 ## Closeout
 
-- [ ] Slices complete or honestly dispositioned.
-- [ ] Proof matrix replayed.
-- [ ] Goalpost issue updated.
-- [ ] Release evidence updated.
+- [x] Slices complete or honestly dispositioned.
+- [x] Proof matrix replayed.
+- [x] Goalpost issue updated.
+- [x] Release evidence updated.

--- a/docs/method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md
+++ b/docs/method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md
@@ -10,7 +10,7 @@
 | Goalpost doc | `docs/method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md` |
 | Design cycle | `docs/design/0271-v18-holographic-slicing-checkpoint-basis/v18-holographic-slicing-checkpoint-basis.md` |
 | Slice budget | `8` |
-| Status | `active` |
+| Status | `landed` |
 | Sponsor human | `James` |
 | Sponsor agent | `Codex` |
 
@@ -21,12 +21,12 @@ slices over a declared checkpoint-tail or streamed checkpoint basis.
 
 ## Current Truth
 
-Design issue [#626](https://github.com/git-stunts/git-warp/issues/626) is closed
-because the design landed. That does not prove the implementation goalpost
-landed. The runtime proof stories are child issues
-[#628](https://github.com/git-stunts/git-warp/issues/628) through
-[#635](https://github.com/git-stunts/git-warp/issues/635), and they remain the
-release-relevant proof surface for this goalpost.
+Design issue [#626](https://github.com/git-stunts/git-warp/issues/626) and
+implementation proof stories [#628](https://github.com/git-stunts/git-warp/issues/628)
+through [#635](https://github.com/git-stunts/git-warp/issues/635) are closed.
+PR [#643](https://github.com/git-stunts/git-warp/pull/643) landed the runtime
+and witness proof surface, then the remaining tracker drift was closed with
+deterministic evidence comments on 2026-06-06.
 
 ## Scope
 
@@ -61,36 +61,38 @@ release-relevant proof surface for this goalpost.
 
 | Slice | Status | Description | Expected proof |
 | ---: | --- | --- | --- |
-| 1 | open | Materialization boundary guard. | test |
-| 2 | open | Checkpoint basis manifest contract. | schema |
-| 3 | open | Streaming checkpoint basis builder. | test |
-| 4 | open | Patch-to-fact stream. | test |
-| 5 | open | Node and property optics on streamed basis. | test |
-| 6 | open | NeighborhoodOptic adjacency slices. | test |
-| 7 | open | TraversalOptic cursorized traversal. | test |
-| 8 | open | Holographic CLI/operator witness playback. | witness |
+| 1 | complete | Materialization boundary guard. | test |
+| 2 | complete | Checkpoint basis manifest contract. | schema |
+| 3 | complete | Streaming checkpoint basis builder. | test |
+| 4 | complete | Patch-to-fact stream. | test |
+| 5 | complete | Node and property optics on streamed basis. | test |
+| 6 | complete | NeighborhoodOptic adjacency slices. | test |
+| 7 | complete | TraversalOptic cursorized traversal. | test |
+| 8 | complete | Holographic CLI/operator witness playback. | witness |
 
 ## Acceptance Criteria
 
-- [ ] App-facing reads do not hide full materialization.
-- [ ] Checkpoint manifests and slice outputs separate byte identity, retained
+- [x] App-facing reads do not hide full materialization.
+- [x] Checkpoint manifests and slice outputs separate byte identity, retained
       payload identity, commitment/proof identity, basis identity, and semantic
       reading identity.
-- [ ] Streaming checkpoint basis construction produces CAS-backed shard roots
+- [x] Streaming checkpoint basis construction produces CAS-backed shard roots
       under memory budget.
-- [ ] Node, property, neighborhood, and traversal optics read through bounded
+- [x] Node, property, neighborhood, and traversal optics read through bounded
       basis facts plus bounded tail.
-- [ ] Missing support obligations are surfaced as obstruction, residual,
+- [x] Missing support obligations are surfaced as obstruction, residual,
       redaction, plurality, or rehydration posture.
-- [ ] CLI/operator witness output is machine-readable.
+- [x] CLI/operator witness output is machine-readable.
 
 ## Deterministic Evidence
 
 | Claim | Canonical fixture or input | Witness | Replay command | Expected deterministic result |
 | --- | --- | --- | --- | --- |
-| Materialization boundary is guarded. | Tag commit source tree. | Focused guard test output. | `npm test -- --run <materialization-boundary-test>` | Public paths fail if they call materializing APIs. |
-| Checkpoint basis identity is explicit. | Checkpoint basis manifest fixture. | Manifest validation output. | `npm test -- --run <checkpoint-basis-manifest-test>` | Manifest validates basis identity, reading identity, roots, frontier, and obstruction posture. |
-| Slices are replayable. | Canonical graph or patch-stream fixture. | CLI/operator witness. | `npm test -- --run <holographic-slice-test>` | Replay reproduces stable slice output or typed obstruction. |
+| Materialization boundary is guarded. | PR #643 merge commit `d52cbea16f6ac1236dbdfd0579fe6da0b9e6a809`. | Focused guard and conformance tests. | `npx vitest run test/conformance/v17CheckpointTailOpticReadBasis.test.ts` | Public paths fail if they call materializing APIs. |
+| Checkpoint basis identity is explicit. | `test/unit/domain/services/optic/CheckpointBasisManifest.test.ts`. | Manifest validation output. | `npx vitest run test/unit/domain/services/optic/CheckpointBasisManifest.test.ts` | Manifest validates basis identity, reading identity, roots, frontier, and obstruction posture. |
+| Streamed basis slices are replayable. | `test/unit/domain/services/optic/StreamingCheckpointBasisBuilder.test.ts` and `test/unit/domain/services/optic/CheckpointPatchFactStream.test.ts`. | Builder and patch-to-fact test output. | `npx vitest run test/unit/domain/services/optic/StreamingCheckpointBasisBuilder.test.ts test/unit/domain/services/optic/CheckpointPatchFactStream.test.ts` | Replay produces stable shard roots, stable fact order, or typed obstruction. |
+| Optics read through bounded basis. | `test/unit/domain/services/optic/CheckpointShardFactReader.manifest.test.ts`. | Manifest-backed shard read output. | `npx vitest run test/unit/domain/services/optic/CheckpointShardFactReader.manifest.test.ts` | Node, property, neighborhood, and traversal reads use targeted basis shards plus bounded tail. |
+| Operator playback is machine-readable. | PR #643 holographic CLI witness implementation. | CLI/operator witness tests. | `npm run test:local` | Holographic witness playback remains part of the full local suite. |
 
 ## Observer Geometry
 
@@ -108,21 +110,20 @@ npm run release:prep
 
 ## Release Gate Impact
 
-This goalpost is the graph-substrate honesty bridge between v18 Optics and the
-bounded-memory product gate. Without it, the release can describe design intent
-but cannot prove the bounded slice substrate needed for the next implementation
-work.
+This landed goalpost is the graph-substrate honesty bridge between v18 Optics
+and the bounded-memory product gate. The release can now cite bounded slice
+substrate evidence while the broader bounded-memory product gate remains open.
 
 ## Residual Risks
 
 | Risk | Rationale | Owner | Follow-up issue |
 | --- | --- | --- | --- |
-| #626 is closed while implementation proof stories remain open. | The design landed separately from implementation; ROADMAP treats #628-#635 as the release proof surface. | `@git-stunts` | [#628](https://github.com/git-stunts/git-warp/issues/628)-[#635](https://github.com/git-stunts/git-warp/issues/635) |
+| Broader bounded-memory release gate remains open. | GP4 proves bounded holographic slice substrate, not the full public-path memory-budget platform required by V18-GP2. | `@git-stunts` | [#549](https://github.com/git-stunts/git-warp/issues/549) |
 
 ## Closeout
 
-- [ ] Slices complete or honestly dispositioned.
-- [ ] Proof matrix replayed.
-- [ ] Goalpost issue updated.
-- [ ] Child proof-story issues closed, superseded, or carried forward.
-- [ ] Release evidence updated.
+- [x] Slices complete or honestly dispositioned.
+- [x] Proof matrix replayed.
+- [x] Goalpost issue updated.
+- [x] Child proof-story issues closed, superseded, or carried forward.
+- [x] Release evidence updated.

--- a/test/unit/scripts/release-policy-shape.test.ts
+++ b/test/unit/scripts/release-policy-shape.test.ts
@@ -215,9 +215,9 @@ describe('release policy shape', () => {
     expect(roadmap).toContain('## Active Planning Instance');
     expect(roadmap).toContain('| Goalposts | `5` |');
     expect(roadmap).toContain('| Total planned slice budget | `53` |');
-    expect(roadmap).toContain('v18.0.0 goalposts: 0/5 landed');
-    expect(roadmap).toContain('v18.0.0 slices: 0/53 landed');
-    expect(roadmap).toContain('next slice: #629 Checkpoint basis manifest contract');
+    expect(roadmap).toContain('v18.0.0 goalposts: 1/5 landed');
+    expect(roadmap).toContain('v18.0.0 slices: 8/53 landed');
+    expect(roadmap).toContain('next slice: reconcile #547 against landed Optics evidence and #549 dependency');
     expect(roadmap).toContain('method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md');
 
     for (const goalpostPath of v18GoalpostPaths) {

--- a/test/unit/scripts/release-policy-shape.test.ts
+++ b/test/unit/scripts/release-policy-shape.test.ts
@@ -215,8 +215,8 @@ describe('release policy shape', () => {
     expect(roadmap).toContain('## Active Planning Instance');
     expect(roadmap).toContain('| Goalposts | `5` |');
     expect(roadmap).toContain('| Total planned slice budget | `53` |');
-    expect(roadmap).toContain('v18.0.0 goalposts: 1/5 landed');
-    expect(roadmap).toContain('v18.0.0 slices: 8/53 landed');
+    expect(roadmap).toContain('v18.0.0 goalposts: 2/5 landed');
+    expect(roadmap).toContain('v18.0.0 slices: 12/53 landed');
     expect(roadmap).toContain('next slice: reconcile #547 against landed Optics evidence and #549 dependency');
     expect(roadmap).toContain('method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md');
 

--- a/test/unit/scripts/release-policy-shape.test.ts
+++ b/test/unit/scripts/release-policy-shape.test.ts
@@ -215,9 +215,9 @@ describe('release policy shape', () => {
     expect(roadmap).toContain('## Active Planning Instance');
     expect(roadmap).toContain('| Goalposts | `5` |');
     expect(roadmap).toContain('| Total planned slice budget | `53` |');
-    expect(roadmap).toContain('v18.0.0 goalposts: 2/5 landed');
-    expect(roadmap).toContain('v18.0.0 slices: 12/53 landed');
-    expect(roadmap).toContain('next slice: reconcile #547 against landed Optics evidence and #549 dependency');
+    expect(roadmap).toContain('v18.0.0 goalposts: 3/5 landed');
+    expect(roadmap).toContain('v18.0.0 slices: 32/53 landed');
+    expect(roadmap).toContain('next slice: reconcile #549 against landed holographic slicing evidence');
     expect(roadmap).toContain('method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md');
 
     for (const goalpostPath of v18GoalpostPaths) {


### PR DESCRIPTION
## Summary

- Reconciles V18 release-tracking docs after closing landed V18 goalposts.
- Marks V18-GP1 public Optics closeout, V18-GP3 content attachment-plane honesty, and V18-GP4 holographic slicing/checkpoint basis as landed.
- Removes stale open-roadmap rows for closed V18 issues and updates release progress to 3/5 goalposts, 32/53 slices.
- Carries full legacy `_content*` storage-plane retirement to #646 outside `lane:v18.0.0`.
- Updates `BEARING.md`, V18 goalpost docs, `ROADMAP.md`, and the roadmap shape guard.

## Evidence

- Closed tracker drift for #629, #630, #631, and #632 with deterministic evidence comments.
- Closed #550 with corrected deterministic closeout evidence comment; #646 owns post-v18 storage-plane retirement.
- Closed #547 with deterministic evidence for public coordinate Optics, first-use honesty, recovery, docs, and consumer typecheck.
- `npx vitest run test/unit/domain/services/optic/CheckpointBasisManifest.test.ts test/unit/domain/services/optic/StreamingCheckpointBasisBuilder.test.ts test/unit/domain/services/optic/CheckpointPatchFactStream.test.ts test/unit/domain/services/optic/CheckpointShardFactReader.manifest.test.ts test/conformance/v17CheckpointTailOpticReadBasis.test.ts`: 5 files / 33 tests passed.
- `npx vitest run test/unit/domain/services/ContentAttachmentProjection.test.ts test/unit/scripts/v18-v17-public-read-legacy-reading-builder.test.ts test/unit/scripts/v18-scratch-public-read-builder.test.ts test/unit/scripts/v18-content-property-closeout-audit.test.ts test/unit/scripts/v18-release-story-shape.test.ts test/unit/scripts/v18-worldline-api-doc-guard.test.ts test/unit/scripts/release-policy-shape.test.ts`: 7 files / 37 tests passed.
- `npx vitest run test/conformance/v18FirstUseOpticsHonesty.test.ts test/conformance/v18CoordinateOpticPublicPath.test.ts test/conformance/v17CheckpointTailOpticReadBasis.test.ts test/unit/scripts/public-api-cost-inventory.test.ts test/unit/scripts/v18-worldline-api-doc-guard.test.ts test/unit/scripts/v18-package-surface-audit.test.ts test/unit/scripts/release-policy-shape.test.ts`: 7 files / 51 tests passed.
- `npm run typecheck:consumer`
- `npm run typecheck:test`
- `npm run lint:links`
- Targeted markdownlint and `npm run lint:md:code` for the touched docs passed.
- Pre-push IRONCLAD M9 passed three times, including `npm run test:local`: 544 files / 7151 tests passed.

## Current gate counts after issue closeout

- Open `lane:v18.0.0`: 2 (#549, #552)
- Open `lane:bad-code`: 214
- Open `lane:asap`: 0

## Release safety

No v18 tag was created.

Refs #547
Refs #549
Refs #550
Refs #552
Refs #646
