### PR TITLE
Reconcile v18 issue taxonomy

### DIFF
--- a/docs/BEARING.md
+++ b/docs/BEARING.md
@@ -77,9 +77,8 @@ backlog cards were migrated on 2026-06-01, labeled by source lane, and archived
 as evidence. The migration map is
 [github-issue-migration-2026-06-01.json](method/github-issue-migration-2026-06-01.json).
 
-Current release-blocking issues:
+Current release-blocking issue:
 
-- [#549 Bounded-memory large-graph product gate](https://github.com/git-stunts/git-warp/issues/549)
 - [#552 v18 public release blockers](https://github.com/git-stunts/git-warp/issues/552)
 
 Completed gate evidence:
@@ -93,6 +92,10 @@ Completed gate evidence:
 - V18-GP1 Optics public API closeout closed on 2026-06-06 with public
   coordinate node/property read, first-use honesty, recovery, docs, and
   consumer type evidence.
+- V18-GP2 Bounded-memory large-graph product gate closed on 2026-06-09 through
+  PR #647 with non-release evidence for memory budgeting, large-graph fixture
+  conformance, bounded reads, patch streams, basis building, fact resolvers,
+  sync batching, capability reporting, and operator witness output.
 
 ## Where Are We
 
@@ -116,9 +119,8 @@ Current release facts:
 - If `main` moves after `5e081cca` before tagging, rerun release preflight from
   the exact commit that will receive the `v18.0.0` tag.
 - No `v18.0.0` tag or registry publish evidence is recorded yet.
-- `v18.0.0` is intentionally delayed until `API_optics-public-api-closeout`,
-  `PERF_bounded-memory-large-graph-product-gate`, and release operation
-  evidence close in GitHub Issues.
+- `v18.0.0` is intentionally delayed until release operation evidence closes in
+  GitHub Issues and the operator explicitly approves tagging.
 
 Current v18 implementation posture:
 
@@ -195,21 +197,15 @@ The next work should stay split into distinct modes:
 1. **Public API product pivot**: make Worldlines and Optics the v18 first-use
    story while deprecating graph/materialize-first public paths. Worldlines are
    done; coordinate Optics exist but are blocked on both gates below.
-2. **V18 honesty gate**: classify public APIs by cost, add first-use
-   materialization tripwires, remove full materialization from
-   `prepareOpticBasis()`, and keep first-use docs honest about transitional
-   surfaces until the bounded-memory gate lands.
-3. **V18 bounded-memory large-graph gate**: add the memory budget, streaming
-   patch and basis substrates, sharded fact indexes, fact-resolver writes,
-   cursorized public reads and sync, bounded content lookup, capability
-   reporting, operator doctor tooling, and bounded-mode legacy rejection needed
-   for large-graph-over-small-pool conformance.
-4. **Optics public API closeout**: prove public success paths for node and
-   property optics through `openWarpWorldline(...).coordinate().optic()`,
-   document basis setup and recovery, and lock the package/consumer type
-   surface against the bounded-memory evidence.
+2. **V18 honesty gate**: landed as V18-GP1 plus gate evidence; keep first-use
+   docs honest about transitional surfaces.
+3. **V18 bounded-memory large-graph gate**: landed as V18-GP2 at the
+   non-release evidence layer. Release/tag evidence remains separate.
+4. **Optics public API closeout**: landed as V18-GP1 with public node/property
+   Optics, setup, recovery, docs, and consumer type evidence.
 5. **Release operation**: cut and publish `v18.0.0` from aligned `main` only
-   after Optics closeout and both gates.
+   after tracker reconciliation, release preflight, explicit tag approval, and
+   recorded publish evidence.
 6. **Substrate debt**: retire one more raw content/property compatibility
    boundary and ratchet the closeout audit.
 7. **v19 runway**: start native Continuum witnesshood work without backdating a
@@ -239,21 +235,21 @@ Release-operation work is paused behind Optics merge and release evidence:
 - [x] Add first-use Optics materialization tripwire evidence.
 - [x] Change `prepareOpticBasis()` to verify existing checkpoint-tail basis evidence or
   fail closed.
-- [~] Start [#549](https://github.com/git-stunts/git-warp/issues/549)
+- [x] Complete [#549](https://github.com/git-stunts/git-warp/issues/549)
   `PERF_bounded-memory-large-graph-product-gate` with
   [0270-v18-bounded-tree-entry-basis-probes](design/0270-v18-bounded-tree-entry-basis-probes/v18-bounded-tree-entry-basis-probes.md):
-  remove the residual full tree-map dependency from checkpoint-tail basis
-  verification.
+  memory-budget, large-graph fixture, bounded read, patch stream, basis builder,
+  fact resolver, sync batch, capability report, and operator witness evidence.
 - [x] Add bounded tree-entry probe evidence for checkpoint-tail basis setup in
   PR #579:
   [0270-v18-bounded-tree-entry-basis-probes](design/0270-v18-bounded-tree-entry-basis-probes/v18-bounded-tree-entry-basis-probes.md).
-- [ ] Complete [#549](https://github.com/git-stunts/git-warp/issues/549)
+- [x] Complete [#549](https://github.com/git-stunts/git-warp/issues/549)
   `PERF_bounded-memory-large-graph-product-gate`.
-- [ ] Add tripwire evidence for documented first-use Optics paths.
-- [ ] Add large-graph-over-small-pool conformance evidence.
-- [ ] Update first-use docs and public API labels so bounded, streaming,
+- [x] Add tripwire evidence for documented first-use Optics paths.
+- [x] Add large-graph-over-small-pool conformance evidence.
+- [x] Update first-use docs and public API labels so bounded, streaming,
   cursor, transitional, diagnostic, offline, and legacy surfaces are explicit.
-- [ ] Complete [#547](https://github.com/git-stunts/git-warp/issues/547)
+- [x] Complete [#547](https://github.com/git-stunts/git-warp/issues/547)
   `API_optics-public-api-closeout` and merge to `main`.
 - [ ] Rerun `npm run release:preflight` from aligned `main` after Optics
   closeout lands.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -29,21 +29,21 @@ goalpost.
 | Release status | `active` |
 | Current public release | `v17.0.0` |
 | Goalposts | `5` |
-| Landed goalposts | `3` |
+| Landed goalposts | `4` |
 | Total planned slice budget | `53` |
-| Target lane | `lane:v18.0.0` |
+| Target milestone | `v18.0.0` |
 | Release evidence packet | `docs/releases/v18.0.0/README.md` |
 
-v18.0.0 is ready only when every goalpost below is landed, every issue in
-`lane:v18.0.0` is closed, superseded work has been closed or moved out of the
-target lane with linked disposition, the release evidence packet is complete
-and placeholder-free, and `npm run release:preflight` passes from aligned
-`main`.
+v18.0.0 is ready only when every goalpost below is landed, every issue in the
+`v18.0.0` milestone is closed, superseded work has been closed or moved out of
+the target milestone with linked disposition, the release evidence packet is
+complete and placeholder-free, and `npm run release:preflight` passes from
+aligned `main`.
 
 | Goalpost | Status | Slice budget | Umbrella or tracker issue | Goalpost doc | Release gate |
 | --- | --- | ---: | --- | --- | --- |
 | V18-GP1 Optics Public API Closeout | landed | 20 | [#547](https://github.com/git-stunts/git-warp/issues/547) | [v18-gp1-optics-public-api-closeout.md](method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md) | First-use Optics are usable and honest without hidden full materialization. |
-| V18-GP2 Bounded-Memory Large-Graph Product Gate | active | 15 | [#549](https://github.com/git-stunts/git-warp/issues/549) | [v18-gp2-bounded-memory-large-graph-gate.md](method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md) | Normal public reads, writes, content lookup, and sync must honor an explicit memory budget. |
+| V18-GP2 Bounded-Memory Large-Graph Product Gate | landed | 15 | [#549](https://github.com/git-stunts/git-warp/issues/549) | [v18-gp2-bounded-memory-large-graph-gate.md](method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md) | Normal public reads, writes, content lookup, and sync must honor an explicit memory budget. |
 | V18-GP3 Content Attachment Plane Honesty | landed | 4 | [#550](https://github.com/git-stunts/git-warp/issues/550) | [v18-gp3-content-attachment-plane-honesty.md](method/roadmap/v18.0.0/v18-gp3-content-attachment-plane-honesty.md) | Release claims now distinguish typed attachment-plane progress from accepted legacy storage residuals. |
 | V18-GP4 Holographic Slicing And Checkpoint Basis | landed | 8 | [#626](https://github.com/git-stunts/git-warp/issues/626), [#628](https://github.com/git-stunts/git-warp/issues/628)-[#635](https://github.com/git-stunts/git-warp/issues/635) | [v18-gp4-holographic-slicing-checkpoint-basis.md](method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md) | Normal public graph-shaped reads now have bounded, witnessed slices over declared basis. |
 | V18-GP5 Release Operation Evidence | active | 6 | [#552](https://github.com/git-stunts/git-warp/issues/552) | [v18-gp5-release-operation-evidence.md](method/roadmap/v18.0.0/v18-gp5-release-operation-evidence.md) | Tagging and publishing must satisfy the release policy and record deterministic evidence. |
@@ -58,20 +58,25 @@ V18-GP4 Holographic slicing basis
   -> V18-GP5 Release operation evidence
 ```
 
-V18-GP1, V18-GP3, and V18-GP4 are landed. The next release-blocking target is
-V18-GP2 [#549](https://github.com/git-stunts/git-warp/issues/549), which owns
-the broader bounded-memory public-path product gate.
+V18-GP1, V18-GP2, V18-GP3, and V18-GP4 are landed. The next release-blocking
+target is V18-GP5 [#552](https://github.com/git-stunts/git-warp/issues/552),
+which owns release operation evidence and must not be completed before explicit
+tag approval.
 
 Release progress should be reported as:
 
 ```text
-v18.0.0 goalposts: 3/5 landed
-v18.0.0 slices: 32/53 landed
-next goalpost: V18-GP2 Bounded-Memory Large-Graph Product Gate
-next slice: reconcile #549 against landed holographic slicing evidence
+v18.0.0 goalposts: 4/5 landed
+v18.0.0 slices: 47/53 landed
+next goalpost: V18-GP5 Release Operation Evidence
+next slice: reconcile #552 against current issue metadata and release evidence
 ```
 
-## Snapshot
+## Pre-Migration Snapshot
+
+This snapshot records the legacy label state before the 2026-06-10 simplified
+taxonomy migration. Current planning authority lives in GitHub milestones and
+the `type:*`, `priority:*`, `status:*`, and `area:*` label axes.
 
 | Metric | Count |
 | --- | ---: |
@@ -84,12 +89,19 @@ next slice: reconcile #549 against landed holographic slicing evidence
 
 ## Release Assignment Rules
 
-- Issues with `lane:release` and a version lane are hard release-plan issues for that major.
-- No planned release slot may contain more than 50 open issues. Oversized buckets must be split into explicit patch or minor waves.
-- `release-home:v17.0.0` is treated as residual maintenance carried forward into the v18 patch train, not as a new v17 release.
-- `release-home:v18.0.0` issues that are not in `lane:release` are treated as v18 hardening unless their feature clearly belongs later.
-- Issues without a release-home label are assigned by feature area: observer work to v19, streaming/materialization work to v20, merge/strand/worldline work to v21, and docs/testing/tooling/runtime-boundary hardening to v18.
-- This is a proposed roadmap. Changing a GitHub issue label is the authoritative way to move an issue between release slots.
+- Issues in a version milestone are hard release-plan issues for that version.
+- No planned release slot may contain more than 50 open issues. Oversized
+  buckets must be split into explicit patch or minor waves.
+- Legacy `release-home:*` labels are migration inputs only. Convert them to
+  GitHub milestones before treating the release bucket as authoritative.
+- Legacy `lane:*`, `feature:*`, and `legend:*` labels are migration inputs only.
+  Convert active issue state to `type:*`, `priority:*`, `status:*`, and
+  `area:*`.
+- Issues without a milestone are assigned by area: observer work to v19,
+  streaming/materialization work to v20, merge/strand/worldline work to v21,
+  and docs/testing/tooling/runtime-boundary hardening to v18.
+- This is a proposed roadmap. Changing a GitHub issue milestone is the
+  authoritative way to move an issue between release slots.
 
 ## Proposed Release Buckets
 
@@ -113,7 +125,7 @@ next slice: reconcile #549 against landed holographic slicing evidence
 | v21.1.0 | 1 | Stabilize WESLEY and Continuum contract surfaces after the merge runtime nouns are no longer speculative. |
 | future | 4 | Issues without enough signal for a release slot. They stay visible here until labels or designs make a sharper call possible. |
 
-## Current Label Counts
+## Legacy Label Counts At Migration Start
 
 ### Lanes
 
@@ -178,8 +190,8 @@ Ship only after bounded-memory public paths and release operation evidence are c
 
 | Issue | Title | Status | Type | Lane | Feature | Release Home | Flags |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| [#549](https://github.com/git-stunts/git-warp/issues/549) | Bounded-memory large-graph product gate | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
-| [#552](https://github.com/git-stunts/git-warp/issues/552) | v18 public release blockers | Blocked | enhancement | release, v18.0.0 | graph-model-substrate | - | blocked, wip, release |
+| [#549](https://github.com/git-stunts/git-warp/issues/549) | Bounded-memory large-graph product gate | Closed | enhancement | release, v18.0.0 | graph-model-substrate | - | release |
+| [#552](https://github.com/git-stunts/git-warp/issues/552) | v18 public release blockers | Blocked | release | release, v18.0.0 | graph-model-substrate | - | blocked, release |
 
 ### v18.0.1 - Public Docs And Release Tooling Repair
 

--- a/docs/design/0272-v18-issue-taxonomy-reconciliation/v18-issue-taxonomy-reconciliation.md
+++ b/docs/design/0272-v18-issue-taxonomy-reconciliation/v18-issue-taxonomy-reconciliation.md
@@ -1,0 +1,113 @@
+# V18 Issue Taxonomy Reconciliation
+
+## Purpose
+
+This cycle reconciles live GitHub issue metadata after the simplified taxonomy
+policy landed. It does not close issues without evidence. An issue may be
+closed only when the closeout comment cites deterministic evidence in this
+shape:
+
+```text
+path/to/file.ext#L<number>@<commit-sha>
+```
+
+If the repository cannot support a closure with file-line evidence at the
+current commit, the issue remains open or the operator is asked for an explicit
+disposition.
+
+## Starting State
+
+At commit `ce663b6783957b06b68769e0925b6ea60e2f20cd`, the live tracker had:
+
+| Query | Count |
+| --- | ---: |
+| Open `priority:asap` issues | 0 |
+| Open legacy `lane:asap` issues | 0 |
+| Open `type:debt` issues | 0 |
+| Open legacy `lane:bad-code` issues | 214 |
+| Open `release-home:v18.0.0` issues | 22 |
+| Open `lane:v18.0.0` issues | 1 |
+
+The counts prove a metadata migration problem: the new policy exists, but open
+issues still use legacy lane and release-home labels.
+
+## Evidence-Gated Closeout Posture
+
+Issue [#547](https://github.com/git-stunts/git-warp/issues/547) is already
+closed and is supported by repository evidence:
+
+| Claim | Evidence |
+| --- | --- |
+| V18-GP1 is landed. | `docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md#L13@ce663b6783957b06b68769e0925b6ea60e2f20cd` |
+| #547 is closed as the public Optics closeout goalpost. | `docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md#L25@ce663b6783957b06b68769e0925b6ea60e2f20cd` |
+| The deterministic replay matrix names the public Optics fixtures. | `docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md#L87@ce663b6783957b06b68769e0925b6ea60e2f20cd` |
+
+Issue [#549](https://github.com/git-stunts/git-warp/issues/549) is already
+closed and is supported by repository evidence:
+
+| Claim | Evidence |
+| --- | --- |
+| V18-GP2 has all 15 slices complete. | `docs/method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md#L50@ce663b6783957b06b68769e0925b6ea60e2f20cd` |
+| Large-graph-over-small-pool and bounded public-path evidence is deterministic. | `docs/method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md#L82@ce663b6783957b06b68769e0925b6ea60e2f20cd` |
+| Release/tag proof remains explicitly out of scope and belongs to #552. | `docs/method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md#L118@ce663b6783957b06b68769e0925b6ea60e2f20cd` |
+
+Issue [#552](https://github.com/git-stunts/git-warp/issues/552) must remain
+open until the operator explicitly approves tag work. The repo has no
+`v18.0.0` tag or publish evidence, and the issue owns release operation rather
+than the already-closed non-release goalposts.
+
+## Metadata Migration Rules
+
+Live issue metadata should follow the simplified taxonomy:
+
+| Legacy metadata | New metadata |
+| --- | --- |
+| `lane:bad-code` | `type:debt` |
+| `type:maintenance` on debt issues | remove after adding `type:debt` |
+| `release-home:vMAJOR.MINOR.PATCH` | GitHub milestone `vMAJOR.MINOR.PATCH` |
+| `lane:vMAJOR.MINOR.PATCH` | GitHub milestone `vMAJOR.MINOR.PATCH` |
+| `lane:cool-ideas` | `priority:later` |
+| `lane:up-next` | `priority:next` |
+| `blocked` | `status:blocked` |
+| `work-in-progress` | `status:active` |
+
+Legacy labels may remain on closed historical issues as migration evidence, but
+open issues should not use them as live coordination state.
+
+## V18 Reconciliation Contract
+
+- [x] Move open `release-home:v18.0.0` and `lane:v18.0.0` issues into the
+      `v18.0.0` milestone.
+- [x] Migrate open `lane:bad-code` issues to `type:debt`.
+- [x] Remove legacy debt lane/type labels from migrated open debt issues.
+- [ ] Update #552 with a comment explaining that #547 and #549 are closed with
+      file-line evidence while release operation remains open.
+- [ ] Do not close #552 without explicit operator approval.
+- [x] Rerun issue-count evidence after migration.
+
+## Post-Migration State
+
+After GitHub metadata reconciliation:
+
+| Query | Count |
+| --- | ---: |
+| Open `priority:asap` issues | 0 |
+| Open legacy `lane:asap` issues | 0 |
+| Open legacy `lane:bad-code` issues | 0 |
+| Open legacy `type:maintenance` issues | 0 |
+| Open `type:debt` issues | 214 |
+| Open legacy `release-home:v18.0.0` issues | 0 |
+| Open legacy `lane:v18.0.0` issues | 0 |
+| Open issues in milestone `v18.0.0` | 23 |
+
+The 23 open `v18.0.0` milestone issues are intentionally visible release
+blockers under the simplified policy. The migration did not close any issue.
+
+## Validation Commands
+
+```bash
+gh issue list --state open --label 'priority:asap' --limit 1000 --json number --jq 'length'
+gh issue list --state open --label 'lane:bad-code' --limit 1000 --json number --jq 'length'
+gh issue list --state open --label 'type:debt' --limit 1000 --json number --jq 'length'
+gh api repos/git-stunts/git-warp/milestones --paginate --jq '.[] | select(.title=="v18.0.0") | .open_issues'
+```

--- a/docs/design/0272-v18-issue-taxonomy-reconciliation/v18-issue-taxonomy-reconciliation.md
+++ b/docs/design/0272-v18-issue-taxonomy-reconciliation/v18-issue-taxonomy-reconciliation.md
@@ -80,9 +80,9 @@ open issues should not use them as live coordination state.
       `v18.0.0` milestone.
 - [x] Migrate open `lane:bad-code` issues to `type:debt`.
 - [x] Remove legacy debt lane/type labels from migrated open debt issues.
-- [ ] Update #552 with a comment explaining that #547 and #549 are closed with
+- [x] Update #552 with a comment explaining that #547 and #549 are closed with
       file-line evidence while release operation remains open.
-- [ ] Do not close #552 without explicit operator approval.
+- [x] Do not close #552 without explicit operator approval.
 - [x] Rerun issue-count evidence after migration.
 
 ## Post-Migration State

--- a/docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md
+++ b/docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md
@@ -26,8 +26,9 @@ Issue [#547](https://github.com/git-stunts/git-warp/issues/547) is closed as
 the public Optics closeout goalpost. The landed evidence proves
 `openWarpWorldline(...).prepareOpticBasis()`, `coordinate()`, and
 `coordinate.optic()` for public node/property reads without hidden full
-materialization. The broader memory-budget product gate remains open in
-[#549](https://github.com/git-stunts/git-warp/issues/549).
+materialization. The broader memory-budget product gate is closed in
+[#549](https://github.com/git-stunts/git-warp/issues/549), and release/tag
+evidence remains under [#552](https://github.com/git-stunts/git-warp/issues/552).
 
 ## Scope
 
@@ -118,7 +119,7 @@ operation evidence before tagging.
 
 | Risk | Rationale | Owner | Follow-up issue |
 | --- | --- | --- | --- |
-| Broader bounded-memory public-path product gate remains open. | GP1 proves the public Optics chain and first-use honesty, not every normal public read/write/content/sync path under memory budget. | `@git-stunts` | [#549](https://github.com/git-stunts/git-warp/issues/549) |
+| Release evidence and tag-time proof remain intentionally skipped. | GP1 proves the public Optics chain and first-use honesty, while V18-GP5 owns explicit tag approval and publish evidence. | `@git-stunts` | [#552](https://github.com/git-stunts/git-warp/issues/552) |
 
 ## Closeout
 

--- a/docs/method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md
+++ b/docs/method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md
@@ -10,7 +10,7 @@
 | Goalpost doc | `docs/method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md` |
 | Design cycle | `docs/design/0267-v18-bounded-memory-large-graph-product-gate/v18-bounded-memory-large-graph-product-gate.md` |
 | Slice budget | `15` |
-| Status | `active` |
+| Status | `landed` |
 | Sponsor human | `James` |
 | Sponsor agent | `Codex` |
 
@@ -21,10 +21,16 @@ git-warp memory budget against a graph larger than that budget.
 
 ## Current Truth
 
-Issue [#549](https://github.com/git-stunts/git-warp/issues/549) is open in
-`lane:v18.0.0` and blocks release. Its issue body states that v18 cannot rely
-on full graph state, full indexes, full patch arrays, full snapshots, or full
-result arrays fitting in process memory.
+Issue [#549](https://github.com/git-stunts/git-warp/issues/549) is closed as
+the non-release bounded-memory product gate. The landed evidence proves the
+memory budget contract, large-graph-over-small-pool fixture, bounded read
+cursor, patch-stream, basis-builder, fact-resolver, sync batch, capability
+report, and operator witness shapes listed below.
+
+Release/tag evidence is explicitly out of scope for this goalpost. Issue
+[#552](https://github.com/git-stunts/git-warp/issues/552) remains the v18
+release-operation blocker until explicit tag approval and publish evidence
+exist.
 
 ## Scope
 
@@ -111,9 +117,10 @@ npm run typecheck
 
 ## Release Gate Impact
 
-This goalpost proves the release's large-graph product promise. Until it lands,
-public v18 docs must not claim arbitrary graph size, bounded content lookup, or
-streaming/cursor safety beyond the evidence already committed.
+This goalpost proves the release's large-graph product promise at the
+non-release evidence layer. Public v18 docs may cite the committed
+bounded-memory fixture and witness paths, but release operation evidence remains
+separate under V18-GP5 and must not be inferred from this closeout.
 
 ## Residual Risks
 

--- a/docs/method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md
+++ b/docs/method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md
@@ -112,13 +112,15 @@ npm run release:prep
 
 This landed goalpost is the graph-substrate honesty bridge between v18 Optics
 and the bounded-memory product gate. The release can now cite bounded slice
-substrate evidence while the broader bounded-memory product gate remains open.
+substrate evidence. The broader bounded-memory product gate is closed in
+[#549](https://github.com/git-stunts/git-warp/issues/549), while release/tag
+evidence remains under [#552](https://github.com/git-stunts/git-warp/issues/552).
 
 ## Residual Risks
 
 | Risk | Rationale | Owner | Follow-up issue |
 | --- | --- | --- | --- |
-| Broader bounded-memory release gate remains open. | GP4 proves bounded holographic slice substrate, not the full public-path memory-budget platform required by V18-GP2. | `@git-stunts` | [#549](https://github.com/git-stunts/git-warp/issues/549) |
+| Release evidence and tag-time proof remain intentionally skipped. | GP4 proves bounded holographic slice substrate; V18-GP5 owns explicit tag approval and publish evidence. | `@git-stunts` | [#552](https://github.com/git-stunts/git-warp/issues/552) |
 
 ## Closeout
 

--- a/test/unit/scripts/release-policy-shape.test.ts
+++ b/test/unit/scripts/release-policy-shape.test.ts
@@ -223,9 +223,9 @@ describe('release policy shape', () => {
     expect(roadmap).toContain('## Active Planning Instance');
     expect(roadmap).toContain('| Goalposts | `5` |');
     expect(roadmap).toContain('| Total planned slice budget | `53` |');
-    expect(roadmap).toContain('v18.0.0 goalposts: 3/5 landed');
-    expect(roadmap).toContain('v18.0.0 slices: 32/53 landed');
-    expect(roadmap).toContain('next slice: reconcile #549 against landed holographic slicing evidence');
+    expect(roadmap).toContain('v18.0.0 goalposts: 4/5 landed');
+    expect(roadmap).toContain('v18.0.0 slices: 47/53 landed');
+    expect(roadmap).toContain('next slice: reconcile #552 against current issue metadata and release evidence');
     expect(roadmap).toContain('method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md');
 
     for (const goalpostPath of v18GoalpostPaths) {


### PR DESCRIPTION
## Summary

- updates v18 roadmap truth so #547 and #549 are closed with deterministic evidence while #552 remains the release-operation blocker
- records the v18 issue taxonomy reconciliation and evidence-gated closure rule
- migrates live issue metadata: legacy bad-code/type-maintenance labels to type:debt, v18 legacy release labels to the v18.0.0 milestone, and #552 to type:release/status:blocked
- updates roadmap shape tests for the 4/5 landed v18 state

## Issue

Refs #552.

## Validation

- npm run lint:md -- docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md docs/method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md docs/BEARING.md docs/ROADMAP.md docs/method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md docs/design/0272-v18-issue-taxonomy-reconciliation/v18-issue-taxonomy-reconciliation.md
- npm run lint:md:code -- docs/method/roadmap/v18.0.0/v18-gp1-optics-public-api-closeout.md docs/method/roadmap/v18.0.0/v18-gp4-holographic-slicing-checkpoint-basis.md docs/BEARING.md docs/ROADMAP.md docs/method/roadmap/v18.0.0/v18-gp2-bounded-memory-large-graph-gate.md docs/design/0272-v18-issue-taxonomy-reconciliation/v18-issue-taxonomy-reconciliation.md
- npx vitest run test/unit/scripts/release-policy-shape.test.ts
- npm run test:local
- pre-push gate: link check, static gates, markdown gates, type checks, unit tests

## Release note

No v18 tag was created. #552 remains open until explicit release/tag approval and publish evidence exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated v18 release status and progress tracking documentation, including current roadmap milestones and completion evidence.
  * Added comprehensive v18 issue taxonomy reconciliation guide documenting release gate criteria and validation procedures.
  * Revised release gate closeout documentation to reflect updated release operation requirements and evidence standards.

* **Tests**
  * Updated release policy validation tests to reflect current v18 progress metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->