### PR TITLE
release: repair v18.1.1 autotag link gate

### DIFF
--- a/.github/workflows/release-autotag.yml
+++ b/.github/workflows/release-autotag.yml
@@ -81,11 +81,24 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "tag_exists=$TAG_EXISTS" >> "$GITHUB_OUTPUT"
 
+      - name: Lychee link check
+        if: steps.release_pr.outputs.should_release == 'true' && steps.metadata.outputs.tag_exists != 'true'
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
+        with:
+          args: >-
+            --config .lychee.toml
+            '**/*.md'
+          fail: true
+          format: markdown
+          output: ${{ runner.temp }}/lychee-report.md
+          jobSummary: true
+
       - name: Final release preflight
         if: steps.release_pr.outputs.should_release == 'true' && steps.metadata.outputs.tag_exists != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.metadata.outputs.tag }}
+          WARP_LINKCHECK_EXTERNAL_OK: "1"
         run: bash scripts/release-preflight.sh --stage final-local --tag "$TAG"
 
       - name: Create release tag

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -127,10 +127,16 @@ if npm run lint:md:code --silent 2>/dev/null; then
 else
   fail "Markdown code sample errors"
 fi
-if npm run lint:links --silent 2>/dev/null; then
-  pass "Documentation links clean"
+if command -v lychee >/dev/null 2>&1; then
+  if npm run lint:links --silent 2>/dev/null; then
+    pass "Documentation links clean"
+  else
+    fail "Documentation link errors"
+  fi
+elif [ "${WARP_LINKCHECK_EXTERNAL_OK:-}" = "1" ]; then
+  pass "Documentation links clean (external gate)"
 else
-  fail "Documentation link errors"
+  fail "Documentation link checker unavailable"
 fi
 
 # ── 6. Type firewall ─────────────────────────────────────────────────────────

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -128,7 +128,7 @@ else
   fail "Markdown code sample errors"
 fi
 if command -v lychee >/dev/null 2>&1; then
-  if npm run lint:links --silent 2>/dev/null; then
+  if npm run lint:links; then
     pass "Documentation links clean"
   else
     fail "Documentation link errors"


### PR DESCRIPTION
## Summary
- run Lychee explicitly in Release Autotag before final preflight
- allow release-preflight to accept an external link-check gate when Lychee is not installed
- keep the v18.1.1 release path on the automated release-branch merge flow

Refs #673

## Validation
- `npm run release:guard -- --stage prep-pr --tag v18.1.1`
- `npm run lint:docs-topology`
- `PATH='/opt/homebrew/bin:/usr/bin:/bin' WARP_LINKCHECK_EXTERNAL_OK=1 bash scripts/release-preflight.sh --stage prep-pr --tag v18.1.1`
- pre-push IRONCLAD M9 gates: link check, static gates, stable unit-test shards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Markdown link verification (“Lychee link check”) to the release process, generating a report and failing the release if issues are found.
  * Release preflight now performs link checking only when the link checker is available, with an approved fallback path when it’s not.

* **Bug Fixes**
  * Prevents release validation from failing when the external link checker is unavailable but the fallback gate is enabled.
  * Improves clarity of pass/fail results for documentation link checks during release preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->