### PR TITLE
Simplify issue taxonomy and release gates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,13 +2,51 @@
 
 ## Planning Sources Of Truth
 
-- `docs/method/backlog/` — lane-organized backlog (inbox/, asap/, up-next/, cool-ideas/, bad-code/)
+- GitHub Issues — live work tracker, triage surface, and release gate input
+- GitHub Milestones — release ownership and release-gate targeting
 - `docs/design/<NNNN-slug>/` — active cycle work; backlog item promotes here
 - `CHANGELOG.md` — what has landed
 - `docs/method/retro/<NNNN-slug>/` — closed cycle retrospectives
 
-No milestones. No ROADMAP. Cycles are the unit of work.
+Local backlog files and migration JSON are historical evidence unless a current
+GitHub Issue links to them. Cycles are the unit of implementation work, but
+GitHub Issues and Milestones are the live planning surface.
 See [METHOD](../docs/METHOD.md) for the full process.
+
+## Issue Triage
+
+Labels are query indexes, not prose decoration. Keep issue metadata boring and
+orthogonal.
+
+Use these live axes for new or edited issues:
+
+| Axis | Required? | Values |
+| --- | --- | --- |
+| Type | Exactly one | `type:bug`, `type:debt`, `type:feature`, `type:docs`, `type:release`, `type:goalpost`, `type:story` |
+| Priority | Zero or one | `priority:asap`, `priority:next`, `priority:later` |
+| Status | Only when true | `status:blocked`, `status:active` |
+| Area | Prefer one | `area:api`, `area:runtime`, `area:storage`, `area:query`, `area:sync`, `area:docs`, `area:testing`, `area:tooling`, `area:release`, `area:architecture` |
+| Release target | When release-owned | GitHub Milestone such as `v18.0.0` or `v19.0.0` |
+
+Do not use release labels for new work. Release targeting belongs in GitHub
+Milestones.
+
+Legacy labels are migration-only:
+
+| Legacy label | Replacement |
+| --- | --- |
+| `lane:bad-code` | `type:debt` |
+| `lane:cool-ideas` | `priority:later` plus the appropriate `type:*` |
+| `lane:up-next` | `priority:next` |
+| `lane:asap` | `priority:asap` |
+| `lane:release` | `type:release` |
+| `blocked` | `status:blocked` |
+| `work-in-progress` | `status:active` |
+| `release-home:vX.Y.Z` / `lane:vX.Y.Z` | GitHub Milestone `vX.Y.Z` |
+| `feature:*` / `legend:*` | One `area:*` label, with doctrine in the issue body |
+
+Release gates must fail when a required label or milestone is missing. A
+missing label is not evidence that no matching issues exist.
 
 ## Cycle Process
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ DTO and stop there**. Do not hallucinate fake domain models.
 - If you wrote files in the turn, commit them in that turn. Do not leave your own edits staged but uncommitted.
 - Cycle-start draft pull requests are allowed and expected. After the design
   doc commit is pushed, open a draft PR that references the issue, label the
-  issue `work-in-progress`, and keep the PR draft until playback, acceptance
+  issue `status:active`, and keep the PR draft until playback, acceptance
   evidence, closeout, and validation make the branch ready to merge into `main`.
 
 ## Process

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,14 +116,52 @@ DTO and stop there**. Do not hallucinate fake domain models.
 ## Process
 
 - Read [METHOD](docs/METHOD.md) and follow it.
-- Backlog lives in `docs/method/backlog/` with lanes `inbox/`, `asap/`, `up-next/`, `cool-ideas/`, and `bad-code/`.
-- As you work, feel free to file concrete jank, stank, or correctness smells under `docs/method/backlog/bad-code/`.
-- As you work, feel free to file speculative improvements or design sparks under `docs/method/backlog/cool-ideas/`.
-- Prefer small, precise backlog notes over leaving useful discoveries only in chat.
+- GitHub Issues are the live work tracker. Local backlog files and migration
+  JSON are historical evidence unless a current issue links to them.
+- Prefer small, precise GitHub Issues over leaving useful discoveries only in
+  chat.
 - Cycles live in `docs/design/<NNNN-slug>/`.
 - Retros live in `docs/method/retro/<NNNN-slug>/`.
 - Signposts are `docs/BEARING.md` and `docs/VISION.md`; update them at cycle boundaries, not mid-cycle.
 - Zero tolerance for brokenness: if you encounter an error or warning in your path, fix it or surface it explicitly.
