### PR TITLE
Add openWarp timeline facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added the v19 `openWarp()` product opener plus `Warp` and `Timeline`
-  facade handles to the root and browser entrypoints.
+  facade handles to the package root only; the browser root remains outside
+  the v19 facade surface.
 - Moved graph-shaped, worldline-shaped, optic-shaped, witness-shaped, and
   diagnostic compatibility exports out of the package root into explicit
   `legacy`, `storage`, `advanced`, and `diagnostics` subpaths. The package root
-  and browser root now reject those nouns through the v19 public API boundary
-  audit.
+  now rejects those nouns through the v19 public API boundary audit.
 - Added visible-state scope helpers to the `diagnostics` subpath so
   materialized-state inspection has an explicit non-legacy import path.
 - Deprecated the entire graph-first legacy API. `legacy` remains migration-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added the v19 `openWarp()` product opener plus `Warp` and `Timeline`
+  facade handles to the root and browser entrypoints.
 - Moved graph-shaped, worldline-shaped, optic-shaped, witness-shaped, and
   diagnostic compatibility exports out of the package root into explicit
   `legacy`, `storage`, `advanced`, and `diagnostics` subpaths. The package root

--- a/browser.ts
+++ b/browser.ts
@@ -22,6 +22,11 @@ import { installDefaultRuntimeHostBrowserPorts } from './src/application/Runtime
 
 installDefaultRuntimeHostBrowserPorts();
 
+export { openWarp } from './src/domain/api/openWarp.ts';
+export { default as Warp } from './src/domain/api/Warp.ts';
+export { default as Timeline } from './src/domain/api/Timeline.ts';
+export type { OpenWarpOptions, WarpStorage } from './src/domain/api/openWarp.ts';
+
 export { default as WebCryptoAdapter } from './src/infrastructure/adapters/WebCryptoAdapter.ts';
 
 // CRDT primitives

--- a/browser.ts
+++ b/browser.ts
@@ -22,11 +22,6 @@ import { installDefaultRuntimeHostBrowserPorts } from './src/application/Runtime
 
 installDefaultRuntimeHostBrowserPorts();
 
-export { openWarp } from './src/domain/api/openWarp.ts';
-export { default as Warp } from './src/domain/api/Warp.ts';
-export { default as Timeline } from './src/domain/api/Timeline.ts';
-export type { OpenWarpOptions, WarpStorage } from './src/domain/api/openWarp.ts';
-
 export { default as WebCryptoAdapter } from './src/infrastructure/adapters/WebCryptoAdapter.ts';
 
 // CRDT primitives

--- a/docs/topics/reference.md
+++ b/docs/topics/reference.md
@@ -30,86 +30,91 @@ public API export, CLI command, package entrypoint, or public error class.
 
 | Module | Kind | Source |
 | --- | --- | --- |
-| `./src/domain/memory/index.ts` | export * | `index.ts#L18` |
+| `./src/domain/memory/index.ts` | export * | `index.ts#L23` |
 
 ## Root API value exports
 
-Source: `index.ts`. Count: 60.
+Source: `index.ts`. Count: 63.
 
 ```text
-AlfredOperationPolicyAdapter @ index.ts#L31
-AuditError @ index.ts#L34
-BunHttpAdapter @ index.ts#L65
-canonicalEmissionJson @ index.ts#L81
-canonicalObservationJson @ index.ts#L87
-CasContentEncryptionPolicy @ index.ts#L25
-checkAborted @ index.ts#L67
-ChunkEffectSink @ index.ts#L97
-ConsoleEffectSink @ index.ts#L96
-ConsoleLogger @ index.ts#L59
-ContinuumArtifactAuthorityError @ index.ts#L35
-createDeliveryObservation @ index.ts#L86
-createEffectEmission @ index.ts#L80
-createExternalizationPolicy @ index.ts#L90
-createTickReceipt @ index.ts#L71
-createTimeoutSignal @ index.ts#L67
-CryptoPort @ index.ts#L61
-DELIVERY_MODES @ index.ts#L82
-DELIVERY_OUTCOMES @ index.ts#L83
-DenoHttpAdapter @ index.ts#L66
-EffectPipeline @ index.ts#L78
-EffectSinkPort @ index.ts#L76
-EncryptionError @ index.ts#L36
-ForkError @ index.ts#L37
-HealthCheckService @ index.ts#L56
-HealthStatus @ index.ts#L56
-HttpServerPort @ index.ts#L62
-IndexError @ index.ts#L38
-INSPECT_LENS @ index.ts#L93
-LIVE_LENS @ index.ts#L91
-LoggerPort @ index.ts#L57
-LogLevel @ index.ts#L59
-MemoryBudgetError @ index.ts#L39
-MultiplexSink @ index.ts#L77
-NodeCryptoAdapter @ index.ts#L63
-NoOpEffectSink @ index.ts#L95
-NoOpLogger @ index.ts#L58
-NoopOperationPolicyAdapter @ index.ts#L32
-OperationAbortedError @ index.ts#L40
-OperationPolicyExhaustedError @ index.ts#L41
-OperationPolicyPort @ index.ts#L20
-OperationPolicyTimeoutError @ index.ts#L42
-PatchError @ index.ts#L43
-QueryError @ index.ts#L44
-REPLAY_LENS @ index.ts#L92
-SchemaUnsupportedError @ index.ts#L45
-ShardCorruptionError @ index.ts#L46
-ShardLoadError @ index.ts#L47
-ShardValidationError @ index.ts#L48
-StorageError @ index.ts#L49
-StrandError @ index.ts#L50
-SyncError @ index.ts#L51
-SyncSecret @ index.ts#L68
-TICK_RECEIPT_OP_TYPES @ index.ts#L73
-TICK_RECEIPT_RESULT_TYPES @ index.ts#L74
-tickReceiptCanonicalJson @ index.ts#L72
-TraversalError @ index.ts#L52
-WebCryptoAdapter @ index.ts#L64
-WormholeError @ index.ts#L53
-WriterError @ index.ts#L60
+AlfredOperationPolicyAdapter @ index.ts#L36
+AuditError @ index.ts#L39
+BunHttpAdapter @ index.ts#L70
+canonicalEmissionJson @ index.ts#L86
+canonicalObservationJson @ index.ts#L92
+CasContentEncryptionPolicy @ index.ts#L30
+checkAborted @ index.ts#L72
+ChunkEffectSink @ index.ts#L102
+ConsoleEffectSink @ index.ts#L101
+ConsoleLogger @ index.ts#L64
+ContinuumArtifactAuthorityError @ index.ts#L40
+createDeliveryObservation @ index.ts#L91
+createEffectEmission @ index.ts#L85
+createExternalizationPolicy @ index.ts#L95
+createTickReceipt @ index.ts#L76
+createTimeoutSignal @ index.ts#L72
+CryptoPort @ index.ts#L66
+DELIVERY_MODES @ index.ts#L87
+DELIVERY_OUTCOMES @ index.ts#L88
+DenoHttpAdapter @ index.ts#L71
+EffectPipeline @ index.ts#L83
+EffectSinkPort @ index.ts#L81
+EncryptionError @ index.ts#L41
+ForkError @ index.ts#L42
+HealthCheckService @ index.ts#L61
+HealthStatus @ index.ts#L61
+HttpServerPort @ index.ts#L67
+IndexError @ index.ts#L43
+INSPECT_LENS @ index.ts#L98
+LIVE_LENS @ index.ts#L96
+LoggerPort @ index.ts#L62
+LogLevel @ index.ts#L64
+MemoryBudgetError @ index.ts#L44
+MultiplexSink @ index.ts#L82
+NodeCryptoAdapter @ index.ts#L68
+NoOpEffectSink @ index.ts#L100
+NoOpLogger @ index.ts#L63
+NoopOperationPolicyAdapter @ index.ts#L37
+openWarp @ index.ts#L18
+OperationAbortedError @ index.ts#L45
+OperationPolicyExhaustedError @ index.ts#L46
+OperationPolicyPort @ index.ts#L25
+OperationPolicyTimeoutError @ index.ts#L47
+PatchError @ index.ts#L48
+QueryError @ index.ts#L49
+REPLAY_LENS @ index.ts#L97
+SchemaUnsupportedError @ index.ts#L50
+ShardCorruptionError @ index.ts#L51
+ShardLoadError @ index.ts#L52
+ShardValidationError @ index.ts#L53
+StorageError @ index.ts#L54
+StrandError @ index.ts#L55
+SyncError @ index.ts#L56
+SyncSecret @ index.ts#L73
+TICK_RECEIPT_OP_TYPES @ index.ts#L78
+TICK_RECEIPT_RESULT_TYPES @ index.ts#L79
+tickReceiptCanonicalJson @ index.ts#L77
+Timeline @ index.ts#L20
+TraversalError @ index.ts#L57
+Warp @ index.ts#L19
+WebCryptoAdapter @ index.ts#L69
+WormholeError @ index.ts#L58
+WriterError @ index.ts#L65
 ```
 
 ## Root API type exports
 
