### PR TITLE
Fix: make release guards consume release profile

### DIFF
--- a/.continuum/release.yml
+++ b/.continuum/release.yml
@@ -21,6 +21,7 @@ version_sources:
     type: json
     field: version
     required: true
+    private: true
 docs:
   changelog: CHANGELOG.md
   front_door: README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,8 @@
         "prettier": "^3.4.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.54.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.0.18",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -5555,9 +5556,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
     "prettier": "^3.4.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "yaml": "^2.9.0"
   },
   "keywords": [
     "git",

--- a/scripts/check-docs-topology.sh
+++ b/scripts/check-docs-topology.sh
@@ -2,27 +2,7 @@
 # Advisory guard for the consolidated documentation topology.
 set -euo pipefail
 
-REQUIRED_DOCS=(
-  ".continuum/release.yml"
-  ".github/RELEASE.md"
-  "README.md"
-  "ARCHITECTURE.md"
-  "CHANGELOG.md"
-  "docs/operations/README.md"
-  "docs/topics/README.md"
-  "docs/topics/getting-started.md"
-  "docs/topics/optic-reads.md"
-  "docs/topics/observers.md"
-  "docs/topics/querying.md"
-  "docs/topics/strands.md"
-  "docs/topics/git-substrate.md"
-  "docs/topics/content-and-cas.md"
-  "docs/topics/continuum-boundary.md"
-  "docs/topics/sync.md"
-  "docs/topics/cli.md"
-  "docs/topics/reference.md"
-  "docs/topics/troubleshooting.md"
-)
+mapfile -t REQUIRED_DOCS < <(node scripts/release-profile.ts required-docs)
 
 RETIRED_PATHS=(
   "docs/archive"

--- a/scripts/check-docs-topology.sh
+++ b/scripts/check-docs-topology.sh
@@ -2,7 +2,18 @@
 # Advisory guard for the consolidated documentation topology.
 set -euo pipefail
 
-mapfile -t REQUIRED_DOCS < <(node scripts/release-profile.ts required-docs)
+REQUIRED_DOCS_OUTPUT=""
+if ! REQUIRED_DOCS_OUTPUT="$(node scripts/release-profile.ts required-docs)"; then
+  echo "docs-topology: failed to read required docs from .continuum/release.yml" >&2
+  exit 1
+fi
+
+if [ "$REQUIRED_DOCS_OUTPUT" = "" ]; then
+  echo "docs-topology: release profile produced no required docs" >&2
+  exit 1
+fi
+
+mapfile -t REQUIRED_DOCS <<< "$REQUIRED_DOCS_OUTPUT"
 
 RETIRED_PATHS=(
   "docs/archive"

--- a/scripts/release-guard.sh
+++ b/scripts/release-guard.sh
@@ -56,28 +56,6 @@ TARGET_VERSION=""
 TARGET_MILESTONE=""
 FAILURES=0
 
-REQUIRED_RELEASE_DOCS=(
-  ".continuum/release.yml"
-  ".github/RELEASE.md"
-  "README.md"
-  "ARCHITECTURE.md"
-  "CHANGELOG.md"
-  "docs/operations/README.md"
-  "docs/topics/README.md"
-  "docs/topics/getting-started.md"
-  "docs/topics/optic-reads.md"
-  "docs/topics/observers.md"
-  "docs/topics/querying.md"
-  "docs/topics/strands.md"
-  "docs/topics/git-substrate.md"
-  "docs/topics/content-and-cas.md"
-  "docs/topics/continuum-boundary.md"
-  "docs/topics/sync.md"
-  "docs/topics/cli.md"
-  "docs/topics/reference.md"
-  "docs/topics/troubleshooting.md"
-)
-
 RETIRED_DOC_PATHS=(
   "docs/archive"
   "docs/audits"
@@ -330,56 +308,8 @@ check_zero_non_release_milestone() {
 }
 
 check_versions() {
-  if TAG_VERSION="$TAG_VERSION" node <<'NODE'
-const { existsSync, readdirSync, readFileSync } = require('node:fs');
-const { join } = require('node:path');
-
-const expected = process.env.TAG_VERSION;
-const failures = [];
-
-function readJson(path) {
-  return JSON.parse(readFileSync(path, 'utf8'));
-}
-
-function expectVersion(label, version) {
-  if (version !== expected) {
-    failures.push(`${label} version ${version} != ${expected}`);
-  }
-}
-
-const rootPackage = readJson('package.json');
-expectVersion('package.json', rootPackage.version);
-expectVersion('jsr.json', readJson('jsr.json').version);
-
-if (existsSync('package-lock.json')) {
-  const lock = readJson('package-lock.json');
-  expectVersion('package-lock.json root package', lock.packages[''].version);
-}
-
-for (const workspace of readdirSync('packages', { withFileTypes: true })) {
-  if (!workspace.isDirectory()) {
-    continue;
-  }
-  const packagePath = join('packages', workspace.name, 'package.json');
-  if (!existsSync(packagePath)) {
-    continue;
-  }
-  const workspacePackage = readJson(packagePath);
-  expectVersion(packagePath, workspacePackage.version);
-  if (workspacePackage.private !== true) {
-    failures.push(`${packagePath} must remain private unless publish policy changes`);
-  }
-}
-
-if (failures.length > 0) {
-  for (const failure of failures) {
-    console.error(failure);
-  }
-  process.exit(1);
-}
-NODE
-  then
-    pass "REL-META-VERSION-LOCKSTEP" "package, JSR, lockfile, and workspace versions match $TAG_VERSION"
+  if node scripts/release-profile.ts check-version-lockstep "$TAG_VERSION"; then
+    pass "REL-META-VERSION-LOCKSTEP" "release profile version sources match $TAG_VERSION"
   else
     fail "REL-META-VERSION-LOCKSTEP" "release metadata is not version-locked"
   fi
@@ -458,12 +388,12 @@ check_release_evidence() {
   local missing=0
   local retired=0
 
-  for path in "${REQUIRED_RELEASE_DOCS[@]}"; do
+  while IFS= read -r path; do
     if [ ! -f "$path" ]; then
       printf '    missing release doc: %s\n' "$path"
       missing=$((missing + 1))
     fi
-  done
+  done < <(node scripts/release-profile.ts required-docs)
 
   for path in "${RETIRED_DOC_PATHS[@]}"; do
     if [ -e "$path" ]; then

--- a/scripts/release-guard.sh
+++ b/scripts/release-guard.sh
@@ -387,13 +387,24 @@ check_changelog() {
 check_release_evidence() {
   local missing=0
   local retired=0
+  local required_docs
+
+  if ! required_docs="$(node scripts/release-profile.ts required-docs)"; then
+    fail "REL-DOC-PROFILE" "could not read required docs from release profile"
+    return
+  fi
+
+  if [ "$required_docs" = "" ]; then
+    fail "REL-DOC-PROFILE" "release profile produced no required docs"
+    return
+  fi
 
   while IFS= read -r path; do
     if [ ! -f "$path" ]; then
       printf '    missing release doc: %s\n' "$path"
       missing=$((missing + 1))
     fi
-  done < <(node scripts/release-profile.ts required-docs)
+  done <<< "$required_docs"
 
   for path in "${RETIRED_DOC_PATHS[@]}"; do
     if [ -e "$path" ]; then

--- a/scripts/release-profile.ts
+++ b/scripts/release-profile.ts
@@ -4,7 +4,8 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { parse } from 'yaml';
+import { isMap, isScalar, isSeq, parseDocument } from 'yaml';
+import type { Node, YAMLMap } from 'yaml';
 
 export type ReleaseVersionSource = {
   readonly path: string;
@@ -40,26 +41,72 @@ class ReleaseProfileError extends Error {
   }
 }
 
-function readJson(path: string) {
-  return JSON.parse(readFileSync(path, 'utf8'));
+function readMapDocument(path: string, label: string): YAMLMap {
+  const document = parseDocument(readFileSync(path, 'utf8'));
+  if (document.errors.length > 0) {
+    const parseError = document.errors[0]?.message ?? 'invalid document';
+    throw new ReleaseProfileError(`${label} could not be parsed: ${parseError}`);
+  }
+  if (!isMap(document.contents)) {
+    throw new ReleaseProfileError(`${label} must be a map`);
+  }
+  return document.contents;
 }
 
-function assertString(value: string | undefined, label: string): string {
+function requireMapNode(node: Node | null | undefined, label: string): YAMLMap {
+  if (!isMap(node)) {
+    throw new ReleaseProfileError(`${label} must be a map`);
+  }
+  return node;
+}
+
+function requireMapField(map: YAMLMap, key: string, label: string): YAMLMap {
+  return requireMapNode(map.get(key, true), label);
+}
+
+function requireStringField(map: YAMLMap, key: string, label: string): string {
+  const node = map.get(key, true);
+  if (!isScalar(node) || typeof node.value !== 'string' || node.value.length === 0) {
+    throw new ReleaseProfileError(`${label} must be a non-empty string`);
+  }
+  return node.value;
+}
+
+function requireNonEmptyString(value: string | undefined, label: string): string {
   if (typeof value !== 'string' || value.length === 0) {
     throw new ReleaseProfileError(`${label} must be a non-empty string`);
   }
   return value;
 }
 
-function assertStringArray(value: readonly string[] | undefined, label: string): readonly string[] {
-  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string' || entry.length === 0)) {
+function requireSchemaOne(map: YAMLMap): 1 {
+  const node = map.get('schema', true);
+  if (!isScalar(node) || node.value !== 1) {
+    throw new ReleaseProfileError('schema must be 1');
+  }
+  return 1;
+}
+
+function requireStringArrayField(map: YAMLMap, key: string, label: string): readonly string[] {
+  const node = map.get(key, true);
+  if (!isSeq(node)) {
     throw new ReleaseProfileError(`${label} must be a non-empty string array`);
   }
-  return value;
+  const values: string[] = [];
+  for (const item of node.items) {
+    if (!isScalar(item) || typeof item.value !== 'string' || item.value.length === 0) {
+      throw new ReleaseProfileError(`${label} must be a non-empty string array`);
+    }
+    values.push(item.value);
+  }
+  if (values.length === 0) {
+    throw new ReleaseProfileError(`${label} must be a non-empty string array`);
+  }
+  return values;
 }
 
 function assertVersionSourceType(
-  value: ReleaseVersionSource['type'] | undefined,
+  value: string,
   label: string
 ): ReleaseVersionSource['type'] {
   if (value !== 'json' && value !== 'npm-lock-root') {
@@ -68,53 +115,60 @@ function assertVersionSourceType(
   return value;
 }
 
-function assertOptionalBoolean(value: boolean | undefined, label: string): boolean | undefined {
-  if (value !== undefined && typeof value !== 'boolean') {
+function optionalBooleanField(map: YAMLMap, key: string, label: string): boolean | undefined {
+  const node = map.get(key, true);
+  if (node === undefined) {
+    return undefined;
+  }
+  if (!isScalar(node) || typeof node.value !== 'boolean') {
     throw new ReleaseProfileError(`${label} must be boolean when present`);
   }
-  return value;
+  return node.value;
 }
 
-function normalizeProfile(profile: Partial<ReleaseProfile>): ReleaseProfile {
-  if (profile.schema !== 1) {
-    throw new ReleaseProfileError('schema must be 1');
-  }
-  if (!Array.isArray(profile.version_sources) || profile.version_sources.length === 0) {
+function normalizeProfile(profile: YAMLMap): ReleaseProfile {
+  const schema = requireSchemaOne(profile);
+  const versionSourcesNode = profile.get('version_sources', true);
+  if (!isSeq(versionSourcesNode) || versionSourcesNode.items.length === 0) {
     throw new ReleaseProfileError('version_sources must contain at least one source');
   }
-  if (profile.docs === undefined) {
-    throw new ReleaseProfileError('docs profile is required');
-  }
+  const docs = requireMapField(profile, 'docs', 'docs profile');
 
   return Object.freeze({
-    schema: 1,
-    version_sources: profile.version_sources.map((source, index) => {
-      const required = assertOptionalBoolean(source.required, `version_sources[${index}].required`);
-      const privateSource = assertOptionalBoolean(source.private, `version_sources[${index}].private`);
+    schema,
+    version_sources: versionSourcesNode.items.map((source, index) => {
+      if (!isMap(source)) {
+        throw new ReleaseProfileError(`version_sources[${index}] must be a map`);
+      }
+      const sourceMap = source;
+      const required = optionalBooleanField(sourceMap, 'required', `version_sources[${index}].required`);
+      const privateSource = optionalBooleanField(sourceMap, 'private', `version_sources[${index}].private`);
       return Object.freeze({
-        path: assertString(source.path, `version_sources[${index}].path`),
-        type: assertVersionSourceType(source.type, `version_sources[${index}].type`),
-        field: assertString(source.field, `version_sources[${index}].field`),
+        path: requireStringField(sourceMap, 'path', `version_sources[${index}].path`),
+        type: assertVersionSourceType(
+          requireStringField(sourceMap, 'type', `version_sources[${index}].type`),
+          `version_sources[${index}].type`
+        ),
+        field: requireStringField(sourceMap, 'field', `version_sources[${index}].field`),
         ...(required === undefined ? {} : { required }),
         ...(privateSource === undefined ? {} : { private: privateSource }),
       });
     }),
     docs: Object.freeze({
-      changelog: assertString(profile.docs.changelog, 'docs.changelog'),
-      front_door: assertString(profile.docs.front_door, 'docs.front_door'),
-      architecture: assertString(profile.docs.architecture, 'docs.architecture'),
-      learning_index: assertString(profile.docs.learning_index, 'docs.learning_index'),
-      learning_topics: assertString(profile.docs.learning_topics, 'docs.learning_topics'),
-      operations: assertString(profile.docs.operations, 'docs.operations'),
-      contributor: assertStringArray(profile.docs.contributor, 'docs.contributor'),
+      changelog: requireStringField(docs, 'changelog', 'docs.changelog'),
+      front_door: requireStringField(docs, 'front_door', 'docs.front_door'),
+      architecture: requireStringField(docs, 'architecture', 'docs.architecture'),
+      learning_index: requireStringField(docs, 'learning_index', 'docs.learning_index'),
+      learning_topics: requireStringField(docs, 'learning_topics', 'docs.learning_topics'),
+      operations: requireStringField(docs, 'operations', 'docs.operations'),
+      contributor: requireStringArrayField(docs, 'contributor', 'docs.contributor'),
     }),
   });
 }
 
 export function loadReleaseProfile(root: string = ROOT): ReleaseProfile {
   const profilePath = join(root, PROFILE_PATH);
-  const parsed = parse(readFileSync(profilePath, 'utf8')) as Partial<ReleaseProfile>;
-  return normalizeProfile(parsed);
+  return normalizeProfile(readMapDocument(profilePath, PROFILE_PATH));
 }
 
 function listMarkdownFiles(root: string, directoryPath: string): readonly string[] {
@@ -167,12 +221,13 @@ function expandVersionSourcePaths(root: string, source: ReleaseVersionSource): r
     .sort();
 }
 
-function readVersion(source: ReleaseVersionSource, packagePath: string, root: string): string {
-  const packageJson = readJson(join(root, packagePath));
+function readVersion(source: ReleaseVersionSource, packageMap: YAMLMap, packagePath: string): string {
   if (source.type === 'npm-lock-root') {
-    return packageJson.packages[''].version;
+    const packagesMap = requireMapField(packageMap, 'packages', `${packagePath}.packages`);
+    const rootPackageMap = requireMapField(packagesMap, '', `${packagePath}.packages[""]`);
+    return requireStringField(rootPackageMap, 'version', `${packagePath}.packages[""].version`);
   }
-  return packageJson[source.field];
+  return requireStringField(packageMap, source.field, `${packagePath}.${source.field}`);
 }
 
 export function collectVersionLockstepFailures(expectedVersion: string, root: string = ROOT): readonly string[] {
@@ -190,11 +245,12 @@ export function collectVersionLockstepFailures(expectedVersion: string, root: st
         failures.push(`${path} is missing`);
         continue;
       }
-      const version = readVersion(source, path, root);
+      const packageMap = readMapDocument(fullPath, path);
+      const version = readVersion(source, packageMap, path);
       if (version !== expectedVersion) {
         failures.push(`${path} ${source.field} ${version} != ${expectedVersion}`);
       }
-      if (source.private === true && readJson(fullPath).private !== true) {
+      if (source.private === true && optionalBooleanField(packageMap, 'private', `${path}.private`) !== true) {
         failures.push(`${path} must remain private unless publish policy changes`);
       }
     }
@@ -212,7 +268,7 @@ export function runReleaseProfileCli(argv: readonly string[]): number {
     return 0;
   }
   if (command === 'check-version-lockstep') {
-    const expectedVersion = assertString(argv[3], 'expected version');
+    const expectedVersion = requireNonEmptyString(argv[3], 'expected version');
     const failures = collectVersionLockstepFailures(expectedVersion);
     for (const failure of failures) {
       console.error(failure);

--- a/scripts/release-profile.ts
+++ b/scripts/release-profile.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { parse } from 'yaml';
+
+export type ReleaseVersionSource = {
+  readonly path: string;
+  readonly type: 'json' | 'npm-lock-root';
+  readonly field: string;
+  readonly required?: boolean;
+  readonly private?: boolean;
+};
+
+export type ReleaseDocsProfile = {
+  readonly changelog: string;
+  readonly front_door: string;
+  readonly architecture: string;
+  readonly learning_index: string;
+  readonly learning_topics: string;
+  readonly operations: string;
+  readonly contributor: readonly string[];
+};
+
+export type ReleaseProfile = {
+  readonly schema: 1;
+  readonly version_sources: readonly ReleaseVersionSource[];
+  readonly docs: ReleaseDocsProfile;
+};
+
+const ROOT = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
+const PROFILE_PATH = '.continuum/release.yml';
+
+class ReleaseProfileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReleaseProfileError';
+  }
+}
+
+function readJson(path: string) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function assertString(value: string | undefined, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new ReleaseProfileError(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function assertStringArray(value: readonly string[] | undefined, label: string): readonly string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string' || entry.length === 0)) {
+    throw new ReleaseProfileError(`${label} must be a non-empty string array`);
+  }
+  return value;
+}
+
+function assertVersionSourceType(
+  value: ReleaseVersionSource['type'] | undefined,
+  label: string
+): ReleaseVersionSource['type'] {
+  if (value !== 'json' && value !== 'npm-lock-root') {
+    throw new ReleaseProfileError(`${label} must be json or npm-lock-root`);
+  }
+  return value;
+}
+
+function assertOptionalBoolean(value: boolean | undefined, label: string): boolean | undefined {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new ReleaseProfileError(`${label} must be boolean when present`);
+  }
+  return value;
+}
+
+function normalizeProfile(profile: Partial<ReleaseProfile>): ReleaseProfile {
+  if (profile.schema !== 1) {
+    throw new ReleaseProfileError('schema must be 1');
+  }
+  if (!Array.isArray(profile.version_sources) || profile.version_sources.length === 0) {
+    throw new ReleaseProfileError('version_sources must contain at least one source');
+  }
+  if (profile.docs === undefined) {
+    throw new ReleaseProfileError('docs profile is required');
+  }
+
+  return Object.freeze({
+    schema: 1,
+    version_sources: profile.version_sources.map((source, index) => {
+      const required = assertOptionalBoolean(source.required, `version_sources[${index}].required`);
+      const privateSource = assertOptionalBoolean(source.private, `version_sources[${index}].private`);
+      return Object.freeze({
+        path: assertString(source.path, `version_sources[${index}].path`),
+        type: assertVersionSourceType(source.type, `version_sources[${index}].type`),
+        field: assertString(source.field, `version_sources[${index}].field`),
+        ...(required === undefined ? {} : { required }),
+        ...(privateSource === undefined ? {} : { private: privateSource }),
+      });
+    }),
+    docs: Object.freeze({
+      changelog: assertString(profile.docs.changelog, 'docs.changelog'),
+      front_door: assertString(profile.docs.front_door, 'docs.front_door'),
+      architecture: assertString(profile.docs.architecture, 'docs.architecture'),
+      learning_index: assertString(profile.docs.learning_index, 'docs.learning_index'),
+      learning_topics: assertString(profile.docs.learning_topics, 'docs.learning_topics'),
+      operations: assertString(profile.docs.operations, 'docs.operations'),
+      contributor: assertStringArray(profile.docs.contributor, 'docs.contributor'),
+    }),
+  });
+}
+
+export function loadReleaseProfile(root: string = ROOT): ReleaseProfile {
+  const profilePath = join(root, PROFILE_PATH);
+  const parsed = parse(readFileSync(profilePath, 'utf8')) as Partial<ReleaseProfile>;
+  return normalizeProfile(parsed);
+}
+
+function listMarkdownFiles(root: string, directoryPath: string): readonly string[] {
+  const absoluteDirectory = join(root, directoryPath);
+  if (!existsSync(absoluteDirectory) || !statSync(absoluteDirectory).isDirectory()) {
+    return [];
+  }
+  return readdirSync(absoluteDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => `${directoryPath.replace(/\/$/, '')}/${entry.name}`)
+    .sort();
+}
+
+export function collectReleaseDocPaths(root: string = ROOT): readonly string[] {
+  const profile = loadReleaseProfile(root);
+  return Array.from(new Set([
+    PROFILE_PATH,
+    profile.docs.changelog,
+    profile.docs.front_door,
+    profile.docs.architecture,
+    profile.docs.learning_index,
+    ...listMarkdownFiles(root, profile.docs.learning_topics),
+    profile.docs.operations,
+    ...profile.docs.contributor,
+  ]));
+}
+
+function expandVersionSourcePaths(root: string, source: ReleaseVersionSource): readonly string[] {
+  if (!source.path.includes('*')) {
+    return [source.path];
+  }
+  if (source.path !== 'packages/*/package.json') {
+    throw new ReleaseProfileError(`unsupported version source glob: ${source.path}`);
+  }
+  const packagesDirectory = join(root, 'packages');
+  if (!existsSync(packagesDirectory)) {
+    return [];
+  }
+  return readdirSync(packagesDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `packages/${entry.name}/package.json`)
+    .filter((path) => existsSync(join(root, path)))
+    .sort();
+}
+
+function readVersion(source: ReleaseVersionSource, packagePath: string, root: string): string {
+  const packageJson = readJson(join(root, packagePath));
+  if (source.type === 'npm-lock-root') {
+    return packageJson.packages[''].version;
+  }
+  return packageJson[source.field];
+}
+
+export function collectVersionLockstepFailures(expectedVersion: string, root: string = ROOT): readonly string[] {
+  const profile = loadReleaseProfile(root);
+  const failures: string[] = [];
+
+  for (const source of profile.version_sources) {
+    const paths = expandVersionSourcePaths(root, source);
+    if (source.required === true && paths.length === 0) {
+      failures.push(`${source.path} did not match any files`);
+    }
+    for (const path of paths) {
+      const fullPath = join(root, path);
+      if (!existsSync(fullPath)) {
+        failures.push(`${path} is missing`);
+        continue;
+      }
+      const version = readVersion(source, path, root);
+      if (version !== expectedVersion) {
+        failures.push(`${path} ${source.field} ${version} != ${expectedVersion}`);
+      }
+      if (source.private === true && readJson(fullPath).private !== true) {
+        failures.push(`${path} must remain private unless publish policy changes`);
+      }
+    }
+  }
+
+  return failures;
+}
+
+export function runReleaseProfileCli(argv: readonly string[]): number {
+  const command = argv[2];
+  if (command === 'required-docs') {
+    for (const path of collectReleaseDocPaths()) {
+      console.log(path);
+    }
+    return 0;
+  }
+  if (command === 'check-version-lockstep') {
+    const expectedVersion = assertString(argv[3], 'expected version');
+    const failures = collectVersionLockstepFailures(expectedVersion);
+    for (const failure of failures) {
+      console.error(failure);
+    }
+    return failures.length === 0 ? 0 : 1;
+  }
+
+  console.error('usage: node scripts/release-profile.ts required-docs');
+  console.error('   or: node scripts/release-profile.ts check-version-lockstep <version>');
+  return 2;
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath !== undefined && import.meta.url === pathToFileURL(invokedPath).href) {
+  process.exitCode = runReleaseProfileCli(process.argv);
+}

--- a/scripts/release-profile.ts
+++ b/scripts/release-profile.ts
@@ -146,16 +146,23 @@ function expandVersionSourcePaths(root: string, source: ReleaseVersionSource): r
   if (!source.path.includes('*')) {
     return [source.path];
   }
-  if (source.path !== 'packages/*/package.json') {
+
+  const segments = source.path.split('/');
+  const globIndex = segments.findIndex((segment) => segment === '*');
+  const globCount = segments.filter((segment) => segment === '*').length;
+  if (globIndex === -1 || globCount !== 1 || source.path.includes('**')) {
     throw new ReleaseProfileError(`unsupported version source glob: ${source.path}`);
   }
-  const packagesDirectory = join(root, 'packages');
-  if (!existsSync(packagesDirectory)) {
+
+  const prefix = segments.slice(0, globIndex);
+  const suffix = segments.slice(globIndex + 1);
+  const parentDirectory = join(root, ...prefix);
+  if (!existsSync(parentDirectory) || !statSync(parentDirectory).isDirectory()) {
     return [];
   }
-  return readdirSync(packagesDirectory, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => `packages/${entry.name}/package.json`)
+
+  return readdirSync(parentDirectory, { withFileTypes: true })
+    .map((entry) => [...prefix, entry.name, ...suffix].join('/'))
     .filter((path) => existsSync(join(root, path)))
     .sort();
 }

--- a/test/unit/scripts/release-profile.test.ts
+++ b/test/unit/scripts/release-profile.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -13,7 +13,7 @@ import {
 
 function writeFixtureFile(root: string, relativePath: string, content: string): void {
   const path = join(root, relativePath);
-  mkdirSync(join(path, '..'), { recursive: true });
+  mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, content);
 }
 

--- a/test/unit/scripts/release-profile.test.ts
+++ b/test/unit/scripts/release-profile.test.ts
@@ -36,6 +36,9 @@ async function createProfileFixture(): Promise<string> {
       '    field: version',
       '    required: true',
       '    private: true',
+      '  - path: "components/*/manifest.json"',
+      '    type: json',
+      '    field: version',
       'docs:',
       '  changelog: CHANGELOG.md',
       '  front_door: README.md',
@@ -57,6 +60,7 @@ async function createProfileFixture(): Promise<string> {
   writeFixtureFile(root, 'jsr.json', '{"version":"1.2.3"}');
   writeFixtureFile(root, 'package-lock.json', '{"packages":{"":{"version":"1.2.3"}}}');
   writeFixtureFile(root, 'packages/kernel/package.json', '{"version":"1.2.3","private":true}');
+  writeFixtureFile(root, 'components/generated/manifest.json', '{"version":"1.2.3"}');
   return root;
 }
 

--- a/test/unit/scripts/release-profile.test.ts
+++ b/test/unit/scripts/release-profile.test.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectReleaseDocPaths,
+  collectVersionLockstepFailures,
+  loadReleaseProfile,
+} from '../../../scripts/release-profile.ts';
+
+function writeFixtureFile(root: string, relativePath: string, content: string): void {
+  const path = join(root, relativePath);
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, content);
+}
+
+async function createProfileFixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'git-warp-release-profile-'));
+  writeFixtureFile(
+    root,
+    '.continuum/release.yml',
+    [
+      'schema: 1',
+      'version_sources:',
+      '  - path: package.json',
+      '    type: json',
+      '    field: version',
+      '  - path: package-lock.json',
+      '    type: npm-lock-root',
+      '    field: version',
+      '  - path: "packages/*/package.json"',
+      '    type: json',
+      '    field: version',
+      '    required: true',
+      '    private: true',
+      'docs:',
+      '  changelog: CHANGELOG.md',
+      '  front_door: README.md',
+      '  architecture: ARCHITECTURE.md',
+      '  learning_index: docs/topics/README.md',
+      '  learning_topics: docs/topics/',
+      '  operations: docs/operations/README.md',
+      '  contributor:',
+      '    - .github/CONTRIBUTING.md',
+      '    - AGENTS.md',
+      '    - .github/RELEASE.md',
+      '',
+    ].join('\n')
+  );
+  writeFixtureFile(root, 'docs/topics/README.md', '# Topics\n');
+  writeFixtureFile(root, 'docs/topics/alpha.md', '# Alpha\n');
+  writeFixtureFile(root, 'docs/topics/zeta.md', '# Zeta\n');
+  writeFixtureFile(root, 'package.json', '{"version":"1.2.3"}');
+  writeFixtureFile(root, 'jsr.json', '{"version":"1.2.3"}');
+  writeFixtureFile(root, 'package-lock.json', '{"packages":{"":{"version":"1.2.3"}}}');
+  writeFixtureFile(root, 'packages/kernel/package.json', '{"version":"1.2.3","private":true}');
+  return root;
+}
+
+describe('release profile', () => {
+  it('loads the checked-in release profile', () => {
+    const profile = loadReleaseProfile();
+
+    expect(profile.schema).toBe(1);
+    expect(profile.version_sources.map((source) => source.path)).toContain('package.json');
+    expect(profile.docs.learning_topics).toBe('docs/topics/');
+  });
+
+  it('derives release docs from the profile and topic shelf', async () => {
+    const root = await createProfileFixture();
+
+    expect(collectReleaseDocPaths(root)).toEqual([
+      '.continuum/release.yml',
+      'CHANGELOG.md',
+      'README.md',
+      'ARCHITECTURE.md',
+      'docs/topics/README.md',
+      'docs/topics/alpha.md',
+      'docs/topics/zeta.md',
+      'docs/operations/README.md',
+      '.github/CONTRIBUTING.md',
+      'AGENTS.md',
+      '.github/RELEASE.md',
+    ]);
+  });
+
+  it('reports drift from profile-owned version sources', async () => {
+    const root = await createProfileFixture();
+    writeFixtureFile(root, 'packages/kernel/package.json', '{"version":"1.2.4","private":false}');
+
+    expect(collectVersionLockstepFailures('1.2.3', root)).toEqual([
+      'packages/kernel/package.json version 1.2.4 != 1.2.3',
+      'packages/kernel/package.json must remain private unless publish policy changes',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- add a typed `.continuum/release.yml` reader for release profile mechanics
- make `scripts/release-guard.sh` validate version sources and release docs from the profile instead of duplicated shell arrays
- make `scripts/check-docs-topology.sh` derive current docs from the profile and topic shelf
- declare `yaml` directly and test release-profile doc/version drift behavior

Closes #689.
Part of #693.

## Validation

- `npx vitest run test/unit/scripts/release-profile.test.ts`
- `npx vitest run test/unit/scripts/release-profile.test.ts test/unit/scripts/source-size-inventory-command.test.ts test/unit/scripts/pre-push-hook.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run lint:docs-topology`
- `npm run release:guard -- --stage prep-pr`
- pre-push IRONCLAD gate: passed on push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release validation now uses a centralized release profile to determine required documentation and to verify version lockstep across configured version sources.
  * Added enforcement to ensure designated version sources remain private during release checks.
* **Bug Fixes**
  * Improved detection and reporting for missing required documentation and version mismatches.
* **Tests**
  * Added unit tests covering release profile loading, required-docs collection, and version lockstep/privateness validation.
* **Chores**
  * Updated release tooling to derive required docs dynamically and added YAML support for the profile parser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->