+- Issue labels are query indexes, not prose decoration. Use exactly these live
+  axes for new or edited issues:
+
+  - `type:*` answers what kind of work it is. Use exactly one of
+    `type:bug`, `type:debt`, `type:feature`, `type:docs`, `type:release`,
+    `type:goalpost`, or `type:story`.
+  - `priority:*` answers when it should be handled. Use zero or one of
+    `priority:asap`, `priority:next`, or `priority:later`.
+  - `status:*` answers active workflow exceptions. Use `status:blocked` or
+    `status:active` only when the issue is actually blocked or actively being
+    worked.
+  - `area:*` answers where the work primarily lives. Prefer one of `area:api`,
+    `area:runtime`, `area:storage`, `area:query`, `area:sync`, `area:docs`,
+    `area:testing`, `area:tooling`, `area:release`, or `area:architecture`.
+  - GitHub Milestones own release targeting. Do not create release-target
+    labels for new work.
+
+- Legacy planning labels are migration-only. Do not add `lane:bad-code`,
+  `lane:cool-ideas`, `lane:release`, `lane:v*`, `release-home:v*`,
+  `feature:*`, `legend:*`, `blocked`, or `work-in-progress` to new issues
+  unless a cleanup cycle is deliberately migrating or removing them.
+- Canonical replacements:
+
+  | Legacy label | Replacement |
+  | --- | --- |
+  | `lane:bad-code` | `type:debt` |
+  | `lane:cool-ideas` | `priority:later` plus the appropriate `type:*` |
+  | `lane:up-next` | `priority:next` |
+  | `lane:asap` | `priority:asap` |
+  | `lane:release` | `type:release` |
+  | `blocked` | `status:blocked` |
+  | `work-in-progress` | `status:active` |
+  | `release-home:vX.Y.Z` / `lane:vX.Y.Z` | GitHub Milestone `vX.Y.Z` |
+  | `feature:*` / `legend:*` | One `area:*` label, with doctrine in the body |
+
+- Release gates must count GitHub Issues by the simplified labels and
+  milestones. Missing required labels or milestones are gate failures, never
+  proof that the count is zero.
 - End every turn with the compact progress footer:
 
   ```text

--- a/docs/METHOD.md
+++ b/docs/METHOD.md
@@ -110,29 +110,29 @@ artifact-history claims, not semantic-provenance claims.
 GitHub Issues are the live tracker. Repository docs are the evidence ledger.
 Issue labels carry Method scheduling state so community contributors can see
 and discuss work without cloning the repository or reading local backlog
-folders.
+folders. Labels are query indexes, not prose decoration.
 
 ### Inbox
 
 Anyone - human, agent, or community contributor - captures raw ideas as
-GitHub Issues with `lane:inbox`. A sentence is enough. Add provenance in the
-issue body or comments when origin or timing matters.
+GitHub Issues. A sentence is enough. Add provenance in the issue body or
+comments when origin or timing matters.
 
-### Lanes
+### Live Axes
 
-| Label                      | Purpose                                          |
-| -------------------------- | ------------------------------------------------ |
-| `lane:inbox`               | Unprocessed intake.                              |
-| `lane:asap`                | Pull into a cycle soon.                          |
-| `lane:up-next`             | Next in line.                                    |
-| `lane:cool-ideas`          | Not committed work.                              |
-| `lane:bad-code`            | Debt, rot, or structural risk.                   |
-| `lane:backlog-root`        | Migrated unlaned work that needs classification. |
-| `lane:v18.0.0` and similar | Release-scoped work for the named lane.          |
+Use these live axes for new and edited GitHub Issues:
 
-Numbered release lanes may also use release milestones or a broad
-`lane:release` label, but the exact source lane label remains useful for
-migration provenance.
+| Axis | Values | Rule |
+| --- | --- | --- |
+| Type | `type:bug`, `type:debt`, `type:feature`, `type:docs`, `type:release`, `type:goalpost`, `type:story` | Exactly one. |
+| Priority | `priority:asap`, `priority:next`, `priority:later` | Zero or one. |
+| Status | `status:blocked`, `status:active` | Only when true. |
+| Area | `area:api`, `area:runtime`, `area:storage`, `area:query`, `area:sync`, `area:docs`, `area:testing`, `area:tooling`, `area:release`, `area:architecture` | Prefer one. |
+| Release target | GitHub Milestone such as `v18.0.0` | Required only for release-owned work. |
+
+Legacy `lane:*`, `release-home:*`, `feature:*`, `legend:*`, `blocked`, and
+`work-in-progress` labels are migration-only. Do not add them to new issues.
+Use GitHub Milestones for release ownership.
 
 ### Naming
 
@@ -147,8 +147,9 @@ legend:MODEL
 legend:DX
 ```
 
