### PR TITLE
Fix: harden Wesley deterministic codec boundary

### DIFF
--- a/src/infrastructure/adapters/wesley/WesleyLeBinaryRuntime.ts
+++ b/src/infrastructure/adapters/wesley/WesleyLeBinaryRuntime.ts
@@ -54,8 +54,9 @@ export class Writer {
    * Writes a 32-bit float in little-endian order.
    */
   writeF32Le(value: number): void {
+    const f32Value = toFiniteF32(value);
     const bytes = new Uint8Array(4);
-    new DataView(bytes.buffer).setFloat32(0, value, true);
+    new DataView(bytes.buffer).setFloat32(0, f32Value, true);
     this.chunks.push(bytes);
   }
 
@@ -195,7 +196,10 @@ export class Reader {
    */
   readF32Le(): number {
     const bytes = this.readBytes(4);
-    return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getFloat32(0, true);
+    const value = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+      .getFloat32(0, true);
+    toFiniteF32(value);
+    return value;
   }
 
   /**
@@ -292,4 +296,15 @@ export class Reader {
     const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     return kind === 'u32' ? view.getUint32(0, true) : view.getInt32(0, true);
   }
+}
+
+/**
+ * Converts a Wesley f32 value only when it has deterministic finite semantics.
+ */
+function toFiniteF32(value: number): number {
+  const f32Value = Math.fround(value);
+  if (!Number.isFinite(value) || !Number.isFinite(f32Value)) {
+    throw new CodecError('Wesley LE-binary f32 value must be finite');
+  }
+  return f32Value;
 }

--- a/test/unit/infrastructure/adapters/WesleyLeBinaryRuntime.test.ts
+++ b/test/unit/infrastructure/adapters/WesleyLeBinaryRuntime.test.ts
@@ -43,6 +43,28 @@ describe('WesleyLeBinaryRuntime', () => {
     expect(() => writer.writeI32Le(-0x8000_0001)).toThrow('i32 out of range');
   });
 
+  it('rejects non-finite floats during encode and decode', () => {
+    for (const value of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      Number.MAX_VALUE,
+    ]) {
+      const writer = new Writer();
+      expect(() => writer.writeF32Le(value)).toThrow('f32 value must be finite');
+    }
+
+    const nonFiniteEncodings = [
+      new Uint8Array([0x00, 0x00, 0xc0, 0x7f]),
+      new Uint8Array([0x00, 0x00, 0x80, 0x7f]),
+      new Uint8Array([0x00, 0x00, 0x80, 0xff]),
+    ];
+
+    for (const bytes of nonFiniteEncodings) {
+      expect(() => new Reader(bytes).readF32Le()).toThrow('f32 value must be finite');
+    }
+  });
+
   it('rejects invalid tags and truncated input during decode', () => {
     expect(() => new Reader(new Uint8Array([0x02])).readBool())
       .toThrow('invalid boolean tag: 2');


### PR DESCRIPTION
## Summary

- harden the Wesley LE-binary runtime so generated f32 codecs reject `NaN`, infinities, and finite JavaScript numbers that overflow to non-finite f32 bytes
- keep generated codec behavior at the infrastructure boundary while handwritten adapters continue constructing validated domain nouns
- preserve the existing Dot boundary evidence for Wesley GraphQL `Int` versus `Dot.counter` range mismatch

## Acceptance evidence

- `Dot` values outside Wesley's current GraphQL `Int` scalar profile fail closed before persistence/signature use through `WesleyDotCodecAdapter.encode`
- decoded Dot wire values are admitted by constructing the runtime `Dot` noun before domain behavior receives them
- generated DTO/codecs remain under `src/infrastructure/adapters/wesley/**`
- f32 generated runtime support now rejects non-deterministic non-finite values in both encode and decode paths

## Validation

- `npx vitest run test/unit/infrastructure/adapters/WesleyLeBinaryRuntime.test.ts` failed before the runtime change for the new non-finite/overflow f32 regression
- `npx vitest run test/unit/infrastructure/adapters/WesleyDotCodecAdapter.test.ts test/unit/infrastructure/adapters/WesleyLeBinaryRuntime.test.ts`
- `npm run typecheck:src`
- `npm run typecheck:test`
- `npx eslint src/infrastructure/adapters/wesley/WesleyLeBinaryRuntime.ts test/unit/infrastructure/adapters/WesleyLeBinaryRuntime.test.ts`
- `npm run lint:source-size`
- pre-push IRONCLAD M9 gate: link check, lint, source/test/consumer typechecks, policy, surface validator, markdown gates, docs topology, source-backed reference, and `npm run test:local`

Closes #694.
Closes #685.
Closes #480.