-Source: `index.ts`. Count: 6.
+Source: `index.ts`. Count: 8.
 
 ```text
-CasContentEncryptionDiagnostics @ index.ts#L27
-CasContentEncryptionScheme @ index.ts#L28
-CasResolvedVaultKeyOptions @ index.ts#L29
-OperationPolicyExecuteOptions @ index.ts#L22
-OperationRetryDecision @ index.ts#L23
-SyncRateLimitConfig @ index.ts#L69
+CasContentEncryptionDiagnostics @ index.ts#L32
+CasContentEncryptionScheme @ index.ts#L33
+CasResolvedVaultKeyOptions @ index.ts#L34
+OpenWarpOptions @ index.ts#L21
+OperationPolicyExecuteOptions @ index.ts#L27
+OperationRetryDecision @ index.ts#L28
+SyncRateLimitConfig @ index.ts#L74
+WarpStorage @ index.ts#L21
 ```
 
 ## CLI command registry

--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,11 @@ import { installDefaultRuntimeHostNodePorts } from './src/application/RuntimeHos
 
 installDefaultRuntimeHostNodePorts();
 
+export { openWarp } from './src/domain/api/openWarp.ts';
+export { default as Warp } from './src/domain/api/Warp.ts';
+export { default as Timeline } from './src/domain/api/Timeline.ts';
+export type { OpenWarpOptions, WarpStorage } from './src/domain/api/openWarp.ts';
+
 export * from './src/domain/memory/index.ts';
 
 export { default as OperationPolicyPort } from './src/ports/OperationPolicyPort.ts';

--- a/src/domain/api/OpenWarpIdentityFailure.ts
+++ b/src/domain/api/OpenWarpIdentityFailure.ts
@@ -1,0 +1,4 @@
+export const OPEN_WARP_IDENTITY_FAILURE = Object.freeze({
+  message: 'openWarp requires non-empty identity fields',
+  code: 'E_OPEN_WARP_IDENTITY',
+});

