### PR TITLE
Expose diagnostics materialization scope helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `legacy`, `storage`, `advanced`, and `diagnostics` subpaths. The package root
   and browser root now reject those nouns through the v19 public API boundary
   audit.
+- Added visible-state scope helpers to the `diagnostics` subpath so
+  materialized-state inspection has an explicit non-legacy import path.
 - Deprecated the entire graph-first legacy API. `legacy` remains migration-only
   and is no longer presented as a valid first-use path.
 

--- a/diagnostics.ts
+++ b/diagnostics.ts
@@ -36,3 +36,12 @@ export type {
   TtdMergeObstructionWitnessFields,
   TtdMergePolicyRequirementFields,
 } from './legacy.ts';
+export {
+  normalizeVisibleStateScope,
+  nodeIdInVisibleStateScope,
+  scopeMaterializedState,
+} from './src/domain/services/VisibleStateScope.ts';
+export type {
+  VisibleStateScope,
+  VisibleStateScopePrefixFilter,
+} from './src/domain/services/VisibleStateScope.ts';

--- a/test/unit/domain/diagnostics.exports.test.ts
+++ b/test/unit/domain/diagnostics.exports.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for the diagnostics inspection exports.
+ *
+ * Verifies that materialized-state inspection helpers have an explicit
+ * diagnostics home instead of forcing operators through legacy.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import ORSet from '../../../src/domain/crdt/ORSet.ts';
+import VersionVector from '../../../src/domain/crdt/VersionVector.ts';
+import WarpState from '../../../src/domain/services/state/WarpState.ts';
+import {
+  normalizeVisibleStateScope,
+  nodeIdInVisibleStateScope,
+  scopeMaterializedState,
+} from '../../../diagnostics.ts';
+
+function emptyWarpState(): WarpState {
+  return new WarpState({
+    nodeAlive: ORSet.empty(),
+    edgeAlive: ORSet.empty(),
+    prop: new Map(),
+    observedFrontier: VersionVector.empty(),
+    edgeBirthEvent: new Map(),
+  });
+}
+
+describe('diagnostics.ts exports', () => {
+  it('exports visible-state scope helpers for materialization inspection', () => {
+    const scope = normalizeVisibleStateScope({
+      nodeIdPrefixes: {
+        exclude: ['task:archived:'],
+        include: ['task:'],
+      },
+    });
+
+    expect(scope).toEqual({
+      nodeIdPrefixes: {
+        exclude: ['task:archived:'],
+        include: ['task:'],
+      },
+    });
+    expect(nodeIdInVisibleStateScope('task:1', scope)).toBe(true);
+    expect(nodeIdInVisibleStateScope('task:archived:1', scope)).toBe(false);
+
+    const state = emptyWarpState();
+
+    expect(scopeMaterializedState(state, null)).toBe(state);
+  });
+});


### PR DESCRIPTION
## Summary

- Expose visible-state scope helpers from `@git-stunts/git-warp/diagnostics` so materialized-state inspection has a non-legacy import path.
- Add a diagnostics export regression test for `normalizeVisibleStateScope`, `nodeIdInVisibleStateScope`, and `scopeMaterializedState`.
- Record the public subpath follow-through in `CHANGELOG.md`.

Fixes #720

## Validation

- `npx vitest run test/unit/domain/diagnostics.exports.test.ts`
- `npx vitest run test/unit/scripts/v18-package-surface-audit.test.ts test/unit/scripts/materialize-api-classification.test.ts`
- `npm run lint:source-backed-reference`
- `npm run typecheck:src`
- `npm run typecheck:test`
- `npm run typecheck:surface`
- `npm run lint -- --quiet`
- `npm run lint:docs-topology`
- `npm run test:local`
- pre-push `IRONCLAD M9` gates passed