-Historical filesystem filenames may survive in archive paths and issue body
-provenance. New work starts as a GitHub Issue.
+Historical filesystem filenames and legend labels may survive in archive paths
+and issue body provenance. New work starts as a GitHub Issue using the live
+axes above.
 
 ### Promoting
 
@@ -158,8 +159,8 @@ When an issue is pulled into a cycle, it becomes a design doc:
 GitHub issue -> docs/design/<cycle>/<task>.md
 ```
 
-The issue is labeled `work-in-progress` and linked from the design doc. New
-cycle design docs follow
+The issue is labeled `status:active` and linked from the design doc. New cycle
+design docs follow
 [design-doc-template.md](method/design-doc-template.md). Work does not silently
 fall back into the queue.
 
@@ -178,7 +179,7 @@ are `#123`, `GH-123`, `git-stunts/git-warp#123`, and
 
 Cycle-start pull requests are non-draft PRs. After the design doc commit is
 pushed, open a PR that references the issue, label the issue
-`work-in-progress`, and link the PR from the issue. The PR is the public cycle
+`status:active`, and link the PR from the issue. The PR is the public cycle
 workspace. It is not ready to merge until the cycle has playback, acceptance
 evidence, closeout material, and validation showing the branch is ready to merge
 into `main`.
@@ -196,7 +197,9 @@ agent) in the design doc. It does not go back.
 
 End of cycle:
 
-- Process `lane:inbox`. Promote, flesh out, or close with a disposition.
+- Process newly filed issues. Add the required `type:*`, optional
+  `priority:*`, status, area, and milestone metadata; flesh out or close with a
+  disposition.
 - Re-prioritize. What you learned changes what matters.
 - Clean up. Merge duplicates, kill the dead.
 
@@ -215,7 +218,7 @@ Same loop regardless:
 
 - **Feature** - design, test, build, ship.
 - **Design** - the deliverable is docs, not code.
-- **Debt** - pull from issues labeled `lane:bad-code`. The hill is
+- **Debt** - pull from issues labeled `type:debt`. The hill is
   "this no longer bothers us."
 
 ---
@@ -238,7 +241,7 @@ The current legends in this repo are:
   `HYGIENE`, `INFRA`, `PERF`, `PROTO`, `SLUDGE`, `TRUST`, `TS`,
   `TUI`, and `VIZ`.
 - **Invariant legends** — debt grouped by the law it violates. These
-  are the canonical legend labels for `lane:bad-code` issues:
+  are issue-body groupings for `type:debt` work:
   - `HEX` — hex boundary honesty
   - `BND` — boundary decode and validation honesty
   - `MODEL` — runtime-backed model honesty
@@ -300,10 +303,10 @@ in one sentence, the cycle is too big. Split it.
 
 2. **Commit and open the cycle PR** - stage the design doc and any cycle-start
    signpost change, commit, push the branch, open a non-draft pull request that
