### PR TITLE
release: prepare v18.1.2

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,11 +10,13 @@ If you are learning the product for the first time, start with:
 
 ## Release posture
 
-`v18.1.1` is the current release target. Architecturally, it carries the v18
+`v18.1.2` is the current release target. Architecturally, it carries the v18
 read-model closeout from the current `main` release state: `Optic` is a
 runtime noun, observer reading envelopes are explicit, bounded support planning
 is named, the public learning shelf is consolidated under `docs/topics/`, and
-operator workflows live outside that shelf under `docs/operations/`.
+operator workflows live outside that shelf under `docs/operations/`. This patch
+adds a generated source-backed reference gate; it does not add a new runtime
+boundary.
 
 The longer release notes live in [CHANGELOG.md](CHANGELOG.md). The runtime
 architecture below describes current implementation boundaries, not aspirational

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [18.1.2] - 2026-06-25
+
+### Release notes
+
+`v18.1.2` is a release-hygiene and public-reference patch for the v18.1 line.
+It publishes the source-backed reference shelf so package entrypoints, root API
+exports, CLI commands, structured CLI error output, and public error classes
+are generated from source instead of hand-maintained Markdown.
+
+It also carries the corrected release publication path: merged `release/*` PRs
+autotag the exact `main` commit after final preflight, and a JSR scope-member
+maintainer manually dispatches the registry publish workflow for that tag.
+That keeps GitHub Release evidence, npm publication, and JSR OIDC identity
+aligned without relying on bot-dispatched registry publishing.
+
 ### Added
 
 - Added a generated source-backed reference topic for package entrypoints, root
   API exports, CLI commands, structured CLI error output, and public error
   classes, plus a docs-topology gate that fails when the reference drifts from
   source.
+
+### Changed
+
+- Updated release automation and maintainer documentation so release autotagging
+  stops after creating the tag, while npm and JSR publication run from an
+  explicit maintainer-dispatched workflow.
+- Added the source-backed reference topic to release guard and documentation
+  topology checks so release prep fails if the generated reference is missing.
 
 ## [18.1.1] - 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ It lets you:
 
 ## Latest release
 
-`v18.1.1` republishes the v18.1 line from the current `main` release state.
-It carries the reified `Optic` read model, observer reading envelopes, bounded
-support planning, the consolidated docs topology, and the upstream
-`@git-stunts/alfred` timeout fix without relying on the old local patch.
+`v18.1.2` publishes the source-backed reference shelf for package entrypoints,
+root API exports, CLI commands, structured CLI errors, and public error classes.
+It also locks the release path to autotag the exact merged `main` commit, then
+publish npm and JSR from a maintainer-dispatched workflow.
 
 See [CHANGELOG.md](CHANGELOG.md) for the full in-repository release notes.
 

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -5,11 +5,13 @@ specific task.
 
 ## Current release
 
-`v18.1.1` focuses the public docs around the shipped v18 read model:
+`v18.1.2` keeps the public docs focused around the shipped v18 read model:
 worldlines, coordinates, reified optics, observers, bounded support, strands,
-Git substrate, sync, CLI, and troubleshooting. Operator workflows live outside
-the topic shelf in [Operations](../operations/). The full release narrative
-lives in the root [CHANGELOG](../../CHANGELOG.md).
+Git substrate, sync, CLI, and troubleshooting. It also adds the generated
+[Source-backed reference](reference.md) for exact package, API, CLI, and error
+inventories. Operator workflows live outside the topic shelf in
+[Operations](../operations/). The full release narrative lives in the root
+[CHANGELOG](../../CHANGELOG.md).
 
 ## Start here
 

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/git-warp",
-  "version": "18.1.1",
+  "version": "18.1.2",
   "imports": {
     "roaring": "npm:roaring@^2.7.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@git-stunts/git-warp",
-  "version": "18.1.1",
+  "version": "18.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@git-stunts/git-warp",
-      "version": "18.1.1",
+      "version": "18.1.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5594,7 +5594,7 @@
     },
     "packages/warp-adapters": {
       "name": "@git-stunts/warp-adapters",
-      "version": "18.1.1",
+      "version": "18.1.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -5602,7 +5602,7 @@
     },
     "packages/warp-kernel": {
       "name": "@git-stunts/warp-kernel",
-      "version": "18.1.1",
+      "version": "18.1.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -5610,7 +5610,7 @@
     },
     "packages/warp-orset": {
       "name": "@git-stunts/warp-orset",
-      "version": "18.1.1",
+      "version": "18.1.2",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/git-warp",
-  "version": "18.1.1",
+  "version": "18.1.2",
   "description": "Worldline-first WARP graph over Git: deterministic multi-writer causal history, readings, and tooling.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/warp-adapters/package.json
+++ b/packages/warp-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/warp-adapters",
-  "version": "18.1.1",
+  "version": "18.1.2",
   "description": "Infrastructure adapters: Git/CAS, crypto, and HTTP for git-warp.",
   "private": true,
   "type": "module",

--- a/packages/warp-kernel/package.json
+++ b/packages/warp-kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/warp-kernel",
-  "version": "18.1.1",
+  "version": "18.1.2",
   "description": "Domain engine: services, WarpState, and controllers for git-warp.",
   "private": true,
   "type": "module",

--- a/packages/warp-orset/package.json
+++ b/packages/warp-orset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/warp-orset",
-  "version": "18.1.1",
+  "version": "18.1.2",
   "description": "ORSet engine: trie, cursor, cache, and session primitives for git-warp.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump npm, JSR, lockfile, and private workspace versions to `18.1.2`.
- Promote the source-backed reference and corrected manual registry publication flow into the release signposts.
- Prepare `v18.1.2` for the runbook flow: release PR merge, autotag on `main`, then maintainer-dispatched publish workflow.

## Issue

Refs #670

## Test plan

- `git diff --check`
- `npm run lint:md -- README.md ARCHITECTURE.md CHANGELOG.md docs/topics/README.md`
- `npm run lint:source-backed-reference`
- `npm run lint:docs-topology`
- `npm run release:prep`
- pre-push IRONCLAD M9 gates, including link check, static gates, and stable unit-test shards

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] If this PR touches persisted op formats, I linked the ADR 3 readiness issue
- [x] If this PR touches wire compatibility, I confirmed canonical-only ops are still rejected on the wire pre-cutover
- [x] If this PR touches schema constants, I confirmed patch and checkpoint namespaces remain distinct

This release prep changes metadata, release notes, and documentation signposts only; it does not change persisted op formats, wire compatibility, or schema constants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version **18.1.2**.
  * Added updated release notes for the latest build, including new coverage for source-backed references and release publishing checks.

* **Documentation**
  * Updated the README and topic docs to reflect the new release version and current release scope.
  * Refreshed the architecture and changelog notes to match the latest release posture.

* **Chores**
  * Bumped package and workspace version numbers to **18.1.2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->