### PR TITLE
Clear legacy v17 release-home backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `EffectSinkPort.deliver()` now returns `DeliveryObservation[]`
+  consistently. Custom sinks must wrap single observations in an array; the
+  built-in no-op, console, chunk, multiplex, and effect-pipeline surfaces all
+  use the array contract so fan-out and single-sink delivery share one return
+  shape.
 - Removed release-versioned runtime names from `src`: current reducer, state
   projection, patch-op, comparison, transfer, trust, and memory capability
   symbols now use unversioned names, while the v17 golden fixture and generated

--- a/docs/ADVANCED_GUIDE.md
+++ b/docs/ADVANCED_GUIDE.md
@@ -123,6 +123,28 @@ Drop below the ordinary app-facing read path when you intentionally need:
 
 These are valid public APIs. What you should not do is treat them as the raw ingredients for a second graph runtime in your app.
 
+## Streams, transforms, and sinks
+
+Advanced storage surfaces use `WarpStream` when the result may grow with graph
+history or index size. A stream is directly usable in `for await` loops and can
+be piped through transforms by infrastructure or diagnostic code that needs a
+bounded pipeline.
+
+The important boundaries are:
+
+- adapters turn host streams, arrays, cursors, or generated rows into
+  `WarpStream`
+- domain services consume semantic stream items, not Node `Readable` objects
+- `PatchJournalPort.scanPatchRange(...)` streams patch entries
+- `IndexStorePort.writeShards(...)` and `IndexStorePort.scanShards(...)`
+  stream index shards
+- `CommitPort.logNodesStream(...)` streams Git commit-log chunks
+
+`Transform` and `Sink` are composition concepts for these pipelines. Use them
+when you are adapting or inspecting substrate flow. Do not wrap ordinary
+worldline/query reads in custom stream layers; those reads already carry their
+own coordinate, aperture, and witness posture.
+
 ## Strands and braids
 
 Strands are the substrate's durable speculative lanes.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -232,6 +232,26 @@ const graph = await openWarpGraph({
 | `indexStore` | `IndexStorePort \| null` | No | Index store |
 | `adjacencyCacheSize` | `number` | No | Adjacency cache size |
 
+### Streamed Advanced Ports
+
+Some lower-level ports expose `WarpStream`-backed methods so callers can handle
+large substrate ranges without forcing full residency:
+
+| Port | Method | Stream item |
+| --- | --- | --- |
+| `CommitPort` | `logNodesStream(options)` | `CommitLogChunk` |
+| `PatchJournalPort` | `scanPatchRange(writerId, fromSha, toSha)` | `PatchEntry` |
+| `IndexStorePort` | `writeShards(shardStream)` | `IndexShard` input |
+| `IndexStorePort` | `scanShards(treeOid)` | `IndexShard` output |
+
+`CheckpointStorePort` owns folded checkpoint persistence. It is listed with the
+advanced storage ports because it participates in bounded recovery, but its
+current surface is checkpoint-oriented rather than a general stream scan.
+
+`WarpStream` is an async iterable. Advanced callers consume it with
+`for await`; adapters are responsible for converting host-specific streams or
+storage cursors into this domain stream boundary.
+
 ### WarpGraph interface
 
 The returned `WarpGraph` is a frozen object with these capability namespaces:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,6 +167,26 @@ dependency bag and owns the orchestration for its domain:
 | ComparisonController | comparison | Coordinate comparison, transfer planning |
 | SubscriptionController | subscriptions | Reactive state change notification |
 
+### Streams and bounded storage ports
+
+`WarpStream` is the domain stream primitive used by storage and traversal
+ports when an operation may be unbounded. It is an async-iterable wrapper with
+composition helpers for stream pipelines; adapters convert host streams,
+arrays, cursors, or generated records into `WarpStream` at the boundary.
+
+The stream layer keeps large reads from pretending to be ordinary in-memory
+arrays. Current advanced ports that use this boundary include:
+
+| Port | Streamed surface | Role |
+| --- | --- | --- |
+| `CommitPort` | `logNodesStream(...)` | Git commit-log chunks without loading the full log |
+| `PatchJournalPort` | `scanPatchRange(...)` | Patch journal entries over a writer/range |
+| `IndexStorePort` | `writeShards(...)`, `scanShards(...)` | Bitmap/index shards as bounded stream units |
+
+`CheckpointStorePort` is the checkpoint storage boundary. It does not expose a
+general stream API today, but it sits beside the streamed stores because it
+owns folded state persistence rather than live query semantics.
+
 ### Domain services (src/domain/services/)
 
 Stateless services that implement domain logic:
@@ -189,6 +209,9 @@ Abstract contracts between domain and infrastructure:
 - **ClockPort** — wall clock (injected, not ambient)
 - **LoggerPort** — structured logging
 - **SeekCachePort** — persistent seek cache for time-travel