-   references the issue, label the issue `work-in-progress`, and link the PR
-   from the issue. The PR is the public cycle workspace; it becomes ready for
-   merge review only after playback, acceptance evidence, closeout material,
-   and validation show the branch is ready to merge into `main`.
+   references the issue, label the issue `status:active`, and link the PR from
+   the issue. The PR is the public cycle workspace; it becomes ready for merge
+   review only after playback, acceptance evidence, closeout material, and
+   validation show the branch is ready to merge into `main`.
 
 3. **RED** - write failing tests. The proof surface becomes the spec.
    Default to agent surface first.
@@ -325,8 +328,9 @@ in one sentence, the cycle is too big. Split it.
 6. **Close** - write the retro and witness packet on the branch.
    - Drift check (mandatory). Undocumented drift is the only true
      failure mode.
-   - New debt to GitHub Issues labeled `lane:bad-code`.
-   - Cool ideas to GitHub Issues labeled `lane:cool-ideas`.
+   - New debt to GitHub Issues labeled `type:debt`.
+   - Cool ideas to GitHub Issues labeled `priority:later` plus the
+     appropriate `type:*`.
    - Issue maintenance.
 
    Closing the cycle packet does not mean `main` has accepted it yet.
@@ -387,7 +391,8 @@ a standup:
 
 - What is everyone working on? -> open design docs
 - What is committed? -> each design doc names its sponsors and hill
-- What is next? -> GitHub Issues labeled `lane:asap`
+- What is next? -> GitHub Issues labeled `priority:asap` or
+  `priority:next`
 - What failed and why? -> `ls docs/method/retro/`
 - What did we decide not to do? -> `ls docs/method/graveyard/`
 
@@ -418,10 +423,11 @@ agenda.
 
 ### Conflict in the tracker
 
-Two people pulling conflicting `lane:asap` issues is a design-doc problem, not
-a process problem. Active design docs are visible through the repo itself. If
-your hill contradicts an active cycle's hill, you should see it at step 1.
-Resolve it there or file it as a tension in `docs/BEARING.md`.
+Two people pulling conflicting `priority:asap` or `priority:next` issues is a
+design-doc problem, not a process problem. Active design docs are visible
+through the repo itself. If your hill contradicts an active cycle's hill, you
+should see it at step 1. Resolve it there or file it as a tension in
+`docs/BEARING.md`.
 
 ### What this does not add
 