--- a/src/domain/api/Timeline.ts
+++ b/src/domain/api/Timeline.ts
@@ -1,3 +1,4 @@
+import WarpError from '../errors/WarpError.ts';
 import { assertIdentity } from './assertIdentity.ts';
 
 type TimelineConstructionOptions = {
@@ -17,6 +18,7 @@ export default class Timeline {
   readonly #writer: string;
 
   constructor(options: TimelineConstructionOptions) {
+    assertTimelineConstructionOptions(options);
     assertIdentity(options.name, 'name', {
       message: 'Timeline requires non-empty identity fields',
       code: 'E_TIMELINE_IDENTITY',
@@ -36,5 +38,14 @@ export default class Timeline {
 
   get writer(): string {
     return this.#writer;
+  }
+}
+
+function assertTimelineConstructionOptions(options: TimelineConstructionOptions): void {
+  if (options === null || options === undefined) {
+    throw new WarpError(
+      'Timeline requires construction options',
+      'E_TIMELINE_CONSTRUCTION_OPTIONS',
+    );
   }
 }

--- a/src/domain/api/Timeline.ts
+++ b/src/domain/api/Timeline.ts
@@ -1,5 +1,5 @@
 import WarpError from '../errors/WarpError.ts';
-import { assertIdentity } from './assertIdentity.ts';
+import { assertTimelineNameIdentity, assertWriterIdentity } from './assertIdentity.ts';
 
 type TimelineConstructionOptions = {
   readonly name: string;
@@ -19,11 +19,11 @@ export default class Timeline {
 
   constructor(options: TimelineConstructionOptions) {
     assertTimelineConstructionOptions(options);
-    assertIdentity(options.name, 'name', {
+    assertTimelineNameIdentity(options.name, 'name', {
       message: 'Timeline requires non-empty identity fields',
       code: 'E_TIMELINE_IDENTITY',
     });
-    assertIdentity(options.writer, 'writer', {
+    assertWriterIdentity(options.writer, 'writer', {
       message: 'Timeline requires non-empty identity fields',
       code: 'E_TIMELINE_IDENTITY',
     });

--- a/src/domain/api/Timeline.ts
+++ b/src/domain/api/Timeline.ts
@@ -1,4 +1,4 @@
-import WarpError from '../errors/WarpError.ts';
+import { assertIdentity } from './assertIdentity.ts';
 
 type TimelineConstructionOptions = {
   readonly name: string;
@@ -17,8 +17,14 @@ export default class Timeline {
   readonly #writer: string;
 
   constructor(options: TimelineConstructionOptions) {
-    assertTimelineIdentity(options.name, 'name');
-    assertTimelineIdentity(options.writer, 'writer');
+    assertIdentity(options.name, 'name', {
+      message: 'Timeline requires non-empty identity fields',
+      code: 'E_TIMELINE_IDENTITY',
+    });
+    assertIdentity(options.writer, 'writer', {
+      message: 'Timeline requires non-empty identity fields',
+      code: 'E_TIMELINE_IDENTITY',
+    });
     this.#name = options.name;
     this.#writer = options.writer;
     Object.freeze(this);
@@ -30,15 +36,5 @@ export default class Timeline {
 
   get writer(): string {
     return this.#writer;
-  }
-}
-
-function assertTimelineIdentity(value: string | null | undefined, field: string): void {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new WarpError(
-      'Timeline requires non-empty identity fields',
-      'E_TIMELINE_IDENTITY',
-      { context: { field } },
-    );
   }
 }

--- a/src/domain/api/Timeline.ts
+++ b/src/domain/api/Timeline.ts
@@ -1,0 +1,44 @@
+import WarpError from '../errors/WarpError.ts';
+
+type TimelineConstructionOptions = {
+  readonly name: string;
+  readonly writer: string;
+};
+
+/**
+ * Public timeline handle for application workflows.
+ *
+ * A timeline is the first-use application noun. Internally it is backed by the
+ * existing WARP history runtime, but that substrate handle is not part of the
+ * root API contract.
+ */
+export default class Timeline {
+  readonly #name: string;
+  readonly #writer: string;
+
+  constructor(options: TimelineConstructionOptions) {
+    assertTimelineIdentity(options.name, 'name');
+    assertTimelineIdentity(options.writer, 'writer');
+    this.#name = options.name;
+    this.#writer = options.writer;
+    Object.freeze(this);
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  get writer(): string {
+    return this.#writer;
+  }
+}
+
+function assertTimelineIdentity(value: string | null | undefined, field: string): void {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new WarpError(
+      'Timeline requires non-empty identity fields',
+      'E_TIMELINE_IDENTITY',
+      { context: { field } },
+    );
+  }
+}

--- a/src/domain/api/TimelineRuntime.ts
+++ b/src/domain/api/TimelineRuntime.ts
@@ -1,0 +1,22 @@
+import WarpError from '../errors/WarpError.ts';
+import type WarpWorldline from '../WarpWorldline.ts';
+import Timeline from './Timeline.ts';
+
+const timelineRuntimes = new WeakMap<Timeline, WarpWorldline>();
+
+export function createTimeline(runtime: WarpWorldline): Timeline {
+  const timeline = new Timeline({
+    name: runtime.worldlineName,
+    writer: runtime.writerId,
+  });
+  timelineRuntimes.set(timeline, runtime);
+  return timeline;
+}
+
+export function requireTimelineRuntime(timeline: Timeline): WarpWorldline {
+  const runtime = timelineRuntimes.get(timeline);
+  if (runtime === undefined) {
+    throw new WarpError('Timeline was not opened by openWarp', 'E_TIMELINE_RUNTIME_UNAVAILABLE');
+  }
+  return runtime;
+}

--- a/src/domain/api/Warp.ts
+++ b/src/domain/api/Warp.ts
@@ -1,5 +1,5 @@
-import WarpError from '../errors/WarpError.ts';
 import type Timeline from './Timeline.ts';
+import { assertIdentity } from './assertIdentity.ts';
 
 type OpenTimeline = (name: string) => Promise<Timeline>;
 
@@ -19,7 +19,10 @@ export default class Warp {
   readonly #writer: string;
 
   constructor(options: WarpConstructionOptions) {
-    assertNonEmpty(options.writer, 'writer');
+    assertIdentity(options.writer, 'writer', {
+      message: 'openWarp requires non-empty identity fields',
+      code: 'E_OPEN_WARP_IDENTITY',
+    });
     this.#writer = options.writer;
     this.#openTimeline = options.openTimeline;
     Object.freeze(this);
@@ -30,17 +33,10 @@ export default class Warp {
   }
 
   async timeline(name: string): Promise<Timeline> {
-    assertNonEmpty(name, 'timeline');
+    assertIdentity(name, 'timeline', {
+      message: 'openWarp requires non-empty identity fields',
+      code: 'E_OPEN_WARP_IDENTITY',
+    });
     return await this.#openTimeline(name);
-  }
-}
-
-export function assertNonEmpty(value: string | null | undefined, field: string): void {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new WarpError(
-      'openWarp requires non-empty identity fields',
-      'E_OPEN_WARP_IDENTITY',
-      { context: { field } },
-    );
   }
 }

--- a/src/domain/api/Warp.ts
+++ b/src/domain/api/Warp.ts
@@ -1,3 +1,4 @@
+import WarpError from '../errors/WarpError.ts';
 import type Timeline from './Timeline.ts';
 import { assertIdentity } from './assertIdentity.ts';
 
@@ -19,6 +20,7 @@ export default class Warp {
   readonly #writer: string;
 
   constructor(options: WarpConstructionOptions) {
+    assertWarpConstructionOptions(options);
     assertIdentity(options.writer, 'writer', {
       message: 'openWarp requires non-empty identity fields',
       code: 'E_OPEN_WARP_IDENTITY',
@@ -38,5 +40,14 @@ export default class Warp {
       code: 'E_OPEN_WARP_IDENTITY',
     });
     return await this.#openTimeline(name);
+  }
+}
+
+function assertWarpConstructionOptions(options: WarpConstructionOptions): void {
+  if (options === null || options === undefined) {
+    throw new WarpError('Warp requires construction options', 'E_WARP_CONSTRUCTION_OPTIONS');
+  }
+  if (typeof options.openTimeline !== 'function') {
+    throw new WarpError('Warp requires an openTimeline function', 'E_WARP_TIMELINE_OPENER');
   }
 }

--- a/src/domain/api/Warp.ts
+++ b/src/domain/api/Warp.ts
@@ -1,0 +1,46 @@
+import WarpError from '../errors/WarpError.ts';
+import type Timeline from './Timeline.ts';
+
+type OpenTimeline = (name: string) => Promise<Timeline>;
+
+type WarpConstructionOptions = {
+  readonly writer: string;
+  readonly openTimeline: OpenTimeline;
+};
+
+/**
+ * Product-level git-warp handle.
+ *
+ * `Warp` owns writer identity and opens named timelines without exposing the
+ * internal history/runtime vocabulary at the package root.
+ */
+export default class Warp {
+  readonly #openTimeline: OpenTimeline;
+  readonly #writer: string;
+
+  constructor(options: WarpConstructionOptions) {
+    assertNonEmpty(options.writer, 'writer');
+    this.#writer = options.writer;
+    this.#openTimeline = options.openTimeline;
+    Object.freeze(this);
+  }
+
+  get writer(): string {
+    return this.#writer;
+  }
+
+  async timeline(name: string): Promise<Timeline> {
+    assertNonEmpty(name, 'timeline');
+    return await this.#openTimeline(name);
+  }
+}
+
+export function assertNonEmpty(value: string | null | undefined, field: string): void {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new WarpError(
+      'openWarp requires non-empty identity fields',
+      'E_OPEN_WARP_IDENTITY',
+      { context: { field } },
+    );
+  }
+}

--- a/src/domain/api/Warp.ts
+++ b/src/domain/api/Warp.ts
@@ -1,6 +1,6 @@
 import WarpError from '../errors/WarpError.ts';
 import type Timeline from './Timeline.ts';
-import { assertIdentity } from './assertIdentity.ts';
+import { assertTimelineNameIdentity, assertWriterIdentity } from './assertIdentity.ts';
 import { OPEN_WARP_IDENTITY_FAILURE } from './OpenWarpIdentityFailure.ts';
 
 type OpenTimeline = (name: string) => Promise<Timeline>;
@@ -22,7 +22,7 @@ export default class Warp {
 
   constructor(options: WarpConstructionOptions) {
     assertWarpConstructionOptions(options);
-    assertIdentity(options.writer, 'writer', OPEN_WARP_IDENTITY_FAILURE);
+    assertWriterIdentity(options.writer, 'writer', OPEN_WARP_IDENTITY_FAILURE);
     this.#writer = options.writer;
     this.#openTimeline = options.openTimeline;
     Object.freeze(this);
@@ -33,7 +33,7 @@ export default class Warp {
   }
 
   async timeline(name: string): Promise<Timeline> {
-    assertIdentity(name, 'timeline', OPEN_WARP_IDENTITY_FAILURE);
+    assertTimelineNameIdentity(name, 'timeline', OPEN_WARP_IDENTITY_FAILURE);
     return await this.#openTimeline(name);
   }
 }

--- a/src/domain/api/Warp.ts
+++ b/src/domain/api/Warp.ts
@@ -1,6 +1,7 @@
 import WarpError from '../errors/WarpError.ts';
 import type Timeline from './Timeline.ts';
 import { assertIdentity } from './assertIdentity.ts';
+import { OPEN_WARP_IDENTITY_FAILURE } from './OpenWarpIdentityFailure.ts';
 
 type OpenTimeline = (name: string) => Promise<Timeline>;
 
@@ -21,10 +22,7 @@ export default class Warp {
 
   constructor(options: WarpConstructionOptions) {
     assertWarpConstructionOptions(options);
-    assertIdentity(options.writer, 'writer', {
-      message: 'openWarp requires non-empty identity fields',
-      code: 'E_OPEN_WARP_IDENTITY',
-    });
+    assertIdentity(options.writer, 'writer', OPEN_WARP_IDENTITY_FAILURE);
     this.#writer = options.writer;
     this.#openTimeline = options.openTimeline;
     Object.freeze(this);
@@ -35,10 +33,7 @@ export default class Warp {
   }
 
   async timeline(name: string): Promise<Timeline> {
-    assertIdentity(name, 'timeline', {
-      message: 'openWarp requires non-empty identity fields',
-      code: 'E_OPEN_WARP_IDENTITY',
-    });
+    assertIdentity(name, 'timeline', OPEN_WARP_IDENTITY_FAILURE);
     return await this.#openTimeline(name);
   }
 }

--- a/src/domain/api/assertIdentity.ts
+++ b/src/domain/api/assertIdentity.ts
@@ -1,4 +1,5 @@
 import WarpError from '../errors/WarpError.ts';
+import { validateGraphName, validateWriterId } from '../utils/RefLayout.ts';
 
 type IdentityAssertionFailure = {
   readonly message: string;
@@ -9,8 +10,26 @@ export function assertIdentity(
   value: string | null | undefined,
   field: string,
   failure: IdentityAssertionFailure,
-): void {
+): asserts value is string {
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new WarpError(failure.message, failure.code, { context: { field } });
   }
+}
+
+export function assertTimelineNameIdentity(
+  value: string | null | undefined,
+  field: string,
+  failure: IdentityAssertionFailure,
+): void {
+  assertIdentity(value, field, failure);
+  validateGraphName(value);
+}
+
+export function assertWriterIdentity(
+  value: string | null | undefined,
+  field: string,
+  failure: IdentityAssertionFailure,
+): void {
+  assertIdentity(value, field, failure);
+  validateWriterId(value);
 }

--- a/src/domain/api/assertIdentity.ts
+++ b/src/domain/api/assertIdentity.ts
@@ -1,0 +1,16 @@
+import WarpError from '../errors/WarpError.ts';
+
+type IdentityAssertionFailure = {
+  readonly message: string;
+  readonly code: string;
+};
+
+export function assertIdentity(
+  value: string | null | undefined,
+  field: string,
+  failure: IdentityAssertionFailure,
+): void {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new WarpError(failure.message, failure.code, { context: { field } });
+  }
+}

--- a/src/domain/api/openWarp.ts
+++ b/src/domain/api/openWarp.ts
@@ -5,6 +5,7 @@ import Warp from './Warp.ts';
 import { assertIdentity } from './assertIdentity.ts';
 import { createTimeline } from './TimelineRuntime.ts';
 import WarpError from '../errors/WarpError.ts';
+import { OPEN_WARP_IDENTITY_FAILURE } from './OpenWarpIdentityFailure.ts';
 
 export type WarpStorage = CorePersistence & Partial<RuntimeStorageCapabilityPort>;
 
@@ -38,8 +39,5 @@ function assertOpenWarpOptions(options: OpenWarpOptions | null | undefined): voi
   if (options.storage === null || options.storage === undefined) {
     throw new WarpError('openWarp requires storage', 'E_OPEN_WARP_STORAGE');
   }
-  assertIdentity(options.writer, 'writer', {
-    message: 'openWarp requires non-empty identity fields',
-    code: 'E_OPEN_WARP_IDENTITY',
-  });
+  assertIdentity(options.writer, 'writer', OPEN_WARP_IDENTITY_FAILURE);
 }

--- a/src/domain/api/openWarp.ts
+++ b/src/domain/api/openWarp.ts
@@ -1,7 +1,8 @@
 import type RuntimeStorageCapabilityPort from '../../ports/RuntimeStorageCapabilityPort.ts';
 import type { CorePersistence } from '../types/WarpPersistence.ts';
 import { openWarpWorldline } from '../WarpWorldline.ts';
-import Warp, { assertNonEmpty } from './Warp.ts';
+import Warp from './Warp.ts';
+import { assertIdentity } from './assertIdentity.ts';
 import { createTimeline } from './TimelineRuntime.ts';
 import WarpError from '../errors/WarpError.ts';
 
@@ -35,5 +36,8 @@ function assertOpenWarpOptions(options: OpenWarpOptions | null | undefined): voi
   if (options.storage === null || options.storage === undefined) {
     throw new WarpError('openWarp requires storage', 'E_OPEN_WARP_STORAGE');
   }
-  assertNonEmpty(options.writer, 'writer');
+  assertIdentity(options.writer, 'writer', {
+    message: 'openWarp requires non-empty identity fields',
+    code: 'E_OPEN_WARP_IDENTITY',
+  });
 }

--- a/src/domain/api/openWarp.ts
+++ b/src/domain/api/openWarp.ts
@@ -2,7 +2,7 @@ import type RuntimeStorageCapabilityPort from '../../ports/RuntimeStorageCapabil
 import type { CorePersistence } from '../types/WarpPersistence.ts';
 import { openWarpWorldline } from '../WarpWorldline.ts';
 import Warp from './Warp.ts';
-import { assertIdentity } from './assertIdentity.ts';
+import { assertWriterIdentity } from './assertIdentity.ts';
 import { createTimeline } from './TimelineRuntime.ts';
 import WarpError from '../errors/WarpError.ts';
 import { OPEN_WARP_IDENTITY_FAILURE } from './OpenWarpIdentityFailure.ts';
@@ -39,5 +39,5 @@ function assertOpenWarpOptions(options: OpenWarpOptions | null | undefined): voi
   if (options.storage === null || options.storage === undefined) {
     throw new WarpError('openWarp requires storage', 'E_OPEN_WARP_STORAGE');
   }
-  assertIdentity(options.writer, 'writer', OPEN_WARP_IDENTITY_FAILURE);
+  assertWriterIdentity(options.writer, 'writer', OPEN_WARP_IDENTITY_FAILURE);
 }

--- a/src/domain/api/openWarp.ts
+++ b/src/domain/api/openWarp.ts
@@ -1,0 +1,39 @@
+import type RuntimeStorageCapabilityPort from '../../ports/RuntimeStorageCapabilityPort.ts';
+import type { CorePersistence } from '../types/WarpPersistence.ts';
+import { openWarpWorldline } from '../WarpWorldline.ts';
+import Warp, { assertNonEmpty } from './Warp.ts';
+import { createTimeline } from './TimelineRuntime.ts';
+import WarpError from '../errors/WarpError.ts';
+
+export type WarpStorage = CorePersistence & Partial<RuntimeStorageCapabilityPort>;
+
+export type OpenWarpOptions = {
+  readonly storage: WarpStorage;
+  readonly writer: string;
+};
+
+export function openWarp(options: OpenWarpOptions): Promise<Warp> {
+  assertOpenWarpOptions(options);
+  const { storage, writer } = options;
+
+  return Promise.resolve(new Warp({
+    writer,
+    openTimeline: async (name) => createTimeline(
+      await openWarpWorldline({
+        persistence: storage,
+        worldlineName: name,
+        writerId: writer,
+      }),
+    ),
+  }));
+}
+
+function assertOpenWarpOptions(options: OpenWarpOptions | null | undefined): void {
+  if (options === null || options === undefined) {
+    throw new WarpError('openWarp options are required', 'E_OPEN_WARP_OPTIONS');
+  }
+  if (options.storage === null || options.storage === undefined) {
+    throw new WarpError('openWarp requires storage', 'E_OPEN_WARP_STORAGE');
+  }
+  assertNonEmpty(options.writer, 'writer');
+}

--- a/src/domain/api/openWarp.ts
+++ b/src/domain/api/openWarp.ts
@@ -12,11 +12,11 @@ export type OpenWarpOptions = {
   readonly writer: string;
 };
 
-export function openWarp(options: OpenWarpOptions): Promise<Warp> {
+export async function openWarp(options: OpenWarpOptions): Promise<Warp> {
   assertOpenWarpOptions(options);
   const { storage, writer } = options;
 
-  return Promise.resolve(new Warp({
+  return new Warp({
     writer,
     openTimeline: async (name) => createTimeline(
       await openWarpWorldline({
@@ -25,7 +25,7 @@ export function openWarp(options: OpenWarpOptions): Promise<Warp> {
         writerId: writer,
       }),
     ),
-  }));
+  });
 }
 
 function assertOpenWarpOptions(options: OpenWarpOptions | null | undefined): void {

--- a/src/domain/api/openWarp.ts
+++ b/src/domain/api/openWarp.ts
@@ -13,19 +13,21 @@ export type OpenWarpOptions = {
   readonly writer: string;
 };
 
-export async function openWarp(options: OpenWarpOptions): Promise<Warp> {
-  assertOpenWarpOptions(options);
-  const { storage, writer } = options;
+export function openWarp(options: OpenWarpOptions): Promise<Warp> {
+  return Promise.resolve().then(() => {
+    assertOpenWarpOptions(options);
+    const { storage, writer } = options;
 
-  return new Warp({
-    writer,
-    openTimeline: async (name) => createTimeline(
-      await openWarpWorldline({
-        persistence: storage,
-        worldlineName: name,
-        writerId: writer,
-      }),
-    ),
+    return new Warp({
+      writer,
+      openTimeline: async (name) => createTimeline(
+        await openWarpWorldline({
+          persistence: storage,
+          worldlineName: name,
+          writerId: writer,
+        }),
+      ),
+    });
   });
 }
 

--- a/test/type-check/tsconfig.json
+++ b/test/type-check/tsconfig.json
@@ -8,5 +8,5 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false
   },
-  "include": ["consumer.ts", "runtime-declarations.d.ts"]
+  "include": ["consumer.ts", "runtime-declarations.d.ts", "v19-consumer.ts"]
 }

--- a/test/type-check/v19-consumer.ts
+++ b/test/type-check/v19-consumer.ts
@@ -1,0 +1,39 @@
+/**
+ * v19 consumer smoke test -- compile-only.
+ *
+ * Exercises the root application API plus explicit storage subpath.
+ */
+
+import {
+  openWarp,
+  Timeline,
+  Warp,
+  type OpenWarpOptions,
+  type WarpStorage,
+} from '../../index.ts';
+import { MemoryStorageAdapter } from '../../storage.ts';
+
+const storage = new MemoryStorageAdapter();
+const publicStorage: WarpStorage = storage;
+
+const options: OpenWarpOptions = {
+  storage: publicStorage,
+  writer: 'agent-1',
+};
+
+const warp: Warp = await openWarp(options);
+const timeline: Timeline = await warp.timeline('events');
+const timelineName: string = timeline.name;
+const timelineWriter: string = timeline.writer;
+
+// @ts-expect-error timelines do not expose legacy worldline names.
+timeline.worldlineName;
+
+// @ts-expect-error timelines do not expose legacy writer ids.
+timeline.writerId;
+
+// @ts-expect-error timelines do not expose patch commits.
+timeline.commit;
+
+void timelineName;
+void timelineWriter;

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -6,6 +6,7 @@ import {
   Timeline,
   Warp,
 } from '../../../index.ts';
+import { OPEN_WARP_IDENTITY_FAILURE } from '../../../src/domain/api/OpenWarpIdentityFailure.ts';
 import { MemoryStorageAdapter } from '../../../storage.ts';
 
 function readRepoSource(path: string): string {
@@ -77,6 +78,13 @@ describe('v19 Warp facade', () => {
     });
 
     await expect(warp.timeline('')).rejects.toThrow('openWarp requires non-empty identity fields');
+  });
+
+  it('names the openWarp identity failure payload once', () => {
+    expect(OPEN_WARP_IDENTITY_FAILURE).toEqual({
+      message: 'openWarp requires non-empty identity fields',
+      code: 'E_OPEN_WARP_IDENTITY',
+    });
   });
 
   it('keeps identity validation in the dedicated validator module', () => {

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -52,16 +52,16 @@ describe('v19 Warp facade', () => {
   });
 
   it('rejects missing storage and blank identities', async () => {
-    expect(() => openWarp({
+    await expect(openWarp({
       // @ts-expect-error runtime validation accepts JavaScript callers.
       storage: null,
       writer: 'agent-1',
-    })).toThrow('openWarp requires storage');
+    })).rejects.toThrow('openWarp requires storage');
 
-    expect(() => openWarp({
+    await expect(openWarp({
       storage: new MemoryStorageAdapter(),
       writer: '   ',
-    })).toThrow('openWarp requires non-empty identity fields');
+    })).rejects.toThrow('openWarp requires non-empty identity fields');
 
     const warp = await openWarp({
       storage: new MemoryStorageAdapter(),

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -11,14 +11,7 @@ import { OPEN_WARP_IDENTITY_FAILURE } from '../../../src/domain/api/OpenWarpIden
 import { MemoryStorageAdapter } from '../../../storage.ts';
 
 function exportedNamesFor(path: string): ReadonlySet<string> {
-  const sourceText = readFileSync(new URL(`../../../${path}`, import.meta.url), 'utf8');
-  const sourceFile = ts.createSourceFile(
-    path,
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
+  const sourceFile = sourceFileFor(path);
   const exportedNames = new Set<string>();
 
   for (const statement of sourceFile.statements) {
@@ -27,6 +20,28 @@ function exportedNamesFor(path: string): ReadonlySet<string> {
   }
 
   return exportedNames;
+}
+
+function allDeclaredNamesFor(path: string): ReadonlySet<string> {
+  const sourceFile = sourceFileFor(path);
+  const declaredNames = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    collectDeclaredStatementName(statement, declaredNames);
+  }
+
+  return declaredNames;
+}
+
+function sourceFileFor(path: string): ts.SourceFile {
+  const sourceText = readFileSync(new URL(`../../../${path}`, import.meta.url), 'utf8');
+  return ts.createSourceFile(
+    path,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
 }
 
 function collectExportDeclarationNames(statement: ts.Statement, exportedNames: Set<string>): void {
@@ -39,6 +54,27 @@ function collectExportDeclarationNames(statement: ts.Statement, exportedNames: S
   }
   for (const element of exportClause.elements) {
     exportedNames.add(element.name.text);
+  }
+}
+
+function collectDeclaredStatementName(statement: ts.Statement, declaredNames: Set<string>): void {
+  if (ts.isVariableStatement(statement)) {
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name)) {
+        declaredNames.add(declaration.name.text);
+      }
+    }
+    return;
+  }
+
+  if (
+    (ts.isClassDeclaration(statement)
+      || ts.isFunctionDeclaration(statement)
+      || ts.isInterfaceDeclaration(statement)
+      || ts.isTypeAliasDeclaration(statement))
+    && statement.name !== undefined
+  ) {
+    declaredNames.add(statement.name.text);
   }
 }
 
@@ -147,12 +183,12 @@ describe('v19 Warp facade', () => {
   });
 
   it('keeps identity validation in the dedicated validator module', () => {
-    const warpExports = exportedNamesFor('src/domain/api/Warp.ts');
-    const timelineExports = exportedNamesFor('src/domain/api/Timeline.ts');
+    const warpNames = allDeclaredNamesFor('src/domain/api/Warp.ts');
+    const timelineNames = allDeclaredNamesFor('src/domain/api/Timeline.ts');
     const validatorExports = exportedNamesFor('src/domain/api/assertIdentity.ts');
 
-    expect(warpExports.has('assertNonEmpty')).toBe(false);
-    expect(timelineExports.has('assertTimelineIdentity')).toBe(false);
+    expect(warpNames.has('assertNonEmpty')).toBe(false);
+    expect(timelineNames.has('assertTimelineIdentity')).toBe(false);
     expect(validatorExports.has('assertIdentity')).toBe(true);
   });
 

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -85,4 +85,21 @@ describe('v19 Warp facade', () => {
     expect(timelineSource).not.toContain('function assertTimelineIdentity');
     expect(validatorSource).toContain('export function assertIdentity');
   });
+
+  it('rejects invalid public facade constructor options with domain errors', () => {
+    expect(() => {
+      // @ts-expect-error runtime validation accepts JavaScript callers.
+      new Warp(null);
+    }).toThrow('Warp requires construction options');
+
+    expect(() => {
+      // @ts-expect-error runtime validation accepts JavaScript callers.
+      new Warp({ writer: 'agent-1' });
+    }).toThrow('Warp requires an openTimeline function');
+
+    expect(() => {
+      // @ts-expect-error runtime validation accepts JavaScript callers.
+      new Timeline(null);
+    }).toThrow('Timeline requires construction options');
+  });
 });

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -8,6 +8,7 @@ import {
   Warp,
 } from '../../../index.ts';
 import { OPEN_WARP_IDENTITY_FAILURE } from '../../../src/domain/api/OpenWarpIdentityFailure.ts';
+import { MAX_WRITER_ID_LENGTH } from '../../../src/domain/utils/RefLayout.ts';
 import { MemoryStorageAdapter } from '../../../storage.ts';
 
 function exportedNamesFor(path: string): ReadonlySet<string> {
@@ -173,6 +174,44 @@ describe('v19 Warp facade', () => {
     });
 
     await expect(warp.timeline('')).rejects.toThrow('openWarp requires non-empty identity fields');
+  });
+
+  it('rejects invalid non-empty facade identities before opening timelines', async () => {
+    await expect(openWarp({
+      storage: new MemoryStorageAdapter(),
+      writer: 'agent 1',
+    })).rejects.toMatchObject({ code: 'E_INVALID_WRITER_ID' });
+
+    const openedNames: string[] = [];
+    const openTimeline = async (name: string): Promise<Timeline> => {
+      openedNames.push(name);
+      return new Timeline({ name, writer: 'agent-1' });
+    };
+
+    expect(() => new Warp({
+      writer: 'agent/1',
+      openTimeline,
+    })).toThrow('Invalid writer ID: contains forward slash');
+
+    const warp = new Warp({
+      writer: 'agent-1',
+      openTimeline,
+    });
+
+    await expect(warp.timeline('../events')).rejects.toMatchObject({
+      code: 'E_INVALID_GRAPH_NAME',
+    });
+    expect(openedNames).toEqual([]);
+
+    expect(() => new Timeline({
+      name: 'bad name',
+      writer: 'agent-1',
+    })).toThrow('Invalid graph name: contains space');
+
+    expect(() => new Timeline({
+      name: 'events',
+      writer: 'x'.repeat(MAX_WRITER_ID_LENGTH + 1),
+    })).toThrow('Invalid writer ID: exceeds maximum length');
   });
 
   it('names the openWarp identity failure payload once', () => {

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  openWarp,
+  Timeline,
+  Warp,
+} from '../../../index.ts';
+import { MemoryStorageAdapter } from '../../../storage.ts';
+
+describe('v19 Warp facade', () => {
+  it('opens named timelines through root application nouns', async () => {
+    const warp = await openWarp({
+      storage: new MemoryStorageAdapter(),
+      writer: 'agent-1',
+    });
+
+    const timeline = await warp.timeline('events');
+
+    expect(warp).toBeInstanceOf(Warp);
+    expect(Object.isFrozen(warp)).toBe(true);
+    expect(warp.writer).toBe('agent-1');
+    expect(timeline).toBeInstanceOf(Timeline);
+    expect(Object.isFrozen(timeline)).toBe(true);
+    expect(timeline.name).toBe('events');
+    expect(timeline.writer).toBe('agent-1');
+  });
+
+  it('exports the same facade from the browser root', async () => {
+    const {
+      openWarp: openBrowserWarp,
+      Timeline: BrowserTimeline,
+      Warp: BrowserWarp,
+    } = await import('../../../browser.ts');
+
+    expect(openBrowserWarp).toBe(openWarp);
+    expect(BrowserWarp).toBe(Warp);
+    expect(BrowserTimeline).toBe(Timeline);
+  });
+
+  it('keeps internal history vocabulary off the public facade objects', async () => {
+    const warp = await openWarp({
+      storage: new MemoryStorageAdapter(),
+      writer: 'agent-1',
+    });
+    const timeline = await warp.timeline('events');
+
+    expect('worldlineName' in timeline).toBe(false);
+    expect('writerId' in timeline).toBe(false);
+    expect('commit' in timeline).toBe(false);
+    expect('live' in timeline).toBe(false);
+    expect('optic' in timeline).toBe(false);
+  });
+
+  it('rejects missing storage and blank identities', async () => {
+    expect(() => openWarp({
+      // @ts-expect-error runtime validation accepts JavaScript callers.
+      storage: null,
+      writer: 'agent-1',
+    })).toThrow('openWarp requires storage');
+
+    expect(() => openWarp({
+      storage: new MemoryStorageAdapter(),
+      writer: '   ',
+    })).toThrow('openWarp requires non-empty identity fields');
+
+    const warp = await openWarp({
+      storage: new MemoryStorageAdapter(),
+      writer: 'agent-1',
+    });
+
+    await expect(warp.timeline('')).rejects.toThrow('openWarp requires non-empty identity fields');
+  });
+});

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -30,16 +30,13 @@ describe('v19 Warp facade', () => {
     expect(timeline.writer).toBe('agent-1');
   });
 
-  it('exports the same facade from the browser root', async () => {
-    const {
-      openWarp: openBrowserWarp,
-      Timeline: BrowserTimeline,
-      Warp: BrowserWarp,
-    } = await import('../../../browser.ts');
+  it('keeps the v19 facade off the browser root', () => {
+    const browserSource = readRepoSource('browser.ts');
 
-    expect(openBrowserWarp).toBe(openWarp);
-    expect(BrowserWarp).toBe(Warp);
-    expect(BrowserTimeline).toBe(Timeline);
+    expect(browserSource).not.toContain("export { openWarp }");
+    expect(browserSource).not.toContain("export { default as Warp }");
+    expect(browserSource).not.toContain("export { default as Timeline }");
+    expect(browserSource).not.toContain("export type { OpenWarpOptions, WarpStorage }");
   });
 
   it('keeps internal history vocabulary off the public facade objects', async () => {

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -9,8 +10,65 @@ import {
 import { OPEN_WARP_IDENTITY_FAILURE } from '../../../src/domain/api/OpenWarpIdentityFailure.ts';
 import { MemoryStorageAdapter } from '../../../storage.ts';
 
-function readRepoSource(path: string): string {
-  return readFileSync(new URL(`../../../${path}`, import.meta.url), 'utf8');
+function exportedNamesFor(path: string): ReadonlySet<string> {
+  const sourceText = readFileSync(new URL(`../../../${path}`, import.meta.url), 'utf8');
+  const sourceFile = ts.createSourceFile(
+    path,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const exportedNames = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    collectExportDeclarationNames(statement, exportedNames);
+    collectExportedDeclarationName(statement, exportedNames);
+  }
+
+  return exportedNames;
+}
+
+function collectExportDeclarationNames(statement: ts.Statement, exportedNames: Set<string>): void {
+  if (!ts.isExportDeclaration(statement)) {
+    return;
+  }
+  const exportClause = statement.exportClause;
+  if (exportClause === undefined || !ts.isNamedExports(exportClause)) {
+    return;
+  }
+  for (const element of exportClause.elements) {
+    exportedNames.add(element.name.text);
+  }
+}
+
+function collectExportedDeclarationName(statement: ts.Statement, exportedNames: Set<string>): void {
+  if (!ts.canHaveModifiers(statement)) {
+    return;
+  }
+  const modifiers = ts.getModifiers(statement);
+  if (modifiers === undefined || !modifiers.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)) {
+    return;
+  }
+
+  if (ts.isVariableStatement(statement)) {
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name)) {
+        exportedNames.add(declaration.name.text);
+      }
+    }
+    return;
+  }
+
+  if (
+    (ts.isClassDeclaration(statement)
+      || ts.isFunctionDeclaration(statement)
+      || ts.isInterfaceDeclaration(statement)
+      || ts.isTypeAliasDeclaration(statement))
+    && statement.name !== undefined
+  ) {
+    exportedNames.add(statement.name.text);
+  }
 }
 
 describe('v19 Warp facade', () => {
@@ -32,12 +90,13 @@ describe('v19 Warp facade', () => {
   });
 
   it('keeps the v19 facade off the browser root', () => {
-    const browserSource = readRepoSource('browser.ts');
+    const browserExports = exportedNamesFor('browser.ts');
 
-    expect(browserSource).not.toContain("export { openWarp }");
-    expect(browserSource).not.toContain("export { default as Warp }");
-    expect(browserSource).not.toContain("export { default as Timeline }");
-    expect(browserSource).not.toContain("export type { OpenWarpOptions, WarpStorage }");
+    expect(browserExports.has('openWarp')).toBe(false);
+    expect(browserExports.has('Warp')).toBe(false);
+    expect(browserExports.has('Timeline')).toBe(false);
+    expect(browserExports.has('OpenWarpOptions')).toBe(false);
+    expect(browserExports.has('WarpStorage')).toBe(false);
   });
 
   it('keeps internal history vocabulary off the public facade objects', async () => {
@@ -88,13 +147,13 @@ describe('v19 Warp facade', () => {
   });
 
   it('keeps identity validation in the dedicated validator module', () => {
-    const warpSource = readRepoSource('src/domain/api/Warp.ts');
-    const timelineSource = readRepoSource('src/domain/api/Timeline.ts');
-    const validatorSource = readRepoSource('src/domain/api/assertIdentity.ts');
+    const warpExports = exportedNamesFor('src/domain/api/Warp.ts');
+    const timelineExports = exportedNamesFor('src/domain/api/Timeline.ts');
+    const validatorExports = exportedNamesFor('src/domain/api/assertIdentity.ts');
 
-    expect(warpSource).not.toContain('export function assertNonEmpty');
-    expect(timelineSource).not.toContain('function assertTimelineIdentity');
-    expect(validatorSource).toContain('export function assertIdentity');
+    expect(warpExports.has('assertNonEmpty')).toBe(false);
+    expect(timelineExports.has('assertTimelineIdentity')).toBe(false);
+    expect(validatorExports.has('assertIdentity')).toBe(true);
   });
 
   it('rejects invalid public facade constructor options with domain errors', () => {

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -56,6 +56,12 @@ describe('v19 Warp facade', () => {
     expect('optic' in timeline).toBe(false);
   });
 
+  it('keeps worldline openers off the root export surface', async () => {
+    const rootModule = await import('../../../index.ts');
+
+    expect('openWarpWorldline' in rootModule).toBe(false);
+  });
+
   it('rejects missing storage and blank identities', async () => {
     await expect(openWarp({
       // @ts-expect-error runtime validation accepts JavaScript callers.

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -6,6 +7,10 @@ import {
   Warp,
 } from '../../../index.ts';
 import { MemoryStorageAdapter } from '../../../storage.ts';
+
+function readRepoSource(path: string): string {
+  return readFileSync(new URL(`../../../${path}`, import.meta.url), 'utf8');
+}
 
 describe('v19 Warp facade', () => {
   it('opens named timelines through root application nouns', async () => {
@@ -69,5 +74,15 @@ describe('v19 Warp facade', () => {
     });
 
     await expect(warp.timeline('')).rejects.toThrow('openWarp requires non-empty identity fields');
+  });
+
+  it('keeps identity validation in the dedicated validator module', () => {
+    const warpSource = readRepoSource('src/domain/api/Warp.ts');
+    const timelineSource = readRepoSource('src/domain/api/Timeline.ts');
+    const validatorSource = readRepoSource('src/domain/api/assertIdentity.ts');
+
+    expect(warpSource).not.toContain('export function assertNonEmpty');
+    expect(timelineSource).not.toContain('function assertTimelineIdentity');
+    expect(validatorSource).toContain('export function assertIdentity');
   });
 });


### PR DESCRIPTION
## Summary

- Add the v19 `openWarp({ storage, writer })` product opener.
- Add public `Warp` and `Timeline` facade handles to root and browser entrypoints.
- Keep legacy worldline runtime details behind an internal timeline runtime bridge.
- Add unit and consumer typecheck coverage for the new facade.
- Regenerate the source-backed public reference.

Fixes #722

## Validation

- `npx vitest run test/unit/domain/WarpFacade.test.ts`
- `npm run typecheck:src`
- `npm run typecheck:test`
- `npm run typecheck:consumer`
- `npm run typecheck:surface`
- `npm run lint -- --quiet`
- `npm run lint:source-backed-reference`
- `npm run lint:docs-topology`
- `npm run test:local`
- pre-push `IRONCLAD M9` gates passed