+- **PatchJournalPort** — streamed patch-entry scans
+- **CheckpointStorePort** — folded checkpoint state storage
+- **IndexStorePort** — streamed index shard storage
 
 ### Infrastructure adapters (src/infrastructure/)
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -127,6 +127,31 @@ Use strands for speculative work. Use ordinary patches for live truth.
 
 For the deeper substrate story behind strands, braids, and transfer planning, use [Advanced Guide -> Strands and braids](ADVANCED_GUIDE.md#strands-and-braids).
 
+## Streamed substrate work
+
+Most application code should not handle substrate streams directly. Use
+worldlines, observers, optics, and query builders first.
+
+When you are writing an adapter or a diagnostic tool, unbounded substrate reads
+use `WarpStream` through advanced ports instead of returning whole arrays.
+Typical examples are commit-log scans, patch-journal ranges, and index-shard
+reads. Consume them with `for await` and keep each streamed item as the unit of
+work:
+
+```typescript
+const stream = await persistence.logNodesStream({
+  ref: 'refs/warp/team/writers/alice',
+});
+
+for await (const chunk of stream) {
+  // Inspect or forward one commit-log chunk at a time.
+}
+```
+
+If you are not implementing a port, prefer the higher-level read APIs in this
+guide. Streams are the substrate boundary, not a second application query
+model.
+
 ## Common read patterns
 
 The patterns in this section are the preferred application API shapes. Their

--- a/docs/design/effect-emission-v1.md
+++ b/docs/design/effect-emission-v1.md
@@ -97,9 +97,13 @@ An **EffectSinkPort** is a hexagonal port. Each sink has an `id` and a
 ```js
 class EffectSinkPort {
   get id()  // → string
-  async deliver(emission, lens)  // → DeliveryObservation
+  async deliver(emission, lens)  // → DeliveryObservation[]
 }
 ```
+
+Single-observation sinks still return an array with one
+`DeliveryObservation`. This keeps the port shape identical for direct sinks and
+fan-out sinks.
 
 Concrete adapters implement this port:
 
@@ -122,12 +126,12 @@ class MultiplexSink extends EffectSinkPort {
   addSink(sink)     // register a child sink
   removeSink(id)    // unregister by id
   get sinks()       // → readonly sink array
-  async deliver(emission, lens)  // → DeliveryObservation[] (one per child)
+  async deliver(emission, lens)  // → DeliveryObservation[] (from children)
 }
 ```
 
-The multiplex sink's own `deliver()` returns an array of observations
-(one per child sink). Its own `id` is `'multiplex'`.
+The multiplex sink's own `deliver()` returns the concatenated child
+observation arrays. Its own `id` is `'multiplex'`.
 
 ### 6. Effect Pipeline
 

--- a/policy/sludge/sludge-map.schema.json
+++ b/policy/sludge/sludge-map.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://git-stunts.dev/git-warp/schemas/sludge-map.schema.json",
+  "title": "git-warp sludge map",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["generated_for_cycle", "source_cycle_blocked", "families"],
+  "properties": {
+    "generated_for_cycle": { "$ref": "#/$defs/nonEmptyString" },
+    "source_cycle_blocked": { "$ref": "#/$defs/nonEmptyString" },
+    "families": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/family" }
+    },
+    "dependency_order": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/nonEmptyString" }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stringList": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/nonEmptyString" }
+    },
+    "family": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "severity", "blocks", "findings"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "label": { "$ref": "#/$defs/nonEmptyString" },
+        "severity": {
+          "type": "string",
+          "enum": ["release-blocking", "watch"]
+        },
+        "blocks": { "$ref": "#/$defs/stringList" },
+        "findings": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/finding" }
+        }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "symptom", "root_cause", "recommended_fix", "blocks"],
+      "properties": {
+        "path": { "$ref": "#/$defs/nonEmptyString" },
+        "lines": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "symptom": { "$ref": "#/$defs/nonEmptyString" },
+        "root_cause": { "$ref": "#/$defs/nonEmptyString" },
+        "recommended_fix": { "$ref": "#/$defs/nonEmptyString" },
+        "blocks": { "$ref": "#/$defs/stringList" },
+        "proposed_nouns": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/proposedNoun" }
+        }
+      }
+    },
+    "proposedNoun": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "constructs", "consumes", "proves_invariant", "layer", "eliminates"],
+      "properties": {
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "constructs": { "$ref": "#/$defs/nonEmptyString" },
+        "consumes": { "$ref": "#/$defs/nonEmptyString" },
+        "proves_invariant": { "$ref": "#/$defs/nonEmptyString" },
+        "layer": {
+          "type": "string",
+          "enum": ["domain", "ports", "policy"]
+        },
+        "eliminates": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    }
+  }
+}

--- a/src/domain/capabilities/CheckpointCapability.ts
+++ b/src/domain/capabilities/CheckpointCapability.ts
@@ -29,9 +29,18 @@ export type MaybeGCResult = {
 };
 
 export default abstract class CheckpointCapability {
+  /** Create a checkpoint commit for the current graph state. */
   abstract createCheckpoint(): Promise<string>;
+
+  /** Synchronize checkpoint coverage metadata with persisted state. */
   abstract syncCoverage(): Promise<void>;
+
+  /** Run garbage collection only when the configured policy says it is due. */
   abstract maybeRunGC(): MaybeGCResult;
+
+  /** Force an immediate garbage-collection pass. */
   abstract runGC(): GCExecuteResult;
+
+  /** Return current garbage-collection metrics, or null when unavailable. */
   abstract getGCMetrics(): GCMetrics | null;
 }

--- a/src/domain/capabilities/ComparisonCapability.ts
+++ b/src/domain/capabilities/ComparisonCapability.ts
@@ -52,22 +52,31 @@ export type PlanCoordinateTransferOptions = {
 };
 
 export default abstract class ComparisonCapability {
+  /** Build a patch-divergence summary from two ordered patch streams. */
   abstract buildPatchDivergence(
     _leftEntries: ComparisonPatchEntry[],
     _rightEntries: ComparisonPatchEntry[],
     _targetId?: string | null,
   ): Record<string, unknown>; // nosemgrep: ts-no-record-string-unknown-outside-adapters -- 0025B; nosemgrep: ts-no-unknown-outside-adapters -- 0025B
+
+  /** Compare a strand against its base, live graph, or another strand. */
   abstract compareStrand(
     _strandId: string,
     _options?: CompareStrandOptions,
   ): Promise<CoordinateComparison>;
+
+  /** Plan how to transfer visible strand state into another coordinate. */
   abstract planStrandTransfer(
     _strandId: string,
     _options?: PlanStrandTransferOptions,
   ): Promise<CoordinateTransferPlan>;
+
+  /** Compare two explicit coordinate selectors. */
   abstract compareCoordinates(
     _options: CompareCoordinatesOptions,
   ): Promise<CoordinateComparison>;
+
+  /** Plan transfer from one explicit coordinate selector into another. */
   abstract planCoordinateTransfer(
     _options: PlanCoordinateTransferOptions,
   ): Promise<CoordinateTransferPlan>;

--- a/src/domain/capabilities/MaterializeCapability.ts
+++ b/src/domain/capabilities/MaterializeCapability.ts
@@ -45,12 +45,16 @@ export type IndexVerifyResult = {
 export default abstract class MaterializeCapability {
   /** @deprecated For application reads, use openWarpWorldline().live(), seek(), or observer reads. */
   abstract materialize(_options: { receipts: true; ceiling?: number | null }): Promise<MaterializeWithReceipts>;
+  /** @deprecated For application reads, use openWarpWorldline().live(), seek(), or observer reads. */
   abstract materialize(_options?: { receipts?: false; ceiling?: number | null }): Promise<SnapshotWarpState>;
+  /** @deprecated For application reads, use openWarpWorldline().live(), seek(), or observer reads. */
   abstract materialize(_options?: MaterializeOptions): Promise<SnapshotWarpState | MaterializeWithReceipts>;
 
   /** @deprecated For application coordinate reads, use worldline seek/read handles. */
   abstract materializeCoordinate(_options: { frontier: Map<string, string> | Record<string, string>; ceiling?: number | null; receipts: true }): Promise<MaterializeWithReceipts>;
+  /** @deprecated For application coordinate reads, use worldline seek/read handles. */
   abstract materializeCoordinate(_options: { frontier: Map<string, string> | Record<string, string>; ceiling?: number | null; receipts?: false }): Promise<SnapshotWarpState>;
+  /** @deprecated For application coordinate reads, use worldline seek/read handles. */
   abstract materializeCoordinate(_options: MaterializeCoordinateOptions): Promise<SnapshotWarpState | MaterializeWithReceipts>;
 
   /** @deprecated For application checkpoint reads, use historical worldline reads. */

--- a/src/domain/capabilities/PatchCapability.ts
+++ b/src/domain/capabilities/PatchCapability.ts
@@ -40,12 +40,27 @@ export type PatchWithSha = {
 };
 
 export default abstract class PatchCapability {
+  /** Start a mutable patch builder for the current writer. */
   abstract createPatch(): Promise<PatchBuilder>;
+
+  /** Build and commit one patch with the current writer. */
   abstract patch(_build: (_p: PatchBuilder) => void | Promise<void>): Promise<string>;
+
+  /** Build and commit multiple patches in order. */
   abstract patchMany(..._builds: Array<(_p: PatchBuilder) => void | Promise<void>>): Promise<string[]>;
+
+  /** Return committed patches for a writer, optionally stopping at a SHA. */
   abstract getWriterPatches(_writerId: string, _stopAtSha?: string | null): Promise<PatchWithSha[]>;
+
+  /** Resolve a writer handle by id or return the current writer. */
   abstract writer(_writerId?: string): Promise<Writer>;
+
+  /** Discover writer ids present in the graph. */
   abstract discoverWriters(): Promise<string[]>;
+
+  /** Discover ticks across all writers. */
   abstract discoverTicks(): Promise<TickDiscoveryResult>;
+
+  /** Merge another state into this graph's current CRDT state. */
   abstract join(_otherState: WarpState): { state: WarpState; receipt: JoinReceipt };
 }

--- a/src/domain/capabilities/ProvenanceCapability.ts
+++ b/src/domain/capabilities/ProvenanceCapability.ts
@@ -16,11 +16,15 @@ export type SliceResult = {
 };
 
 export default abstract class ProvenanceCapability {
+  /** Return patch SHAs in the backward cone for an entity id. */
   abstract patchesFor(_entityId: string): Promise<string[]>;
+
   /** Diagnostic/provenance slice inspection; not a first-use application read path. */
   abstract materializeSlice(
     _nodeId: string,
     _options?: { receipts?: boolean },
   ): Promise<SliceResult>;
+
+  /** Load and decode a patch by content-addressable SHA. */
   abstract loadPatchBySha(_sha: string): Promise<Patch>;
 }

--- a/src/domain/capabilities/QueryCapability.ts
+++ b/src/domain/capabilities/QueryCapability.ts
@@ -64,35 +64,74 @@ export type VisibleEdge = {
 };
 
 export default abstract class QueryCapability {
+  /** Return whether a visible node exists. */
   abstract hasNode(_nodeId: string): Promise<boolean>;
+
+  /** Return visible node properties, or null when the node is absent. */
   abstract getNodeProps(_nodeId: string): Promise<QueryPropertyBag | null>;
+
+  /** Return visible edge properties, or null when the edge is absent. */
   abstract getEdgeProps(_from: string, _to: string, _label: string): Promise<QueryPropertyBag | null>;
+
+  /** Return neighboring nodes reachable by direction and optional label. */
   abstract neighbors(
     _nodeId: string,
     _direction?: 'outgoing' | 'incoming' | 'both',
     _edgeLabel?: string,
   ): Promise<NeighborEntry[]>;
+
+  /** Return a snapshot of visible state, or null when no state is loaded. */
   abstract getStateSnapshot(): Promise<SnapshotWarpState | null>;
+
+  /** Return visible node ids. */
   abstract getNodes(): Promise<string[]>;
+
+  /** Return visible edge entries. */
   abstract getEdges(): Promise<VisibleEdge[]>;
+
+  /** Return the count of visible node and edge properties. */
   abstract getPropertyCount(): Promise<number>;
+
+  /** Create a fluent query builder over the current read model. */
   abstract query(): QueryBuilder;
+
+  /** Create a worldline read handle pinned by the given options. */
   abstract worldline(_options?: WorldlineOptions): Worldline;
+
+  /** Create an observer lens for filtered visible reads. */
   abstract observer(
     _nameOrConfig: string | ObserverConfig,
     _configOrOptions?: ObserverConfig | ObserverOptions,
     _options?: ObserverOptions,
   ): Promise<Observer>;
+
+  /** Estimate translation cost between two observer configurations. */
   abstract translationCost(
     _configA: ObserverConfig,
     _configB: ObserverConfig,
   ): Promise<TranslationCostResult>;
+
+  /** Return the content blob OID attached to a node, if any. */
   abstract getContentOid(_nodeId: string): Promise<string | null>;
+
+  /** Return content metadata attached to a node, if any. */
   abstract getContentMeta(_nodeId: string): Promise<ContentMeta | null>;
+
+  /** Return content bytes attached to a node, if any. */
   abstract getContent(_nodeId: string): Promise<Uint8Array | null>;
+
+  /** Return the content blob OID attached to an edge, if any. */
   abstract getEdgeContentOid(_from: string, _to: string, _label: string): Promise<string | null>;
+
+  /** Return content metadata attached to an edge, if any. */
   abstract getEdgeContentMeta(_from: string, _to: string, _label: string): Promise<ContentMeta | null>;
+
+  /** Return content bytes attached to an edge, if any. */
   abstract getEdgeContent(_from: string, _to: string, _label: string): Promise<Uint8Array | null>;
+
+  /** Return a node content byte stream, if content exists. */
   abstract getContentStream(_nodeId: string): Promise<AsyncIterable<Uint8Array> | null>;
+
+  /** Return an edge content byte stream, if content exists. */
   abstract getEdgeContentStream(_from: string, _to: string, _label: string): Promise<AsyncIterable<Uint8Array> | null>;
 }

--- a/src/domain/capabilities/StrandCapability.ts
+++ b/src/domain/capabilities/StrandCapability.ts
@@ -31,22 +31,47 @@ export type StrandMaterializeWithReceipts = {
 };
 
 export default abstract class StrandCapability {
+  /** Create a new strand descriptor. */
   abstract createStrand(_options?: StrandCreateOptions): Promise<StrandDescriptor>;
+
+  /** Braid an existing strand onto another coordinate. */
   abstract braidStrand(_strandId: string, _options?: StrandBraidOptions): Promise<StrandDescriptor>;
+
+  /** Load a strand descriptor by id, or null when absent. */
   abstract getStrand(_strandId: string): Promise<StrandDescriptor | null>;
+
+  /** List known strand descriptors. */
   abstract listStrands(): Promise<StrandDescriptor[]>;
+
+  /** Drop a strand descriptor and return whether it existed. */
   abstract dropStrand(_strandId: string): Promise<boolean>;
 
   /** Diagnostic/speculative-lane snapshot inspection; not a first-use application read path. */
   abstract materializeStrand(_strandId: string, _options: { receipts: true; ceiling?: number | null }): Promise<StrandMaterializeWithReceipts>;
+  /** Diagnostic/speculative-lane snapshot inspection; not a first-use application read path. */
   abstract materializeStrand(_strandId: string, _options?: { receipts?: false; ceiling?: number | null }): Promise<SnapshotWarpState>;
 
+  /** Return patches written on a strand, optionally bounded by ceiling. */
   abstract getStrandPatches(_strandId: string, _options?: { ceiling?: number | null }): Promise<StrandPatchEntry[]>;
+
+  /** Return patch SHAs in a strand-local backward cone for an entity id. */
   abstract patchesForStrand(_strandId: string, _entityId: string, _options?: { ceiling?: number | null }): Promise<string[]>;
+
+  /** Start a mutable patch builder for a strand. */
   abstract createStrandPatch(_strandId: string): Promise<PatchBuilder>;
+
+  /** Build and commit one patch to a strand. */
   abstract patchStrand(_strandId: string, _build: (_p: PatchBuilder) => void | Promise<void>): Promise<string>;
+
+  /** Queue a strand intent for later ticking. */
   abstract queueStrandIntent(_strandId: string, _build: (_p: PatchBuilder) => void | Promise<void>): Promise<StrandIntentDescriptor>;
+
+  /** List queued strand intents. */
   abstract listStrandIntents(_strandId: string): Promise<StrandIntentDescriptor[]>;
+
+  /** Advance a strand by committing queued intents. */
   abstract tickStrand(_strandId: string): Promise<StrandTickRecord>;
+
+  /** Analyze current strand conflicts. */
   abstract analyzeConflicts(_options?: AnalyzeConflictsOptions): Promise<ConflictAnalysis>;
 }

--- a/src/domain/capabilities/SubscriptionCapability.ts
+++ b/src/domain/capabilities/SubscriptionCapability.ts
@@ -26,6 +26,9 @@ export type SubscriptionHandle = {
 };
 
 export default abstract class SubscriptionCapability {
+  /** Subscribe to state diffs, optionally replaying the current state. */
   abstract subscribe(_options: SubscribeOptions): SubscriptionHandle;
+
+  /** Watch matching graph changes with polling behavior. */
   abstract watch(_pattern: string | string[], _options: WatchOptions): SubscriptionHandle;
 }

--- a/src/domain/capabilities/SyncCapability.ts
+++ b/src/domain/capabilities/SyncCapability.ts
@@ -108,13 +108,30 @@ export type ServeHandle = {
 };
 
 export default abstract class SyncCapability {
+  /** Return the local writer frontier. */
   abstract getFrontier(): Promise<Map<string, string>>;
+
+  /** Return whether the local frontier has changed since the last check. */
   abstract hasFrontierChanged(): Promise<boolean>;
+
+  /** Return a lightweight local sync status snapshot. */
   abstract status(): Promise<WarpStatus>;
+
+  /** Create a sync request from the local frontier. */
   abstract createSyncRequest(): Promise<SyncRequest>;
+
+  /** Process an incoming sync request and return missing patches. */
   abstract processSyncRequest(_request: SyncRequest): Promise<SyncResponse>;
+
+  /** Apply patches from a sync response to local state. */
   abstract applySyncResponse(_response: SyncResponse): Promise<ApplySyncResult>;
+
+  /** Return whether syncing is needed for a remote frontier. */
   abstract syncNeeded(_remoteFrontier: Map<string, string>): Promise<boolean>;
+
+  /** Sync with an in-process peer, public capability peer, or remote URL. */
   abstract syncWith(_remote: SyncRemote, _options?: SyncWithOptions): Promise<SyncWithResult>;
+
+  /** Serve sync requests over a supplied HTTP server port. */
   abstract serve(_options: ServeOptions): Promise<ServeHandle>;
 }

--- a/src/domain/orset/route/RouteKey.ts
+++ b/src/domain/orset/route/RouteKey.ts
@@ -19,14 +19,14 @@ export const ROUTE_KEY_BITS = ROUTE_KEY_BYTES * 8;
  * Supported nibble widths in bits.
  *
  * The trie geometry parameterizes branching factor via nibble width.
- * 4 bits gives 16-way branching, 8 bits gives 256-way. Nibble width
- * must divide 8 evenly so a nibble never straddles a byte boundary
- * that way simple, or must be small enough that straddling is handled
- * by the byte-shift extraction below. Supported widths are 1, 2, 4, 8.
+ * 4 bits gives 16-way branching, 6 bits gives 64-way branching, and
+ * 8 bits gives 256-way branching. Non-byte-aligned widths may
+ * straddle byte boundaries; extraction reads individual bits
+ * MSB-first so every supported width has the same semantics.
  */
-export type NibbleBits = 1 | 2 | 4 | 8;
+export type NibbleBits = 1 | 2 | 4 | 6 | 8;
 
-const SUPPORTED_NIBBLE_BITS: ReadonlyArray<NibbleBits> = [1, 2, 4, 8];
+const SUPPORTED_NIBBLE_BITS: ReadonlyArray<NibbleBits> = [1, 2, 4, 6, 8];
 
 /**
  * Binary route key derived from an element ID via blake3.
@@ -94,19 +94,7 @@ export default class RouteKey {
   nibbleAt(depth: number, nibbleBits: NibbleBits): number {
     validateNibbleAtArgs(depth, nibbleBits);
     const bitOffset = depth * nibbleBits;
-    const byteIndex = Math.floor(bitOffset / 8);
-    const bitInByte = bitOffset % 8;
-    // Bits read MSB-first within a byte; shift so the nibble's high bit sits at position nibbleBits-1.
-    const shift = 8 - nibbleBits - bitInByte;
-    const mask = (1 << nibbleBits) - 1;
-    const byte = this.bytes[byteIndex];
-    if (byte === undefined) {
-      throw new RouteKeyError(
-        `RouteKey.nibbleAt internal error: byte index ${String(byteIndex)} out of bounds`,
-        { code: "E_ROUTE_KEY_BYTES" },
-      );
-    }
-    return (byte >>> shift) & mask;
+    return readBitsMsbFirst(this.bytes, bitOffset, nibbleBits);
   }
 
   /**
@@ -127,7 +115,7 @@ export default class RouteKey {
 function validateNibbleAtArgs(depth: number, nibbleBits: NibbleBits): void {
   if (!SUPPORTED_NIBBLE_BITS.includes(nibbleBits)) {
     throw new RouteKeyError(
-      `RouteKey.nibbleAt requires nibbleBits in {1,2,4,8}; received ${String(nibbleBits)}`,
+      `RouteKey.nibbleAt requires nibbleBits in {1,2,4,6,8}; received ${String(nibbleBits)}`,
       { code: "E_ROUTE_KEY_NIBBLE_BITS" },
     );
   }
@@ -137,11 +125,32 @@ function validateNibbleAtArgs(depth: number, nibbleBits: NibbleBits): void {
       { code: "E_ROUTE_KEY_DEPTH" },
     );
   }
-  const maxDepth = ROUTE_KEY_BITS / nibbleBits;
+  const maxDepth = Math.floor(ROUTE_KEY_BITS / nibbleBits);
   if (depth >= maxDepth) {
     throw new RouteKeyError(
       `RouteKey.nibbleAt depth ${String(depth)} exceeds maximum ${String(maxDepth - 1)} for nibbleBits=${String(nibbleBits)}`,
       { code: "E_ROUTE_KEY_DEPTH" },
     );
   }
+}
+
+function readBitsMsbFirst(bytes: Uint8Array, bitOffset: number, width: NibbleBits): number {
+  let value = 0;
+  for (let bitIndex = 0; bitIndex < width; bitIndex += 1) {
+    value = (value << 1) | readBitMsbFirst(bytes, bitOffset + bitIndex);
+  }
+  return value;
+}
+
+function readBitMsbFirst(bytes: Uint8Array, bitOffset: number): number {
+  const byteIndex = Math.floor(bitOffset / 8);
+  const byte = bytes[byteIndex];
+  if (byte === undefined) {
+    throw new RouteKeyError(
+      `RouteKey.nibbleAt internal error: byte index ${String(byteIndex)} out of bounds`,
+      { code: "E_ROUTE_KEY_BYTES" },
+    );
+  }
+  const bitInByte = bitOffset % 8;
+  return (byte >>> (7 - bitInByte)) & 1;
 }

--- a/src/domain/orset/trie/TrieCompactor.ts
+++ b/src/domain/orset/trie/TrieCompactor.ts
@@ -5,12 +5,13 @@ import TrieBranch from "./TrieBranch.ts";
 import type TrieGeometry from "./TrieGeometry.ts";
 import TrieLeaf, { type TrieLeafEntry } from "./TrieLeaf.ts";
 import { compareBytes, pendingChildOid } from "./trieCursorHelpers.ts";
+import type { NibbleBits } from "../route/RouteKey.ts";
 
 type LoadChildKind = "leaf" | "branch" | null;
 
 export type TrieCompactorInit = {
   readonly geometry: TrieGeometry;
-  readonly nibbleBits: 1 | 2 | 4 | 8;
+  readonly nibbleBits: NibbleBits;
   readonly loadRootIfNeeded: () => Promise<void>;
   readonly hasRoot: () => boolean;
   readonly leafAt: (path: readonly number[]) => TrieLeaf | null;
@@ -49,7 +50,7 @@ type MergeCandidate = {
 
 export default class TrieCompactor {
   readonly #geometry: TrieGeometry;
-  readonly #nibbleBits: 1 | 2 | 4 | 8;
+  readonly #nibbleBits: NibbleBits;
   readonly #loadRootIfNeeded: () => Promise<void>;
   readonly #hasRoot: () => boolean;
   readonly #leafAt: (path: readonly number[]) => TrieLeaf | null;
@@ -326,7 +327,7 @@ function collapseLeafUp(
   leaf: TrieLeaf,
   childNibble: number,
   childDepth: number,
-  nibbleBits: 1 | 2 | 4 | 8,
+  nibbleBits: NibbleBits,
   geometry: TrieGeometry,
 ): TrieLeaf {
   const lengthened = leaf.entries().map((entry) => ({
@@ -348,9 +349,9 @@ function prependNibbleToSuffix(args: {
   readonly suffix: Uint8Array;
   readonly nibble: number;
   readonly depth: number;
-  readonly nibbleBits: 1 | 2 | 4 | 8;
+  readonly nibbleBits: NibbleBits;
 }): Uint8Array {
-  const oldSlots = (256 - args.depth * args.nibbleBits) / args.nibbleBits;
+  const oldSlots = Math.floor((256 - args.depth * args.nibbleBits) / args.nibbleBits);
   const totalSlots = oldSlots + 1;
   const totalBits = totalSlots * args.nibbleBits;
   const out = new Uint8Array(Math.ceil(totalBits / 8));
@@ -364,26 +365,40 @@ function prependNibbleToSuffix(args: {
 function readSlot(
   suffix: Uint8Array,
   slot: number,
-  nibbleBits: 1 | 2 | 4 | 8,
+  nibbleBits: NibbleBits,
 ): number {
   const bitOffset = slot * nibbleBits;
-  const byteIndex = Math.floor(bitOffset / 8);
-  const bitInByte = bitOffset % 8;
-  const shift = 8 - nibbleBits - bitInByte;
-  const mask = (1 << nibbleBits) - 1;
-  return ((suffix[byteIndex] ?? 0) >>> shift) & mask;
+  let value = 0;
+  for (let bitIndex = 0; bitIndex < nibbleBits; bitIndex += 1) {
+    value = (value << 1) | readBitMsbFirst(suffix, bitOffset + bitIndex);
+  }
+  return value;
 }
 
 function writeSlot(
   out: Uint8Array,
   slot: number,
-  nibbleBits: 1 | 2 | 4 | 8,
+  nibbleBits: NibbleBits,
   value: number,
 ): void {
   const bitOffset = slot * nibbleBits;
+  for (let bitIndex = 0; bitIndex < nibbleBits; bitIndex += 1) {
+    const bit = (value >>> (nibbleBits - bitIndex - 1)) & 1;
+    writeBitMsbFirst(out, bitOffset + bitIndex, bit);
+  }
+}
+
+function writeBitMsbFirst(out: Uint8Array, bitOffset: number, bit: number): void {
   const byteIndex = Math.floor(bitOffset / 8);
+  const byte = out[byteIndex] ?? 0;
   const bitInByte = bitOffset % 8;
-  const shift = 8 - nibbleBits - bitInByte;
-  const prev = out[byteIndex] ?? 0;
-  out[byteIndex] = (prev | (value << shift)) & 0xff;
+  const mask = 1 << (7 - bitInByte);
+  out[byteIndex] = bit === 1 ? byte | mask : byte & ~mask;
+}
+
+function readBitMsbFirst(bytes: Uint8Array, bitOffset: number): number {
+  const byteIndex = Math.floor(bitOffset / 8);
+  const byte = bytes[byteIndex] ?? 0;
+  const bitInByte = bitOffset % 8;
+  return (byte >>> (7 - bitInByte)) & 1;
 }

--- a/src/domain/orset/trie/TrieCursor.ts
+++ b/src/domain/orset/trie/TrieCursor.ts
@@ -3,8 +3,7 @@ import type VersionVector from "../../crdt/VersionVector.ts";
 import TrieCursorError from "../../errors/TrieCursorError.ts";
 import ORSetElementState from "../ORSetElementState.ts";
 import type CodecPort from "../../../ports/CodecPort.ts";
-import RouteKey from "../route/RouteKey.ts";
-import type { NibbleBits } from "../route/RouteKey.ts";
+import RouteKey, { type NibbleBits } from "../route/RouteKey.ts";
 
 import DirtyPageSet, { encodeDirtyPath } from "./DirtyPageSet.ts";
 import type PageCache from "./PageCache.ts";

--- a/src/domain/orset/trie/TrieCursor.ts
+++ b/src/domain/orset/trie/TrieCursor.ts
@@ -4,6 +4,7 @@ import TrieCursorError from "../../errors/TrieCursorError.ts";
 import ORSetElementState from "../ORSetElementState.ts";
 import type CodecPort from "../../../ports/CodecPort.ts";
 import RouteKey from "../route/RouteKey.ts";
+import type { NibbleBits } from "../route/RouteKey.ts";
 
 import DirtyPageSet, { encodeDirtyPath } from "./DirtyPageSet.ts";
 import type PageCache from "./PageCache.ts";
@@ -46,7 +47,7 @@ interface InsertContext {
   readonly element: string;
   readonly encodedDot: string;
   readonly depth: number;
-  readonly nibbleBits: 1 | 2 | 4 | 8;
+  readonly nibbleBits: NibbleBits;
   readonly maxDepth: number;
 }
 
@@ -55,7 +56,7 @@ interface SplitContext {
   readonly leafPath: readonly number[];
   readonly nibbleInParent: number;
   readonly leafDepth: number;
-  readonly nibbleBits: 1 | 2 | 4 | 8;
+  readonly nibbleBits: NibbleBits;
   readonly maxDepth: number;
 }
 
@@ -191,7 +192,7 @@ export default class TrieCursor {
       encodedDot,
       depth: 0,
       nibbleBits,
-      maxDepth: 256 / nibbleBits,
+      maxDepth: Math.floor(256 / nibbleBits),
     };
   }
 
@@ -416,9 +417,9 @@ export default class TrieCursor {
   async #descendForLookup(
     routeKey: RouteKey,
     element: string,
-    nibbleBits: 1 | 2 | 4 | 8,
+    nibbleBits: NibbleBits,
   ): Promise<TrieLeafEntry | null> {
-    const maxDepth = 256 / nibbleBits;
+    const maxDepth = Math.floor(256 / nibbleBits);
     let path: readonly number[] = [];
     for (let depth = 0; depth < maxDepth; depth += 1) {
       const step = await this.#stepLookup({ routeKey, path, depth, nibbleBits });
@@ -440,7 +441,7 @@ export default class TrieCursor {
     readonly routeKey: RouteKey;
     readonly path: readonly number[];
     readonly depth: number;
-    readonly nibbleBits: 1 | 2 | 4 | 8;
+    readonly nibbleBits: NibbleBits;
   }): Promise<LookupStep> {
     const branch = this.#branchAt(args.path);
     if (branch === null) {
@@ -606,25 +607,30 @@ export default class TrieCursor {
     }
     const partitions = partitionEntriesByNextNibble(leaf, ctx.nibbleBits);
     this.#clearLeafAt(ctx.leafPath);
-    const newBranch = this.#installPartitionedLeaves(ctx.leafPath, partitions);
+    const newBranch = this.#installPartitionedLeaves(ctx, partitions);
     this.#markBranchDirty(ctx.leafPath, newBranch);
     this.#rebindParentBranch(ctx.parentPath, ctx.nibbleInParent);
     await this.#cascadeSplitsInto(ctx, newBranch);
   }
 
   #installPartitionedLeaves(
-    leafPath: readonly number[],
+    ctx: SplitContext,
     partitions: ReadonlyMap<number, readonly TrieLeafEntry[]>,
   ): TrieBranch {
     const childEntries = new Map<number, string>();
+    const suffixNibbles = ctx.maxDepth - ctx.leafDepth;
     for (const [childNibble, childEntriesList] of partitions) {
-      const childPath = [...leafPath, childNibble];
+      const childPath = [...ctx.leafPath, childNibble];
       const childLeaf = new TrieLeaf(
-        shortenEntries(childEntriesList, nibbleBitsOf(this.#geometry.nibbleBits)),
+        shortenEntries(
+          childEntriesList,
+          nibbleBitsOf(this.#geometry.nibbleBits),
+          suffixNibbles,
+        ),
         this.#geometry,
       );
       this.#markLeafDirty(childPath, childLeaf);
-      childEntries.set(childNibble, pendingChildOid(leafPath, childNibble));
+      childEntries.set(childNibble, pendingChildOid(ctx.leafPath, childNibble));
     }
     return new TrieBranch(childEntries, this.#geometry);
   }

--- a/src/domain/orset/trie/trieCursorHelpers.ts
+++ b/src/domain/orset/trie/trieCursorHelpers.ts
@@ -2,6 +2,7 @@ import TrieCursorError from "../../errors/TrieCursorError.ts";
 import TrieStoreError from "../../errors/TrieStoreError.ts";
 import type { Dot } from "../../crdt/Dot.ts";
 import type RouteKey from "../route/RouteKey.ts";
+import type { NibbleBits } from "../route/RouteKey.ts";
 
 import { encodeDirtyPath } from "./DirtyPageSet.ts";
 import TrieLeaf, { type TrieLeafEntry } from "./TrieLeaf.ts";
@@ -16,16 +17,16 @@ import TrieLeaf, { type TrieLeafEntry } from "./TrieLeaf.ts";
  * pure and testable in isolation.
  */
 
-const VALID_NIBBLE_BITS: ReadonlyArray<1 | 2 | 4 | 8> = [1, 2, 4, 8];
+const VALID_NIBBLE_BITS: ReadonlyArray<NibbleBits> = [1, 2, 4, 6, 8];
 
-export function nibbleBitsOf(n: number): 1 | 2 | 4 | 8 {
+export function nibbleBitsOf(n: number): NibbleBits {
   for (const candidate of VALID_NIBBLE_BITS) {
     if (candidate === n) {
       return candidate;
     }
   }
   throw new TrieCursorError(
-    `TrieCursor geometry nibbleBits must be 1, 2, 4, or 8; received ${String(n)}`,
+    `TrieCursor geometry nibbleBits must be 1, 2, 4, 6, or 8; received ${String(n)}`,
     { code: "E_TRIE_CURSOR_INPUT", context: { nibbleBits: n } },
   );
 }
@@ -66,7 +67,7 @@ function hasValidCounter(dot: Dot): boolean {
 export function suffixOfRouteKey(
   routeKey: RouteKey,
   depth: number,
-  nibbleBits: 1 | 2 | 4 | 8,
+  nibbleBits: NibbleBits,
 ): Uint8Array {
   // Always pack MSB-first so the representation is consistent
   // across byte-aligned and sub-byte-aligned depths. A consistent
@@ -78,9 +79,9 @@ export function suffixOfRouteKey(
 function packSuffixMsbFirst(
   routeKey: RouteKey,
   depth: number,
-  nibbleBits: 1 | 2 | 4 | 8,
+  nibbleBits: NibbleBits,
 ): Uint8Array {
-  const maxDepth = 256 / nibbleBits;
+  const maxDepth = Math.floor(256 / nibbleBits);
   const nibblesLeft = maxDepth - depth;
   const byteCount = Math.ceil((nibblesLeft * nibbleBits) / 8);
   const out = new Uint8Array(byteCount);
@@ -93,22 +94,29 @@ function packSuffixMsbFirst(
 function writeNibbleAt(args: {
   readonly out: Uint8Array;
   readonly slot: number;
-  readonly nibbleBits: 1 | 2 | 4 | 8;
+  readonly nibbleBits: NibbleBits;
   readonly value: number;
 }): void {
   const bitOffset = args.slot * args.nibbleBits;
+  for (let bitIndex = 0; bitIndex < args.nibbleBits; bitIndex += 1) {
+    const bit = (args.value >>> (args.nibbleBits - bitIndex - 1)) & 1;
+    writeBitMsbFirst(args.out, bitOffset + bitIndex, bit);
+  }
+}
+
+function writeBitMsbFirst(out: Uint8Array, bitOffset: number, bit: number): void {
   const byteIndex = Math.floor(bitOffset / 8);
+  const byte = out[byteIndex] ?? 0;
   const bitInByte = bitOffset % 8;
-  const shift = 8 - args.nibbleBits - bitInByte;
-  const prev = args.out[byteIndex] ?? 0;
-  args.out[byteIndex] = (prev | (args.value << shift)) & 0xff;
+  const mask = 1 << (7 - bitInByte);
+  out[byteIndex] = bit === 1 ? byte | mask : byte & ~mask;
 }
 
 export interface UpsertArgs {
   readonly leaf: TrieLeaf;
   readonly routeKey: RouteKey;
   readonly leafDepth: number;
-  readonly nibbleBits: 1 | 2 | 4 | 8;
+  readonly nibbleBits: NibbleBits;
   readonly element: string;
   readonly encodedDot: string;
 }
@@ -229,7 +237,7 @@ export interface FindEntryArgs {
   readonly leaf: TrieLeaf;
   readonly routeKey: RouteKey;
   readonly depth: number;
-  readonly nibbleBits: 1 | 2 | 4 | 8;
+  readonly nibbleBits: NibbleBits;
   readonly element: string;
 }
 
@@ -320,7 +328,7 @@ function bytesEqualInRange(
 
 export function partitionEntriesByNextNibble(
   leaf: TrieLeaf,
-  nibbleBits: 1 | 2 | 4 | 8,
+  nibbleBits: NibbleBits,
 ): ReadonlyMap<number, readonly TrieLeafEntry[]> {
   const out = new Map<number, TrieLeafEntry[]>();
   for (const entry of leaf.entries()) {
@@ -345,7 +353,7 @@ function pushIntoBucket(
 
 function firstNibbleOfSuffix(
   suffix: Uint8Array,
-  nibbleBits: 1 | 2 | 4 | 8,
+  nibbleBits: NibbleBits,
 ): number {
   const byte = suffix[0] ?? 0;
   const shift = 8 - nibbleBits;
@@ -355,10 +363,15 @@ function firstNibbleOfSuffix(
 
 export function shortenEntries(
   entries: readonly TrieLeafEntry[],
-  nibbleBits: 1 | 2 | 4 | 8,
+  nibbleBits: NibbleBits,
+  suffixNibbles: number,
 ): TrieLeafEntry[] {
   const shortened = entries.map((entry) => ({
-    routeKeySuffix: shiftSuffixLeftByOneNibble(entry.routeKeySuffix, nibbleBits),
+    routeKeySuffix: shiftSuffixLeftByOneNibble(
+      entry.routeKeySuffix,
+      nibbleBits,
+      suffixNibbles,
+    ),
     element: entry.element,
     dots: entry.dots,
     tombstonedDots: entry.tombstonedDots,
@@ -375,20 +388,30 @@ export function shortenEntries(
  */
 export function shiftSuffixLeftByOneNibble(
   suffix: Uint8Array,
-  nibbleBits: 1 | 2 | 4 | 8,
+  nibbleBits: NibbleBits,
+  suffixNibbles: number,
 ): Uint8Array {
-  const totalBits = suffix.length * 8 - nibbleBits;
+  const totalBits = (suffixNibbles - 1) * nibbleBits;
   if (totalBits <= 0) {
     return new Uint8Array(0);
   }
   const newLength = Math.ceil(totalBits / 8);
   const out = new Uint8Array(newLength);
-  for (let i = 0; i < newLength; i += 1) {
-    const hi = (suffix[i] ?? 0) << nibbleBits;
-    const lo = (suffix[i + 1] ?? 0) >>> (8 - nibbleBits);
-    out[i] = (hi | lo) & 0xff;
+  for (let bitIndex = 0; bitIndex < totalBits; bitIndex += 1) {
+    writeBitMsbFirst(
+      out,
+      bitIndex,
+      readBitMsbFirst(suffix, nibbleBits + bitIndex),
+    );
   }
   return out;
+}
+
+function readBitMsbFirst(bytes: Uint8Array, bitOffset: number): number {
+  const byteIndex = Math.floor(bitOffset / 8);
+  const byte = bytes[byteIndex] ?? 0;
+  const bitInByte = bitOffset % 8;
+  return (byte >>> (7 - bitInByte)) & 1;
 }
 
 export function tombstoneEntry(

--- a/src/domain/services/EffectPipeline.ts
+++ b/src/domain/services/EffectPipeline.ts
@@ -14,6 +14,7 @@
 import { createEffectEmission, type EffectEmission } from '../types/EffectEmission.ts';
 import type { ExternalizationPolicy } from '../types/ExternalizationPolicy.ts';
 import type { DeliveryObservation } from '../types/DeliveryObservation.ts';
+import { requireDeliveryObservationBatch } from '../types/DeliveryObservationBatch.ts';
 import type EffectSinkPort from '../../ports/EffectSinkPort.ts';
 
 const NULL_COORDINATE: { frontier: Record<string, string> | null; ceiling: number | null } = {
@@ -125,7 +126,10 @@ export class EffectPipeline {
 
     this._emissions.push(emission);
 
-    const observations = await this._sink.deliver(emission, this._lens);
+    const observations = requireDeliveryObservationBatch(
+      await this._sink.deliver(emission, this._lens),
+      this._sink.id,
+    );
     this._recordObservations(observations);
 
     return { emission, observations };

--- a/src/domain/services/EffectPipeline.ts
+++ b/src/domain/services/EffectPipeline.ts
@@ -113,7 +113,7 @@ export class EffectPipeline {
       writer?: string | null;
       coordinate?: { frontier?: Record<string, string> | null; ceiling?: number | null };
     },
-  ): Promise<{ emission: EffectEmission; observations: DeliveryObservation | DeliveryObservation[] }> {
+  ): Promise<{ emission: EffectEmission; observations: DeliveryObservation[] }> {
     const emission = createEffectEmission({
       id: options?.id ?? '',
       kind,
@@ -134,13 +134,9 @@ export class EffectPipeline {
   /**
    * Appends one or more delivery observations to the internal observation log.
    */
-  private _recordObservations(observations: DeliveryObservation | DeliveryObservation[]): void {
-    if (Array.isArray(observations)) {
-      for (const obs of observations) {
-        this._observations.push(obs);
-      }
-    } else {
-      this._observations.push(observations);
+  private _recordObservations(observations: readonly DeliveryObservation[]): void {
+    for (const obs of observations) {
+      this._observations.push(obs);
     }
   }
 }

--- a/src/domain/services/MultiplexSink.ts
+++ b/src/domain/services/MultiplexSink.ts
@@ -14,6 +14,7 @@ import WarpError from '../errors/WarpError.ts';
 import type { EffectEmission } from '../types/EffectEmission.ts';
 import type { ExternalizationPolicy } from '../types/ExternalizationPolicy.ts';
 import type { DeliveryObservation } from '../types/DeliveryObservation.ts';
+import { requireDeliveryObservationBatch } from '../types/DeliveryObservationBatch.ts';
 
 /** Default sink ID for MultiplexSink. */
 const MULTIPLEX_SINK_ID = 'multiplex';
@@ -69,7 +70,11 @@ export class MultiplexSink extends EffectSinkPort {
   ): Promise<DeliveryObservation[]> {
     const observations: DeliveryObservation[] = [];
     for (const sink of this._sinks) {
-      observations.push(...await sink.deliver(emission, lens));
+      const childObservations = requireDeliveryObservationBatch(
+        await sink.deliver(emission, lens),
+        sink.id,
+      );
+      observations.push(...childObservations);
     }
     return observations;
   }

--- a/src/domain/services/MultiplexSink.ts
+++ b/src/domain/services/MultiplexSink.ts
@@ -69,12 +69,7 @@ export class MultiplexSink extends EffectSinkPort {
   ): Promise<DeliveryObservation[]> {
     const observations: DeliveryObservation[] = [];
     for (const sink of this._sinks) {
-      const obs = await sink.deliver(emission, lens);
-      if (Array.isArray(obs)) {
-        observations.push(...obs);
-      } else {
-        observations.push(obs);
-      }
+      observations.push(...await sink.deliver(emission, lens));
     }
     return observations;
   }

--- a/src/domain/types/DeliveryObservationBatch.ts
+++ b/src/domain/types/DeliveryObservationBatch.ts
@@ -1,0 +1,31 @@
+import WarpError from '../errors/WarpError.ts';
+import { DeliveryObservation } from './DeliveryObservation.ts';
+
+export const EFFECT_SINK_INVALID_OBSERVATION_BATCH =
+  'E_EFFECT_SINK_INVALID_OBSERVATION_BATCH';
+export const EFFECT_SINK_INVALID_OBSERVATION =
+  'E_EFFECT_SINK_INVALID_OBSERVATION';
+
+export function requireDeliveryObservationBatch(
+  observations: DeliveryObservation[],
+  sinkId: string,
+): DeliveryObservation[] {
+  if (!Array.isArray(observations)) {
+    throw new WarpError(
+      `Effect sink ${sinkId} must return DeliveryObservation[]`,
+      EFFECT_SINK_INVALID_OBSERVATION_BATCH,
+      { context: { sinkId } },
+    );
+  }
+  for (let index = 0; index < observations.length; index += 1) {
+    const observation = observations[index];
+    if (!(observation instanceof DeliveryObservation)) {
+      throw new WarpError(
+        `Effect sink ${sinkId} returned a non-DeliveryObservation at index ${String(index)}`,
+        EFFECT_SINK_INVALID_OBSERVATION,
+        { context: { sinkId, index } },
+      );
+    }
+  }
+  return observations;
+}

--- a/src/domain/warp/PatchSession.ts
+++ b/src/domain/warp/PatchSession.ts
@@ -17,10 +17,10 @@ import type Patch from '../types/Patch.ts';
 
 const NONE_DISPLAY = '(none)';
 
-/**
- * Extracts the error message and cause from an unknown error value. // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
- */
-function _extractErrorInfo(err: unknown): { errMsg: string; cause: Error | undefined } { // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
+type CommitFailure = Error | string;
+
+/** Extracts the error message and cause from a commit failure. */
+function _extractErrorInfo(err: CommitFailure): { errMsg: string; cause: Error | undefined } {
   const errMsg = err instanceof Error ? err.message : String(err);
   const cause = err instanceof Error ? err : undefined;
   return { errMsg, cause };
@@ -59,7 +59,7 @@ function _buildCasConflictError(
 /**
  * Classifies a commit error into the appropriate WriterError code.
  */
-function _classifyCommitError(err: unknown, ctx: CommitContext): WriterError { // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
+function _classifyCommitError(err: CommitFailure, ctx: CommitContext): WriterError {
   if (err instanceof WriterError && err.code === 'WRITER_CAS_CONFLICT') {
     return _buildCasConflictError(err, ctx);
   }
@@ -199,7 +199,12 @@ export class PatchSession {
       this._committed = true;
       return sha;
     } catch (err) {
-      throw _classifyCommitError(err, { graphName: this._graphName, writerId: this._writerId, expectedOldHead: this._expectedOldHead });
+      const classifiedInput: CommitFailure = err instanceof Error ? err : String(err);
+      throw _classifyCommitError(classifiedInput, {
+        graphName: this._graphName,
+        writerId: this._writerId,
+        expectedOldHead: this._expectedOldHead,
+      });
     }
   }
 

--- a/src/domain/warp/PatchSession.ts
+++ b/src/domain/warp/PatchSession.ts
@@ -26,16 +26,6 @@ function _extractErrorInfo(err: unknown): { errMsg: string; cause: Error | undef
   return { errMsg, cause };
 }
 
-/**
- * Extracts the CAS error object from an unknown error if applicable. // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
- */
-function _extractCasError(err: unknown): { code?: unknown; expectedSha?: unknown; actualSha?: unknown } | null { // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
-  if (err !== null && err !== undefined && typeof err === 'object') {
-    return err as { code?: unknown; expectedSha?: unknown; actualSha?: unknown }; // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
-  }
-  return null;
-}
-
 /** Formats a nullable SHA for display in error messages. */
 function _displaySha(sha: string | null): string {
   return (sha !== null && sha.length > 0) ? sha : NONE_DISPLAY;
@@ -51,19 +41,18 @@ interface CommitContext {
  * Builds a CAS conflict WriterError with ref details.
  */
 function _buildCasConflictError(
-  casError: { code?: unknown; expectedSha?: unknown; actualSha?: unknown }, // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
-  cause: Error | undefined,
+  casError: WriterError,
   ctx: CommitContext,
 ): WriterError {
   const { graphName, writerId, expectedOldHead } = ctx;
   const writerRef = buildWriterRef(graphName, writerId);
-  const expectedSha = typeof casError.expectedSha === 'string' ? casError.expectedSha : expectedOldHead;
-  const actualSha = typeof casError.actualSha === 'string' ? casError.actualSha : null;
+  const expectedSha = casError.expectedSha ?? expectedOldHead;
+  const actualSha = casError.actualSha ?? null;
   return new WriterError(
     `Writer ref ${writerRef} has advanced since beginPatch(). ` +
     `Expected ${_displaySha(expectedSha)}, found ${_displaySha(actualSha)}. ` +
     'Call beginPatch() again to retry.',
-    { code: 'WRITER_REF_ADVANCED', cause },
+    { code: 'WRITER_REF_ADVANCED', cause: casError },
   );
 }
 
@@ -71,14 +60,13 @@ function _buildCasConflictError(
  * Classifies a commit error into the appropriate WriterError code.
  */
 function _classifyCommitError(err: unknown, ctx: CommitContext): WriterError { // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
+  if (err instanceof WriterError && err.code === 'WRITER_CAS_CONFLICT') {
+    return _buildCasConflictError(err, ctx);
+  }
+  if (err instanceof WriterError && err.code === 'WRITER_REF_ADVANCED') {
+    return err;
+  }
   const { errMsg, cause } = _extractErrorInfo(err);
-  const casError = _extractCasError(err);
-  if (casError !== null && casError.code === 'WRITER_CAS_CONFLICT') {
-    return _buildCasConflictError(casError, cause, ctx);
-  }
-  if (errMsg.includes('Concurrent commit detected') || errMsg.includes('has advanced')) {
-    return new WriterError(errMsg, { code: 'WRITER_REF_ADVANCED', cause });
-  }
   return new WriterError(`Failed to persist patch: ${errMsg}`, { code: 'PERSIST_WRITE_FAILED', cause });
 }
 

--- a/src/infrastructure/adapters/ChunkEffectSink.ts
+++ b/src/infrastructure/adapters/ChunkEffectSink.ts
@@ -72,25 +72,25 @@ export class ChunkEffectSink extends EffectSinkPort {
     return this._id;
   }
 
-  async deliver(emission: EffectEmission, lens: ExternalizationPolicy): Promise<DeliveryObservation> {
+  async deliver(emission: EffectEmission, lens: ExternalizationPolicy): Promise<DeliveryObservation[]> {
     try {
       await this._write(emission);
-      return createDeliveryObservation({
+      return [createDeliveryObservation({
         emissionId: emission.id,
         sinkId: this._id,
         outcome: OUTCOME_DELIVERED,
         timestamp: Date.now(),
         lens,
-      });
+      })];
     } catch (err: unknown) {
-      return createDeliveryObservation({
+      return [createDeliveryObservation({
         emissionId: emission.id,
         sinkId: this._id,
         outcome: OUTCOME_FAILED,
         reason: err instanceof Error ? err.message : String(err),
         timestamp: Date.now(),
         lens,
-      });
+      })];
     }
   }
 

--- a/src/infrastructure/adapters/ConsoleEffectSink.ts
+++ b/src/infrastructure/adapters/ConsoleEffectSink.ts
@@ -57,9 +57,9 @@ export class ConsoleEffectSink extends EffectSinkPort {
     return this._id;
   }
 
-  deliver(emission: EffectEmission, lens: ExternalizationPolicy): Promise<DeliveryObservation> {
+  deliver(emission: EffectEmission, lens: ExternalizationPolicy): Promise<DeliveryObservation[]> {
     if (lens.suppressExternal) {
-      return Promise.resolve(buildSuppressedObservation(this._id, emission, lens));
+      return Promise.resolve([buildSuppressedObservation(this._id, emission, lens)]);
     }
 
     if (this._logger !== null) {
@@ -67,13 +67,13 @@ export class ConsoleEffectSink extends EffectSinkPort {
     }
 
     return Promise.resolve(
-      createDeliveryObservation({
+      [createDeliveryObservation({
         emissionId: emission.id,
         sinkId: this._id,
         outcome: OUTCOME_DELIVERED,
         timestamp: Date.now(),
         lens,
-      }),
+      })],
     );
   }
 }

--- a/src/infrastructure/adapters/InMemoryGraphAdapter.ts
+++ b/src/infrastructure/adapters/InMemoryGraphAdapter.ts
@@ -70,7 +70,7 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
   private readonly _author: string;
   private readonly _clock: { now(): number };
   private readonly _hash: HashFn;
-  private readonly _cryptoReady: Promise<void>;
+  private readonly _cryptoReady: Promise<boolean>;
   private readonly _commits = new Map<string, CommitRecord>();
   private readonly _blobs = new Map<string, Uint8Array>();
   private readonly _trees = new Map<string, TreeEntry[]>();
@@ -81,10 +81,11 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
   constructor(options?: InMemoryAdapterOptions) {
     super();
     const opts = options ?? {};
+    const hasInjectedHash = opts.hash !== null && opts.hash !== undefined;
     this._author = (opts.author !== undefined && opts.author.length > 0) ? opts.author : 'InMemory <inmemory@test>';
     this._clock = opts.clock ?? { now: () => Date.now() };
-    this._hash = opts.hash ?? defaultHash;
-    this._cryptoReady = initCryptoReady(opts.hash);
+    this._hash = hasInjectedHash ? opts.hash : defaultHash;
+    this._cryptoReady = initCryptoReady(hasInjectedHash ? opts.hash : undefined);
   }
 
   // -- TreePort -------------------------------------------------------------
@@ -94,7 +95,7 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
   }
 
   async writeTree(entries: string[]): Promise<string> {
-    await this._cryptoReady;
+    await this._ensureHashReady();
     const parsed = entries.map(line => parseMktreeEntry(line));
     const oid = hashTree(this._hash, parsed);
     this._trees.set(oid, parsed);
@@ -183,7 +184,7 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
   // -- BlobPort -------------------------------------------------------------
 
   async writeBlob(content: Uint8Array | string): Promise<string> {
-    await this._cryptoReady;
+    await this._ensureHashReady();
     const bytes = toBytes(content);
     const oid = hashBlob(this._hash, bytes);
     this._blobs.set(oid, bytes);
@@ -361,11 +362,21 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
   }
 
   private async _createCommit(treeOid: string, parents: string[], message: string): Promise<string> {
-    await this._cryptoReady;
+    await this._ensureHashReady();
     const date = new Date(this._clock.now()).toISOString();
     const sha = hashCommit(this._hash, { treeOid, parents, message, author: this._author, date });
     this._commits.set(sha, { treeOid, parents: [...parents], message, author: this._author, date });
     return sha;
+  }
+
+  private async _ensureHashReady(): Promise<void> {
+    if (await this._cryptoReady) {
+      return;
+    }
+    throw new WarpError(
+      'No hash function available. Pass { hash } to InMemoryGraphAdapter constructor.',
+      'E_NO_HASH',
+    );
   }
 
   private _resolveRef(ref: string): string | null {

--- a/src/infrastructure/adapters/InMemoryGraphAdapter.ts
+++ b/src/infrastructure/adapters/InMemoryGraphAdapter.ts
@@ -70,7 +70,7 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
   private readonly _author: string;
   private readonly _clock: { now(): number };
   private readonly _hash: HashFn;
-  private readonly _cryptoReady: Promise<unknown>;
+  private readonly _cryptoReady: Promise<void>;
   private readonly _commits = new Map<string, CommitRecord>();
   private readonly _blobs = new Map<string, Uint8Array>();
   private readonly _trees = new Map<string, TreeEntry[]>();

--- a/src/infrastructure/adapters/LoggerObservabilityBridge.ts
+++ b/src/infrastructure/adapters/LoggerObservabilityBridge.ts
@@ -18,6 +18,7 @@
 import type LoggerPort from '../../ports/LoggerPort.ts';
 import type LogFields from '../../domain/types/log/LogFields.ts';
 import type LogFieldValue from '../../domain/types/log/LogFieldValue.ts';
+import WarpError from '../../domain/errors/WarpError.ts';
 
 /**
  * Narrows a raw `Record<string, unknown>` context into the typed
@@ -69,6 +70,12 @@ export default class LoggerObservabilityBridge {
 
   /** Creates a bridge that forwards CAS observability events to the given logger. */
   constructor(logger: LoggerPort) {
+    if (logger === null || logger === undefined) {
+      throw new WarpError(
+        'LoggerObservabilityBridge requires a logger',
+        'E_OBSERVABILITY_LOGGER_REQUIRED',
+      );
+    }
     this._logger = logger;
   }
 

--- a/src/infrastructure/adapters/NoOpEffectSink.ts
+++ b/src/infrastructure/adapters/NoOpEffectSink.ts
@@ -30,27 +30,27 @@ export class NoOpEffectSink extends EffectSinkPort {
     return this._id;
   }
 
-  deliver(emission: EffectEmission, lens: ExternalizationPolicy): Promise<DeliveryObservation> {
+  deliver(emission: EffectEmission, lens: ExternalizationPolicy): Promise<DeliveryObservation[]> {
     if (lens.suppressExternal) {
       return Promise.resolve(
-        createDeliveryObservation({
+        [createDeliveryObservation({
           emissionId: emission.id,
           sinkId: this._id,
           outcome: OUTCOME_SUPPRESSED,
           reason: `suppressed by ${lens.mode} lens`,
           timestamp: Date.now(),
           lens,
-        }),
+        })],
       );
     }
     return Promise.resolve(
-      createDeliveryObservation({
+      [createDeliveryObservation({
         emissionId: emission.id,
         sinkId: this._id,
         outcome: OUTCOME_DELIVERED,
         timestamp: Date.now(),
         lens,
-      }),
+      })],
     );
   }
 }

--- a/src/infrastructure/adapters/NodeHttpAdapter.ts
+++ b/src/infrastructure/adapters/NodeHttpAdapter.ts
@@ -1,16 +1,7 @@
 import HttpServerPort, { HttpRequest, HttpResponse, type HttpServerHandle } from '../../ports/HttpServerPort.ts';
-import { MAX_BODY_BYTES, noopLogger } from './httpAdapterUtils.ts';
+import { MAX_BODY_BYTES, PayloadTooLargeError, noopLogger } from './httpAdapterUtils.ts';
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import WarpError from '../../domain/errors/WarpError.ts';
-
-/**
- * Error thrown when the request body exceeds the size limit.
- */
-class PayloadTooLargeError extends WarpError {
-  constructor(totalBytes: number) {
-    super('Payload Too Large', 'E_PAYLOAD_TOO_LARGE', { context: { totalBytes } });
-  }
-}
 
 /**
  * Reads the request body from a Node.js IncomingMessage stream, enforcing a size limit.

--- a/src/infrastructure/adapters/httpAdapterUtils.ts
+++ b/src/infrastructure/adapters/httpAdapterUtils.ts
@@ -14,7 +14,7 @@ import { HttpRequest } from '../../ports/HttpServerPort.ts';
 /**
  * Error thrown when a request body exceeds the size limit.
  */
-class PayloadTooLargeError extends WarpError {
+export class PayloadTooLargeError extends WarpError {
   readonly status: number;
 
   constructor(totalBytes: number) {

--- a/src/infrastructure/adapters/inMemoryHashing.ts
+++ b/src/infrastructure/adapters/inMemoryHashing.ts
@@ -54,24 +54,31 @@ async function probeNodeCrypto(): Promise<CreateHashFn | null> {
 
 /** Default hash function using node:crypto SHA-1. */
 export function defaultHash(data: Uint8Array): string {
-  if (_nodeCreateHash === null) {
+  const createHash = _nodeCreateHash;
+  if (createHash === null) {
     throw new WarpError(
-      'No hash function available. Pass { hash } to InMemoryGraphAdapter constructor.',
-      'E_NO_HASH',
+      'defaultHash called before node:crypto initialization completed',
+      'E_HASH_NOT_READY',
     );
   }
-  return _nodeCreateHash('sha1').update(data).digest('hex');
+  return createHash('sha1').update(data).digest('hex');
 }
 
 /**
  * Eagerly kicks off the async crypto probe when no custom hash is provided.
  * Returns a promise that resolves when the probe completes.
  */
-export function initCryptoReady(hash: HashFn | undefined): Promise<CreateHashFn | null> {
+export async function initCryptoReady(hash: HashFn | undefined): Promise<void> {
   if (hash !== null && hash !== undefined) {
-    return Promise.resolve(null);
+    return;
   }
-  return probeNodeCrypto();
+  const createHash = await probeNodeCrypto();
+  if (createHash === null) {
+    throw new WarpError(
+      'No hash function available. Pass { hash } to InMemoryGraphAdapter constructor.',
+      'E_NO_HASH',
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/infrastructure/adapters/inMemoryHashing.ts
+++ b/src/infrastructure/adapters/inMemoryHashing.ts
@@ -42,12 +42,14 @@ async function probeNodeCrypto(): Promise<CreateHashFn | null> {
   if (_cryptoProbed) {
     return _nodeCreateHash;
   }
-  _cryptoProbed = true;
   try {
     const nodeCrypto = await import('node:crypto');
     _nodeCreateHash = nodeCrypto.createHash as CreateHashFn;
+    _cryptoProbed = true;
   } catch {
-    // Browser or non-Node runtime — hash must be injected via constructor
+    // Browser, non-Node runtime, or test-level module mock: callers decide
+    // whether missing ambient hashing is acceptable for their boundary.
+    _cryptoProbed = false;
   }
   return _nodeCreateHash;
 }
@@ -68,17 +70,12 @@ export function defaultHash(data: Uint8Array): string {
  * Eagerly kicks off the async crypto probe when no custom hash is provided.
  * Returns a promise that resolves when the probe completes.
  */
-export async function initCryptoReady(hash: HashFn | undefined): Promise<void> {
+export async function initCryptoReady(hash: HashFn | undefined): Promise<boolean> {
   if (hash !== null && hash !== undefined) {
-    return;
+    return true;
   }
   const createHash = await probeNodeCrypto();
-  if (createHash === null) {
-    throw new WarpError(
-      'No hash function available. Pass { hash } to InMemoryGraphAdapter constructor.',
-      'E_NO_HASH',
-    );
-  }
+  return createHash !== null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ports/EffectSinkPort.ts
+++ b/src/ports/EffectSinkPort.ts
@@ -8,7 +8,7 @@ import type { DeliveryObservation } from '../domain/types/DeliveryObservation.ts
  * Each sink has a unique `id` and a `deliver()` method that accepts
  * an EffectEmission and an ExternalizationPolicy. The sink decides
  * its behavior based on the policy (e.g., suppress during replay)
- * and returns a DeliveryObservation recording the outcome.
+ * and returns delivery observations recording the outcome.
  *
  * This is a host-domain port for externalization, not a substrate
  * contract. Sinks operate outside the graph.
@@ -25,5 +25,5 @@ export default abstract class EffectSinkPort {
   abstract deliver(
     _emission: EffectEmission,
     _lens: ExternalizationPolicy,
-  ): Promise<DeliveryObservation | DeliveryObservation[]>;
+  ): Promise<DeliveryObservation[]>;
 }

--- a/test/conformance/sludgeAtlas.test.ts
+++ b/test/conformance/sludgeAtlas.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import sludgeMap from '../../policy/sludge/sludge-map.json' with { type: 'json' };
+import sludgeMapJsonSchema from '../../policy/sludge/sludge-map.schema.json' with { type: 'json' };
 
 const REQUIRED_FAMILY_IDS = Object.freeze([
   'cast-theater',
@@ -19,35 +21,46 @@ const REQUIRED_FINDING_PATHS = Object.freeze([
   'src/domain/services/index/PropertyIndexReader.ts',
 ]);
 
-type SludgeFinding = {
-  readonly path?: string;
-  readonly symptom?: string;
-  readonly root_cause?: string;
-  readonly recommended_fix?: string;
-  readonly blocks?: readonly string[];
-  readonly proposed_nouns?: readonly ProposedNoun[];
-};
+const nonEmptyString = z.string().trim().min(1);
 
-type ProposedNoun = {
-  readonly name?: string;
-  readonly constructs?: string;
-  readonly consumes?: string;
-  readonly proves_invariant?: string;
-  readonly layer?: string;
-  readonly eliminates?: string;
-};
+const proposedNounSchema = z.object({
+  name: nonEmptyString,
+  constructs: nonEmptyString,
+  consumes: nonEmptyString,
+  proves_invariant: nonEmptyString,
+  layer: z.enum(['domain', 'ports', 'policy']),
+  eliminates: nonEmptyString,
+}).strict();
 
-type SludgeFamily = {
-  readonly id?: string;
-  readonly findings?: readonly SludgeFinding[];
-};
+const findingSchema = z.object({
+  path: nonEmptyString,
+  lines: z.array(z.number().int().positive()).min(1).optional(),
+  symptom: nonEmptyString,
+  root_cause: nonEmptyString,
+  recommended_fix: nonEmptyString,
+  blocks: z.array(nonEmptyString),
+  proposed_nouns: z.array(proposedNounSchema).min(1).optional(),
+}).strict();
 
-type SludgeMap = {
-  readonly source_cycle_blocked?: string;
-  readonly families?: readonly SludgeFamily[];
-};
+const familySchema = z.object({
+  id: nonEmptyString,
+  label: nonEmptyString,
+  severity: z.enum(['release-blocking', 'watch']),
+  blocks: z.array(nonEmptyString),
+  findings: z.array(findingSchema).min(1),
+}).strict();
 
-const atlas: SludgeMap = sludgeMap;
+const sludgeMapSchema = z.object({
+  generated_for_cycle: nonEmptyString,
+  source_cycle_blocked: nonEmptyString,
+  families: z.array(familySchema).min(1),
+  dependency_order: z.array(nonEmptyString).optional(),
+}).strict();
+
+type SludgeMap = z.infer<typeof sludgeMapSchema>;
+type SludgeFinding = z.infer<typeof findingSchema>;
+
+const atlas: SludgeMap = sludgeMapSchema.parse(sludgeMap);
 
 class SludgeAtlasTestError extends Error {}
 
@@ -61,6 +74,19 @@ function assertNonEmptyString(value: string | undefined, field: string): void {
 }
 
 describe('sludge atlas contract', () => {
+  it('publishes a formal schema for the sludge map', () => {
+    expect(sludgeMapJsonSchema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    expect(sludgeMapJsonSchema.$id).toBe('https://git-stunts.dev/git-warp/schemas/sludge-map.schema.json');
+    expect(sludgeMapJsonSchema.additionalProperties).toBe(false);
+    expect(sludgeMapJsonSchema.required).toEqual(['generated_for_cycle', 'source_cycle_blocked', 'families']);
+    expect(sludgeMapJsonSchema.$defs.proposedNoun.properties.layer.enum)
+      .toEqual(['domain', 'ports', 'policy']);
+  });
+
+  it('validates the sludge map against the strict runtime schema', () => {
+    expect(() => sludgeMapSchema.parse(sludgeMap)).not.toThrow();
+  });
+
   it('publishes structured release-blocking families for the blocked cycle', () => {
     const familyIds = new Set((atlas.families ?? []).map((family) => family.id));
 

--- a/test/helpers/MockStreamingIndexStorage.ts
+++ b/test/helpers/MockStreamingIndexStorage.ts
@@ -17,6 +17,10 @@ export default class MockStreamingIndexStorage extends StreamingIndexStoragePort
   private _blobCounter: number = 0;
   private _treeCounter: number = 0;
 
+  get emptyTree(): string {
+    return '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+  }
+
   writeBlob = vi.fn(async (content: Uint8Array | string) => {
     const oid = String(this._blobCounter++).padStart(40, '0');
     const bytes = typeof content === 'string' ? new TextEncoder().encode(content) : content;
@@ -68,6 +72,15 @@ export default class MockStreamingIndexStorage extends StreamingIndexStoragePort
       throw new Error(`Tree not found: ${treeOid}`);
     }
     return { ...tree };
+  });
+
+  readTree = vi.fn(async (treeOid: string) => {
+    const tree = await this.readTreeOids(treeOid);
+    const files: Record<string, Uint8Array> = {};
+    for (const [path, oid] of Object.entries(tree)) {
+      files[path] = await this.readBlob(oid);
+    }
+    return files;
   });
 
   updateRef = vi.fn(async (ref: string, oid: string) => {

--- a/test/helpers/MockStreamingIndexStorage.ts
+++ b/test/helpers/MockStreamingIndexStorage.ts
@@ -10,6 +10,8 @@ function singleChunkStream(bytes: Uint8Array): AsyncIterable<Uint8Array> {
   return normalizeToAsyncIterable(bytes);
 }
 
+const EMPTY_TREE_OID = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
 export default class MockStreamingIndexStorage extends StreamingIndexStoragePort {
   private readonly _blobStore: Map<string, Uint8Array> = new Map();
   private readonly _treeStore: Map<string, Record<string, string>> = new Map();
@@ -17,8 +19,13 @@ export default class MockStreamingIndexStorage extends StreamingIndexStoragePort
   private _blobCounter: number = 0;
   private _treeCounter: number = 0;
 
+  constructor() {
+    super();
+    this._treeStore.set(EMPTY_TREE_OID, {});
+  }
+
   get emptyTree(): string {
-    return '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+    return EMPTY_TREE_OID;
   }
 
   writeBlob = vi.fn(async (content: Uint8Array | string) => {

--- a/test/unit/benchmark/TrieGeometryProfile.profile.test.ts
+++ b/test/unit/benchmark/TrieGeometryProfile.profile.test.ts
@@ -11,16 +11,15 @@ import {
 describe("Trie geometry profile harness", () => {
   it("runs the default matrix when GIT_WARP_PROFILE=1", async () => {
     if (process.env["GIT_WARP_PROFILE"] !== "1") {
-      expect(true).toBe(true);
+      expect(process.env["GIT_WARP_PROFILE"]).not.toBe("1");
       return;
     }
 
     const rows: TrieGeometryProfileRow[] = [];
     const onlyLabel = process.env["GIT_WARP_PROFILE_ONLY_LABEL"] ?? null;
-    for (const scenario of createTrieGeometryProfilePlan()) {
-      if (onlyLabel !== null && scenario.label !== onlyLabel) {
-        continue;
-      }
+    const scenarios = createTrieGeometryProfilePlan()
+      .filter((scenario) => onlyLabel === null || scenario.label === onlyLabel);
+    for (const scenario of scenarios) {
       const row = await runTrieGeometryProfileScenario(scenario);
       rows.push(row);
       console.log(
@@ -32,24 +31,21 @@ describe("Trie geometry profile harness", () => {
     console.log("");
     console.log(formatTrieGeometryProfileReport({ recommendation, rows }));
 
-    expect(rows).toHaveLength(createTrieGeometryProfilePlan().length);
+    expect(rows).toHaveLength(scenarios.length);
   }, 300_000);
 
   it("runs the 1M-entry stress scale when GIT_WARP_PROFILE_STRESS=1", async () => {
     if (process.env["GIT_WARP_PROFILE_STRESS"] !== "1") {
-      expect(true).toBe(true);
+      expect(process.env["GIT_WARP_PROFILE_STRESS"]).not.toBe("1");
       return;
     }
 
     const rows: TrieGeometryProfileRow[] = [];
     const onlyLabel = process.env["GIT_WARP_PROFILE_ONLY_LABEL"] ?? null;
-    for (const scenario of createTrieGeometryProfilePlan({ includeStress: true })) {
-      if (scenario.totalEntries !== 1_000_000) {
-        continue;
-      }
-      if (onlyLabel !== null && scenario.label !== onlyLabel) {
-        continue;
-      }
+    const scenarios = createTrieGeometryProfilePlan({ includeStress: true })
+      .filter((scenario) => scenario.totalEntries === 1_000_000)
+      .filter((scenario) => onlyLabel === null || scenario.label === onlyLabel);
+    for (const scenario of scenarios) {
       const row = await runTrieGeometryProfileScenario(scenario);
       rows.push(row);
       console.log(
@@ -63,6 +59,12 @@ describe("Trie geometry profile harness", () => {
       console.log(formatTrieGeometryProfileReport({ recommendation, rows }));
     }
 
-    expect(rows.length).toBeGreaterThanOrEqual(0);
+    if (onlyLabel === null) {
+      expect(rows.length).toBeGreaterThan(0);
+    }
+    expect(rows).toHaveLength(scenarios.length);
+    for (const row of rows) {
+      expect(row.totalEntries).toBe(1_000_000);
+    }
   }, 900_000);
 });

--- a/test/unit/domain/WarpCore.effectPipeline.test.ts
+++ b/test/unit/domain/WarpCore.effectPipeline.test.ts
@@ -144,8 +144,7 @@ describe('WarpCore — effect pipeline (host-domain infra)', () => {
       const pipeline = (core.effectPipeline as EffectPipeline);
       const result = await pipeline.emit('test', null, { id: 'emit-replay', timestamp: 0 });
 
-      const obs = Array.isArray(result.observations) ? result.observations[0] : result.observations;
-      expect(obs?.outcome).toBe('suppressed');
+      expect(result.observations[0]?.outcome).toBe('suppressed');
     });
   });
 });

--- a/test/unit/domain/WarpGraph.coverageGaps.test.ts
+++ b/test/unit/domain/WarpGraph.coverageGaps.test.ts
@@ -263,9 +263,12 @@ describe('WarpCore coverage gaps', () => {
 
       graph.join(otherState);
 
-      expect((graph as any)._stateDirty).toBe(false);
-      const materialized = (graph as any)._materializedGraph;
+      expect(graph._stateDirty).toBe(false);
+      const materialized = graph._materializedGraph;
       expect(materialized).not.toBeNull();
+      if (materialized === null) {
+        throw new Error('expected materialized graph');
+      }
       expect(materialized.state.nodeAlive.elements()).toEqual(['user:alice']);
       expect(materialized.adjacency.outgoing.size).toBe(0);
       expect(materialized.adjacency.incoming.size).toBe(0);

--- a/test/unit/domain/WarpGraph.coverageGaps.test.ts
+++ b/test/unit/domain/WarpGraph.coverageGaps.test.ts
@@ -213,7 +213,9 @@ describe('WarpCore coverage gaps', () => {
 
       const { state, receipt } = graph.join(otherState);
 
-      expect(state).toBeDefined();
+      expect(state.nodeAlive.elements()).toEqual([]);
+      expect(state.edgeAlive.elements()).toEqual([]);
+      expect(state.propSize()).toBe(0);
       expect(receipt.nodesAdded).toBe(0);
       expect(receipt.nodesRemoved).toBe(0);
       expect(receipt.edgesAdded).toBe(0);
@@ -262,10 +264,12 @@ describe('WarpCore coverage gaps', () => {
       graph.join(otherState);
 
       expect((graph as any)._stateDirty).toBe(false);
-      expect((graph)._materializedGraph).not.toBeNull();
-      expect((graph as any)._materializedGraph?.state).toBeDefined();
-      expect((graph as any)._materializedGraph?.adjacency).toBeDefined();
-      expect((graph as any)._materializedGraph?.stateHash).toBeNull();
+      const materialized = (graph as any)._materializedGraph;
+      expect(materialized).not.toBeNull();
+      expect(materialized.state.nodeAlive.elements()).toEqual(['user:alice']);
+      expect(materialized.adjacency.outgoing.size).toBe(0);
+      expect(materialized.adjacency.incoming.size).toBe(0);
+      expect(materialized.stateHash).toBeNull();
     });
 
     it('preserves merged state — _ensureFreshState() does not throw or rematerialize', async () => {
@@ -424,9 +428,14 @@ describe('WarpCore coverage gaps', () => {
 
       expect(setStateSpy).toHaveBeenCalledTimes(1);
       const [, options] = (setStateSpy.mock.calls[0] as [unknown, any]);
-      expect(options).toBeDefined();
-      expect(options.diff).toBeDefined();
-      expect(options.diff.nodesAdded).toContain('user:alice');
+      expect(options).toMatchObject({
+        diff: {
+          nodesAdded: ['user:alice'],
+          nodesRemoved: [],
+          edgesAdded: [],
+          edgesRemoved: [],
+        },
+      });
     });
 
     it('passes diff:null to _setMaterializedState when audit is enabled', async () => {
@@ -594,8 +603,15 @@ describe('WarpCore coverage gaps', () => {
       const result = graph.maybeRunGC();
 
       expect(result.ran).toBe(true);
-      expect(result.result).toBeDefined();
-      expect(result.reasons.length).toBeGreaterThan(0);
+      expect(result.result).toMatchObject({
+        nodesCompacted: 0,
+        edgesCompacted: 0,
+        tombstonesRemoved: 0,
+      });
+      expect(result.reasons).toEqual([
+        'Entry count 1 exceeds threshold 0',
+        'Patches since compaction 10000 exceeds minimum 0',
+      ]);
     });
   });
 
@@ -902,8 +918,12 @@ describe('WarpCore coverage gaps', () => {
 
       const wormhole = await graph.createWormhole(fromSha, toSha);
 
-      expect(wormhole).toBeDefined();
-      expect(wormhole.patchCount).toBeGreaterThanOrEqual(0);
+      expect(wormhole.fromSha).toBe(fromSha);
+      expect(wormhole.toSha).toBe(toSha);
+      expect(wormhole.writerId).toBe('writer-1');
+      expect(wormhole.patchCount).toBe(2);
+      expect(wormhole.payload.length).toBe(2);
+      expect(wormhole.payload.entries().map((entry) => entry.sha)).toEqual([fromSha, toSha]);
     });
   });
 

--- a/test/unit/domain/WarpGraph.status.test.ts
+++ b/test/unit/domain/WarpGraph.status.test.ts
@@ -192,10 +192,7 @@ describe('WarpCore.status() (LH/STATUS/1)', () => {
 
     await graph.materialize();
     const status = await graph.status();
-    // Empty patches produce 0 tombstones
-    expect(typeof status.tombstoneRatio).toBe('number');
-    expect(status.tombstoneRatio).toBeGreaterThanOrEqual(0);
-    expect(status.tombstoneRatio).toBeLessThanOrEqual(1);
+    expect(status.tombstoneRatio).toBe(0);
   });
 
   // =========================================================================

--- a/test/unit/domain/orset/route/RouteKey.test.ts
+++ b/test/unit/domain/orset/route/RouteKey.test.ts
@@ -4,7 +4,6 @@ import fc from "fast-check";
 import RouteKey, {
   ROUTE_KEY_BYTES,
   ROUTE_KEY_BITS,
-  type NibbleBits,
 } from "../../../../../src/domain/orset/route/RouteKey.ts";
 import RouteKeyError from "../../../../../src/domain/errors/RouteKeyError.ts";
 
@@ -135,6 +134,14 @@ describe("RouteKey", () => {
       expect(key.nibbleAt(3, 2)).toBe(0b11);
     });
 
+    it("extracts 6-bit nibbles across byte boundaries", () => {
+      // 0xabcd... = 101010 111100 110100...
+      const key = new RouteKey(pattern);
+      expect(key.nibbleAt(0, 6)).toBe(0b101010);
+      expect(key.nibbleAt(1, 6)).toBe(0b111100);
+      expect(key.nibbleAt(2, 6)).toBe(0b110100);
+    });
+
     it("rejects negative depth", () => {
       const key = new RouteKey(allZeros);
       expect(() => key.nibbleAt(-1, 4)).toThrow(RouteKeyError);
@@ -151,17 +158,18 @@ describe("RouteKey", () => {
       expect(() => key.nibbleAt(64, 4)).toThrow(RouteKeyError);
       // 8-bit nibbles: max depth is 32 (exclusive)
       expect(() => key.nibbleAt(32, 8)).toThrow(RouteKeyError);
+      // 6-bit nibbles: max whole-slot depth is 42 (exclusive)
+      expect(() => key.nibbleAt(42, 6)).toThrow(RouteKeyError);
       // 1-bit nibbles: max depth is 256 (exclusive)
       expect(() => key.nibbleAt(256, 1)).toThrow(RouteKeyError);
     });
 
     it("rejects unsupported nibble widths", () => {
       const key = new RouteKey(allZeros);
-      // Cast through a local any-free escape hatch: use a typed variable the runtime will reject.
-      const bad = 3 as unknown as NibbleBits;
-      expect(() => key.nibbleAt(0, bad)).toThrow(RouteKeyError);
-      const badLarge = 16 as unknown as NibbleBits;
-      expect(() => key.nibbleAt(0, badLarge)).toThrow(RouteKeyError);
+      // @ts-expect-error runtime rejects unsupported JavaScript callers.
+      expect(() => key.nibbleAt(0, 3)).toThrow(RouteKeyError);
+      // @ts-expect-error runtime rejects unsupported JavaScript callers.
+      expect(() => key.nibbleAt(0, 16)).toThrow(RouteKeyError);
     });
   });
 

--- a/test/unit/domain/orset/trie/TrieCursor.test.ts
+++ b/test/unit/domain/orset/trie/TrieCursor.test.ts
@@ -4,10 +4,15 @@ import { Dot } from "../../../../../src/domain/crdt/Dot.ts";
 import TrieCursor from "../../../../../src/domain/orset/trie/TrieCursor.ts";
 import TrieCursorError from "../../../../../src/domain/errors/TrieCursorError.ts";
 import TrieStoreError from "../../../../../src/domain/errors/TrieStoreError.ts";
+import RouteKey from "../../../../../src/domain/orset/route/RouteKey.ts";
 import PageCache from "../../../../../src/domain/orset/trie/PageCache.ts";
 import TrieGeometry from "../../../../../src/domain/orset/trie/TrieGeometry.ts";
 import TrieLeaf from "../../../../../src/domain/orset/trie/TrieLeaf.ts";
 import TrieBranch from "../../../../../src/domain/orset/trie/TrieBranch.ts";
+import {
+  shiftSuffixLeftByOneNibble,
+  suffixOfRouteKey,
+} from "../../../../../src/domain/orset/trie/trieCursorHelpers.ts";
 import cborCodec from "../../../../../src/infrastructure/codecs/CborCodec.ts";
 import {
   InMemoryTrieStore,
@@ -222,6 +227,39 @@ describe("TrieCursor", () => {
       for (const id of ids) {
         expect(await cursor.contains(id)).toBe(true);
       }
+    });
+
+    it("keeps all elements reachable with 64-way geometry", async () => {
+      const geometry64 = new TrieGeometry({
+        fanout: 64,
+        nibbleBits: 6,
+        leafCapacity: 2,
+        leafFloor: 1,
+      });
+      const { cursor } = makeCursor({ geometry: geometry64 });
+      const ids = Array.from({ length: 40 }, (_, i) => `node64:${i}`);
+      for (let i = 0; i < ids.length; i += 1) {
+        const id = ids[i];
+        if (id === undefined) {
+          continue;
+        }
+        await cursor.add(id, dotOf("w64", i + 1));
+      }
+      for (const id of ids) {
+        expect(await cursor.contains(id)).toBe(true);
+      }
+      expect(new Set(await cursor.elements())).toEqual(new Set(ids));
+    });
+
+    it("shortens 64-way suffixes without preserving padding bits", () => {
+      const routeKey = RouteKey.fromElement("node64:padding-regression");
+      const maxDepth = Math.floor(256 / 6);
+      const parentSuffix = suffixOfRouteKey(routeKey, 1, 6);
+      const childSuffix = shiftSuffixLeftByOneNibble(parentSuffix, 6, maxDepth - 1);
+
+      expect(parentSuffix.length).toBe(31);
+      expect(childSuffix).toEqual(suffixOfRouteKey(routeKey, 2, 6));
+      expect(childSuffix.length).toBe(30);
     });
 
     it("a snapshot after splits enumerates bottom-up (deepest first)", async () => {

--- a/test/unit/domain/services/EffectPipeline.test.ts
+++ b/test/unit/domain/services/EffectPipeline.test.ts
@@ -24,14 +24,14 @@ class RecordingSink extends EffectSinkPort {
 
   async deliver(emission: any, lens: any) {
     this.delivered.push({ emission, lens });
-    return createDeliveryObservation({
+    return [createDeliveryObservation({
       emissionId: emission.id,
       sinkId: this._id,
       outcome: lens.suppressExternal ? 'suppressed' : 'delivered',
       ...(lens.suppressExternal ? { reason: `suppressed by ${lens.mode} lens` } : {}),
       timestamp: Date.now(),
       lens,
-    });
+    })];
   }
 }
 
@@ -64,7 +64,7 @@ describe('EffectPipeline', () => {
       expect(result.emission.payload).toEqual({ text: 'hi' });
       expect(result.emission.timestamp).toBe(42);
       expect(result.observations).toHaveLength(1);
-      const obs0 = /** @type {{ outcome: string }} */ (Array.isArray(result.observations) ? result.observations[0] : result.observations);
+      const obs0 = result.observations[0];
       expect(obs0!.outcome).toBe('delivered');
       expect(sink.delivered).toHaveLength(1);
     });
@@ -151,7 +151,7 @@ describe('EffectPipeline', () => {
       const { pipeline } = setup(REPLAY_LENS);
       const result = await pipeline.emit('notification', null, emitOpts());
 
-      const obs0 = /** @type {{ outcome: string, reason: string }} */ (Array.isArray(result.observations) ? result.observations[0] : result.observations);
+      const obs0 = result.observations[0];
       expect(obs0!.outcome).toBe('suppressed');
       expect(obs0!.reason).toContain('replay');
     });
@@ -211,8 +211,7 @@ describe('EffectPipeline', () => {
       const pipeline = new EffectPipeline({ sink, lens: LIVE_LENS });
       const result = await pipeline.emit('test', null, { id: 'direct-1', timestamp: 0 });
 
-      const obs = /** @type {{ outcome: string }} */ (result.observations);
-      expect((obs as any).outcome).toBe('delivered');
+      expect(result.observations[0]?.outcome).toBe('delivered');
       expect(sink.delivered).toHaveLength(1);
     });
   });

--- a/test/unit/domain/services/EffectPipeline.test.ts
+++ b/test/unit/domain/services/EffectPipeline.test.ts
@@ -5,9 +5,11 @@ import {
   LIVE_LENS,
   REPLAY_LENS,
   INSPECT_LENS,
+  type ExternalizationPolicy,
 } from '../../../../src/domain/types/ExternalizationPolicy.ts';
 import EffectSinkPort from '../../../../src/ports/EffectSinkPort.ts';
-import { createDeliveryObservation } from '../../../../src/domain/types/DeliveryObservation.ts';
+import { createDeliveryObservation, type DeliveryObservation } from '../../../../src/domain/types/DeliveryObservation.ts';
+import type { EffectEmission } from '../../../../src/domain/types/EffectEmission.ts';
 
 class RecordingSink extends EffectSinkPort {
   _id: string;
@@ -32,6 +34,26 @@ class RecordingSink extends EffectSinkPort {
       timestamp: Date.now(),
       lens,
     })];
+  }
+}
+
+class SingleObservationSink extends EffectSinkPort {
+  get id(): string {
+    return 'single-observation';
+  }
+
+  async deliver(
+    emission: EffectEmission,
+    lens: ExternalizationPolicy,
+  ): Promise<DeliveryObservation[]> {
+    // @ts-expect-error exercising runtime validation for stale JavaScript sinks
+    return Promise.resolve(createDeliveryObservation({
+      emissionId: emission.id,
+      sinkId: this.id,
+      outcome: 'delivered',
+      timestamp: 0,
+      lens,
+    }));
   }
 }
 
@@ -213,6 +235,20 @@ describe('EffectPipeline', () => {
 
       expect(result.observations[0]?.outcome).toBe('delivered');
       expect(sink.delivered).toHaveLength(1);
+    });
+
+    it('rejects a direct sink that does not return an observation array', async () => {
+      const pipeline = new EffectPipeline({
+        sink: new SingleObservationSink(),
+        lens: LIVE_LENS,
+      });
+
+      await expect(
+        pipeline.emit('test', null, { id: 'bad-direct-1', timestamp: 0 }),
+      ).rejects.toMatchObject({
+        code: 'E_EFFECT_SINK_INVALID_OBSERVATION_BATCH',
+        context: { sinkId: 'single-observation' },
+      });
     });
   });
 });

--- a/test/unit/domain/services/IndexRebuildService.streaming.test.ts
+++ b/test/unit/domain/services/IndexRebuildService.streaming.test.ts
@@ -3,6 +3,9 @@ import IndexRebuildService from '../../../../src/domain/services/index/IndexRebu
 import GraphNode from '../../../../src/domain/entities/GraphNode.ts';
 import MockStreamingIndexStorage from '../../../helpers/MockStreamingIndexStorage.ts';
 
+const ROOT_SHA = 'a'.repeat(40);
+const CHILD_SHA = 'b'.repeat(40);
+
 describe('IndexRebuildService streaming mode', () => {
     let service;
     let mockStorage;
@@ -85,8 +88,8 @@ describe('IndexRebuildService streaming mode', () => {
     it('produces valid index that can be loaded', async () => {
       mockGraphService = {
         async *iterateNodes() {
-          yield new GraphNode({ sha: 'aa1111', author: 'test', date: '2026-01-28', message: 'root', parents: [] });
-          yield new GraphNode({ sha: 'bb2222', author: 'test', date: '2026-01-28', message: 'child', parents: ['aa1111'] });
+          yield new GraphNode({ sha: ROOT_SHA, author: 'test', date: '2026-01-28', message: 'root', parents: [] });
+          yield new GraphNode({ sha: CHILD_SHA, author: 'test', date: '2026-01-28', message: 'child', parents: [ROOT_SHA] });
         }
       };
 
@@ -99,20 +102,9 @@ describe('IndexRebuildService streaming mode', () => {
       expect(treeEntries.some((/** @type {any} */ e) => e.includes('meta_'))).toBe(true);
       expect(treeEntries.some((/** @type {any} */ e) => e.includes('shards_'))).toBe(true);
 
-      // Should be able to load the index (mock the tree OIDs)
-            const shardOids = ({}) as Record<string, string>;
-      treeEntries.forEach((/** @type {any} */ entry) => {
-        const match = entry.match(/100644 blob (\S+)\t(\S+)/);
-        if (match) {
-          shardOids[match[2]] = match[1];
-        }
-      });
-      mockStorage.readTreeOids.mockResolvedValue(shardOids);
-
       const reader = await service.load(treeOid);
-      expect(reader).toBeDefined();
-      expect(typeof reader.getParents).toBe('function');
-      expect(typeof reader.getChildren).toBe('function');
+      await expect(reader.getParents(CHILD_SHA)).resolves.toEqual([ROOT_SHA]);
+      await expect(reader.getChildren(ROOT_SHA)).resolves.toEqual([CHILD_SHA]);
     });
   });
 

--- a/test/unit/domain/services/IndexRebuildService.test.ts
+++ b/test/unit/domain/services/IndexRebuildService.test.ts
@@ -4,6 +4,26 @@ import GraphNode from '../../../../src/domain/entities/GraphNode.ts';
 import defaultCodec from '../../../../src/domain/utils/defaultCodec.ts';
 import MockStreamingIndexStorage from '../../../helpers/MockStreamingIndexStorage.ts';
 
+const ROOT_SHA = 'a'.repeat(40);
+const CHILD_SHA = 'b'.repeat(40);
+const GRANDCHILD_SHA = 'c'.repeat(40);
+
+function createReadableIndexHarness() {
+  const storage = new MockStreamingIndexStorage();
+  const graphService = {
+    async *iterateNodes() {
+      yield { sha: ROOT_SHA, parents: [] };
+      yield { sha: CHILD_SHA, parents: [ROOT_SHA] };
+      yield { sha: GRANDCHILD_SHA, parents: [CHILD_SHA] };
+    },
+  };
+  const indexService = new IndexRebuildService({
+    storage,
+    graphService,
+  });
+  return { indexService, storage };
+}
+
 describe('IndexRebuildService', () => {
     let service;
     let mockStorage;
@@ -46,48 +66,43 @@ describe('IndexRebuildService', () => {
     });
   });
 
-  it('rebuilds the index and persists it', async () => {
-    const treeOid = await service.rebuild('main');
+  it('rebuilds, persists, and reloads a readable index', async () => {
+    const { indexService, storage } = createReadableIndexHarness();
 
-    // Verify blobs are written (one per shard type)
-    expect(mockStorage.writeBlob).toHaveBeenCalled();
-    expect(mockStorage.writeBlob.mock.calls.length).toBeGreaterThan(0);
-    expect(mockStorage.writeTree).toHaveBeenCalled();
-    expect(treeOid).toBe('tree-oid');
+    const treeOid = await indexService.rebuild('main');
+    const reader = await indexService.load(treeOid);
+
+    expect(storage.writeBlob).toHaveBeenCalled();
+    expect(storage.writeTree).toHaveBeenCalled();
+    await expect(reader.getParents(CHILD_SHA)).resolves.toEqual([ROOT_SHA]);
+    await expect(reader.getChildren(ROOT_SHA)).resolves.toEqual([CHILD_SHA]);
   });
 
-  it('loads an index from a tree OID', async () => {
-    const reader = await service.load('tree-oid');
+  it('loads an index from a tree OID and answers relationship lookups', async () => {
+    const { indexService } = createReadableIndexHarness();
+    const treeOid = await indexService.rebuild('main');
 
-    expect(mockStorage.readTreeOids).toHaveBeenCalledWith('tree-oid');
-    expect(reader).toBeDefined();
-    expect(typeof reader.getParents).toBe('function');
-    expect(typeof reader.getChildren).toBe('function');
+    const reader = await indexService.load(treeOid);
+
+    await expect(reader.getParents(GRANDCHILD_SHA)).resolves.toEqual([CHILD_SHA]);
+    await expect(reader.getChildren(CHILD_SHA)).resolves.toEqual([GRANDCHILD_SHA]);
   });
 
-  // Testing _persistIndex directly to verify shard file creation without full rebuild overhead
-  it('persists index from builder to storage', async () => {
-    // Create a minimal builder with known data
-    const BitmapIndexBuilder = (await import('../../../../src/domain/services/index/BitmapIndexBuilder.ts')).default;
-    const builder = new BitmapIndexBuilder();
-    builder.registerNode('aabbccdd');
-    builder.addEdge('aabbccdd', 'eeffgghh');
+  it('persists shard blobs and tree entries during rebuild', async () => {
+    const { indexService, storage } = createReadableIndexHarness();
 
-    const treeOid = await service._persistIndex(builder);
+    const treeOid = await indexService.rebuild('main');
+    const treeCall = storage.writeTree.mock.calls[0];
+    if (treeCall === undefined) {
+      throw new Error('expected writeTree call');
+    }
+    const treeEntries = treeCall[0];
 
-    // Verify blobs were written for each shard
-    expect(mockStorage.writeBlob).toHaveBeenCalled();
-    // Should have meta shards and edge shards
-    const blobCalls = mockStorage.writeBlob.mock.calls;
-    expect(blobCalls.length).toBeGreaterThanOrEqual(2);
-
-    // Verify tree was created with all entries
-    expect(mockStorage.writeTree).toHaveBeenCalledTimes(1);
-    const treeEntries = mockStorage.writeTree.mock.calls[0][0];
+    expect(treeOid).toMatch(/^tree_/);
+    expect(storage.writeBlob.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(storage.writeTree).toHaveBeenCalledTimes(1);
     expect(treeEntries.length).toBeGreaterThanOrEqual(2);
-    expect(treeEntries.every((/** @type {any} */ e) => e.startsWith('100644 blob'))).toBe(true);
-
-    expect(treeOid).toBe('tree-oid');
+    expect(treeEntries.every((entry: string) => entry.startsWith('100644 blob'))).toBe(true);
   });
 
   describe('rebuild validation', () => {

--- a/test/unit/domain/services/MessageCodecModules.test.ts
+++ b/test/unit/domain/services/MessageCodecModules.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  decodeAnchorMessage,
+  encodeAnchorMessage,
+} from '../../../../src/domain/services/codec/AnchorMessageCodec.ts';
+import {
+  decodeCheckpointMessage,
+  encodeCheckpointMessage,
+} from '../../../../src/domain/services/codec/CheckpointMessageCodec.ts';
+import {
+  getCodec,
+  validateOid,
+  validatePositiveInteger,
+  validateSha256,
+} from '../../../../src/domain/services/codec/MessageCodecInternal.ts';
+import {
+  assertOpsCompatible,
+  detectMessageKind,
+  detectSchemaVersion,
+  EDGE_PROPERTY_PATCH_SCHEMA_VERSION,
+} from '../../../../src/domain/services/codec/MessageSchemaDetector.ts';
+import {
+  decodePatchMessage,
+  encodePatchMessage,
+} from '../../../../src/domain/services/codec/PatchMessageCodec.ts';
+import {
+  parsePositiveIntTrailer,
+  requireTrailer,
+  validateKindDiscriminator,
+} from '../../../../src/domain/services/codec/TrailerValidation.ts';
+import { EDGE_PROP_PREFIX } from '../../../../src/domain/services/KeyCodec.ts';
+import SchemaUnsupportedError from '../../../../src/domain/errors/SchemaUnsupportedError.ts';
+
+const OID = 'a'.repeat(40);
+const STATE_HASH = 'b'.repeat(64);
+
+describe('message codec modules', () => {
+  it('round-trips patch, checkpoint, and anchor messages through individual modules', () => {
+    const patchMessage = encodePatchMessage({
+      graph: 'events',
+      writer: 'writer-1',
+      lamport: 7,
+      patchOid: OID,
+      schema: 3,
+    });
+    const checkpointMessage = encodeCheckpointMessage({
+      graph: 'events',
+      stateHash: STATE_HASH,
+      frontierOid: OID,
+      indexOid: OID,
+      schema: 3,
+    });
+    const anchorMessage = encodeAnchorMessage({ graph: 'events', schema: 3 });
+
+    expect(decodePatchMessage(patchMessage)).toMatchObject({
+      kind: 'patch',
+      graph: 'events',
+      writer: 'writer-1',
+      lamport: 7,
+      patchOid: OID,
+      schema: 3,
+    });
+    expect(decodeCheckpointMessage(checkpointMessage)).toMatchObject({
+      kind: 'checkpoint',
+      graph: 'events',
+      stateHash: STATE_HASH,
+      frontierOid: OID,
+      indexOid: OID,
+      schema: 3,
+    });
+    expect(decodeAnchorMessage(anchorMessage)).toMatchObject({
+      kind: 'anchor',
+      graph: 'events',
+      schema: 3,
+    });
+  });
+
+  it('detects message kind and schema compatibility from shared detector module', () => {
+    const edgePropOp = {
+      type: 'PropSet',
+      node: `${EDGE_PROP_PREFIX}node:a\0node:b\0rel\0weight`,
+    };
+    const anchorMessage = encodeAnchorMessage({ graph: 'events', schema: 2 });
+
+    expect(detectSchemaVersion([edgePropOp])).toBe(EDGE_PROPERTY_PATCH_SCHEMA_VERSION);
+    expect(() => assertOpsCompatible([edgePropOp], 2)).toThrow(SchemaUnsupportedError);
+    expect(detectMessageKind(anchorMessage)).toBe('anchor');
+    expect(detectMessageKind('not a warp trailer message')).toBeNull();
+  });
+
+  it('validates trailer presence, integer parsing, and kind discriminators', () => {
+    const trailers = {
+      'eg-kind': 'patch',
+      'eg-lamport': '7',
+    };
+
+    expect(requireTrailer(trailers, 'lamport', 'patch')).toBe('7');
+    expect(parsePositiveIntTrailer(trailers, 'lamport', 'patch')).toBe(7);
+    expect(() => validateKindDiscriminator(trailers, 'patch')).not.toThrow();
+    expect(() => requireTrailer(trailers, 'graph', 'patch')).toThrow('eg-graph');
+    expect(() => parsePositiveIntTrailer({ ...trailers, 'eg-lamport': '7x' }, 'lamport', 'patch')).toThrow(
+      'positive integer',
+    );
+    expect(() => validateKindDiscriminator({ ...trailers, 'eg-kind': 'anchor' }, 'patch')).toThrow(
+      "eg-kind must be 'patch'",
+    );
+  });
+
+  it('validates shared scalar fields and reuses a singleton trailer codec', () => {
+    expect(getCodec()).toBe(getCodec());
+    expect(() => validateOid(OID, 'patchOid')).not.toThrow();
+    expect(() => validateSha256(STATE_HASH, 'stateHash')).not.toThrow();
+    expect(() => validatePositiveInteger(1, 'schema')).not.toThrow();
+    expect(() => validateOid('A'.repeat(40), 'patchOid')).toThrow('40 or 64 character hex string');
+    expect(() => validateSha256(OID, 'stateHash')).toThrow('64 character hex string');
+    expect(() => validatePositiveInteger(0, 'schema')).toThrow('positive integer');
+  });
+});

--- a/test/unit/domain/services/MultiplexSink.test.ts
+++ b/test/unit/domain/services/MultiplexSink.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { MultiplexSink } from '../../../../src/domain/services/MultiplexSink.ts';
 import { createEffectEmission } from '../../../../src/domain/types/EffectEmission.ts';
-import { LIVE_LENS, REPLAY_LENS } from '../../../../src/domain/types/ExternalizationPolicy.ts';
+import type { EffectEmission } from '../../../../src/domain/types/EffectEmission.ts';
+import { LIVE_LENS, REPLAY_LENS, type ExternalizationPolicy } from '../../../../src/domain/types/ExternalizationPolicy.ts';
+import type { DeliveryObservation } from '../../../../src/domain/types/DeliveryObservation.ts';
 import EffectSinkPort from '../../../../src/ports/EffectSinkPort.ts';
 
 /** @returns {import('../../../../src/domain/types/EffectEmission.ts').EffectEmission} */
@@ -65,6 +67,20 @@ class FailingSink extends EffectSinkPort {
       timestamp: Date.now(),
       lens: (lens),
     })];
+  }
+}
+
+class InvalidObservationSink extends EffectSinkPort {
+  get id(): string {
+    return 'invalid-observation';
+  }
+
+  async deliver(
+    _emission: EffectEmission,
+    _lens: ExternalizationPolicy,
+  ): Promise<DeliveryObservation[]> {
+    // @ts-expect-error exercising runtime validation for stale JavaScript sinks
+    return Promise.resolve(['not-an-observation']);
   }
 }
 
@@ -169,5 +185,17 @@ describe('MultiplexSink', () => {
     await mux.deliver(emission, REPLAY_LENS);
 
     expect(((stub as any).calls[0] as any).lens).toBe(REPLAY_LENS);
+  });
+
+  it('rejects child sinks that return non-observation entries', async () => {
+    const mux = new MultiplexSink();
+    mux.addSink(new InvalidObservationSink());
+
+    await expect(
+      mux.deliver(makeEmission('bad-child-1'), LIVE_LENS),
+    ).rejects.toMatchObject({
+      code: 'E_EFFECT_SINK_INVALID_OBSERVATION',
+      context: { sinkId: 'invalid-observation', index: 0 },
+    });
   });
 });

--- a/test/unit/domain/services/MultiplexSink.test.ts
+++ b/test/unit/domain/services/MultiplexSink.test.ts
@@ -37,13 +37,13 @@ class StubSink extends EffectSinkPort {
     const { createDeliveryObservation } = await import(
       '../../../../src/domain/types/DeliveryObservation.ts'
     );
-    return createDeliveryObservation({
+    return [createDeliveryObservation({
       emissionId: (emission).id,
       sinkId: this._id,
       outcome: 'delivered',
       timestamp: Date.now(),
       lens: (lens),
-    });
+    })];
   }
 }
 
@@ -57,14 +57,14 @@ class FailingSink extends EffectSinkPort {
     const { createDeliveryObservation } = await import(
       '../../../../src/domain/types/DeliveryObservation.ts'
     );
-    return createDeliveryObservation({
+    return [createDeliveryObservation({
       emissionId: (emission).id,
       sinkId: 'failing',
       outcome: 'failed',
       reason: 'boom',
       timestamp: Date.now(),
       lens: (lens),
-    });
+    })];
   }
 }
 

--- a/test/unit/domain/services/StateReader.test.ts
+++ b/test/unit/domain/services/StateReader.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { createStateReader } from '../../../../src/domain/services/state/StateReader.ts';
+import { createStateBuilder } from '../../../helpers/stateBuilder.ts';
+
+describe('StateReader', () => {
+  it('projects visible nodes, edges, properties, and neighbors', () => {
+    const state = createStateBuilder()
+      .node('node:a')
+      .node('node:b')
+      .node('node:c')
+      .edge('node:a', 'node:b', 'knows')
+      .edge('node:a', 'node:c', 'likes')
+      .edge('node:b', 'node:a', 'replies')
+      .nodeProp('node:a', 'status', 'ready')
+      .nodeProp('node:b', 'rank', 2)
+      .edgeProp('node:a', 'node:b', 'knows', 'weight', 3)
+      .build();
+
+    const reader = createStateReader(state);
+
+    expect(reader.project()).toEqual({
+      nodes: ['node:a', 'node:b', 'node:c'],
+      edges: [
+        { from: 'node:a', to: 'node:b', label: 'knows' },
+        { from: 'node:a', to: 'node:c', label: 'likes' },
+        { from: 'node:b', to: 'node:a', label: 'replies' },
+      ],
+      props: [
+        { node: 'node:a', key: 'status', value: 'ready' },
+        { node: 'node:b', key: 'rank', value: 2 },
+      ],
+    });
+    expect(reader.hasNode('node:a')).toBe(true);
+    expect(reader.getNodes()).toEqual(['node:a', 'node:b', 'node:c']);
+    expect(reader.getEdges()).toEqual([
+      { from: 'node:a', to: 'node:b', label: 'knows', props: { weight: 3 } },
+      { from: 'node:a', to: 'node:c', label: 'likes', props: {} },
+      { from: 'node:b', to: 'node:a', label: 'replies', props: {} },
+    ]);
+    expect(reader.getNodeProps('node:a')).toEqual({ status: 'ready' });
+    expect(reader.getEdgeProps('node:a', 'node:b', 'knows')).toEqual({ weight: 3 });
+    expect(reader.neighbors('node:a', 'outgoing')).toEqual([
+      { nodeId: 'node:b', label: 'knows', direction: 'outgoing' },
+      { nodeId: 'node:c', label: 'likes', direction: 'outgoing' },
+    ]);
+    expect(reader.neighbors('node:a', 'incoming')).toEqual([
+      { nodeId: 'node:b', label: 'replies', direction: 'incoming' },
+    ]);
+    expect(reader.neighbors('node:a', 'both', 'knows')).toEqual([
+      { nodeId: 'node:b', label: 'knows', direction: 'outgoing' },
+    ]);
+    expect(reader.inspectNode('node:a')).toEqual({
+      nodeId: 'node:a',
+      props: { status: 'ready' },
+      outgoing: [
+        { nodeId: 'node:b', label: 'knows', direction: 'outgoing' },
+        { nodeId: 'node:c', label: 'likes', direction: 'outgoing' },
+      ],
+      incoming: [
+        { nodeId: 'node:b', label: 'replies', direction: 'incoming' },
+      ],
+      content: null,
+    });
+  });
+
+  it('returns null or empty views for invisible entities', () => {
+    const state = createStateBuilder()
+      .node('node:a')
+      .nodeProp('node:a', 'status', 'ready')
+      .build();
+
+    const reader = createStateReader(state);
+
+    expect(reader.hasNode('node:missing')).toBe(false);
+    expect(reader.getNodeProps('node:missing')).toBeNull();
+    expect(reader.getEdgeProps('node:a', 'node:missing', 'knows')).toBeNull();
+    expect(reader.neighbors('node:missing')).toEqual([]);
+    expect(reader.getNodeContentMeta('node:missing')).toBeNull();
+    expect(reader.getEdgeContentMeta('node:a', 'node:missing', 'knows')).toBeNull();
+    expect(reader.inspectNode('node:missing')).toBeNull();
+  });
+
+  it('returns fresh cloned views without exposing internal mutable indexes', () => {
+    const state = createStateBuilder()
+      .node('node:a')
+      .node('node:b')
+      .edge('node:a', 'node:b', 'knows')
+      .nodeProp('node:a', 'status', 'ready')
+      .edgeProp('node:a', 'node:b', 'knows', 'weight', 3)
+      .build();
+
+    const reader = createStateReader(state);
+
+    const firstNodeProps = reader.getNodeProps('node:a');
+    const secondNodeProps = reader.getNodeProps('node:a');
+    const firstEdges = reader.getEdges();
+    const secondEdges = reader.getEdges();
+    const firstNeighbors = reader.neighbors('node:a');
+    const secondNeighbors = reader.neighbors('node:a');
+
+    expect(firstNodeProps).toEqual({ status: 'ready' });
+    expect(secondNodeProps).toEqual({ status: 'ready' });
+    expect(firstNodeProps).not.toBe(secondNodeProps);
+    expect(Object.isFrozen(firstNodeProps)).toBe(true);
+    expect(firstEdges).not.toBe(secondEdges);
+    expect(firstEdges[0]).not.toBe(secondEdges[0]);
+    expect(firstNeighbors).not.toBe(secondNeighbors);
+    expect(firstNeighbors[0]).not.toBe(secondNeighbors[0]);
+  });
+});

--- a/test/unit/domain/services/VisibleStateComparison.test.ts
+++ b/test/unit/domain/services/VisibleStateComparison.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareVisibleState } from '../../../../src/domain/services/comparison/VisibleStateComparison.ts';
+import { createStateBuilder } from '../../../helpers/stateBuilder.ts';
+
+describe('VisibleStateComparison', () => {
+  it('reports deterministic visible topology and property deltas', () => {
+    const left = createStateBuilder()
+      .node('alpha')
+      .node('legacy')
+      .edge('legacy', 'alpha', 'old')
+      .nodeProp('alpha', 'status', 'old')
+      .nodeProp('legacy', 'retired', true)
+      .edgeProp('legacy', 'alpha', 'old', 'weight', 1)
+      .build();
+
+    const right = createStateBuilder()
+      .node('alpha')
+      .node('beta')
+      .edge('alpha', 'beta', 'fresh')
+      .nodeProp('alpha', 'status', 'new')
+      .nodeProp('beta', 'kind', 'fresh')
+      .edgeProp('alpha', 'beta', 'fresh', 'weight', 2)
+      .build();
+
+    const comparison = compareVisibleState(left, right, { targetId: 'alpha' });
+
+    expect(comparison.comparisonVersion).toBe('visible-state-compare/v1');
+    expect(comparison.changed).toBe(true);
+    expect(comparison.summary).toEqual({
+      left: {
+        nodeCount: 2,
+        edgeCount: 1,
+        nodePropertyCount: 2,
+        edgePropertyCount: 1,
+      },
+      right: {
+        nodeCount: 2,
+        edgeCount: 1,
+        nodePropertyCount: 2,
+        edgePropertyCount: 1,
+      },
+      nodes: { added: 1, removed: 1 },
+      edges: { added: 1, removed: 1 },
+      nodeProperties: { added: 1, removed: 1, changed: 1 },
+      edgeProperties: { added: 1, removed: 1, changed: 0 },
+    });
+    expect(comparison.nodes).toEqual({
+      added: ['beta'],
+      removed: ['legacy'],
+    });
+    expect(comparison.edges).toEqual({
+      added: [{ from: 'alpha', to: 'beta', label: 'fresh' }],
+      removed: [{ from: 'legacy', to: 'alpha', label: 'old' }],
+    });
+    expect(comparison.nodeProperties).toEqual({
+      added: [{ node: 'beta', key: 'kind', value: 'fresh' }],
+      removed: [{ node: 'legacy', key: 'retired', value: true }],
+      changed: [{ node: 'alpha', key: 'status', leftValue: 'old', rightValue: 'new' }],
+    });
+    expect(comparison.edgeProperties).toEqual({
+      added: [{ from: 'alpha', to: 'beta', label: 'fresh', key: 'weight', value: 2 }],
+      removed: [{ from: 'legacy', to: 'alpha', label: 'old', key: 'weight', value: 1 }],
+      changed: [],
+    });
+    expect(comparison.target).toMatchObject({
+      targetId: 'alpha',
+      leftExists: true,
+      rightExists: true,
+      changed: true,
+      contentChanged: false,
+    });
+  });
+
+  it('reports no changes for identical visible states', () => {
+    const state = createStateBuilder()
+      .node('alpha')
+      .nodeProp('alpha', 'status', 'ready')
+      .build();
+
+    const comparison = compareVisibleState(state, state, { targetId: 'alpha' });
+
+    expect(comparison.changed).toBe(false);
+    expect(comparison.nodes).toEqual({ added: [], removed: [] });
+    expect(comparison.edges).toEqual({ added: [], removed: [] });
+    expect(comparison.nodeProperties).toEqual({ added: [], removed: [], changed: [] });
+    expect(comparison.edgeProperties).toEqual({ added: [], removed: [], changed: [] });
+    expect(comparison.target).toMatchObject({
+      targetId: 'alpha',
+      leftExists: true,
+      rightExists: true,
+      changed: false,
+    });
+  });
+});

--- a/test/unit/domain/warp/PatchSession.test.ts
+++ b/test/unit/domain/warp/PatchSession.test.ts
@@ -82,26 +82,28 @@ describe('PatchSession', () => {
     });
   });
 
-  it('classifies non-CAS advanced-ref errors as WRITER_REF_ADVANCED', async () => {
+  it('classifies typed CAS conflicts as WRITER_REF_ADVANCED', async () => {
     const { builder, session } = createSession();
-    builder.commit.mockRejectedValue(new Error('writer ref has advanced unexpectedly'));
+    const cause = new WriterError('typed CAS conflict', { code: 'WRITER_CAS_CONFLICT' });
+    cause.expectedSha = 'a'.repeat(40);
+    cause.actualSha = 'b'.repeat(40);
+    builder.commit.mockRejectedValue(cause);
 
     await expect(session.commit()).rejects.toMatchObject({
       code: 'WRITER_REF_ADVANCED',
+      cause,
+      message: expect.stringContaining('Expected aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
     });
   });
 
-  it('preserves the original cause on classified commit failures', async () => {
+  it('does not classify raw advanced-looking messages as CAS conflicts', async () => {
     const { builder, session } = createSession();
-    const cause = new Error('Concurrent commit detected while writing patch');
+    const cause = new Error('writer ref has advanced unexpectedly');
     builder.commit.mockRejectedValue(cause);
 
-    try {
-      await session.commit();
-      expect.unreachable('commit should fail');
-    } catch (err) {
-      expect(err).toBeInstanceOf(WriterError);
-      expect(err).toMatchObject({ code: 'WRITER_REF_ADVANCED', cause });
-    }
+    await expect(session.commit()).rejects.toMatchObject({
+      code: 'PERSIST_WRITE_FAILED',
+      cause,
+    });
   });
 });

--- a/test/unit/helpers/MockStreamingIndexStorage.test.ts
+++ b/test/unit/helpers/MockStreamingIndexStorage.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import MockStreamingIndexStorage from '../../helpers/MockStreamingIndexStorage.ts';
+
+describe('MockStreamingIndexStorage', () => {
+  it('serves the canonical empty tree', async () => {
+    const storage = new MockStreamingIndexStorage();
+
+    await expect(storage.readTreeOids(storage.emptyTree)).resolves.toEqual({});
+    await expect(storage.readTree(storage.emptyTree)).resolves.toEqual({});
+  });
+});

--- a/test/unit/infrastructure/adapters/ChunkEffectSink.test.ts
+++ b/test/unit/infrastructure/adapters/ChunkEffectSink.test.ts
@@ -47,9 +47,9 @@ describe('ChunkEffectSink', () => {
 
   it('writes an emission to a file as NDJSON', async () => {
     const sink = new ChunkEffectSink({ dir });
-    const obs = await sink.deliver(makeEmission(), LIVE_LENS);
+    const [obs] = await sink.deliver(makeEmission(), LIVE_LENS);
 
-    expect(obs.outcome).toBe('delivered');
+    expect(obs?.outcome).toBe('delivered');
 
     const files = await readdir(dir);
     expect(files.length).toBeGreaterThanOrEqual(1);
@@ -92,11 +92,11 @@ describe('ChunkEffectSink', () => {
 
   it('still writes during replay (chunk sink is replay-safe)', async () => {
     const sink = new ChunkEffectSink({ dir });
-    const obs = await sink.deliver(makeEmission(), REPLAY_LENS);
+    const [obs] = await sink.deliver(makeEmission(), REPLAY_LENS);
 
     // ChunkEffectSink is replay-safe: it writes to local forensic log
     // regardless of delivery lens
-    expect(obs.outcome).toBe('delivered');
+    expect(obs?.outcome).toBe('delivered');
 
     const files = await readdir(dir);
     expect(files.length).toBeGreaterThanOrEqual(1);

--- a/test/unit/infrastructure/adapters/ConsoleEffectSink.test.ts
+++ b/test/unit/infrastructure/adapters/ConsoleEffectSink.test.ts
@@ -34,27 +34,27 @@ describe('ConsoleEffectSink', () => {
   it('logs to the provided logger in live mode', async () => {
     const info = vi.fn();
     const sink = new ConsoleEffectSink({ logger: { info } });
-    const obs = await sink.deliver(makeEmission(), LIVE_LENS);
+    const [obs] = await sink.deliver(makeEmission(), LIVE_LENS);
 
-    expect(obs.outcome).toBe('delivered');
+    expect(obs?.outcome).toBe('delivered');
     expect(info).toHaveBeenCalledTimes(1);
   });
 
   it('suppresses in replay mode', async () => {
     const info = vi.fn();
     const sink = new ConsoleEffectSink({ logger: { info } });
-    const obs = await sink.deliver(makeEmission(), REPLAY_LENS);
+    const [obs] = await sink.deliver(makeEmission(), REPLAY_LENS);
 
-    expect(obs.outcome).toBe('suppressed');
+    expect(obs?.outcome).toBe('suppressed');
     expect(info).not.toHaveBeenCalled();
   });
 
   it('suppresses in inspect mode', async () => {
     const info = vi.fn();
     const sink = new ConsoleEffectSink({ logger: { info } });
-    const obs = await sink.deliver(makeEmission(), INSPECT_LENS);
+    const [obs] = await sink.deliver(makeEmission(), INSPECT_LENS);
 
-    expect(obs.outcome).toBe('suppressed');
+    expect(obs?.outcome).toBe('suppressed');
     expect(info).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/infrastructure/adapters/LoggerObservabilityBridge.test.ts
+++ b/test/unit/infrastructure/adapters/LoggerObservabilityBridge.test.ts
@@ -12,6 +12,18 @@ function mockLogger() {
 }
 
 describe('LoggerObservabilityBridge', () => {
+  describe('constructor', () => {
+    it('rejects a missing logger at construction time', () => {
+      // @ts-expect-error exercising runtime validation for untyped callers
+      expect(() => new LoggerObservabilityBridge(null))
+        .toThrow('LoggerObservabilityBridge requires a logger');
+
+      // @ts-expect-error exercising runtime validation for untyped callers
+      expect(() => new LoggerObservabilityBridge(undefined))
+        .toThrow('LoggerObservabilityBridge requires a logger');
+    });
+  });
+
   describe('metric()', () => {
     it('forwards metric as debug log with channel prefix', () => {
       const logger = mockLogger();

--- a/test/unit/infrastructure/adapters/NoOpEffectSink.test.ts
+++ b/test/unit/infrastructure/adapters/NoOpEffectSink.test.ts
@@ -34,18 +34,18 @@ describe('NoOpEffectSink', () => {
 
   it('always returns delivered in live mode', async () => {
     const sink = new NoOpEffectSink();
-    const obs = await sink.deliver(makeEmission(), LIVE_LENS);
+    const [obs] = await sink.deliver(makeEmission(), LIVE_LENS);
 
-    expect(obs.outcome).toBe('delivered');
-    expect(obs.sinkId).toBe('noop');
-    expect(obs.emissionId).toBe('em-1');
+    expect(obs?.outcome).toBe('delivered');
+    expect(obs?.sinkId).toBe('noop');
+    expect(obs?.emissionId).toBe('em-1');
   });
 
   it('returns suppressed in replay mode with suppressExternal', async () => {
     const sink = new NoOpEffectSink();
-    const obs = await sink.deliver(makeEmission(), REPLAY_LENS);
+    const [obs] = await sink.deliver(makeEmission(), REPLAY_LENS);
 
-    expect(obs.outcome).toBe('suppressed');
-    expect(obs.reason).toContain('replay');
+    expect(obs?.outcome).toBe('suppressed');
+    expect(obs?.reason).toContain('replay');
   });
 });

--- a/test/unit/infrastructure/adapters/inMemoryHashing.test.ts
+++ b/test/unit/infrastructure/adapters/inMemoryHashing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   defaultHash,
@@ -6,6 +6,11 @@ import {
 } from '../../../../src/infrastructure/adapters/inMemoryHashing.ts';
 
 describe('inMemoryHashing', () => {
+  afterEach(() => {
+    vi.doUnmock('node:crypto');
+    vi.resetModules();
+  });
+
   it('treats node crypto probing as an explicit readiness boundary', async () => {
     await expect(initCryptoReady(undefined)).resolves.toBe(true);
 
@@ -17,5 +22,21 @@ describe('inMemoryHashing', () => {
     const injectedHash = () => '0'.repeat(40);
 
     await expect(initCryptoReady(injectedHash)).resolves.toBe(true);
+  });
+
+  it('reports E_NO_HASH at the first hash boundary when node crypto is unavailable', async () => {
+    vi.resetModules();
+    vi.doMock('node:crypto', () => {
+      throw new Error('node crypto unavailable');
+    });
+    const { default: InMemoryGraphAdapter } = await import(
+      '../../../../src/infrastructure/adapters/InMemoryGraphAdapter.ts'
+    );
+
+    const adapter = new InMemoryGraphAdapter();
+
+    await expect(adapter.writeBlob('payload')).rejects.toMatchObject({
+      code: 'E_NO_HASH',
+    });
   });
 });

--- a/test/unit/infrastructure/adapters/inMemoryHashing.test.ts
+++ b/test/unit/infrastructure/adapters/inMemoryHashing.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe('inMemoryHashing', () => {
   it('treats node crypto probing as an explicit readiness boundary', async () => {
-    await expect(initCryptoReady(undefined)).resolves.toBeUndefined();
+    await expect(initCryptoReady(undefined)).resolves.toBe(true);
 
     expect(defaultHash(new Uint8Array([1, 2, 3])))
       .toMatch(/^[0-9a-f]{40}$/);
@@ -16,6 +16,6 @@ describe('inMemoryHashing', () => {
   it('does not probe node crypto when a hash function is injected', async () => {
     const injectedHash = () => '0'.repeat(40);
 
-    await expect(initCryptoReady(injectedHash)).resolves.toBeUndefined();
+    await expect(initCryptoReady(injectedHash)).resolves.toBe(true);
   });
 });

--- a/test/unit/infrastructure/adapters/inMemoryHashing.test.ts
+++ b/test/unit/infrastructure/adapters/inMemoryHashing.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultHash,
+  initCryptoReady,
+} from '../../../../src/infrastructure/adapters/inMemoryHashing.ts';
+
+describe('inMemoryHashing', () => {
+  it('treats node crypto probing as an explicit readiness boundary', async () => {
+    await expect(initCryptoReady(undefined)).resolves.toBeUndefined();
+
+    expect(defaultHash(new Uint8Array([1, 2, 3])))
+      .toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it('does not probe node crypto when a hash function is injected', async () => {
+    const injectedHash = () => '0'.repeat(40);
+
+    await expect(initCryptoReady(injectedHash)).resolves.toBeUndefined();
+  });
+});

--- a/test/unit/ports/EffectSinkPort.test.ts
+++ b/test/unit/ports/EffectSinkPort.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import EffectSinkPort from '../../../src/ports/EffectSinkPort.ts';
-import type { EffectEmission } from '../../../src/domain/types/EffectEmission.ts';
-import type { ExternalizationPolicy } from '../../../src/domain/types/ExternalizationPolicy.ts';
-import type { DeliveryObservation } from '../../../src/domain/types/DeliveryObservation.ts';
+import { createEffectEmission, type EffectEmission } from '../../../src/domain/types/EffectEmission.ts';
+import { LIVE_LENS, type ExternalizationPolicy } from '../../../src/domain/types/ExternalizationPolicy.ts';
+import { createDeliveryObservation, type DeliveryObservation } from '../../../src/domain/types/DeliveryObservation.ts';
 
 describe('EffectSinkPort', () => {
   it('abstract members are not callable on base prototype', () => {
@@ -14,12 +14,31 @@ describe('EffectSinkPort', () => {
   it('concrete subclass satisfies the contract', async () => {
     class TestSink extends EffectSinkPort {
       get id() { return 'test-sink'; }
-      async deliver(_emission: EffectEmission, _lens: ExternalizationPolicy): Promise<DeliveryObservation[]> {
-        return [{ outcome: 'delivered' } as unknown as DeliveryObservation];
+      async deliver(emission: EffectEmission, lens: ExternalizationPolicy): Promise<DeliveryObservation[]> {
+        return [createDeliveryObservation({
+          emissionId: emission.id,
+          sinkId: this.id,
+          outcome: 'delivered',
+          timestamp: 0,
+          lens,
+        })];
       }
     }
     const sink = new TestSink();
+    const observations = await sink.deliver(
+      createEffectEmission({
+        id: 'emission-1',
+        kind: 'test',
+        payload: null,
+        timestamp: 0,
+        writer: null,
+        coordinate: { frontier: null, ceiling: null },
+      }),
+      LIVE_LENS,
+    );
+
     expect(sink).toBeInstanceOf(EffectSinkPort);
     expect(sink.id).toBe('test-sink');
+    expect(observations[0]?.outcome).toBe('delivered');
   });
 });

--- a/test/unit/ports/EffectSinkPort.test.ts
+++ b/test/unit/ports/EffectSinkPort.test.ts
@@ -14,8 +14,8 @@ describe('EffectSinkPort', () => {
   it('concrete subclass satisfies the contract', async () => {
     class TestSink extends EffectSinkPort {
       get id() { return 'test-sink'; }
-      async deliver(_emission: EffectEmission, _lens: ExternalizationPolicy): Promise<DeliveryObservation> {
-        return { outcome: 'delivered' } as unknown as DeliveryObservation;
+      async deliver(_emission: EffectEmission, _lens: ExternalizationPolicy): Promise<DeliveryObservation[]> {
+        return [{ outcome: 'delivered' } as unknown as DeliveryObservation];
       }
     }
     const sink = new TestSink();


### PR DESCRIPTION
## Summary

- Fixes the code-backed v17 cleanup items already repaired on this branch.
- Retires the legacy `release-home:v17.0.0` label from every open issue that still carried it.
- Keeps unresolved future debt open under canonical labels instead of treating it as v17 release-home work.

## Fixed By This PR

Closes #389
Closes #373
Closes #372
Closes #367
Closes #281
Closes #275
Closes #272
Closes #271
Closes #259
Closes #257
Closes #255
Closes #245
Closes #217
Closes #151

## Tracker Disposition

The live query for open issues labeled `release-home:v17.0.0` is now zero. Each issue that had that legacy label at the start of the final cleanup pass has a dedicated trace commit documenting either branch-backed fix tracking or label retirement.

Retargeted debt remains open as normal debt under canonical labels. The PR does not claim those broader architecture/testing/runtime issues are solved; it removes their stale v17 release-home classification.

## Validation

- Focused local checks during implementation:
  - `npm run lint`
  - `npm run typecheck -- --pretty false`
  - `git diff --check`
  - focused Vitest suites for touched effect, HTTP, logger, hashing, index, and sludge-atlas code
- Pre-push hook on final branch push:
  - link check passed
  - lint/typecheck/policy/consumer/surface/markdown gates passed
  - stable unit-test shards passed: 545 files, 7175 tests
- Current GitHub issue query:
  - `gh issue list --state open --label release-home:v17.0.0 --limit 200 --json number --jq 'length'` -> `0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guidance for streamed consumption using async iteration, including clearer advanced streaming port boundaries.
  * Expanded advanced architecture and API docs around streamed ports.

* **New Features**
  * Enabled 6-bit nibble geometry support in route-key/trie operations.

* **Bug Fixes**
  * Improved commit/CAS conflict classification and strengthened runtime validation (e.g., observability logger and hashing readiness).
  * Standardized effect sink delivery to consistently return a batch of delivery observations.

* **Tests**
  * Added stricter schema conformance for sludge maps and updated streaming/trie and delivery-batch tests to match the new contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->