@@ -442,10 +448,10 @@ to resurrect something, you must address the note.
 ## Flow
 
 ```text
-idea -> lane:inbox -> lane:cool-ideas -> lane:up-next -> lane:asap
+idea -> issue with type/priority/status/area/milestone metadata
   -> issue + synced merge target + cycle branch
   -> design/<cycle>/  (committed issue)
-  -> non-draft work-in-progress PR
+  -> non-draft status:active PR
   -> RED -> GREEN -> playback (witness)
   -> retro/<cycle>/   (cycle packet closed)
   -> review -> main

--- a/docs/checklists/release-evidence-template.md
+++ b/docs/checklists/release-evidence-template.md
@@ -29,10 +29,12 @@ Paste or summarize the `npm run release:guard -- --tag vX.Y.Z` output.
 | `REL-TOOL-GH` | `TBD` | GitHub CLI available when live issue gates are required, or not required for this stage. |
 | `REL-TAG-FORMAT` | `TBD` | Tag uses leading-`v` SemVer. |
 | `REL-GH-ACCESS` | `TBD` | GitHub repository readable when live issue gates are required. |
-| `REL-GH-ASAP-ZERO` | `TBD` | No open `lane:asap` issues. |
-| `REL-GH-TARGET-LANE-ZERO` | `TBD` | No open target-version lane issues. |
-| `REL-GH-PRIOR-RELEASE-LABELS` | `TBD` | All `release-home:v*` labels use release SemVer. |
-| `REL-GH-PRIOR-RELEASE-ZERO` | `TBD` | No open prior-release-home issues. |
+| `REL-GH-PRIORITY-ASAP-LABEL` | `TBD` | Required `priority:asap` label exists. |
+| `REL-GH-ASAP-ZERO` | `TBD` | No open `priority:asap` issues. |
+| `REL-GH-TARGET-MILESTONE-EXISTS` | `TBD` | Target GitHub Milestone exists. |
+| `REL-GH-TARGET-MILESTONE-ZERO` | `TBD` | No open issues in the target GitHub Milestone. |
+| `REL-GH-PRIOR-RELEASE-MILESTONES` | `TBD` | All release GitHub Milestones use release SemVer. |
+| `REL-GH-PRIOR-RELEASE-ZERO` | `TBD` | No open issues in prior release GitHub Milestones. |
 | `REL-GH-STAGE` | `TBD` | Stage-specific issue gate posture recorded. |
 | `REL-META-VERSION-LOCKSTEP` | `TBD` | Package, JSR, lockfile, and workspace versions match. |
 | `REL-GIT-CLEAN` | `TBD` | Worktree clean at tag time. |

--- a/docs/method/release.md
+++ b/docs/method/release.md
@@ -88,10 +88,12 @@ publishing. It enforces:
 | `REL-TOOL-GH` | GitHub CLI is available when the stage enforces live GitHub issue gates. |
 | `REL-TAG-FORMAT` | The release tag uses leading-`v` SemVer, with optional `alpha`, `beta`, or `rc` prerelease suffix. |
 | `REL-GH-ACCESS` | The configured GitHub repository is readable before live issue gates run. |
-| `REL-GH-ASAP-ZERO` | There are zero open GitHub Issues labeled `lane:asap`. |
-| `REL-GH-TARGET-LANE-ZERO` | There are zero open GitHub Issues in the target version lane, such as `lane:v18.0.0`. |
-| `REL-GH-PRIOR-RELEASE-LABELS` | Every `release-home:v*` label uses valid release SemVer before prior-release arithmetic runs. |
-| `REL-GH-PRIOR-RELEASE-ZERO` | There are zero open GitHub Issues with `release-home:` labels lower than the target version. |
+| `REL-GH-PRIORITY-ASAP-LABEL` | The required `priority:asap` label exists before urgent-issue counts run. |
+| `REL-GH-ASAP-ZERO` | There are zero open GitHub Issues labeled `priority:asap`. |
+| `REL-GH-TARGET-MILESTONE-EXISTS` | The target GitHub Milestone, such as `v18.0.0`, exists before target counts run. |
+| `REL-GH-TARGET-MILESTONE-ZERO` | There are zero open GitHub Issues in the target GitHub Milestone. |
+| `REL-GH-PRIOR-RELEASE-MILESTONES` | Every `v*` GitHub Milestone uses valid release SemVer before prior-release arithmetic runs. |
+| `REL-GH-PRIOR-RELEASE-ZERO` | There are zero open GitHub Issues in GitHub Milestones lower than the target version. |
 | `REL-GH-STAGE` | Stages that intentionally skip live issue gates state why. |
 | `REL-META-VERSION-LOCKSTEP` | Root `package.json`, `jsr.json`, `package-lock.json`, and private workspace package versions all match the tag version. |
 | `REL-GIT-CLEAN` | The worktree has no unstaged or staged-but-uncommitted changes. |

--- a/docs/method/roadmap-planning.md
+++ b/docs/method/roadmap-planning.md
@@ -244,20 +244,18 @@ Labels are query indexes, not prose decoration.
 
 git-warp keeps its structured label model:
 
-| Label | Meaning |
+| Axis | Meaning |
 | --- | --- |
-| `type:goalpost` | Umbrella milestone issue. |
-| `type:proof-story` | Child issue scoped to one actor story or proof contract. |
-| `lane:asap` | Immediate release pressure. |
-| `lane:vX.Y.Z` | Active version lane for the named release. |
-| `release-home:vX.Y.Z` | Release ownership for planning and prior-release cleanup. |
-| `feature:*` | Capability area. |
-| `legend:*` | Work doctrine or theme. |
-| `work-in-progress` | Current active implementation cycle. |
+| `type:*` | Work kind. Use exactly one of `type:bug`, `type:debt`, `type:feature`, `type:docs`, `type:release`, `type:goalpost`, or `type:story`. Existing `type:proof-story` issues are migration residue for proof-story children. |
+| `priority:*` | Scheduling pressure. Use zero or one of `priority:asap`, `priority:next`, or `priority:later`. |
+| `status:*` | Active workflow exception. Use `status:blocked` or `status:active` only when true. |
+| `area:*` | Primary work area, such as `area:api`, `area:runtime`, `area:storage`, `area:query`, `area:sync`, `area:docs`, `area:testing`, `area:tooling`, `area:release`, or `area:architecture`. |
+| GitHub Milestone | Release ownership and prior-release cleanup target. |
 
-The important invariant is that `type:goalpost` and `type:proof-story` are not
+The important invariant is that `type:goalpost` and child story types are not
 mixed casually. Umbrella issues get `type:goalpost`; child proof-story issues
-get `type:proof-story`.
+prefer `type:story` for new work while existing `type:proof-story` issues are
+migrated.
 
 ## Lifecycle
 

--- a/scripts/release-guard.sh
+++ b/scripts/release-guard.sh
@@ -53,7 +53,7 @@ esac
 
 TAG_VERSION=""
 TARGET_VERSION=""
-TARGET_LANE=""
+TARGET_MILESTONE=""
 EVIDENCE_FILE=""
 FAILURES=0
 
@@ -98,14 +98,14 @@ derive_and_validate_tag() {
   if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; then
     TAG_VERSION="${TAG#v}"
     TARGET_VERSION="${TAG_VERSION%%-*}"
-    TARGET_LANE="lane:v${TARGET_VERSION}"
+    TARGET_MILESTONE="v${TARGET_VERSION}"
     EVIDENCE_FILE="docs/releases/v${TARGET_VERSION}/README.md"
     pass "REL-TAG-FORMAT" "$TAG is a valid release tag"
   else
     fail "REL-TAG-FORMAT" "$TAG is not vMAJOR.MINOR.PATCH or prerelease"
     TAG_VERSION="0.0.0"
     TARGET_VERSION="0.0.0"
-    TARGET_LANE="lane:v${TARGET_VERSION}"
+    TARGET_MILESTONE="v${TARGET_VERSION}"
     EVIDENCE_FILE="docs/releases/v${TARGET_VERSION}/README.md"
   fi
 }
@@ -170,6 +170,61 @@ count_open_issues_with_label() {
     --jq '.data.search.issueCount'
 }
 
+count_open_issues_with_milestone() {
+  local milestone="$1"
+  local search_query="repo:$REPO is:issue is:open milestone:\"$milestone\""
+  gh api graphql \
+    -f query='query($searchQuery: String!) { search(query: $searchQuery, type: ISSUE, first: 1) { issueCount } }' \
+    -f searchQuery="$search_query" \
+    --jq '.data.search.issueCount'
+}
+
+label_exists() {
+  local label="$1"
+  gh label list \
+    --repo "$REPO" \
+    --search "$label" \
+    --limit 100 \
+    --json name \
+    --jq '.[].name' \
+    | grep -Fx -- "$label" >/dev/null
+}
+
+milestone_exists() {
+  local milestone="$1"
+  gh api "repos/$REPO/milestones?state=all&per_page=100" \
+    --paginate \
+    --jq '.[].title' \
+    | grep -Fx -- "$milestone" >/dev/null
+}
+
+list_release_milestones() {
+  gh api "repos/$REPO/milestones?state=all&per_page=100" \
+    --paginate \
+    --jq '.[].title' \
+    | grep '^v' || true
+}
+
+require_label() {
+  local check_id="$1"
+  local label="$2"
+  if label_exists "$label"; then
+    pass "$check_id" "GitHub label $label exists"
+  else
+    fail "$check_id" "GitHub label $label is missing"
+  fi
+}
+
+require_milestone() {
+  local check_id="$1"
+  local milestone="$2"
+  if milestone_exists "$milestone"; then
+    pass "$check_id" "GitHub milestone $milestone exists"
+  else
+    fail "$check_id" "GitHub milestone $milestone is missing"
+  fi
+}
+
 check_zero_label() {
   local check_id="$1"
   local label="$2"
@@ -183,6 +238,25 @@ check_zero_label() {
       --repo "$REPO" \
       --state open \
       --label "$label" \
+      --limit 20 \
+      --json number,title,url \
+      --template '{{range .}}{{printf "#%v %s %s\n" .number .title .url}}{{end}}'
+  fi
+}
+
+check_zero_milestone() {
+  local check_id="$1"
+  local milestone="$2"
+  local count
+  count="$(count_open_issues_with_milestone "$milestone")"
+  if [ "$count" = "0" ]; then
+    pass "$check_id" "no open issues in milestone $milestone"
+  else
+    fail "$check_id" "$count open issue(s) in milestone $milestone"
+    gh issue list \
+      --repo "$REPO" \
+      --state open \
+      --milestone "$milestone" \
       --limit 20 \
       --json number,title,url \
       --template '{{range .}}{{printf "#%v %s %s\n" .number .title .url}}{{end}}'
@@ -372,43 +446,45 @@ check_release_evidence() {
 }
 
 check_issue_gates() {
-  check_zero_label "REL-GH-ASAP-ZERO" "lane:asap"
-  check_zero_label "REL-GH-TARGET-LANE-ZERO" "$TARGET_LANE"
+  require_label "REL-GH-PRIORITY-ASAP-LABEL" "priority:asap"
+  check_zero_label "REL-GH-ASAP-ZERO" "priority:asap"
+  require_milestone "REL-GH-TARGET-MILESTONE-EXISTS" "$TARGET_MILESTONE"
+  check_zero_milestone "REL-GH-TARGET-MILESTONE-ZERO" "$TARGET_MILESTONE"
 
   local prior_failures=0
-  local malformed_labels=0
-  while IFS= read -r label; do
-    [ "$label" = "" ] && continue
-    case "$label" in
-      release-home:v*) ;;
+  local malformed_milestones=0
+  while IFS= read -r milestone; do
+    [ "$milestone" = "" ] && continue
+    case "$milestone" in
+      v*) ;;
       *) continue ;;
     esac
-    local version="${label#release-home:v}"
+    local version="${milestone#v}"
     if ! is_release_version "$version"; then
-      printf '    malformed release-home label: %s\n' "$label"
-      malformed_labels=$((malformed_labels + 1))
+      printf '    malformed release milestone: %s\n' "$milestone"
+      malformed_milestones=$((malformed_milestones + 1))
       continue
     fi
     if semver_less_than "$version" "$TARGET_VERSION"; then
       local count
-      count="$(count_open_issues_with_label "$label")"
+      count="$(count_open_issues_with_milestone "$milestone")"
       if [ "$count" != "0" ]; then
-        printf '    %s has %s open issue(s)\n' "$label" "$count"
+        printf '    milestone %s has %s open issue(s)\n' "$milestone" "$count"
         prior_failures=$((prior_failures + count))
       fi
     fi
-  done < <(gh label list --repo "$REPO" --search "release-home:v" --limit 1000 --json name --jq '.[].name')
+  done < <(list_release_milestones)
 
-  if [ "$malformed_labels" -eq 0 ]; then
-    pass "REL-GH-PRIOR-RELEASE-LABELS" "all release-home labels use release SemVer"
+  if [ "$malformed_milestones" -eq 0 ]; then
+    pass "REL-GH-PRIOR-RELEASE-MILESTONES" "all release milestones use release SemVer"
   else
-    fail "REL-GH-PRIOR-RELEASE-LABELS" "$malformed_labels malformed release-home label(s)"
+    fail "REL-GH-PRIOR-RELEASE-MILESTONES" "$malformed_milestones malformed release milestone(s)"
   fi
 
   if [ "$prior_failures" -eq 0 ]; then
-    pass "REL-GH-PRIOR-RELEASE-ZERO" "no open prior-release-home issues before v${TARGET_VERSION}"
+    pass "REL-GH-PRIOR-RELEASE-ZERO" "no open prior-release milestone issues before v${TARGET_VERSION}"
   else
-    fail "REL-GH-PRIOR-RELEASE-ZERO" "$prior_failures open issue(s) remain from prior release-home labels"
+    fail "REL-GH-PRIOR-RELEASE-ZERO" "$prior_failures open issue(s) remain from prior release milestones"
   fi
 }
 

--- a/test/unit/scripts/release-policy-shape.test.ts
+++ b/test/unit/scripts/release-policy-shape.test.ts
@@ -115,12 +115,20 @@ describe('release policy shape', () => {
 
     expect(releaseDoc).toContain('Tag-time release law');
     expect(releaseDoc).toContain('The guard is stage-aware');
+    expect(releaseDoc).toContain('REL-GH-PRIORITY-ASAP-LABEL');
     expect(releaseDoc).toContain('REL-GH-ASAP-ZERO');
-    expect(releaseDoc).toContain('REL-GH-TARGET-LANE-ZERO');
+    expect(releaseDoc).toContain('REL-GH-TARGET-MILESTONE-EXISTS');
+    expect(releaseDoc).toContain('REL-GH-TARGET-MILESTONE-ZERO');
+    expect(releaseDoc).toContain('REL-GH-PRIOR-RELEASE-MILESTONES');
     expect(releaseDoc).toContain('REL-GH-PRIOR-RELEASE-ZERO');
-    expect(releaseGuard).toContain('check_zero_label "REL-GH-ASAP-ZERO" "lane:asap"');
-    expect(releaseGuard).toContain('check_zero_label "REL-GH-TARGET-LANE-ZERO" "$TARGET_LANE"');
-    expect(releaseGuard).toContain('release-home:v');
+    expect(releaseGuard).toContain('require_label "REL-GH-PRIORITY-ASAP-LABEL" "priority:asap"');
+    expect(releaseGuard).toContain('check_zero_label "REL-GH-ASAP-ZERO" "priority:asap"');
+    expect(releaseGuard).toContain('require_milestone "REL-GH-TARGET-MILESTONE-EXISTS" "$TARGET_MILESTONE"');
+    expect(releaseGuard).toContain('check_zero_milestone "REL-GH-TARGET-MILESTONE-ZERO" "$TARGET_MILESTONE"');
+    expect(releaseGuard).toContain('REL-GH-PRIOR-RELEASE-MILESTONES');
+    expect(releaseGuard).not.toContain('check_zero_label "REL-GH-ASAP-ZERO" "lane:asap"');
+    expect(releaseGuard).not.toContain('REL-GH-TARGET-LANE-ZERO');
+    expect(releaseGuard).not.toContain('release-home:v');
     expect(releaseGuard).toContain('git status --porcelain');
   });
 


### PR DESCRIPTION
## Summary

Locks the simplified issue taxonomy into contributor and agent policy, then starts enforcing the new release-gate model.

- define live issue axes: `type:*`, `priority:*`, `status:*`, `area:*`
- mark legacy `lane:*`, `release-home:*`, `feature:*`, `legend:*`, `blocked`, and `work-in-progress` labels as migration-only
- update Method and roadmap planning docs so they no longer instruct new work to use legacy lanes
- update `scripts/release-guard.sh` to require `priority:asap`, require target milestones, and count milestone-owned release issues
- update release evidence docs and release-policy shape tests for the new gate names

GitHub setup performed before opening this PR:

- created simplified labels: `type:*`, `priority:*`, `status:*`, `area:*`
- created release milestones from `v17.0.0` through `v21.1.0`
- did not mass-relabel existing issues

## Validation

- `bash -n scripts/release-guard.sh`
- `npx vitest run test/unit/scripts/release-policy-shape.test.ts`
- `npm run lint:md -- AGENTS.md .github/CONTRIBUTING.md docs/METHOD.md docs/method/roadmap-planning.md docs/method/release.md docs/checklists/release-evidence-template.md`
- `npm run lint:md:code -- AGENTS.md .github/CONTRIBUTING.md docs/METHOD.md docs/method/roadmap-planning.md docs/method/release.md docs/checklists/release-evidence-template.md`
- pre-push hook: link check, static gates, markdown gates, and `npm run test:local` (558 files / 7204 tests)

Refs #618.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines with new issue triage requirements and planning sources (GitHub Issues, Milestones, design docs, retrospectives).
  * Revised method workflow to use GitHub issue axes (type, priority, status, area) instead of lane-based planning.
  * Updated release process documentation and templates to use milestone-based gates.
  * Clarified project planning model and information sources.

* **Chores**
  * Updated release automation to enforce new label and milestone requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->