### PR TITLE
Seal Git substrate out of v19 receipts and evidence

### DIFF
--- a/diagnostics.ts
+++ b/diagnostics.ts
@@ -2,7 +2,29 @@
  * Operator-facing inspection helpers for the v19 application API.
  */
 
+import { resolveReceiptProvenance } from './src/application/ReceiptProvenanceRegistry.ts';
+import type WarpStorage from './src/application/WarpStorage.ts';
+import WarpError from './src/domain/errors/WarpError.ts';
+import type ReadIdentity from './src/domain/services/optic/ReadIdentity.ts';
 import type { Receipt } from './src/domain/api/Receipt.ts';
+
+export type InspectReceiptOptions = {
+  readonly storage: WarpStorage;
+};
+
+export type ReceiptSubstrateInspection =
+  | {
+      readonly operation: 'write';
+      readonly patchSha: string | undefined;
+    }
+  | {
+      readonly operation: 'read';
+      readonly identity: ReadIdentity | undefined;
+    }
+  | {
+      readonly operation: 'join';
+      readonly patchShas: readonly string[];
+    };
 
 export type ReceiptInspection = {
   readonly operation: Receipt['operation'];
@@ -12,33 +34,58 @@ export type ReceiptInspection = {
   readonly reason: string | undefined;
   readonly evidence: 'present' | 'absent';
   readonly objectIds: readonly string[];
+  readonly substrate: ReceiptSubstrateInspection;
 };
 
-export function inspectReceipt(receipt: Receipt): ReceiptInspection {
-  const objectIds = receiptObjectIds(receipt);
+export function inspectReceipt(
+  receipt: Receipt,
+  options: InspectReceiptOptions
+): ReceiptInspection {
+  const provenance = resolveReceiptProvenance(receipt, requireInspectStorage(options));
+  if (provenance.operation !== receipt.operation) {
+    throw new WarpError(
+      'Receipt provenance operation does not match the receipt',
+      'E_RECEIPT_PROVENANCE_MISMATCH'
+    );
+  }
   return Object.freeze({
     operation: receipt.operation,
     outcome: receipt.outcome,
     timeline: receipt.timeline,
     writer: receipt.writer,
     reason: receipt.reason,
-    evidence: receipt.operation === 'read' && receipt.evidence !== undefined ? 'present' : 'absent',
-    objectIds: Object.freeze(objectIds),
+    evidence: receipt.evidence === undefined ? 'absent' : 'present',
+    objectIds: Object.freeze(receiptObjectIds(provenance)),
+    substrate: provenance,
   });
 }
 
-function receiptObjectIds(receipt: Receipt): string[] {
-  if (receipt.operation === 'write') {
-    return receipt.patchSha === undefined ? [] : [receipt.patchSha];
+function requireInspectStorage(options: InspectReceiptOptions): WarpStorage {
+  if (typeof options !== 'object' || options === null || !('storage' in options)) {
+    throw new WarpError(
+      'Receipt inspection requires an explicit storage context',
+      'E_RECEIPT_INSPECTION_OPTIONS'
+    );
   }
-  if (receipt.operation === 'join') {
-    return [...receipt.patchShas];
+  return options.storage;
+}
+
+function receiptObjectIds(provenance: ReceiptSubstrateInspection): string[] {
+  if (provenance.operation === 'write') {
+    return provenance.patchSha === undefined ? [] : [provenance.patchSha];
   }
-  if (receipt.evidence === undefined) {
+  if (provenance.operation === 'join') {
+    return [...provenance.patchShas];
+  }
+  if (provenance.identity === undefined) {
     return [];
   }
   return [
-    receipt.evidence.checkpointSha,
-    ...receipt.evidence.tailWitnesses.map((witness) => witness.sha),
+    ...new Set([
+      provenance.identity.checkpointSha,
+      ...provenance.identity.checkpointFrontier.map((entry) => entry.patchSha),
+      ...provenance.identity.checkpointIndexShards.map((shard) => shard.oid),
+      ...provenance.identity.tailWitnesses.map((witness) => witness.sha),
+    ]),
   ];
 }

--- a/docs/migrations/v19/README.md
+++ b/docs/migrations/v19/README.md
@@ -36,12 +36,12 @@ Diagnostics and expert WARP terms move to explicit subpaths:
 
 ## Subpath Policy
 
-| Subpath       | Contract                                            |
-| ------------- | --------------------------------------------------- |
-| Root          | first-use public API; no graph substrate            |
-| `storage`     | supported opaque storage constructors               |
+| Subpath       | Contract                                                  |
+| ------------- | --------------------------------------------------------- |
+| Root          | first-use public API; no graph substrate                  |
+| `storage`     | supported opaque storage constructors                     |
 | `advanced`    | bounded coordinate capture, `Optic`, and `Witness` access |
-| `diagnostics` | receipt inspection                                  |
+| `diagnostics` | receipt inspection                                        |
 
 The former `browser` and `legacy` subpaths do not exist in v19. Consumers must
 remove those imports before upgrading.
@@ -108,7 +108,7 @@ const receipt = await events.write(
 
 switch (receipt.outcome) {
   case 'accepted':
-    console.log(receipt.patchSha);
+    console.log(receipt.evidence?.basis.id);
     break;
   case 'obstructed':
   case 'conflicted':
@@ -226,44 +226,44 @@ and joins first.
 
 ## Symbol Disposition Table
 
-| v18 or earlier symbol      | v19 path                              | Notes                                             |
-| -------------------------- | ------------------------------------- | ------------------------------------------------- |
-| `openWarpWorldline()`      | root `openWarp().timeline(name)`      | preferred application opener                      |
-| `WarpWorldline`            | root `Timeline`                       | public handle rename                              |
-| `Warp`                     | root type                             | obtain the runtime handle from `openWarp()`       |
-| `Timeline`                 | root type                             | obtain the runtime handle from `warp.timeline()`  |
-| `DraftTimeline`            | root type                             | obtain the runtime handle from `timeline.draft()` |
-| `Intent`                   | root type                             | construct with the root `intent` builders         |
-| `Reading`                  | root type                             | construct with the root `reading` builders        |
-| `ReadingResult`            | root type                             | returned by `timeline.read()`                     |
-| `WriteReceipt`             | root type                             | returned by `timeline.write()`                    |
-| `ReadReceipt`              | root type                             | returned on `ReadingResult.receipt`               |
-| `JoinReceipt`              | root type                             | returned on `JoinResult.receipt`                  |
-| `JoinResult`               | root type                             | returned by `previewJoin()` and `join()`          |
-| `StorageAdapter`           | root `WarpStorage`                    | opaque storage handle replaces persistence port  |
-| `ReadReceiptOutcome`       | root `ReadOutcome`                    | operation-specific outcome alias rename           |
-| `JoinReceiptOutcome`       | root `JoinOutcome`                    | operation-specific outcome alias rename           |
-| `EdgePropertyIntentFields` | removed                               | no edge-property intent ships in the v19 root     |
-| `GitGraphAdapter`          | `storage` `GitStorage.open({ cwd })`  | plumbing and CAS composition are internal         |
-| `InMemoryGraphAdapter`     | `storage` `MemoryStorage.create()`    | graph name and adapter constructor removed        |
-| `GraphPersistencePort`     | root `WarpStorage` for app options    | old graph-shaped port removed from public API     |
-| `commit((patch) => ...)`   | `timeline.write(intent.*)`            | receipt-returning                                 |
-| `PatchBuilder`             | removed                               | replace with intent builders                      |
-| `PatchSession`             | removed                               | replace with receipt-returning writes             |
-| `createNodeAdd()`          | removed                               | use intent builders                               |
-| `createEdgeAdd()`          | removed                               | use intent builders                               |
-| `createPropSet()`          | removed                               | use intent builders                               |
-| `openWarpGraph()`          | removed                               | replace diagnostics with explicit diagnostic APIs |
-| `WarpApp`                  | removed                               | no root default export in v19                     |
-| `WarpCore`                 | removed                               | replace diagnostics with explicit diagnostic APIs |
-| `GraphNode`                | removed                               | no public export                                  |
-| `GraphDiff`                | removed                               | no public-handle comparison API ships in v19      |
-| `Optic`                    | `advanced`                            | readings are root                                 |
-| `Coordinate`               | `advanced` or receipt fields          | capture with advanced `captureCoordinate()`       |
-| `Observer`                 | removed                               | readings are first-use root                       |
-| `Strand`                   | removed                               | drafts are first-use root                         |
-| `Braid`                    | removed                               | joins are first-use root                          |
-| Continuum evidence nouns   | removed                               | receipt evidence stays root-facing                |
+| v18 or earlier symbol      | v19 path                             | Notes                                             |
+| -------------------------- | ------------------------------------ | ------------------------------------------------- |
+| `openWarpWorldline()`      | root `openWarp().timeline(name)`     | preferred application opener                      |
+| `WarpWorldline`            | root `Timeline`                      | public handle rename                              |
+| `Warp`                     | root type                            | obtain the runtime handle from `openWarp()`       |
+| `Timeline`                 | root type                            | obtain the runtime handle from `warp.timeline()`  |
+| `DraftTimeline`            | root type                            | obtain the runtime handle from `timeline.draft()` |
+| `Intent`                   | root type                            | construct with the root `intent` builders         |
+| `Reading`                  | root type                            | construct with the root `reading` builders        |
+| `ReadingResult`            | root type                            | returned by `timeline.read()`                     |
+| `WriteReceipt`             | root type                            | returned by `timeline.write()`                    |
+| `ReadReceipt`              | root type                            | returned on `ReadingResult.receipt`               |
+| `JoinReceipt`              | root type                            | returned on `JoinResult.receipt`                  |
+| `JoinResult`               | root type                            | returned by `previewJoin()` and `join()`          |
+| `StorageAdapter`           | root `WarpStorage`                   | opaque storage handle replaces persistence port   |
+| `ReadReceiptOutcome`       | root `ReadOutcome`                   | operation-specific outcome alias rename           |
+| `JoinReceiptOutcome`       | root `JoinOutcome`                   | operation-specific outcome alias rename           |
+| `EdgePropertyIntentFields` | removed                              | no edge-property intent ships in the v19 root     |
+| `GitGraphAdapter`          | `storage` `GitStorage.open({ cwd })` | plumbing and CAS composition are internal         |
+| `InMemoryGraphAdapter`     | `storage` `MemoryStorage.create()`   | graph name and adapter constructor removed        |
+| `GraphPersistencePort`     | root `WarpStorage` for app options   | old graph-shaped port removed from public API     |
+| `commit((patch) => ...)`   | `timeline.write(intent.*)`           | receipt-returning                                 |
+| `PatchBuilder`             | removed                              | replace with intent builders                      |
+| `PatchSession`             | removed                              | replace with receipt-returning writes             |
+| `createNodeAdd()`          | removed                              | use intent builders                               |
+| `createEdgeAdd()`          | removed                              | use intent builders                               |
+| `createPropSet()`          | removed                              | use intent builders                               |
+| `openWarpGraph()`          | removed                              | replace diagnostics with explicit diagnostic APIs |
+| `WarpApp`                  | removed                              | no root default export in v19                     |
+| `WarpCore`                 | removed                              | replace diagnostics with explicit diagnostic APIs |
+| `GraphNode`                | removed                              | no public export                                  |
+| `GraphDiff`                | removed                              | no public-handle comparison API ships in v19      |
+| `Optic`                    | `advanced`                           | readings are root                                 |
+| `Coordinate`               | `advanced` or receipt fields         | capture with advanced `captureCoordinate()`       |
+| `Observer`                 | removed                              | readings are first-use root                       |
+| `Strand`                   | removed                              | drafts are first-use root                         |
+| `Braid`                    | removed                              | joins are first-use root                          |
+| Continuum evidence nouns   | removed                              | receipt evidence stays root-facing                |
 
 ## Receipt Outcome Migration
 
@@ -283,7 +283,7 @@ const receipt = await timeline.write(
 
 switch (receipt.outcome) {
   case 'accepted':
-    console.log(receipt.patchSha);
+    console.log(receipt.evidence?.basis.id);
     break;
   case 'obstructed':
   case 'conflicted':
@@ -304,6 +304,18 @@ underdetermined
 rejected
 ```
 
+Receipt provenance also changes shape:
+
+| v18 or pre-release v19 field     | v19 replacement                              |
+| -------------------------------- | -------------------------------------------- |
+| `WriteReceipt.patchSha`          | `WriteReceipt.evidence.basis` and `.support` |
+| `JoinReceipt.patchShas`          | `JoinReceipt.evidence.basis` and `.support`  |
+| Git-shaped `ReadEvidence` fields | storage-neutral `Evidence` handles           |
+| exact substrate identifiers      | `inspectReceipt(receipt, { storage })`       |
+
+Evidence-handle IDs are opaque and must not be parsed. Equal support IDs may be
+used to correlate the same support across receipts.
+
 Operation names such as `join`, `sync`, and `read` belong in distinct receipt
 classes or operation fields, not in `receipt.outcome`.
 
@@ -315,8 +327,9 @@ classes or operation fields, not in `receipt.outcome`.
 3. Convert `commit((patch) => ...)` calls to `timeline.write(intent.*)` calls.
 4. Rewrite direct live/query/optic reads as `timeline.read(reading.*)` calls.
 5. Move `seek()`/coordinate-first call sites to `tick()` and `at(tick)`.
-6. Replace direct diagnostics with `inspectReceipt()`; keep graph diff and
-   materialization integrations internal until they accept public handles.
+6. Replace direct diagnostics with `inspectReceipt(receipt, { storage })`; keep
+   graph diff and materialization integrations internal until they accept
+   public handles.
 7. Remove remaining graph-shaped package imports.
 
 ## Compatibility Window

--- a/docs/topics/api/README.md
+++ b/docs/topics/api/README.md
@@ -116,7 +116,7 @@ const write = await timeline.write(
 
 switch (write.outcome) {
   case 'accepted':
-    console.log(write.patchSha);
+    console.log(write.evidence?.basis.id);
     break;
   case 'obstructed':
   case 'conflicted':
@@ -158,6 +158,28 @@ result.receipt;
 
 A convenience method such as `readValue()` can exist, but it should be clearly
 documented as the provenance-light path.
+
+## Opaque Evidence
+
+Receipts expose storage-neutral evidence handles:
+
+```typescript
+receipt.evidence?.basis.id;
+receipt.evidence?.support.map((handle) => handle.id);
+receipt.evidence?.tick;
+```
+
+`basis` identifies the causal basis used for the operation. `support` contains
+opaque handles for the supporting objects; the same support has the same ID
+across write, preview, join, and read receipts, so callers can correlate it
+without learning a substrate identifier. A historical read also carries the
+exact public `Tick` used for that read. Live reads do not invent a historical
+tick.
+
+Evidence IDs are deliberately opaque. Do not parse them. Operator code that
+needs exact substrate provenance must call
+`inspectReceipt(receipt, { storage })` from the diagnostics subpath with the
+same storage handle that issued the receipt.
 
 ## Intent Builders
 
@@ -238,7 +260,7 @@ read paths can still lower readings to optics internally:
 
 1. validate the `Reading`;
 2. lower `Reading` to `Optic`;
-3. prepare or check an optic basis;
+3. check an optic basis without broad materialization;
 4. capture the observer position;
 5. execute the bounded read;
 6. return `ReadingResult` and `ReadReceipt`.
@@ -256,7 +278,7 @@ const receipt = await timeline.write(assignRole('user:alice', 'admin'));
 
 switch (receipt.outcome) {
   case 'accepted':
-    console.log(receipt.patchSha);
+    console.log(receipt.evidence?.basis.id);
     break;
   case 'obstructed':
   case 'conflicted':
@@ -388,12 +410,12 @@ Use explicit subpaths:
 
 The boundaries mean different things:
 
-| Surface       | Meaning                                             |
-| ------------- | --------------------------------------------------- |
-| Root          | first-use product API                               |
-| `storage`     | supported opaque storage constructors                |
+| Surface       | Meaning                                                   |
+| ------------- | --------------------------------------------------------- |
+| Root          | first-use product API                                     |
+| `storage`     | supported opaque storage constructors                     |
 | `advanced`    | bounded coordinate capture, `Optic`, and `Witness` access |
-| `diagnostics` | receipt inspection                                  |
+| `diagnostics` | receipt inspection                                        |
 
 Do not turn `advanced` into a junk drawer. Symbols that exist only for removed
 graph-first consumers are not part of the v19 package boundary.
@@ -408,7 +430,7 @@ Each old root symbol needs one explicit disposition:
 | `GitGraphAdapter`        | `GitStorage.open({ cwd })` from `storage`                  |
 | `InMemoryGraphAdapter`   | `MemoryStorage.create()` from `storage`                    |
 | `commit((patch) => ...)` | `timeline.write(intent.*)`                                 |
-| `coordinate()`           | `tick()` publicly; use advanced `captureCoordinate()`       |
+| `coordinate()`           | `tick()` publicly; use advanced `captureCoordinate()`      |
 | `optic()`                | `timeline.read(reading.*)` or `advanced`                   |
 | `openWarpGraph()`        | removed; replace diagnostics with explicit diagnostic APIs |
 | `PatchBuilder`           | removed; use intent builders                               |

--- a/docs/topics/getting-started.md
+++ b/docs/topics/getting-started.md
@@ -47,15 +47,15 @@ const receipt = await audit.write(
 );
 
 if (receipt.outcome === 'accepted') {
-  console.log(receipt.patchSha);
+  console.log(receipt.evidence?.basis.id);
 } else {
   console.error(receipt.reason);
 }
 ```
 
 Every call writes one intent and returns a `WriteReceipt`. Treat
-`receipt.outcome` as the settlement result instead of treating a returned SHA
-as the only success signal.
+`receipt.outcome` as the settlement result. Accepted writes carry opaque causal
+evidence handles; substrate identities are not part of normal control flow.
 
 ## Read A Bounded Value
 
@@ -80,7 +80,7 @@ console.log(exists.value, exists.receipt);
 ```
 
 Readings ask bounded questions. The receipt records how the runtime supported
-the answer. An accepted receipt carries checkpoint-tail evidence. If no bounded
+the answer. An accepted receipt carries opaque causal evidence. If no bounded
 basis exists, `read()` returns an `obstructed` receipt with repair hints instead
 of materializing the whole timeline.
 

--- a/docs/topics/querying.md
+++ b/docs/topics/querying.md
@@ -97,8 +97,15 @@ as a bounded read.
 ## Diagnostics
 
 `@git-stunts/git-warp/diagnostics` exports `inspectReceipt()`. It accepts the
-same write, read, and join receipts returned by the root API and does not
-require an internal runtime host.
+same write, read, and join receipts returned by the root API together with the
+opaque storage handle that issued them:
+
+```typescript
+const inspection = inspectReceipt(receipt, { storage });
+```
+
+The explicit storage context lets diagnostics recover exact substrate
+provenance without putting those identifiers on normal receipt objects.
 
 ## Advanced Read Machinery
 

--- a/docs/topics/reference.md
+++ b/docs/topics/reference.md
@@ -29,9 +29,9 @@ First-use product API: `openWarp`, `intent`, `reading`, timelines, and receipts.
 Source: `index.ts`. Count: 3.
 
 ```text
-intent @ index.ts#L14
-openWarp @ index.ts#L13
-reading @ index.ts#L15
+intent @ index.ts#L15
+openWarp @ index.ts#L14
+reading @ index.ts#L16
 ```
 
 ### Type exports
@@ -39,50 +39,50 @@ reading @ index.ts#L15
 Source: `index.ts`. Count: 44.
 
 ```text
-DraftTimeline @ index.ts#L16
-EdgeIntentFields @ index.ts#L32
-Evidence @ index.ts#L21
-EvidenceHandle @ index.ts#L21
-Intent @ index.ts#L22
-IntentBuilders @ index.ts#L38
-IntentDescriptor @ index.ts#L33
-IntentKind @ index.ts#L34
-JoinMode @ index.ts#L39
-JoinOptions @ index.ts#L41
-JoinOutcome @ index.ts#L55
-JoinPolicy @ index.ts#L41
-JoinReceipt @ index.ts#L23
-JoinReceiptOptions @ index.ts#L39
-JoinResult @ index.ts#L24
-JoinResultOptions @ index.ts#L40
-NeighborhoodReadingFields @ index.ts#L43
-NodeIntentFields @ index.ts#L35
-NodeReadingFields @ index.ts#L44
-OpenWarpOptions @ index.ts#L29
-PropertyIntentFields @ index.ts#L36
-PropertyReadingFields @ index.ts#L45
-Reading @ index.ts#L25
-ReadingBuilders @ index.ts#L50
-ReadingDescriptor @ index.ts#L47
-ReadingDirection @ index.ts#L46
-ReadingKind @ index.ts#L48
-ReadingResult @ index.ts#L26
-ReadingResultOptions @ index.ts#L51
-ReadingValue @ index.ts#L51
-ReadOutcome @ index.ts#L56
-ReadReceipt @ index.ts#L27
-ReadReceiptOptions @ index.ts#L53
-Receipt @ index.ts#L52
-ReceiptOutcome @ index.ts#L57
-RepairHint @ index.ts#L60
-Tick @ index.ts#L19
-Timeline @ index.ts#L18
-TimelineView @ index.ts#L20
-Warp @ index.ts#L17
-WarpStorage @ index.ts#L30
-WriteOutcome @ index.ts#L58
-WriteReceipt @ index.ts#L28
-WriteReceiptOptions @ index.ts#L61
+DraftTimeline @ index.ts#L17
+EdgeIntentFields @ index.ts#L33
+Evidence @ index.ts#L22
+EvidenceHandle @ index.ts#L22
+Intent @ index.ts#L23
+IntentBuilders @ index.ts#L39
+IntentDescriptor @ index.ts#L34
+IntentKind @ index.ts#L35
+JoinMode @ index.ts#L40
+JoinOptions @ index.ts#L42
+JoinOutcome @ index.ts#L56
+JoinPolicy @ index.ts#L42
+JoinReceipt @ index.ts#L24
+JoinReceiptOptions @ index.ts#L40
+JoinResult @ index.ts#L25
+JoinResultOptions @ index.ts#L41
+NeighborhoodReadingFields @ index.ts#L44
+NodeIntentFields @ index.ts#L36
+NodeReadingFields @ index.ts#L45
+OpenWarpOptions @ index.ts#L30
+PropertyIntentFields @ index.ts#L37
+PropertyReadingFields @ index.ts#L46
+Reading @ index.ts#L26
+ReadingBuilders @ index.ts#L51
+ReadingDescriptor @ index.ts#L48
+ReadingDirection @ index.ts#L47
+ReadingKind @ index.ts#L49
+ReadingResult @ index.ts#L27
+ReadingResultOptions @ index.ts#L52
+ReadingValue @ index.ts#L52
+ReadOutcome @ index.ts#L57
+ReadReceipt @ index.ts#L28
+ReadReceiptOptions @ index.ts#L54
+Receipt @ index.ts#L53
+ReceiptOutcome @ index.ts#L58
+RepairHint @ index.ts#L61
+Tick @ index.ts#L20
+Timeline @ index.ts#L19
+TimelineView @ index.ts#L21
+Warp @ index.ts#L18
+WarpStorage @ index.ts#L31
+WriteOutcome @ index.ts#L59
+WriteReceipt @ index.ts#L29
+WriteReceiptOptions @ index.ts#L62
 ```
 
 ## Storage export surface

--- a/docs/topics/reference.md
+++ b/docs/topics/reference.md
@@ -36,52 +36,53 @@ reading @ index.ts#L15
 
 ### Type exports
 
-Source: `index.ts`. Count: 43.
+Source: `index.ts`. Count: 44.
 
 ```text
 DraftTimeline @ index.ts#L16
-EdgeIntentFields @ index.ts#L31
-Intent @ index.ts#L21
-IntentBuilders @ index.ts#L37
-IntentDescriptor @ index.ts#L32
-IntentKind @ index.ts#L33
-JoinMode @ index.ts#L38
-JoinOptions @ index.ts#L40
-JoinOutcome @ index.ts#L54
-JoinPolicy @ index.ts#L40
-JoinReceipt @ index.ts#L22
-JoinReceiptOptions @ index.ts#L38
-JoinResult @ index.ts#L23
-JoinResultOptions @ index.ts#L39
-NeighborhoodReadingFields @ index.ts#L42
-NodeIntentFields @ index.ts#L34
-NodeReadingFields @ index.ts#L43
-OpenWarpOptions @ index.ts#L28
-PropertyIntentFields @ index.ts#L35
-PropertyReadingFields @ index.ts#L44
-ReadEvidence @ index.ts#L52
-Reading @ index.ts#L24
-ReadingBuilders @ index.ts#L49
-ReadingDescriptor @ index.ts#L46
-ReadingDirection @ index.ts#L45
-ReadingKind @ index.ts#L47
-ReadingResult @ index.ts#L25
-ReadingResultOptions @ index.ts#L50
-ReadingValue @ index.ts#L50
-ReadOutcome @ index.ts#L55
-ReadReceipt @ index.ts#L26
-ReadReceiptOptions @ index.ts#L52
-Receipt @ index.ts#L51
-ReceiptOutcome @ index.ts#L56
-RepairHint @ index.ts#L59
+EdgeIntentFields @ index.ts#L32
+Evidence @ index.ts#L21
+EvidenceHandle @ index.ts#L21
+Intent @ index.ts#L22
+IntentBuilders @ index.ts#L38
+IntentDescriptor @ index.ts#L33
+IntentKind @ index.ts#L34
+JoinMode @ index.ts#L39
+JoinOptions @ index.ts#L41
+JoinOutcome @ index.ts#L55
+JoinPolicy @ index.ts#L41
+JoinReceipt @ index.ts#L23
+JoinReceiptOptions @ index.ts#L39
+JoinResult @ index.ts#L24
+JoinResultOptions @ index.ts#L40
+NeighborhoodReadingFields @ index.ts#L43
+NodeIntentFields @ index.ts#L35
+NodeReadingFields @ index.ts#L44
+OpenWarpOptions @ index.ts#L29
+PropertyIntentFields @ index.ts#L36
+PropertyReadingFields @ index.ts#L45
+Reading @ index.ts#L25
+ReadingBuilders @ index.ts#L50
+ReadingDescriptor @ index.ts#L47
+ReadingDirection @ index.ts#L46
+ReadingKind @ index.ts#L48
+ReadingResult @ index.ts#L26
+ReadingResultOptions @ index.ts#L51
+ReadingValue @ index.ts#L51
+ReadOutcome @ index.ts#L56
+ReadReceipt @ index.ts#L27
+ReadReceiptOptions @ index.ts#L53
+Receipt @ index.ts#L52
+ReceiptOutcome @ index.ts#L57
+RepairHint @ index.ts#L60
 Tick @ index.ts#L19
 Timeline @ index.ts#L18
 TimelineView @ index.ts#L20
 Warp @ index.ts#L17
-WarpStorage @ index.ts#L29
-WriteOutcome @ index.ts#L57
-WriteReceipt @ index.ts#L27
-WriteReceiptOptions @ index.ts#L60
+WarpStorage @ index.ts#L30
+WriteOutcome @ index.ts#L58
+WriteReceipt @ index.ts#L28
+WriteReceiptOptions @ index.ts#L61
 ```
 
 ## Storage export surface
@@ -145,15 +146,17 @@ Operator inspection helpers that consume public receipt handles.
 Source: `diagnostics.ts`. Count: 1.
 
 ```text
-inspectReceipt @ diagnostics.ts#L17
+inspectReceipt @ diagnostics.ts#L40
 ```
 
 ### Type exports
 
-Source: `diagnostics.ts`. Count: 1.
+Source: `diagnostics.ts`. Count: 3.
 
 ```text
-ReceiptInspection @ diagnostics.ts#L7
+InspectReceiptOptions @ diagnostics.ts#L11
+ReceiptInspection @ diagnostics.ts#L29
+ReceiptSubstrateInspection @ diagnostics.ts#L15
 ```
 
 ## CLI command registry

--- a/index.ts
+++ b/index.ts
@@ -5,9 +5,10 @@
  *
  * Root users should write intents, read timelines, and keep receipts. The
  * graph-first compatibility surface is no longer publicly exported.
- * Storage adapters live under `@git-stunts/git-warp/storage`; formal read,
- * evidence, and support machinery lives under `@git-stunts/git-warp/advanced`;
- * operator inspection tools live under `@git-stunts/git-warp/diagnostics`.
+ * Opaque evidence is part of this first-use boundary. Storage adapters live
+ * under `@git-stunts/git-warp/storage`; formal optic, coordinate, and witness
+ * machinery lives under `@git-stunts/git-warp/advanced`; operator inspection
+ * tools live under `@git-stunts/git-warp/diagnostics`.
  */
 
 export { openWarp } from './src/application/openWarp.ts';

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ export type { default as Warp } from './src/domain/api/Warp.ts';
 export type { default as Timeline } from './src/domain/api/Timeline.ts';
 export type { default as Tick } from './src/domain/api/Tick.ts';
 export type { default as TimelineView } from './src/domain/api/TimelineView.ts';
+export type { default as Evidence, EvidenceHandle } from './src/domain/api/Evidence.ts';
 export type { default as Intent } from './src/domain/api/Intent.ts';
 export type { default as JoinReceipt } from './src/domain/api/JoinReceipt.ts';
 export type { default as JoinResult } from './src/domain/api/JoinResult.ts';
@@ -49,7 +50,7 @@ export type {
 export type { ReadingBuilders } from './src/domain/api/ReadingBuilders.ts';
 export type { ReadingResultOptions, ReadingValue } from './src/domain/api/ReadingResult.ts';
 export type { Receipt } from './src/domain/api/Receipt.ts';
-export type { ReadEvidence, ReadReceiptOptions } from './src/domain/api/ReadReceipt.ts';
+export type { ReadReceiptOptions } from './src/domain/api/ReadReceipt.ts';
 export type {
   JoinOutcome,
   ReadOutcome,

--- a/scripts/check-dts-surface.ts
+++ b/scripts/check-dts-surface.ts
@@ -15,6 +15,7 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { findForbiddenRootDeclarationVocabulary } from './v19-root-declaration-gate.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -220,8 +221,19 @@ function runSourceSurfaceCheck(): SurfaceErrorReport {
   checkIncludedTargets('package.json files', readStringArray(packageJson['files']), report);
   checkJsrExports(jsrJson, report);
   checkJsrPublish(jsrJson, report);
+  checkRootDeclarationVocabulary(report);
 
   return report;
+}
+
+function checkRootDeclarationVocabulary(report: SurfaceErrorReport): void {
+  const entry = resolve(root, 'dist/index.d.ts');
+  for (const violation of findForbiddenRootDeclarationVocabulary(entry)) {
+    report.errors.push(
+      `root declaration graph contains forbidden ${violation.token} vocabulary at ` +
+        `${violation.file}:${violation.line}:${violation.column} (${violation.identifier})`
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -247,7 +259,7 @@ export function parseExportBlock(blockBody: string): Set<string> {
     const withoutTypeKeyword = trimmed.replace(/^type\s+/, '');
     // Handle `Foo as Bar` — the exported name is Bar
     const asParts = withoutTypeKeyword.split(/\s+as\s+/);
-    const exportedName = (asParts.length > 1 ? asParts[1] ?? '' : asParts[0] ?? '').trim();
+    const exportedName = (asParts.length > 1 ? (asParts[1] ?? '') : (asParts[0] ?? '')).trim();
     if (exportedName) {
       names.add(exportedName);
     }
@@ -348,7 +360,10 @@ const TYPE_ONLY_KINDS = new Set(['interface', 'type']);
  * @param {{ exports?: Record<string, { kind?: string }>, typeExports?: Record<string, { kind?: string }> }} manifest
  * @returns {{ manifestNames: Set<string>, runtimeNames: Set<string>, typeOnlyNames: Set<string>, duplicateNames: Set<string>, invalidRuntimeTypeOnly: Set<string>, invalidTypeSectionRuntime: Set<string> }}
  */
-export function classifyManifestExports(manifest: { exports?: Record<string, { kind?: string }>, typeExports?: Record<string, { kind?: string }> }) {
+export function classifyManifestExports(manifest: {
+  exports?: Record<string, { kind?: string }>;
+  typeExports?: Record<string, { kind?: string }>;
+}) {
   const manifestNames = new Set<string>();
   const runtimeNames = new Set<string>();
   const typeOnlyNames = new Set<string>();
@@ -415,6 +430,6 @@ if (isMain) {
   }
 
   if (!quiet) {
-    process.stdout.write('PASS: package and JSR surface targets exist\n');
+    process.stdout.write('PASS: publication targets and v19 root declarations are clean\n');
   }
 }

--- a/scripts/v19-root-declaration-gate.ts
+++ b/scripts/v19-root-declaration-gate.ts
@@ -62,16 +62,18 @@ export function findForbiddenRootDeclarationVocabulary(
             token,
           });
         }
-        const compound = FORBIDDEN_COMPOUNDS.get(tokens.join(''));
-        if (compound !== undefined) {
-          const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-          violations.push({
-            file: relative(declarationRoot, file),
-            line: position.line + 1,
-            column: position.character + 1,
-            identifier,
-            token: compound,
-          });
+        for (let index = 0; index + 1 < tokens.length; index += 1) {
+          const compound = FORBIDDEN_COMPOUNDS.get(`${tokens[index]}${tokens[index + 1]}`);
+          if (compound !== undefined) {
+            const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+            violations.push({
+              file: relative(declarationRoot, file),
+              line: position.line + 1,
+              column: position.character + 1,
+              identifier,
+              token: compound,
+            });
+          }
         }
       }
       ts.forEachChild(node, visit);

--- a/scripts/v19-root-declaration-gate.ts
+++ b/scripts/v19-root-declaration-gate.ts
@@ -1,0 +1,177 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import ts from 'typescript';
+
+const FORBIDDEN_TOKENS = new Set([
+  'blob',
+  'cas',
+  'commit',
+  'git',
+  'oid',
+  'plumbing',
+  'ref',
+  'sha',
+  'tree',
+]);
+
+const FORBIDDEN_COMPOUNDS = new Map([
+  ['objectid', 'object-id'],
+  ['objectids', 'object-id'],
+]);
+
+export type DeclarationVocabularyViolation = {
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+  readonly identifier: string;
+  readonly token: string;
+};
+
+export function findForbiddenRootDeclarationVocabulary(
+  entryFile: string
+): readonly DeclarationVocabularyViolation[] {
+  const entry = resolve(entryFile);
+  const declarationRoot = dirname(entry);
+  const files = declarationClosure(entry, declarationRoot);
+  const violations: DeclarationVocabularyViolation[] = [];
+
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    const sourceFile = ts.createSourceFile(
+      file,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS
+    );
+    const visit = (node: ts.Node): void => {
+      if (ts.isIdentifier(node) || ts.isStringLiteralLike(node)) {
+        const identifier = node.text;
+        const tokens = vocabularyTokens(identifier);
+        for (const rawToken of tokens) {
+          const token = singularForbiddenToken(rawToken);
+          if (token === null) {
+            continue;
+          }
+          const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+          violations.push({
+            file: relative(declarationRoot, file),
+            line: position.line + 1,
+            column: position.character + 1,
+            identifier,
+            token,
+          });
+        }
+        const compound = FORBIDDEN_COMPOUNDS.get(tokens.join(''));
+        if (compound !== undefined) {
+          const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+          violations.push({
+            file: relative(declarationRoot, file),
+            line: position.line + 1,
+            column: position.character + 1,
+            identifier,
+            token: compound,
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  return violations;
+}
+
+function singularForbiddenToken(token: string): string | null {
+  if (FORBIDDEN_TOKENS.has(token)) {
+    return token;
+  }
+  if (token.endsWith('s') && FORBIDDEN_TOKENS.has(token.slice(0, -1))) {
+    return token.slice(0, -1);
+  }
+  return null;
+}
+
+function declarationClosure(entry: string, root: string): readonly string[] {
+  const pending = [entry];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (file === undefined || visited.has(file)) {
+      continue;
+    }
+    if (!existsSync(file)) {
+      throw new Error(`Declaration dependency does not exist: ${file}`);
+    }
+    visited.add(file);
+    const sourceFile = ts.createSourceFile(
+      file,
+      readFileSync(file, 'utf8'),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS
+    );
+    for (const specifier of moduleSpecifiers(sourceFile)) {
+      const dependency = resolveDeclarationDependency(file, root, specifier);
+      if (dependency !== null && !visited.has(dependency)) {
+        pending.push(dependency);
+      }
+    }
+  }
+  return [...visited].sort();
+}
+
+function moduleSpecifiers(sourceFile: ts.SourceFile): readonly string[] {
+  const specifiers: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      specifiers.push(node.moduleSpecifier.text);
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      specifiers.push(node.argument.literal.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return specifiers;
+}
+
+function resolveDeclarationDependency(
+  importer: string,
+  root: string,
+  specifier: string
+): string | null {
+  if (!specifier.startsWith('.')) {
+    return null;
+  }
+  const unresolved = resolve(dirname(importer), specifier);
+  const candidates = [
+    unresolved.replace(/\.(?:d\.)?(?:ts|js)$/, '.d.ts'),
+    `${unresolved}.d.ts`,
+    resolve(unresolved, 'index.d.ts'),
+  ];
+  const dependency = candidates.find((candidate) => existsSync(candidate));
+  if (dependency === undefined) {
+    throw new Error(`Cannot resolve declaration dependency ${specifier} from ${importer}`);
+  }
+  const relativeDependency = relative(root, dependency);
+  if (relativeDependency.startsWith('..')) {
+    throw new Error(`Declaration dependency escapes the package: ${dependency}`);
+  }
+  return dependency;
+}
+
+function vocabularyTokens(identifier: string): readonly string[] {
+  return identifier
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^A-Za-z0-9]+/)
+    .filter((token) => token.length > 0)
+    .map((token) => token.toLowerCase());
+}

--- a/src/application/ReceiptProvenanceRegistry.ts
+++ b/src/application/ReceiptProvenanceRegistry.ts
@@ -1,0 +1,65 @@
+import WarpError from '../domain/errors/WarpError.ts';
+import type { ApiRuntimeContext, ReceiptProvenance } from '../domain/api/ApiRuntimeContext.ts';
+import type { Receipt } from '../domain/api/Receipt.ts';
+import type CryptoPort from '../ports/CryptoPort.ts';
+import type WarpStorage from './WarpStorage.ts';
+import { resolveWarpStorage } from './WarpStorageRegistry.ts';
+
+type ReceiptProvenanceBinding = {
+  readonly provenance: ReceiptProvenance;
+  readonly storage: WarpStorage;
+};
+
+const RECEIPT_PROVENANCE = new WeakMap<Receipt, ReceiptProvenanceBinding>();
+
+export function createApiRuntimeContext(
+  storage: WarpStorage,
+  crypto: CryptoPort
+): ApiRuntimeContext {
+  return Object.freeze({
+    createOpaqueId: async (namespace, parts) => {
+      const digest = await crypto.hash('sha256', JSON.stringify([namespace, parts]));
+      return `${namespace}:${digest}`;
+    },
+    bindReceipt: (receipt, provenance) => {
+      if (RECEIPT_PROVENANCE.has(receipt)) {
+        throw new WarpError('Receipt provenance is already bound', 'E_RECEIPT_PROVENANCE_BOUND');
+      }
+      RECEIPT_PROVENANCE.set(
+        receipt,
+        Object.freeze({ storage, provenance: freezeProvenance(provenance) })
+      );
+    },
+  });
+}
+
+export function resolveReceiptProvenance(
+  receipt: Receipt,
+  storage: WarpStorage
+): ReceiptProvenance {
+  resolveWarpStorage(storage);
+  const binding = RECEIPT_PROVENANCE.get(receipt);
+  if (binding === undefined) {
+    throw new WarpError(
+      'Receipt was not issued by an openWarp runtime',
+      'E_RECEIPT_PROVENANCE_UNAVAILABLE'
+    );
+  }
+  if (binding.storage !== storage) {
+    throw new WarpError(
+      'Receipt does not belong to the supplied storage',
+      'E_RECEIPT_STORAGE_MISMATCH'
+    );
+  }
+  return binding.provenance;
+}
+
+function freezeProvenance(provenance: ReceiptProvenance): ReceiptProvenance {
+  if (provenance.operation === 'join') {
+    return Object.freeze({
+      operation: provenance.operation,
+      patchShas: Object.freeze([...provenance.patchShas]),
+    });
+  }
+  return Object.freeze({ ...provenance });
+}

--- a/src/application/ReceiptProvenanceRegistry.ts
+++ b/src/application/ReceiptProvenanceRegistry.ts
@@ -18,7 +18,7 @@ export function createApiRuntimeContext(
 ): ApiRuntimeContext {
   return Object.freeze({
     createOpaqueId: async (namespace, parts) => {
-      const digest = await crypto.hash('sha256', JSON.stringify([namespace, parts]));
+      const digest = await crypto.hash('sha256', opaqueIdPayload(namespace, parts));
       return `${namespace}:${digest}`;
     },
     bindReceipt: (receipt, provenance) => {
@@ -31,6 +31,16 @@ export function createApiRuntimeContext(
       );
     },
   });
+}
+
+function opaqueIdPayload(namespace: string, parts: readonly (string | number)[]): string {
+  return [namespace, ...parts].map(encodeOpaqueIdPart).join('');
+}
+
+function encodeOpaqueIdPart(part: string | number): string {
+  const value = String(part);
+  const type = typeof part === 'number' ? 'n' : 's';
+  return `${type}${value.length}:${value}`;
 }
 
 export function resolveReceiptProvenance(

--- a/src/application/ReceiptProvenanceRegistry.ts
+++ b/src/application/ReceiptProvenanceRegistry.ts
@@ -10,7 +10,13 @@ type ReceiptProvenanceBinding = {
   readonly storage: WarpStorage;
 };
 
+type RecoveryNonceState = {
+  readonly nonce: string;
+  sequence: number;
+};
+
 const RECEIPT_PROVENANCE = new WeakMap<Receipt, ReceiptProvenanceBinding>();
+const RECOVERY_NONCES = new WeakMap<WarpStorage, RecoveryNonceState>();
 
 export function createApiRuntimeContext(
   storage: WarpStorage,
@@ -21,6 +27,7 @@ export function createApiRuntimeContext(
       const digest = await crypto.hash('sha256', opaqueIdPayload(namespace, parts));
       return `${namespace}:${digest}`;
     },
+    reserveRecoveryNonce: () => reserveRecoveryNonce(storage),
     bindReceipt: (receipt, provenance) => {
       if (RECEIPT_PROVENANCE.has(receipt)) {
         throw new WarpError('Receipt provenance is already bound', 'E_RECEIPT_PROVENANCE_BOUND');
@@ -31,6 +38,16 @@ export function createApiRuntimeContext(
       );
     },
   });
+}
+
+function reserveRecoveryNonce(storage: WarpStorage): string {
+  let state = RECOVERY_NONCES.get(storage);
+  if (state === undefined) {
+    state = { nonce: globalThis.crypto.randomUUID(), sequence: 0 };
+    RECOVERY_NONCES.set(storage, state);
+  }
+  state.sequence += 1;
+  return `${state.nonce}:${state.sequence}`;
 }
 
 function opaqueIdPayload(namespace: string, parts: readonly (string | number)[]): string {

--- a/src/application/openWarp.ts
+++ b/src/application/openWarp.ts
@@ -4,6 +4,7 @@ import { OPEN_WARP_IDENTITY_FAILURE } from '../domain/api/OpenWarpIdentityFailur
 import { createTimeline } from '../domain/api/TimelineRuntime.ts';
 import WarpError from '../domain/errors/WarpError.ts';
 import { openWarpWorldline } from '../domain/WarpWorldline.ts';
+import { createApiRuntimeContext } from './ReceiptProvenanceRegistry.ts';
 import { getDefaultRuntimeHostNodePorts } from './RuntimeHostNodeDefaults.ts';
 import WarpStorage from './WarpStorage.ts';
 import { resolveWarpStorage } from './WarpStorageRegistry.ts';
@@ -21,19 +22,22 @@ export function openWarp(options: OpenWarpOptions): Promise<Warp> {
 
     return new Warp({
       writer: options.writer,
-      openTimeline: async (name) =>
-        createTimeline(
-          await openWarpWorldline({
-            persistence: binding.history,
-            runtimeStorage: binding.runtimeStorage,
-            worldlineName: name,
-            writerId: options.writer,
-            codec: runtimePorts.codec,
-            crypto: runtimePorts.crypto,
-            trustCrypto: runtimePorts.trustCrypto,
-            commitMessageCodec: runtimePorts.commitMessageCodec,
-          }),
-        ),
+      openTimeline: async (name) => {
+        const runtime = await openWarpWorldline({
+          persistence: binding.history,
+          runtimeStorage: binding.runtimeStorage,
+          worldlineName: name,
+          writerId: options.writer,
+          codec: runtimePorts.codec,
+          crypto: runtimePorts.crypto,
+          trustCrypto: runtimePorts.trustCrypto,
+          commitMessageCodec: runtimePorts.commitMessageCodec,
+        });
+        return createTimeline(
+          runtime,
+          createApiRuntimeContext(options.storage, runtimePorts.crypto)
+        );
+      },
     });
   });
 }
@@ -43,10 +47,7 @@ function assertOpenWarpOptions(options: OpenWarpOptions | null | undefined): voi
     throw new WarpError('openWarp options are required', 'E_OPEN_WARP_OPTIONS');
   }
   if (!(options.storage instanceof WarpStorage)) {
-    throw new WarpError(
-      'openWarp requires a WarpStorage handle',
-      'E_OPEN_WARP_STORAGE',
-    );
+    throw new WarpError('openWarp requires a WarpStorage handle', 'E_OPEN_WARP_STORAGE');
   }
   assertWriterIdentity(options.writer, 'writer', OPEN_WARP_IDENTITY_FAILURE);
 }

--- a/src/domain/api/ApiRuntimeContext.ts
+++ b/src/domain/api/ApiRuntimeContext.ts
@@ -22,5 +22,6 @@ export type ApiRuntimeContext = {
     namespace: 'tick' | 'evidence',
     parts: readonly OpaqueIdPart[]
   ) => Promise<string>;
+  readonly reserveRecoveryNonce: () => string;
   readonly bindReceipt: (receipt: Receipt, provenance: ReceiptProvenance) => void;
 };

--- a/src/domain/api/ApiRuntimeContext.ts
+++ b/src/domain/api/ApiRuntimeContext.ts
@@ -1,0 +1,26 @@
+import type ReadIdentity from '../services/optic/ReadIdentity.ts';
+import type { Receipt } from './Receipt.ts';
+
+export type ReceiptProvenance =
+  | {
+      readonly operation: 'write';
+      readonly patchSha: string | undefined;
+    }
+  | {
+      readonly operation: 'read';
+      readonly identity: ReadIdentity | undefined;
+    }
+  | {
+      readonly operation: 'join';
+      readonly patchShas: readonly string[];
+    };
+
+export type OpaqueIdPart = string | number;
+
+export type ApiRuntimeContext = {
+  readonly createOpaqueId: (
+    namespace: 'tick' | 'evidence',
+    parts: readonly OpaqueIdPart[]
+  ) => Promise<string>;
+  readonly bindReceipt: (receipt: Receipt, provenance: ReceiptProvenance) => void;
+};

--- a/src/domain/api/DraftTimelineRuntime.ts
+++ b/src/domain/api/DraftTimelineRuntime.ts
@@ -2,7 +2,8 @@ import type WarpWorldline from '../WarpWorldline.ts';
 import WarpError from '../errors/WarpError.ts';
 import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
 import DraftTimeline from './DraftTimeline.ts';
-import { createJoinEvidence } from './EvidenceRuntime.ts';
+import type Evidence from './Evidence.ts';
+import { createJoinEvidence, createJoinRecoveryEvidence } from './EvidenceRuntime.ts';
 import type Intent from './Intent.ts';
 import { applyIntentToPatch } from './IntentRuntime.ts';
 import JoinReceipt from './JoinReceipt.ts';
@@ -17,6 +18,7 @@ type DraftTimelineState = {
   readonly draftPatchShas: string[];
   readonly intents: Intent[];
   readonly joinPatchShas: string[];
+  joinRecoveryEvidence: Evidence | undefined;
   joinFailed: boolean;
   joining: boolean;
   joined: boolean;
@@ -41,6 +43,7 @@ type JoinResultFieldsBase = {
   readonly draft: DraftTimeline;
   readonly mode: 'preview' | 'join';
   readonly patchShas: readonly string[];
+  readonly recoveryEvidence?: Evidence;
 };
 
 type JoinResultFields = JoinResultFieldsBase &
@@ -64,13 +67,17 @@ type RejectedJoinFields = {
   readonly draft: DraftTimeline;
   readonly reason: string;
   readonly patchShas?: readonly string[];
+  readonly recoveryEvidence?: Evidence;
 };
+
+type JoinPreconditionRejection = Omit<RejectedJoinFields, 'runtime' | 'draft'>;
 
 type JoinCompletionFields = {
   readonly runtime: WarpWorldline;
   readonly draft: DraftTimeline;
   readonly state: DraftTimelineState;
   readonly patchShas: readonly string[];
+  readonly recoveryEvidence: Evidence;
 };
 
 const draftStates = new WeakMap<DraftTimeline, DraftTimelineState>();
@@ -121,46 +128,68 @@ export async function joinDraftTimeline(
 ): Promise<JoinResult> {
   void options;
   const state = requireDraftState(runtime, draft);
-  const rejected = await rejectedJoinPrecondition(runtime, draft, state);
+  const rejected = rejectedJoinPrecondition(state);
   if (rejected !== null) {
-    return rejected;
+    return await rejectedJoin({ runtime, draft, ...rejected });
   }
 
   state.joining = true;
-  const patchShas = await commitDraftIntents(runtime, state);
-  const failed = await rejectedIncompleteJoin({ runtime, draft, state, patchShas });
-  if (failed !== null) {
+  try {
+    return await performDraftJoin(runtime, draft, state);
+  } finally {
     state.joining = false;
-    return failed;
   }
-  state.joined = true;
-  state.joining = false;
-  return await acceptedJoin({ runtime, draft, state, patchShas });
 }
 
-async function rejectedJoinPrecondition(
+async function performDraftJoin(
   runtime: WarpWorldline,
   draft: DraftTimeline,
   state: DraftTimelineState
-): Promise<JoinResult | null> {
+): Promise<JoinResult> {
+  const recoveryEvidence = await createJoinRecoveryEvidence(runtime, state.context, {
+    draft: draft.name,
+    mode: 'join',
+  });
+  state.joinRecoveryEvidence = recoveryEvidence;
+  const fields = {
+    runtime,
+    draft,
+    state,
+    patchShas: await commitDraftIntents(runtime, state),
+    recoveryEvidence,
+  };
+  const failed = await rejectedIncompleteJoin(fields);
+  if (failed !== null) {
+    return failed;
+  }
+  state.joined = true;
+  return await acceptedJoin(fields);
+}
+
+function rejectedJoinPrecondition(state: DraftTimelineState): JoinPreconditionRejection | null {
   if (state.joined) {
-    return await rejectedJoin({ runtime, draft, reason: 'Draft has already joined' });
+    return { reason: 'Draft has already joined' };
   }
   if (state.joining) {
-    return await rejectedJoin({ runtime, draft, reason: 'Draft join is already in progress' });
+    return { reason: 'Draft join is already in progress' };
   }
   if (state.joinFailed) {
-    return await rejectedJoin({
-      runtime,
-      draft,
-      reason: 'Draft join already has a failed commit attempt',
-      patchShas: state.joinPatchShas,
-    });
+    return failedJoinPrecondition(state);
   }
   if (state.intents.length === 0) {
-    return await rejectedJoin({ runtime, draft, reason: 'Draft has no public intents to join' });
+    return { reason: 'Draft has no public intents to join' };
   }
   return null;
+}
+
+function failedJoinPrecondition(state: DraftTimelineState): JoinPreconditionRejection {
+  const rejection: JoinPreconditionRejection = {
+    reason: 'Draft join already has a failed commit attempt',
+    patchShas: state.joinPatchShas,
+  };
+  return state.joinRecoveryEvidence === undefined
+    ? rejection
+    : { ...rejection, recoveryEvidence: state.joinRecoveryEvidence };
 }
 
 async function rejectedIncompleteJoin(fields: JoinCompletionFields): Promise<JoinResult | null> {
@@ -173,6 +202,7 @@ async function rejectedIncompleteJoin(fields: JoinCompletionFields): Promise<Joi
     draft: fields.draft,
     reason: 'Draft join failed while committing intents',
     patchShas: fields.patchShas,
+    recoveryEvidence: fields.recoveryEvidence,
   });
 }
 
@@ -183,6 +213,7 @@ async function acceptedJoin(fields: JoinCompletionFields): Promise<JoinResult> {
     mode: 'join',
     outcome: 'accepted',
     patchShas: fields.patchShas,
+    recoveryEvidence: fields.recoveryEvidence,
   });
 }
 
@@ -193,6 +224,7 @@ function createDraftState(runtime: WarpWorldline, context: ApiRuntimeContext): D
     draftPatchShas: [],
     intents: [],
     joinPatchShas: [],
+    joinRecoveryEvidence: undefined,
     joinFailed: false,
     joining: false,
     joined: false,
@@ -229,6 +261,7 @@ async function rejectedJoin(fields: RejectedJoinFields): Promise<JoinResult> {
     outcome: 'rejected',
     patchShas: fields.patchShas ?? [],
     reason: fields.reason,
+    ...(fields.recoveryEvidence === undefined ? {} : { recoveryEvidence: fields.recoveryEvidence }),
   });
 }
 
@@ -285,11 +318,7 @@ async function acceptedJoinReceipt(
     draft: fields.draft,
     mode: fields.mode,
     outcome: fields.outcome,
-    evidence: await createJoinEvidence(fields.runtime, context, {
-      draft: fields.draft.name,
-      mode: fields.mode,
-      patchShas: fields.patchShas,
-    }),
+    evidence: await resolvedJoinEvidence(fields, context),
   });
 }
 
@@ -298,13 +327,7 @@ async function unacceptedJoinReceipt(
   context: ApiRuntimeContext
 ): Promise<JoinReceipt> {
   const evidence =
-    fields.patchShas.length === 0
-      ? undefined
-      : await createJoinEvidence(fields.runtime, context, {
-          draft: fields.draft.name,
-          mode: fields.mode,
-          patchShas: fields.patchShas,
-        });
+    fields.patchShas.length === 0 ? undefined : await resolvedJoinEvidence(fields, context);
   return new JoinReceipt({
     timeline: fields.runtime.worldlineName,
     writer: fields.runtime.writerId,
@@ -314,4 +337,23 @@ async function unacceptedJoinReceipt(
     ...(evidence === undefined ? {} : { evidence }),
     reason: fields.reason,
   });
+}
+
+async function resolvedJoinEvidence(
+  fields: JoinResultFieldsBase,
+  context: ApiRuntimeContext
+): Promise<Evidence> {
+  try {
+    return await createJoinEvidence(fields.runtime, context, {
+      draft: fields.draft.name,
+      mode: fields.mode,
+      patchShas: fields.patchShas,
+    });
+  } catch (error) {
+    if (fields.recoveryEvidence === undefined) {
+      throw error;
+    }
+    // At least one patch may be durable; retain a receipt without inventing support.
+    return fields.recoveryEvidence;
+  }
 }

--- a/src/domain/api/DraftTimelineRuntime.ts
+++ b/src/domain/api/DraftTimelineRuntime.ts
@@ -1,6 +1,8 @@
 import type WarpWorldline from '../WarpWorldline.ts';
 import WarpError from '../errors/WarpError.ts';
+import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
 import DraftTimeline from './DraftTimeline.ts';
+import { createJoinEvidence } from './EvidenceRuntime.ts';
 import type Intent from './Intent.ts';
 import { applyIntentToPatch } from './IntentRuntime.ts';
 import JoinReceipt from './JoinReceipt.ts';
@@ -10,6 +12,7 @@ import type WriteReceipt from './WriteReceipt.ts';
 import { executeIntentWrite } from './WriteRuntime.ts';
 
 type DraftTimelineState = {
+  readonly context: ApiRuntimeContext;
   readonly runtime: WarpWorldline;
   readonly draftPatchShas: string[];
   readonly intents: Intent[];
@@ -26,6 +29,13 @@ type DraftWriteFields = {
   readonly intent: Intent;
 };
 
+type CreateDraftTimelineFields = {
+  readonly runtime: WarpWorldline;
+  readonly context: ApiRuntimeContext;
+  readonly timelineName: string;
+  readonly draftName: string;
+};
+
 type JoinResultFieldsBase = {
   readonly runtime: WarpWorldline;
   readonly draft: DraftTimeline;
@@ -38,6 +48,16 @@ type JoinResultFields = JoinResultFieldsBase &
     | { readonly outcome: 'accepted'; readonly reason?: never }
     | { readonly outcome: 'rejected'; readonly reason: string }
   );
+
+type AcceptedJoinResultFields = JoinResultFieldsBase & {
+  readonly outcome: 'accepted';
+  readonly reason?: never;
+};
+
+type UnacceptedJoinResultFields = JoinResultFieldsBase & {
+  readonly outcome: 'rejected';
+  readonly reason: string;
+};
 
 type RejectedJoinFields = {
   readonly runtime: WarpWorldline;
@@ -56,12 +76,11 @@ type JoinCompletionFields = {
 const draftStates = new WeakMap<DraftTimeline, DraftTimelineState>();
 
 export async function createDraftTimeline(
-  runtime: WarpWorldline,
-  timelineName: string,
-  draftName: string
+  fields: CreateDraftTimelineFields
 ): Promise<DraftTimeline> {
+  const { runtime, context, timelineName, draftName } = fields;
   await runtime.createDraft(draftName);
-  const state = createDraftState(runtime);
+  const state = createDraftState(runtime, context);
   const draft = new DraftTimeline({
     name: draftName,
     timeline: timelineName,
@@ -86,7 +105,7 @@ export async function previewDraftJoin(
   void options;
   requireDraftState(runtime, draft);
   const patchShas = await runtime.previewDraftJoin(draft.name);
-  return joinResult({
+  return await joinResult({
     runtime,
     draft,
     mode: 'preview',
@@ -102,36 +121,36 @@ export async function joinDraftTimeline(
 ): Promise<JoinResult> {
   void options;
   const state = requireDraftState(runtime, draft);
-  const rejected = rejectedJoinPrecondition(runtime, draft, state);
+  const rejected = await rejectedJoinPrecondition(runtime, draft, state);
   if (rejected !== null) {
     return rejected;
   }
 
   state.joining = true;
   const patchShas = await commitDraftIntents(runtime, state);
-  const failed = rejectedIncompleteJoin({ runtime, draft, state, patchShas });
+  const failed = await rejectedIncompleteJoin({ runtime, draft, state, patchShas });
   if (failed !== null) {
     state.joining = false;
     return failed;
   }
   state.joined = true;
   state.joining = false;
-  return acceptedJoin({ runtime, draft, state, patchShas });
+  return await acceptedJoin({ runtime, draft, state, patchShas });
 }
 
-function rejectedJoinPrecondition(
+async function rejectedJoinPrecondition(
   runtime: WarpWorldline,
   draft: DraftTimeline,
   state: DraftTimelineState
-): JoinResult | null {
+): Promise<JoinResult | null> {
   if (state.joined) {
-    return rejectedJoin({ runtime, draft, reason: 'Draft has already joined' });
+    return await rejectedJoin({ runtime, draft, reason: 'Draft has already joined' });
   }
   if (state.joining) {
-    return rejectedJoin({ runtime, draft, reason: 'Draft join is already in progress' });
+    return await rejectedJoin({ runtime, draft, reason: 'Draft join is already in progress' });
   }
   if (state.joinFailed) {
-    return rejectedJoin({
+    return await rejectedJoin({
       runtime,
       draft,
       reason: 'Draft join already has a failed commit attempt',
@@ -139,17 +158,17 @@ function rejectedJoinPrecondition(
     });
   }
   if (state.intents.length === 0) {
-    return rejectedJoin({ runtime, draft, reason: 'Draft has no public intents to join' });
+    return await rejectedJoin({ runtime, draft, reason: 'Draft has no public intents to join' });
   }
   return null;
 }
 
-function rejectedIncompleteJoin(fields: JoinCompletionFields): JoinResult | null {
+async function rejectedIncompleteJoin(fields: JoinCompletionFields): Promise<JoinResult | null> {
   if (fields.patchShas.length === fields.state.intents.length) {
     return null;
   }
   fields.state.joinFailed = true;
-  return rejectedJoin({
+  return await rejectedJoin({
     runtime: fields.runtime,
     draft: fields.draft,
     reason: 'Draft join failed while committing intents',
@@ -157,8 +176,8 @@ function rejectedIncompleteJoin(fields: JoinCompletionFields): JoinResult | null
   });
 }
 
-function acceptedJoin(fields: JoinCompletionFields): JoinResult {
-  return joinResult({
+async function acceptedJoin(fields: JoinCompletionFields): Promise<JoinResult> {
+  return await joinResult({
     runtime: fields.runtime,
     draft: fields.draft,
     mode: 'join',
@@ -167,8 +186,9 @@ function acceptedJoin(fields: JoinCompletionFields): JoinResult {
   });
 }
 
-function createDraftState(runtime: WarpWorldline): DraftTimelineState {
+function createDraftState(runtime: WarpWorldline, context: ApiRuntimeContext): DraftTimelineState {
   return {
+    context,
     runtime,
     draftPatchShas: [],
     intents: [],
@@ -180,25 +200,29 @@ function createDraftState(runtime: WarpWorldline): DraftTimelineState {
 }
 
 async function writeDraftIntent(fields: DraftWriteFields): Promise<WriteReceipt> {
-  const receipt = await executeIntentWrite(
-    fields.runtime,
-    fields.intent,
-    async (build) => await fields.runtime.patchDraft(fields.draftName, build)
-  );
+  let draftPatchSha: string | undefined;
+  const receipt = await executeIntentWrite({
+    runtime: fields.runtime,
+    context: fields.state.context,
+    intent: fields.intent,
+    commit: async (build) => {
+      draftPatchSha = await fields.runtime.patchDraft(fields.draftName, build);
+      return draftPatchSha;
+    },
+  });
   if (receipt.outcome !== 'accepted') {
     return receipt;
   }
-  const { patchSha } = receipt;
-  if (patchSha === undefined) {
+  if (draftPatchSha === undefined) {
     throw new WarpError('Accepted draft write is missing its patch SHA', 'E_DRAFT_WRITE_RECEIPT');
   }
-  fields.state.draftPatchShas.push(patchSha);
+  fields.state.draftPatchShas.push(draftPatchSha);
   fields.state.intents.push(fields.intent);
   return receipt;
 }
 
-function rejectedJoin(fields: RejectedJoinFields): JoinResult {
-  return joinResult({
+async function rejectedJoin(fields: RejectedJoinFields): Promise<JoinResult> {
+  return await joinResult({
     runtime: fields.runtime,
     draft: fields.draft,
     mode: 'join',
@@ -236,27 +260,58 @@ function requireDraftState(runtime: WarpWorldline, draft: DraftTimeline): DraftT
   return state;
 }
 
-function joinResult(fields: JoinResultFields): JoinResult {
+async function joinResult(fields: JoinResultFields): Promise<JoinResult> {
+  const { context } = requireDraftState(fields.runtime, fields.draft);
   const receipt =
     fields.outcome === 'accepted'
-      ? new JoinReceipt({
-          timeline: fields.runtime.worldlineName,
-          writer: fields.runtime.writerId,
-          draft: fields.draft,
-          mode: fields.mode,
-          outcome: fields.outcome,
-          patchShas: fields.patchShas,
-        })
-      : new JoinReceipt({
-          timeline: fields.runtime.worldlineName,
-          writer: fields.runtime.writerId,
-          draft: fields.draft,
-          mode: fields.mode,
-          outcome: fields.outcome,
-          patchShas: fields.patchShas,
-          reason: fields.reason,
-        });
+      ? await acceptedJoinReceipt(fields, context)
+      : await unacceptedJoinReceipt(fields, context);
+  context.bindReceipt(receipt, {
+    operation: 'join',
+    patchShas: fields.patchShas,
+  });
   return new JoinResult({
     receipt,
+  });
+}
+
+async function acceptedJoinReceipt(
+  fields: AcceptedJoinResultFields,
+  context: ApiRuntimeContext
+): Promise<JoinReceipt> {
+  return new JoinReceipt({
+    timeline: fields.runtime.worldlineName,
+    writer: fields.runtime.writerId,
+    draft: fields.draft,
+    mode: fields.mode,
+    outcome: fields.outcome,
+    evidence: await createJoinEvidence(fields.runtime, context, {
+      draft: fields.draft.name,
+      mode: fields.mode,
+      patchShas: fields.patchShas,
+    }),
+  });
+}
+
+async function unacceptedJoinReceipt(
+  fields: UnacceptedJoinResultFields,
+  context: ApiRuntimeContext
+): Promise<JoinReceipt> {
+  const evidence =
+    fields.patchShas.length === 0
+      ? undefined
+      : await createJoinEvidence(fields.runtime, context, {
+          draft: fields.draft.name,
+          mode: fields.mode,
+          patchShas: fields.patchShas,
+        });
+  return new JoinReceipt({
+    timeline: fields.runtime.worldlineName,
+    writer: fields.runtime.writerId,
+    draft: fields.draft,
+    mode: fields.mode,
+    outcome: fields.outcome,
+    ...(evidence === undefined ? {} : { evidence }),
+    reason: fields.reason,
   });
 }

--- a/src/domain/api/Evidence.ts
+++ b/src/domain/api/Evidence.ts
@@ -1,0 +1,15 @@
+import type Tick from './Tick.ts';
+
+/** Opaque, storage-neutral handle for one item of causal support. */
+export type EvidenceHandle = Readonly<{
+  readonly id: string;
+}>;
+
+/** Public causal evidence without substrate object identities. */
+type Evidence = Readonly<{
+  readonly basis: EvidenceHandle;
+  readonly support: readonly EvidenceHandle[];
+  readonly tick?: Tick;
+}>;
+
+export default Evidence;

--- a/src/domain/api/EvidenceRuntime.ts
+++ b/src/domain/api/EvidenceRuntime.ts
@@ -13,6 +13,14 @@ type JoinEvidenceFields = {
   readonly patchShas: readonly string[];
 };
 
+const WRITE_EVIDENCE = 'write';
+const JOIN_EVIDENCE = 'join';
+const READ_EVIDENCE = 'read';
+const PATCH_SUPPORT = 'patch';
+const INDEX_SUPPORT = 'index';
+const RECOVERY_EVIDENCE = 'recovery';
+const recoverySequences = new WeakMap<ApiRuntimeContext, number>();
+
 export async function createWriteEvidence(
   runtime: WarpWorldline,
   context: ApiRuntimeContext,
@@ -20,13 +28,20 @@ export async function createWriteEvidence(
 ): Promise<Evidence> {
   return freezeCreatedEvidence({
     basis: await createHandle(context, [
-      'write',
+      WRITE_EVIDENCE,
       runtime.worldlineName,
       runtime.writerId,
       patchSha,
     ]),
-    support: [await createHandle(context, ['patch', patchSha])],
+    support: [await createHandle(context, [PATCH_SUPPORT, patchSha])],
   });
+}
+
+export async function createWriteRecoveryEvidence(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext
+): Promise<Evidence> {
+  return await createRecoveryEvidence(runtime, context, [WRITE_EVIDENCE]);
 }
 
 export async function createJoinEvidence(
@@ -35,11 +50,11 @@ export async function createJoinEvidence(
   fields: JoinEvidenceFields
 ): Promise<Evidence> {
   const support = await Promise.all(
-    fields.patchShas.map(async (patchSha) => await createHandle(context, ['patch', patchSha]))
+    fields.patchShas.map(async (patchSha) => await createHandle(context, [PATCH_SUPPORT, patchSha]))
   );
   return freezeCreatedEvidence({
     basis: await createHandle(context, [
-      'join',
+      JOIN_EVIDENCE,
       runtime.worldlineName,
       runtime.writerId,
       fields.draft,
@@ -48,6 +63,14 @@ export async function createJoinEvidence(
     ]),
     support,
   });
+}
+
+export async function createJoinRecoveryEvidence(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext,
+  fields: Pick<JoinEvidenceFields, 'draft' | 'mode'>
+): Promise<Evidence> {
+  return await createRecoveryEvidence(runtime, context, [JOIN_EVIDENCE, fields.draft, fields.mode]);
 }
 
 export async function createReadEvidence(
@@ -59,7 +82,7 @@ export async function createReadEvidence(
   const frontier = identity.checkpointFrontier.flatMap((entry) => [entry.writerId, entry.patchSha]);
   const evidence = {
     basis: await createHandle(context, [
-      'read',
+      READ_EVIDENCE,
       identity.kind,
       identity.basis,
       identity.worldline,
@@ -82,18 +105,48 @@ export function freezeEvidence(evidence: Evidence, field: string): Evidence {
   return freezeCreatedEvidence(tick === undefined ? { basis, support } : { basis, support, tick });
 }
 
+export function freezeOptionalEvidence(
+  evidence: Evidence | undefined,
+  field: string
+): Evidence | undefined {
+  return evidence === undefined ? undefined : freezeEvidence(evidence, field);
+}
+
 async function createReadSupport(
   context: ApiRuntimeContext,
   identity: ReadIdentity
 ): Promise<readonly EvidenceHandle[]> {
   return await Promise.all([
     ...identity.checkpointIndexShards.map(
-      async (shard) => await createHandle(context, ['index', shard.path, shard.oid])
+      async (shard) => await createHandle(context, [INDEX_SUPPORT, shard.path, shard.oid])
     ),
     ...identity.tailWitnesses.map(
-      async (witness) => await createHandle(context, ['patch', witness.sha])
+      async (witness) => await createHandle(context, [PATCH_SUPPORT, witness.sha])
     ),
   ]);
+}
+
+async function createRecoveryEvidence(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext,
+  parts: readonly OpaqueIdPart[]
+): Promise<Evidence> {
+  return freezeCreatedEvidence({
+    basis: await createHandle(context, [
+      RECOVERY_EVIDENCE,
+      runtime.worldlineName,
+      runtime.writerId,
+      ...parts,
+      nextRecoverySequence(context),
+    ]),
+    support: [],
+  });
+}
+
+function nextRecoverySequence(context: ApiRuntimeContext): number {
+  const sequence = (recoverySequences.get(context) ?? 0) + 1;
+  recoverySequences.set(context, sequence);
+  return sequence;
 }
 
 function assertEvidenceObject(evidence: Evidence, field: string): void {

--- a/src/domain/api/EvidenceRuntime.ts
+++ b/src/domain/api/EvidenceRuntime.ts
@@ -1,0 +1,151 @@
+import type WarpWorldline from '../WarpWorldline.ts';
+import WarpError from '../errors/WarpError.ts';
+import type ReadIdentity from '../services/optic/ReadIdentity.ts';
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+import type { ApiRuntimeContext, OpaqueIdPart } from './ApiRuntimeContext.ts';
+import type Evidence from './Evidence.ts';
+import type { EvidenceHandle } from './Evidence.ts';
+import Tick from './Tick.ts';
+
+type JoinEvidenceFields = {
+  readonly draft: string;
+  readonly mode: 'preview' | 'join';
+  readonly patchShas: readonly string[];
+};
+
+export async function createWriteEvidence(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext,
+  patchSha: string
+): Promise<Evidence> {
+  return freezeCreatedEvidence({
+    basis: await createHandle(context, [
+      'write',
+      runtime.worldlineName,
+      runtime.writerId,
+      patchSha,
+    ]),
+    support: [await createHandle(context, ['patch', patchSha])],
+  });
+}
+
+export async function createJoinEvidence(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext,
+  fields: JoinEvidenceFields
+): Promise<Evidence> {
+  const support = await Promise.all(
+    fields.patchShas.map(async (patchSha) => await createHandle(context, ['patch', patchSha]))
+  );
+  return freezeCreatedEvidence({
+    basis: await createHandle(context, [
+      'join',
+      runtime.worldlineName,
+      runtime.writerId,
+      fields.draft,
+      fields.mode,
+      ...fields.patchShas,
+    ]),
+    support,
+  });
+}
+
+export async function createReadEvidence(
+  context: ApiRuntimeContext,
+  identity: ReadIdentity,
+  tick?: Tick
+): Promise<Evidence> {
+  const support = await createReadSupport(context, identity);
+  const frontier = identity.checkpointFrontier.flatMap((entry) => [entry.writerId, entry.patchSha]);
+  const evidence = {
+    basis: await createHandle(context, [
+      'read',
+      identity.kind,
+      identity.basis,
+      identity.worldline,
+      identity.entityAspect,
+      identity.checkpointSha,
+      identity.reducerVersion,
+      identity.projectionVersion,
+      ...frontier,
+    ]),
+    support,
+  };
+  return freezeCreatedEvidence(tick === undefined ? evidence : { ...evidence, tick });
+}
+
+export function freezeEvidence(evidence: Evidence, field: string): Evidence {
+  assertEvidenceObject(evidence, field);
+  const basis = freezeHandle(evidence.basis, `${field}.basis`);
+  const support = freezeSupport(evidence.support, `${field}.support`);
+  const tick = validateTick(evidence.tick, `${field}.tick`);
+  return freezeCreatedEvidence(tick === undefined ? { basis, support } : { basis, support, tick });
+}
+
+async function createReadSupport(
+  context: ApiRuntimeContext,
+  identity: ReadIdentity
+): Promise<readonly EvidenceHandle[]> {
+  return await Promise.all([
+    ...identity.checkpointIndexShards.map(
+      async (shard) => await createHandle(context, ['index', shard.path, shard.oid])
+    ),
+    ...identity.tailWitnesses.map(
+      async (witness) => await createHandle(context, ['patch', witness.sha])
+    ),
+  ]);
+}
+
+function assertEvidenceObject(evidence: Evidence, field: string): void {
+  if (typeof evidence !== 'object' || evidence === null) {
+    throw new WarpError(`${field} must be causal evidence`, 'E_RECEIPT_EVIDENCE');
+  }
+}
+
+function freezeSupport(
+  support: readonly EvidenceHandle[],
+  field: string
+): readonly EvidenceHandle[] {
+  if (!Array.isArray(support)) {
+    throw new WarpError(`${field} must be an array`, 'E_RECEIPT_EVIDENCE');
+  }
+  return Object.freeze(support.map((handle, index) => freezeHandle(handle, `${field}[${index}]`)));
+}
+
+function validateTick(tick: Tick | undefined, field: string): Tick | undefined {
+  if (tick !== undefined && !(tick instanceof Tick)) {
+    throw new WarpError(`${field} must be a Tick`, 'E_RECEIPT_EVIDENCE');
+  }
+  return tick;
+}
+
+async function createHandle(
+  context: ApiRuntimeContext,
+  parts: readonly OpaqueIdPart[]
+): Promise<EvidenceHandle> {
+  const id = await context.createOpaqueId('evidence', parts);
+  return Object.freeze({ id });
+}
+
+function freezeHandle(handle: EvidenceHandle, field: string): EvidenceHandle {
+  if (typeof handle !== 'object' || handle === null) {
+    throw new WarpError(`${field} must be an evidence handle`, 'E_RECEIPT_EVIDENCE');
+  }
+  requireNonEmptyString(handle.id, `${field}.id`);
+  return Object.freeze({ id: handle.id });
+}
+
+function freezeCreatedEvidence(evidence: Evidence): Evidence {
+  const result: {
+    readonly basis: EvidenceHandle;
+    readonly support: readonly EvidenceHandle[];
+    tick?: Tick;
+  } = {
+    basis: evidence.basis,
+    support: Object.freeze([...evidence.support]),
+  };
+  if (evidence.tick !== undefined) {
+    result.tick = evidence.tick;
+  }
+  return Object.freeze(result);
+}

--- a/src/domain/api/EvidenceRuntime.ts
+++ b/src/domain/api/EvidenceRuntime.ts
@@ -19,7 +19,6 @@ const READ_EVIDENCE = 'read';
 const PATCH_SUPPORT = 'patch';
 const INDEX_SUPPORT = 'index';
 const RECOVERY_EVIDENCE = 'recovery';
-const recoverySequences = new WeakMap<ApiRuntimeContext, number>();
 
 export async function createWriteEvidence(
   runtime: WarpWorldline,
@@ -137,16 +136,10 @@ async function createRecoveryEvidence(
       runtime.worldlineName,
       runtime.writerId,
       ...parts,
-      nextRecoverySequence(context),
+      context.reserveRecoveryNonce(),
     ]),
     support: [],
   });
-}
-
-function nextRecoverySequence(context: ApiRuntimeContext): number {
-  const sequence = (recoverySequences.get(context) ?? 0) + 1;
-  recoverySequences.set(context, sequence);
-  return sequence;
 }
 
 function assertEvidenceObject(evidence: Evidence, field: string): void {

--- a/src/domain/api/JoinReceipt.ts
+++ b/src/domain/api/JoinReceipt.ts
@@ -1,6 +1,8 @@
 import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
 import DraftTimeline from './DraftTimeline.ts';
+import type Evidence from './Evidence.ts';
+import { freezeEvidence } from './EvidenceRuntime.ts';
 import { RECEIPT_OUTCOMES, type JoinOutcome } from './ReceiptOutcome.ts';
 
 export type JoinMode = 'preview' | 'join';
@@ -11,17 +13,18 @@ type JoinReceiptFields = {
   readonly writer: string;
   readonly draft: DraftTimeline;
   readonly mode: JoinMode;
-  readonly patchShas?: readonly string[];
 };
 
 export type JoinReceiptOptions = JoinReceiptFields &
   (
     | {
         readonly outcome: 'accepted';
+        readonly evidence: Evidence;
         readonly reason?: never;
       }
     | {
         readonly outcome: Exclude<JoinReceiptOutcome, 'accepted'>;
+        readonly evidence?: Evidence;
         readonly reason: string;
       }
   );
@@ -31,10 +34,10 @@ const JOIN_RECEIPT_OUTCOMES: ReadonlySet<JoinReceiptOutcome> = RECEIPT_OUTCOMES;
 
 export default class JoinReceipt {
   readonly draft: DraftTimeline;
+  readonly evidence: Evidence | undefined;
   readonly mode: JoinMode;
   readonly operation: 'join' = 'join';
   readonly outcome: JoinReceiptOutcome;
-  readonly patchShas: readonly string[];
   readonly reason: string | undefined;
   readonly timeline: string;
   readonly writer: string;
@@ -42,14 +45,16 @@ export default class JoinReceipt {
   constructor(options: JoinReceiptOptions | null | undefined) {
     const fields = requireJoinReceiptOptions(options);
     validateJoinReceiptFields(fields);
-    const patchShas = validatePatchShas(fields.patchShas ?? []);
 
     this.timeline = fields.timeline;
     this.writer = fields.writer;
     this.draft = fields.draft;
+    this.evidence =
+      fields.evidence === undefined
+        ? undefined
+        : freezeEvidence(fields.evidence, 'joinReceipt.evidence');
     this.mode = fields.mode;
     this.outcome = fields.outcome;
-    this.patchShas = patchShas;
     this.reason = fields.reason;
     Object.freeze(this);
   }
@@ -84,6 +89,9 @@ function validateJoinOutcome(outcome: JoinReceiptOutcome): void {
 
 function validateJoinReason(fields: JoinReceiptOptions): void {
   if (fields.outcome === 'accepted') {
+    if (fields.evidence === undefined) {
+      throw new WarpError('Accepted JoinReceipt requires evidence', 'E_JOIN_RECEIPT_EVIDENCE');
+    }
     rejectAcceptedJoinReason(fields.reason);
     return;
   }
@@ -103,13 +111,4 @@ function requireJoinReceiptOptions(
     throw new WarpError('JoinReceipt options are required', 'E_JOIN_RECEIPT_OPTIONS');
   }
   return options;
-}
-
-function validatePatchShas(patchShas: readonly string[]): readonly string[] {
-  const checked: string[] = [];
-  for (const patchSha of patchShas) {
-    requireNonEmptyString(patchSha, 'joinReceipt.patchSha');
-    checked.push(patchSha);
-  }
-  return Object.freeze(checked);
 }

--- a/src/domain/api/JoinReceipt.ts
+++ b/src/domain/api/JoinReceipt.ts
@@ -2,7 +2,7 @@ import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
 import DraftTimeline from './DraftTimeline.ts';
 import type Evidence from './Evidence.ts';
-import { freezeEvidence } from './EvidenceRuntime.ts';
+import { freezeOptionalEvidence } from './EvidenceRuntime.ts';
 import { RECEIPT_OUTCOMES, type JoinOutcome } from './ReceiptOutcome.ts';
 
 export type JoinMode = 'preview' | 'join';
@@ -49,10 +49,7 @@ export default class JoinReceipt {
     this.timeline = fields.timeline;
     this.writer = fields.writer;
     this.draft = fields.draft;
-    this.evidence =
-      fields.evidence === undefined
-        ? undefined
-        : freezeEvidence(fields.evidence, 'joinReceipt.evidence');
+    this.evidence = freezeOptionalEvidence(fields.evidence, 'joinReceipt.evidence');
     this.mode = fields.mode;
     this.outcome = fields.outcome;
     this.reason = fields.reason;

--- a/src/domain/api/ReadReceipt.ts
+++ b/src/domain/api/ReadReceipt.ts
@@ -1,7 +1,7 @@
 import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
 import type Evidence from './Evidence.ts';
-import { freezeEvidence } from './EvidenceRuntime.ts';
+import { freezeOptionalEvidence } from './EvidenceRuntime.ts';
 import Reading from './Reading.ts';
 import { RECEIPT_OUTCOMES, type ReadOutcome } from './ReceiptOutcome.ts';
 import { freezeRepairHints, type RepairHint } from './ReceiptSupport.ts';
@@ -49,10 +49,7 @@ export default class ReadReceipt {
     this.writer = fields.writer;
     this.reading = fields.reading;
     this.outcome = fields.outcome;
-    this.evidence =
-      fields.evidence === undefined
-        ? undefined
-        : freezeEvidence(fields.evidence, 'readReceipt.evidence');
+    this.evidence = freezeOptionalEvidence(fields.evidence, 'readReceipt.evidence');
     this.repairHints = freezeRepairHints(fields.repairHints ?? []);
     this.reason = fields.reason;
     Object.freeze(this);

--- a/src/domain/api/ReadReceipt.ts
+++ b/src/domain/api/ReadReceipt.ts
@@ -1,6 +1,7 @@
 import WarpError from '../errors/WarpError.ts';
-import type ReadIdentity from '../services/optic/ReadIdentity.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+import type Evidence from './Evidence.ts';
+import { freezeEvidence } from './EvidenceRuntime.ts';
 import Reading from './Reading.ts';
 import { RECEIPT_OUTCOMES, type ReadOutcome } from './ReceiptOutcome.ts';
 import { freezeRepairHints, type RepairHint } from './ReceiptSupport.ts';
@@ -18,36 +19,20 @@ export type ReadReceiptOptions = ReadReceiptFields &
   (
     | {
         readonly outcome: 'accepted';
-        readonly evidence: ReadEvidence;
+        readonly evidence: Evidence;
         readonly reason?: never;
       }
     | {
         readonly outcome: Exclude<ReadReceiptOutcome, 'accepted'>;
-        readonly evidence?: ReadEvidence;
+        readonly evidence?: Evidence;
         readonly reason: string;
       }
   );
 
-export type ReadEvidence = Readonly<
-  Pick<
-    ReadIdentity,
-    | 'kind'
-    | 'basis'
-    | 'worldline'
-    | 'entityAspect'
-    | 'checkpointSha'
-    | 'checkpointFrontier'
-    | 'checkpointIndexShards'
-    | 'tailWitnesses'
-    | 'reducerVersion'
-    | 'projectionVersion'
-  >
->;
-
 const READ_RECEIPT_OUTCOMES: ReadonlySet<ReadReceiptOutcome> = RECEIPT_OUTCOMES;
 
 export default class ReadReceipt {
-  readonly evidence: ReadEvidence | undefined;
+  readonly evidence: Evidence | undefined;
   readonly operation: 'read' = 'read';
   readonly outcome: ReadReceiptOutcome;
   readonly reading: Reading;
@@ -64,7 +49,10 @@ export default class ReadReceipt {
     this.writer = fields.writer;
     this.reading = fields.reading;
     this.outcome = fields.outcome;
-    this.evidence = fields.evidence;
+    this.evidence =
+      fields.evidence === undefined
+        ? undefined
+        : freezeEvidence(fields.evidence, 'readReceipt.evidence');
     this.repairHints = freezeRepairHints(fields.repairHints ?? []);
     this.reason = fields.reason;
     Object.freeze(this);

--- a/src/domain/api/ReadingRuntime.ts
+++ b/src/domain/api/ReadingRuntime.ts
@@ -6,11 +6,14 @@ import type NeighborhoodOpticReadResult from '../services/optic/NeighborhoodOpti
 import type WorldlineOptic from '../services/optic/WorldlineOptic.ts';
 import { createSnapshotPropValue } from '../services/ImmutableSnapshot.ts';
 import type { SnapshotPropValue } from '../services/snapshot/SnapshotPropValue.ts';
+import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
+import { createReadEvidence } from './EvidenceRuntime.ts';
 import type Reading from './Reading.ts';
 import type { ReadingDescriptor, ReadingKind } from './Reading.ts';
 import ReadReceipt, { type ReadReceiptOutcome } from './ReadReceipt.ts';
 import type { RepairHint } from './ReceiptSupport.ts';
 import ReadingResult from './ReadingResult.ts';
+import type Tick from './Tick.ts';
 
 type BoundedReading = {
   readonly evidence: ReadIdentity;
@@ -21,6 +24,27 @@ type ReadingExecutor = (
   descriptor: ReadingDescriptor,
   optic: WorldlineOptic
 ) => Promise<BoundedReading>;
+
+type ReadingBasis = {
+  readonly optic: WorldlineOptic;
+  readonly tick: Tick;
+};
+
+type ReadingExecutionFields = {
+  readonly runtime: WarpWorldline;
+  readonly context: ApiRuntimeContext;
+  readonly reading: Reading;
+  readonly basis?: ReadingBasis;
+};
+
+type AcceptedReadingFields = Omit<ReadingExecutionFields, 'basis'> & {
+  readonly basis: ReadingBasis | undefined;
+  readonly result: BoundedReading;
+};
+
+type UnresolvedReadingFields = ReadingExecutionFields & {
+  readonly failure: OperationalReadFailure;
+};
 
 type OperationalReadFailure = {
   readonly outcome: Exclude<ReadReceiptOutcome, 'accepted' | 'rejected'>;
@@ -42,26 +66,30 @@ const readers: ReadonlyMap<ReadingKind, ReadingExecutor> = new Map([
   ['neighborhood', readNeighborhood],
 ]);
 
-export async function executeReading(
-  runtime: WarpWorldline,
-  reading: Reading,
-  optic?: WorldlineOptic
-): Promise<ReadingResult> {
-  const { descriptor } = reading;
-  const reader = requireReader(reading.kind);
+export async function executeReading(fields: ReadingExecutionFields): Promise<ReadingResult> {
   try {
-    const result = await reader(descriptor, optic ?? runtime.optic());
-    return readingResult(runtime, reading, result);
+    return await executeResolvedReading(fields);
   } catch (error) {
     if (!(error instanceof WarpError)) {
       throw error;
     }
-    const failure = operationalReadFailure(error);
-    if (failure === null) {
-      throw error;
-    }
-    return unresolvedReadingResult(runtime, reading, failure);
+    return handleReadingFailure(fields, error);
   }
+}
+
+async function executeResolvedReading(fields: ReadingExecutionFields): Promise<ReadingResult> {
+  const { runtime, context, reading, basis } = fields;
+  const reader = requireReader(reading.kind);
+  const result = await reader(reading.descriptor, basis?.optic ?? runtime.optic());
+  return await readingResult({ runtime, context, reading, basis, result });
+}
+
+function handleReadingFailure(fields: ReadingExecutionFields, error: WarpError): ReadingResult {
+  const failure = operationalReadFailure(error);
+  if (failure === null) {
+    throw error;
+  }
+  return unresolvedReadingResult({ ...fields, failure });
 }
 
 function requireReader(kind: ReadingKind): ReadingExecutor {
@@ -149,36 +177,34 @@ function neighborhoodValue(result: NeighborhoodOpticReadResult): SnapshotPropVal
   });
 }
 
-function readingResult(
-  runtime: WarpWorldline,
-  reading: Reading,
-  result: BoundedReading
-): ReadingResult {
+async function readingResult(fields: AcceptedReadingFields): Promise<ReadingResult> {
+  const { runtime, context, reading, result, basis } = fields;
+  const receipt = new ReadReceipt({
+    timeline: runtime.worldlineName,
+    writer: runtime.writerId,
+    reading,
+    outcome: 'accepted',
+    evidence: await createReadEvidence(context, result.evidence, basis?.tick),
+  });
+  context.bindReceipt(receipt, { operation: 'read', identity: result.evidence });
   return new ReadingResult({
     value: result.value,
-    receipt: new ReadReceipt({
-      timeline: runtime.worldlineName,
-      writer: runtime.writerId,
-      reading,
-      outcome: 'accepted',
-      evidence: result.evidence,
-    }),
+    receipt,
   });
 }
 
-function unresolvedReadingResult(
-  runtime: WarpWorldline,
-  reading: Reading,
-  failure: OperationalReadFailure
-): ReadingResult {
+function unresolvedReadingResult(fields: UnresolvedReadingFields): ReadingResult {
+  const { runtime, context, reading, failure } = fields;
+  const receipt = new ReadReceipt({
+    timeline: runtime.worldlineName,
+    writer: runtime.writerId,
+    reading,
+    ...failure,
+  });
+  context.bindReceipt(receipt, { operation: 'read', identity: undefined });
   return new ReadingResult({
     value: null,
-    receipt: new ReadReceipt({
-      timeline: runtime.worldlineName,
-      writer: runtime.writerId,
-      reading,
-      ...failure,
-    }),
+    receipt,
   });
 }
 

--- a/src/domain/api/TickRuntime.ts
+++ b/src/domain/api/TickRuntime.ts
@@ -1,6 +1,7 @@
 import type WarpWorldline from '../WarpWorldline.ts';
 import type WarpWorldlineCoordinate from '../WarpWorldlineCoordinate.ts';
 import WarpError from '../errors/WarpError.ts';
+import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
 import Tick from './Tick.ts';
 
 type TickBinding = {
@@ -10,12 +11,23 @@ type TickBinding = {
 
 const tickBindings = new WeakMap<Tick, TickBinding>();
 
-export async function createTick(runtime: WarpWorldline): Promise<Tick> {
+export async function createTick(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext
+): Promise<Tick> {
   await runtime.prepareOpticBasis();
   const coordinate = await runtime.coordinate();
+  return await createTickFromCoordinate(runtime, context, coordinate);
+}
+
+export async function createTickFromCoordinate(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext,
+  coordinate: WarpWorldlineCoordinate
+): Promise<Tick> {
   const tick = new Tick({
     timeline: runtime.worldlineName,
-    id: tickId(coordinate),
+    id: await tickId(context, coordinate),
   });
   tickBindings.set(tick, { coordinate, runtime });
   return tick;
@@ -33,9 +45,14 @@ export function requireTickCoordinate(runtime: WarpWorldline, tick: Tick): WarpW
   return binding.coordinate;
 }
 
-function tickId(coordinate: WarpWorldlineCoordinate): string {
-  const frontier = coordinate.frontierEntries
-    .map((entry) => `${encodeURIComponent(entry.writerId)}=${entry.patchSha}`)
-    .join(',');
-  return `tick:${coordinate.checkpointSha}:${frontier}`;
+async function tickId(
+  context: ApiRuntimeContext,
+  coordinate: WarpWorldlineCoordinate
+): Promise<string> {
+  const frontier = coordinate.frontierEntries.flatMap((entry) => [entry.writerId, entry.patchSha]);
+  return await context.createOpaqueId('tick', [
+    coordinate.worldlineName,
+    coordinate.checkpointSha,
+    ...frontier,
+  ]);
 }

--- a/src/domain/api/TimelineRuntime.ts
+++ b/src/domain/api/TimelineRuntime.ts
@@ -1,5 +1,6 @@
 import WarpError from '../errors/WarpError.ts';
 import type WarpWorldline from '../WarpWorldline.ts';
+import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
 import {
   createDraftTimeline,
   joinDraftTimeline,
@@ -13,18 +14,29 @@ import { executeIntentWrite } from './WriteRuntime.ts';
 
 const timelineRuntimes = new WeakMap<Timeline, WarpWorldline>();
 
-export function createTimeline(runtime: WarpWorldline): Timeline {
+export function createTimeline(runtime: WarpWorldline, context: ApiRuntimeContext): Timeline {
   const timeline = new Timeline({
     name: runtime.worldlineName,
     writer: runtime.writerId,
-    captureTick: async () => await createTick(runtime),
+    captureTick: async () => await createTick(runtime, context),
     joinDraft: (draft, options) => joinDraftTimeline(runtime, draft, options),
-    openDraft: (name) => createDraftTimeline(runtime, runtime.worldlineName, name),
-    openView: (tick) => createTimelineView(runtime, tick),
+    openDraft: (name) =>
+      createDraftTimeline({
+        runtime,
+        context,
+        timelineName: runtime.worldlineName,
+        draftName: name,
+      }),
+    openView: (tick) => createTimelineView(runtime, context, tick),
     previewJoinDraft: (draft, options) => previewDraftJoin(runtime, draft, options),
-    readReading: (reading) => executeReading(runtime, reading),
+    readReading: (reading) => executeReading({ runtime, context, reading }),
     writeIntent: async (intent) =>
-      await executeIntentWrite(runtime, intent, runtime.commit.bind(runtime)),
+      await executeIntentWrite({
+        runtime,
+        context,
+        intent,
+        commit: runtime.commit.bind(runtime),
+      }),
   });
   timelineRuntimes.set(timeline, runtime);
   return timeline;

--- a/src/domain/api/TimelineViewRuntime.ts
+++ b/src/domain/api/TimelineViewRuntime.ts
@@ -1,15 +1,26 @@
 import type WarpWorldline from '../WarpWorldline.ts';
+import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
 import { executeReading } from './ReadingRuntime.ts';
 import type Tick from './Tick.ts';
 import { requireTickCoordinate } from './TickRuntime.ts';
 import TimelineView from './TimelineView.ts';
 
-export function createTimelineView(runtime: WarpWorldline, tick: Tick): TimelineView {
+export function createTimelineView(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext,
+  tick: Tick
+): TimelineView {
   const coordinate = requireTickCoordinate(runtime, tick);
   return new TimelineView({
     name: runtime.worldlineName,
     writer: runtime.writerId,
     tick,
-    readReading: async (reading) => await executeReading(runtime, reading, coordinate.optic()),
+    readReading: async (reading) =>
+      await executeReading({
+        runtime,
+        context,
+        reading,
+        basis: { optic: coordinate.optic(), tick },
+      }),
   });
 }

--- a/src/domain/api/WriteReceipt.ts
+++ b/src/domain/api/WriteReceipt.ts
@@ -1,5 +1,7 @@
 import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+import type Evidence from './Evidence.ts';
+import { freezeEvidence } from './EvidenceRuntime.ts';
 import Intent from './Intent.ts';
 import { RECEIPT_OUTCOMES, type WriteOutcome } from './ReceiptOutcome.ts';
 import { freezeRepairHints, type RepairHint } from './ReceiptSupport.ts';
@@ -15,21 +17,21 @@ export type WriteReceiptOptions = WriteReceiptFields &
   (
     | {
         readonly outcome: 'accepted';
-        readonly patchSha: string;
+        readonly evidence: Evidence;
         readonly reason?: never;
       }
     | {
         readonly outcome: Exclude<WriteOutcome, 'accepted'>;
-        readonly patchSha?: never;
+        readonly evidence?: never;
         readonly reason: string;
       }
   );
 
 export default class WriteReceipt {
+  readonly evidence: Evidence | undefined;
   readonly intent: Intent;
   readonly operation: 'write' = 'write';
   readonly outcome: WriteOutcome;
-  readonly patchSha: string | undefined;
   readonly repairHints: readonly RepairHint[];
   readonly reason: string | undefined;
   readonly timeline: string;
@@ -43,7 +45,10 @@ export default class WriteReceipt {
     this.writer = fields.writer;
     this.intent = fields.intent;
     this.outcome = fields.outcome;
-    this.patchSha = fields.patchSha;
+    this.evidence =
+      fields.evidence === undefined
+        ? undefined
+        : freezeEvidence(fields.evidence, 'writeReceipt.evidence');
     this.repairHints = freezeRepairHints(fields.repairHints ?? []);
     this.reason = fields.reason;
     Object.freeze(this);
@@ -72,17 +77,19 @@ function validateWriteOutcome(outcome: WriteOutcome): void {
 
 function validateWriteSettlement(fields: WriteReceiptOptions): void {
   if (fields.outcome === 'accepted') {
-    requireNonEmptyString(fields.patchSha, 'writeReceipt.patchSha');
+    if (fields.evidence === undefined) {
+      throw new WarpError('Accepted WriteReceipt requires evidence', 'E_WRITE_RECEIPT_EVIDENCE');
+    }
     if (fields.reason !== undefined) {
       throw new WarpError('Accepted WriteReceipt cannot carry a reason', 'E_WRITE_RECEIPT_REASON');
     }
     return;
   }
   requireNonEmptyString(fields.reason, 'writeReceipt.reason');
-  if (fields.patchSha !== undefined) {
+  if (fields.evidence !== undefined) {
     throw new WarpError(
-      'Unaccepted WriteReceipt cannot carry a patch SHA',
-      'E_WRITE_RECEIPT_PATCH'
+      'Unaccepted WriteReceipt cannot carry evidence',
+      'E_WRITE_RECEIPT_EVIDENCE'
     );
   }
 }

--- a/src/domain/api/WriteReceipt.ts
+++ b/src/domain/api/WriteReceipt.ts
@@ -1,7 +1,7 @@
 import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
 import type Evidence from './Evidence.ts';
-import { freezeEvidence } from './EvidenceRuntime.ts';
+import { freezeOptionalEvidence } from './EvidenceRuntime.ts';
 import Intent from './Intent.ts';
 import { RECEIPT_OUTCOMES, type WriteOutcome } from './ReceiptOutcome.ts';
 import { freezeRepairHints, type RepairHint } from './ReceiptSupport.ts';
@@ -45,10 +45,7 @@ export default class WriteReceipt {
     this.writer = fields.writer;
     this.intent = fields.intent;
     this.outcome = fields.outcome;
-    this.evidence =
-      fields.evidence === undefined
-        ? undefined
-        : freezeEvidence(fields.evidence, 'writeReceipt.evidence');
+    this.evidence = freezeOptionalEvidence(fields.evidence, 'writeReceipt.evidence');
     this.repairHints = freezeRepairHints(fields.repairHints ?? []);
     this.reason = fields.reason;
     Object.freeze(this);

--- a/src/domain/api/WriteRuntime.ts
+++ b/src/domain/api/WriteRuntime.ts
@@ -1,7 +1,8 @@
 import type { default as WarpWorldline, WarpWorldlinePatchBuild } from '../WarpWorldline.ts';
 import WarpError from '../errors/WarpError.ts';
 import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
-import { createWriteEvidence } from './EvidenceRuntime.ts';
+import type Evidence from './Evidence.ts';
+import { createWriteEvidence, createWriteRecoveryEvidence } from './EvidenceRuntime.ts';
 import type Intent from './Intent.ts';
 import { applyIntentToPatch } from './IntentRuntime.ts';
 import type { WriteOutcome } from './ReceiptOutcome.ts';
@@ -19,6 +20,7 @@ type IntentWriteFields = {
 
 type AcceptedWriteFields = Omit<IntentWriteFields, 'commit'> & {
   readonly patchSha: string;
+  readonly recoveryEvidence: Evidence;
 };
 
 type OperationalWriteFailure = {
@@ -35,11 +37,12 @@ const MATERIALIZE_HINT = Object.freeze([
 ]);
 export async function executeIntentWrite(fields: IntentWriteFields): Promise<WriteReceipt> {
   const { runtime, context, intent, commit } = fields;
+  const recoveryEvidence = await createWriteRecoveryEvidence(runtime, context);
+  let patchSha: string;
   try {
-    const patchSha = await commit((patch) => {
+    patchSha = await commit((patch) => {
       applyIntentToPatch(intent, patch);
     });
-    return await acceptedWriteReceipt({ runtime, context, intent, patchSha });
   } catch (error) {
     if (!(error instanceof WarpError)) {
       throw error;
@@ -57,6 +60,7 @@ export async function executeIntentWrite(fields: IntentWriteFields): Promise<Wri
     context.bindReceipt(receipt, { operation: 'write', patchSha: undefined });
     return receipt;
   }
+  return await acceptedWriteReceipt({ runtime, context, intent, patchSha, recoveryEvidence });
 }
 
 async function acceptedWriteReceipt(fields: AcceptedWriteFields): Promise<WriteReceipt> {
@@ -66,10 +70,19 @@ async function acceptedWriteReceipt(fields: AcceptedWriteFields): Promise<WriteR
     writer: runtime.writerId,
     intent,
     outcome: 'accepted',
-    evidence: await createWriteEvidence(runtime, context, patchSha),
+    evidence: await committedWriteEvidence(fields),
   });
   context.bindReceipt(receipt, { operation: 'write', patchSha });
   return receipt;
+}
+
+async function committedWriteEvidence(fields: AcceptedWriteFields): Promise<Evidence> {
+  try {
+    return await createWriteEvidence(fields.runtime, fields.context, fields.patchSha);
+  } catch {
+    // The patch is durable; return an honest basis without claiming correlated support.
+    return fields.recoveryEvidence;
+  }
 }
 
 function operationalWriteFailure(error: WarpError): OperationalWriteFailure | null {

--- a/src/domain/api/WriteRuntime.ts
+++ b/src/domain/api/WriteRuntime.ts
@@ -1,5 +1,7 @@
 import type { default as WarpWorldline, WarpWorldlinePatchBuild } from '../WarpWorldline.ts';
 import WarpError from '../errors/WarpError.ts';
+import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
+import { createWriteEvidence } from './EvidenceRuntime.ts';
 import type Intent from './Intent.ts';
 import { applyIntentToPatch } from './IntentRuntime.ts';
 import type { WriteOutcome } from './ReceiptOutcome.ts';
@@ -7,6 +9,17 @@ import type { RepairHint } from './ReceiptSupport.ts';
 import WriteReceipt from './WriteReceipt.ts';
 
 type IntentCommit = (build: WarpWorldlinePatchBuild) => Promise<string>;
+
+type IntentWriteFields = {
+  readonly runtime: WarpWorldline;
+  readonly context: ApiRuntimeContext;
+  readonly intent: Intent;
+  readonly commit: IntentCommit;
+};
+
+type AcceptedWriteFields = Omit<IntentWriteFields, 'commit'> & {
+  readonly patchSha: string;
+};
 
 type OperationalWriteFailure = {
   readonly outcome: Exclude<WriteOutcome, 'accepted' | 'underdetermined'>;
@@ -20,16 +33,13 @@ const MATERIALIZE_HINT = Object.freeze([
     message: 'Materialize the timeline before retrying this state-dependent intent.',
   }),
 ]);
-export async function executeIntentWrite(
-  runtime: WarpWorldline,
-  intent: Intent,
-  commit: IntentCommit
-): Promise<WriteReceipt> {
+export async function executeIntentWrite(fields: IntentWriteFields): Promise<WriteReceipt> {
+  const { runtime, context, intent, commit } = fields;
   try {
     const patchSha = await commit((patch) => {
       applyIntentToPatch(intent, patch);
     });
-    return acceptedWriteReceipt(runtime, intent, patchSha);
+    return await acceptedWriteReceipt({ runtime, context, intent, patchSha });
   } catch (error) {
     if (!(error instanceof WarpError)) {
       throw error;
@@ -38,27 +48,28 @@ export async function executeIntentWrite(
     if (failure === null) {
       throw error;
     }
-    return new WriteReceipt({
+    const receipt = new WriteReceipt({
       timeline: runtime.worldlineName,
       writer: runtime.writerId,
       intent,
       ...failure,
     });
+    context.bindReceipt(receipt, { operation: 'write', patchSha: undefined });
+    return receipt;
   }
 }
 
-function acceptedWriteReceipt(
-  runtime: WarpWorldline,
-  intent: Intent,
-  patchSha: string
-): WriteReceipt {
-  return new WriteReceipt({
+async function acceptedWriteReceipt(fields: AcceptedWriteFields): Promise<WriteReceipt> {
+  const { runtime, context, intent, patchSha } = fields;
+  const receipt = new WriteReceipt({
     timeline: runtime.worldlineName,
     writer: runtime.writerId,
     intent,
     outcome: 'accepted',
-    patchSha,
+    evidence: await createWriteEvidence(runtime, context, patchSha),
   });
+  context.bindReceipt(receipt, { operation: 'write', patchSha });
+  return receipt;
 }
 
 function operationalWriteFailure(error: WarpError): OperationalWriteFailure | null {

--- a/test/conformance/v18FirstUseOpticsHonesty.test.ts
+++ b/test/conformance/v18FirstUseOpticsHonesty.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { inspectReceipt } from '../../diagnostics.ts';
 import { openWarp, reading } from '../../index.ts';
 import WarpStorage from '../../src/application/WarpStorage.ts';
 import { bindWarpStorage } from '../../src/application/WarpStorageRegistry.ts';
@@ -126,10 +127,7 @@ class FirstUseOpticsTrapAdapter extends InMemoryGraphAdapter {
 }
 
 class FirstUseOpticsStorage extends WarpStorage {
-  constructor(
-    history: FirstUseOpticsTrapAdapter,
-    runtimeStorage: MemoryRuntimeStorageAdapter,
-  ) {
+  constructor(history: FirstUseOpticsTrapAdapter, runtimeStorage: MemoryRuntimeStorageAdapter) {
     super();
     bindWarpStorage(this, { history, runtimeStorage });
   }
@@ -187,6 +185,7 @@ describe('v18 first-use Optics honesty gate', () => {
         key: PROPERTY_KEY,
       })
     );
+    const inspection = inspectReceipt(property.receipt, { storage });
 
     persistence.forbidTreeOidMapReads();
     const basis = await events.prepareOpticBasis();
@@ -200,7 +199,15 @@ describe('v18 first-use Optics honesty gate', () => {
     expect(property.value).toBe('open');
     expect(property.receipt).toMatchObject({
       outcome: 'accepted',
-      evidence: { checkpointSha },
+      evidence: {
+        basis: { id: expect.any(String) },
+        support: expect.any(Array),
+      },
+    });
+    expect(property.receipt.evidence).not.toHaveProperty('checkpointSha');
+    expect(inspection.substrate).toMatchObject({
+      operation: 'read',
+      identity: { checkpointSha },
     });
     expect(persistence.forbiddenOperations()).toEqual([]);
   });

--- a/test/helpers/BoundedReadBasis.ts
+++ b/test/helpers/BoundedReadBasis.ts
@@ -1,0 +1,18 @@
+import { resolveWarpStorage } from '../../src/application/WarpStorageRegistry.ts';
+import type { MemoryStorage } from '../../storage.ts';
+import { openMemoryRuntimeHostProduct } from './MemoryRuntimeHost.ts';
+
+export async function createBoundedReadBasis(
+  storage: MemoryStorage,
+  graphName: string
+): Promise<void> {
+  const binding = resolveWarpStorage(storage);
+  const runtime = await openMemoryRuntimeHostProduct({
+    persistence: binding.history,
+    runtimeStorage: binding.runtimeStorage,
+    graphName,
+    writerId: 'agent-1',
+  });
+  await runtime.materialize();
+  await runtime.createCheckpoint();
+}

--- a/test/type-check/v19-consumer.ts
+++ b/test/type-check/v19-consumer.ts
@@ -9,6 +9,8 @@ import {
   openWarp,
   reading,
   type DraftTimeline,
+  type Evidence,
+  type EvidenceHandle,
   type Intent,
   type JoinOutcome,
   type JoinReceipt,
@@ -17,7 +19,6 @@ import {
   type JoinPolicy,
   type NeighborhoodReadingFields,
   type OpenWarpOptions,
-  type ReadEvidence,
   type ReadOutcome,
   type Reading,
   type ReadingResult,
@@ -76,7 +77,8 @@ const convenienceValue: ReadingValue = await timeline.readValue(readRequest);
 const readValue: ReadingValue = readResult.value;
 const readReceipt: ReadReceipt = readResult.receipt;
 const readOutcome: ReadOutcome = readReceipt.outcome;
-const readEvidence: ReadEvidence | undefined = readReceipt.evidence;
+const readEvidence: Evidence | undefined = readReceipt.evidence;
+const evidenceBasis: EvidenceHandle | undefined = readEvidence?.basis;
 const repairHints: readonly RepairHint[] = readReceipt.repairHints;
 const draft: DraftTimeline = await timeline.draft('try-admin-role');
 const draftReceipt: WriteReceipt = await draft.write(writeIntent);
@@ -109,6 +111,15 @@ timeline.writerId;
 // @ts-expect-error timelines do not expose patch commits.
 timeline.commit;
 
+// @ts-expect-error write receipts expose opaque evidence, not substrate ids.
+receipt.patchSha;
+
+// @ts-expect-error join receipts expose opaque evidence, not substrate ids.
+joinReceipt.patchShas;
+
+// @ts-expect-error read evidence does not expose checkpoint object ids.
+readReceipt.evidence?.checkpointSha;
+
 void timelineName;
 void timelineWriter;
 void historicalResult;
@@ -120,6 +131,7 @@ void convenienceValue;
 void neighborhoodRequest;
 void readOutcome;
 void readEvidence;
+void evidenceBasis;
 void readOperationOutcome;
 void retiredReadOutcome;
 void repairHints;

--- a/test/type-check/v19-subpaths.ts
+++ b/test/type-check/v19-subpaths.ts
@@ -5,14 +5,15 @@
  * named expert surfaces.
  */
 
-import {
-  GitStorage,
-  MemoryStorage,
-  type GitStorageOptions,
-} from '../../storage.ts';
+import { GitStorage, MemoryStorage, type GitStorageOptions } from '../../storage.ts';
 import { type Receipt, type Timeline } from '../../index.ts';
 import { captureCoordinate, Coordinate, Optic, type Witness } from '../../advanced.ts';
-import { inspectReceipt, type ReceiptInspection } from '../../diagnostics.ts';
+import {
+  inspectReceipt,
+  type InspectReceiptOptions,
+  type ReceiptInspection,
+  type ReceiptSubstrateInspection,
+} from '../../diagnostics.ts';
 
 declare const gitStorageOptions: GitStorageOptions;
 
@@ -24,10 +25,16 @@ const optic: InstanceType<typeof Optic> = coordinate.optic();
 const node = await optic.node('user:alice').read();
 const witness: Witness = node.readIdentity;
 declare const receipt: Receipt;
-const inspection: ReceiptInspection = inspectReceipt(receipt);
+const inspectionOptions: InspectReceiptOptions = { storage: memoryStorage };
+const inspection: ReceiptInspection = inspectReceipt(receipt, inspectionOptions);
+const substrate: ReceiptSubstrateInspection = inspection.substrate;
+
+// @ts-expect-error diagnostics require explicit storage context.
+inspectReceipt(receipt);
 
 void memoryStorage;
 void gitStorage;
 void optic;
 void witness;
 void inspection;
+void substrate;

--- a/test/unit/domain/DraftTimelineRuntime.test.ts
+++ b/test/unit/domain/DraftTimelineRuntime.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import WarpWorldline, { type WarpWorldlinePatchBuild } from '../../../src/domain/WarpWorldline.ts';
+import type {
+  ApiRuntimeContext,
+  ReceiptProvenance,
+} from '../../../src/domain/api/ApiRuntimeContext.ts';
 import {
   createDraftTimeline,
   joinDraftTimeline,
@@ -12,6 +16,20 @@ type RuntimeOptions = {
   readonly commitPatch?: (build: WarpWorldlinePatchBuild) => Promise<string>;
   readonly previewDraftJoin?: (name: string) => Promise<readonly string[]>;
 };
+
+function createRuntimeContext(): {
+  readonly context: ApiRuntimeContext;
+  readonly provenance: ReceiptProvenance[];
+} {
+  const provenance: ReceiptProvenance[] = [];
+  return {
+    context: {
+      createOpaqueId: async (namespace, payload) => `${namespace}:${payload.length}`,
+      bindReceipt: (_receipt, record) => provenance.push(record),
+    },
+    provenance,
+  };
+}
 
 function createRuntime(options: RuntimeOptions = {}): WarpWorldline {
   return new WarpWorldline({
@@ -53,7 +71,13 @@ describe('DraftTimelineRuntime', () => {
         return `join-patch-${commitAttempts}`;
       },
     });
-    const draft = await createDraftTimeline(runtime, 'events', 'try-admin-role');
+    const { context } = createRuntimeContext();
+    const draft = await createDraftTimeline({
+      runtime,
+      context,
+      timelineName: 'events',
+      draftName: 'try-admin-role',
+    });
 
     await draft.write(intent.node.add({ subject: 'user:alice' }));
     const firstJoin = joinDraftTimeline(runtime, draft, { policy: 'deterministic' });
@@ -68,17 +92,28 @@ describe('DraftTimelineRuntime', () => {
     expect(commitAttempts).toBe(1);
   });
 
-  it('reports preview patch shas from runtime materialization', async () => {
+  it('keeps preview object identities behind opaque evidence handles', async () => {
     const runtime = createRuntime({
       previewDraftJoin: async () => ['materialized-preview-patch'],
     });
-    const draft = await createDraftTimeline(runtime, 'events', 'try-admin-role');
+    const { context, provenance } = createRuntimeContext();
+    const draft = await createDraftTimeline({
+      runtime,
+      context,
+      timelineName: 'events',
+      draftName: 'try-admin-role',
+    });
 
     await draft.write(intent.node.add({ subject: 'user:alice' }));
     const preview = await previewDraftJoin(runtime, draft, { policy: 'deterministic' });
 
     expect(preview.receipt.outcome).toBe('accepted');
-    expect(preview.receipt.patchShas).toEqual(['materialized-preview-patch']);
+    expect(preview.receipt.evidence?.support).toHaveLength(1);
+    expect('patchShas' in preview.receipt).toBe(false);
+    expect(provenance.at(-1)).toEqual({
+      operation: 'join',
+      patchShas: ['materialized-preview-patch'],
+    });
   });
 
   it('does not replay committed draft intents after a partial join failure', async () => {
@@ -92,24 +127,36 @@ describe('DraftTimelineRuntime', () => {
         return `join-patch-${commitAttempts}`;
       },
     });
-    const draft = await createDraftTimeline(runtime, 'events', 'try-admin-role');
+    const { context, provenance } = createRuntimeContext();
+    const draft = await createDraftTimeline({
+      runtime,
+      context,
+      timelineName: 'events',
+      draftName: 'try-admin-role',
+    });
 
     await draft.write(intent.node.add({ subject: 'user:alice' }));
-    await draft.write(intent.property.set({
-      subject: 'user:alice',
-      key: 'role',
-      value: 'admin',
-    }));
+    await draft.write(
+      intent.property.set({
+        subject: 'user:alice',
+        key: 'role',
+        value: 'admin',
+      })
+    );
 
     const failedJoin = await joinDraftTimeline(runtime, draft, { policy: 'deterministic' });
     const retryJoin = await joinDraftTimeline(runtime, draft, { policy: 'deterministic' });
 
     expect(failedJoin.receipt.outcome).toBe('rejected');
-    expect(failedJoin.receipt.patchShas).toEqual(['join-patch-1']);
+    expect(failedJoin.receipt.evidence?.support).toHaveLength(1);
     expect(failedJoin.receipt.reason).toBe('Draft join failed while committing intents');
     expect(retryJoin.receipt.outcome).toBe('rejected');
-    expect(retryJoin.receipt.patchShas).toEqual(['join-patch-1']);
+    expect(retryJoin.receipt.evidence?.support).toHaveLength(1);
     expect(retryJoin.receipt.reason).toBe('Draft join already has a failed commit attempt');
     expect(commitAttempts).toBe(2);
+    expect(provenance.slice(-2)).toEqual([
+      { operation: 'join', patchShas: ['join-patch-1'] },
+      { operation: 'join', patchShas: ['join-patch-1'] },
+    ]);
   });
 });

--- a/test/unit/domain/DraftTimelineRuntime.test.ts
+++ b/test/unit/domain/DraftTimelineRuntime.test.ts
@@ -27,10 +27,12 @@ function createRuntimeContext(options: RuntimeContextOptions = {}): {
   readonly provenance: ReceiptProvenance[];
 } {
   const provenance: ReceiptProvenance[] = [];
+  let recoverySequence = 0;
   return {
     context: {
       createOpaqueId:
         options.createOpaqueId ?? (async (namespace, payload) => `${namespace}:${payload.length}`),
+      reserveRecoveryNonce: () => `test-runtime:${(recoverySequence += 1)}`,
       bindReceipt: (_receipt, record) => provenance.push(record),
     },
     provenance,

--- a/test/unit/domain/DraftTimelineRuntime.test.ts
+++ b/test/unit/domain/DraftTimelineRuntime.test.ts
@@ -14,17 +14,23 @@ import { intent } from '../../../src/domain/api/IntentBuilders.ts';
 
 type RuntimeOptions = {
   readonly commitPatch?: (build: WarpWorldlinePatchBuild) => Promise<string>;
+  readonly patchDraft?: (name: string, build: WarpWorldlinePatchBuild) => Promise<string>;
   readonly previewDraftJoin?: (name: string) => Promise<readonly string[]>;
 };
 
-function createRuntimeContext(): {
+type RuntimeContextOptions = {
+  readonly createOpaqueId?: ApiRuntimeContext['createOpaqueId'];
+};
+
+function createRuntimeContext(options: RuntimeContextOptions = {}): {
   readonly context: ApiRuntimeContext;
   readonly provenance: ReceiptProvenance[];
 } {
   const provenance: ReceiptProvenance[] = [];
   return {
     context: {
-      createOpaqueId: async (namespace, payload) => `${namespace}:${payload.length}`,
+      createOpaqueId:
+        options.createOpaqueId ?? (async (namespace, payload) => `${namespace}:${payload.length}`),
       bindReceipt: (_receipt, record) => provenance.push(record),
     },
     provenance,
@@ -40,7 +46,7 @@ function createRuntime(options: RuntimeOptions = {}): WarpWorldline {
     createWorldline: () => {
       throw new Error('ProjectionHandle is not used by DraftTimelineRuntime tests');
     },
-    patchDraft: async (name) => `${name}-draft-patch`,
+    patchDraft: options.patchDraft ?? (async (name) => `${name}-draft-patch`),
     previewDraftJoin: options.previewDraftJoin ?? (async (name) => [`${name}-preview-patch`]),
     admitIntent: async (descriptor) => ({
       admitted: true,
@@ -81,8 +87,9 @@ describe('DraftTimelineRuntime', () => {
 
     await draft.write(intent.node.add({ subject: 'user:alice' }));
     const firstJoin = joinDraftTimeline(runtime, draft, { policy: 'deterministic' });
+    const secondJoinPending = joinDraftTimeline(runtime, draft, { policy: 'deterministic' });
     await firstCommitStarted;
-    const secondJoin = await joinDraftTimeline(runtime, draft, { policy: 'deterministic' });
+    const secondJoin = await secondJoinPending;
     releaseFirstCommit();
     const firstResult = await firstJoin;
 
@@ -90,6 +97,76 @@ describe('DraftTimelineRuntime', () => {
     expect(secondJoin.receipt.outcome).toBe('rejected');
     expect(secondJoin.receipt.reason).toBe('Draft join is already in progress');
     expect(commitAttempts).toBe(1);
+  });
+
+  it('returns an accepted draft-write receipt when canonical evidence hashing fails', async () => {
+    let draftCommitted = false;
+    let draftCommits = 0;
+    const runtime = createRuntime({
+      patchDraft: async () => {
+        draftCommits += 1;
+        draftCommitted = true;
+        return 'committed-draft-patch';
+      },
+    });
+    const { context, provenance } = createRuntimeContext({
+      createOpaqueId: async (namespace, parts) => {
+        if (draftCommitted && parts[0] !== 'recovery') {
+          throw new Error('canonical evidence hashing failed after commit');
+        }
+        return `${namespace}:opaque-${parts.length}`;
+      },
+    });
+    const draft = await createDraftTimeline({
+      runtime,
+      context,
+      timelineName: 'events',
+      draftName: 'try-admin-role',
+    });
+
+    const receipt = await draft.write(intent.node.add({ subject: 'user:alice' }));
+
+    expect(receipt.outcome).toBe('accepted');
+    expect(receipt.evidence?.support).toEqual([]);
+    expect(draftCommits).toBe(1);
+    expect(provenance.at(-1)).toEqual({
+      operation: 'write',
+      patchSha: 'committed-draft-patch',
+    });
+  });
+
+  it('returns an accepted join receipt when canonical evidence hashing fails after commit', async () => {
+    let joinCommitted = false;
+    const runtime = createRuntime({
+      commitPatch: async () => {
+        joinCommitted = true;
+        return 'committed-join-patch';
+      },
+    });
+    const { context, provenance } = createRuntimeContext({
+      createOpaqueId: async (namespace, parts) => {
+        if (joinCommitted && parts[0] !== 'recovery') {
+          throw new Error('canonical join evidence hashing failed after commit');
+        }
+        return `${namespace}:opaque-${parts.length}`;
+      },
+    });
+    const draft = await createDraftTimeline({
+      runtime,
+      context,
+      timelineName: 'events',
+      draftName: 'try-admin-role',
+    });
+    await draft.write(intent.node.add({ subject: 'user:alice' }));
+
+    const result = await joinDraftTimeline(runtime, draft, { policy: 'deterministic' });
+
+    expect(result.receipt.outcome).toBe('accepted');
+    expect(result.receipt.evidence?.support).toEqual([]);
+    expect(provenance.at(-1)).toEqual({
+      operation: 'join',
+      patchShas: ['committed-join-patch'],
+    });
   });
 
   it('keeps preview object identities behind opaque evidence handles', async () => {

--- a/test/unit/domain/ReceiptDiagnostics.test.ts
+++ b/test/unit/domain/ReceiptDiagnostics.test.ts
@@ -1,39 +1,170 @@
 import { describe, expect, it } from 'vitest';
 
 import { inspectReceipt } from '../../../diagnostics.ts';
+import { openWarp } from '../../../src/application/openWarp.ts';
+import { createApiRuntimeContext } from '../../../src/application/ReceiptProvenanceRegistry.ts';
+import { resolveWarpStorage } from '../../../src/application/WarpStorageRegistry.ts';
 import { intent } from '../../../src/domain/api/IntentBuilders.ts';
+import { reading } from '../../../src/domain/api/ReadingBuilders.ts';
 import WriteReceipt from '../../../src/domain/api/WriteReceipt.ts';
+import NodeCryptoAdapter from '../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
+import { MemoryStorage } from '../../../storage.ts';
+import { openMemoryRuntimeHostProduct } from '../../helpers/MemoryRuntimeHost.ts';
+
+async function createBoundedReadBasis(storage: MemoryStorage, graphName: string): Promise<void> {
+  const binding = resolveWarpStorage(storage);
+  const runtime = await openMemoryRuntimeHostProduct({
+    persistence: binding.history,
+    runtimeStorage: binding.runtimeStorage,
+    graphName,
+    writerId: 'agent-1',
+  });
+  await runtime.materialize();
+  await runtime.createCheckpoint();
+}
 
 describe('receipt diagnostics', () => {
-  it('inspects accepted write receipts without requiring substrate handles', () => {
-    const receipt = new WriteReceipt({
-      timeline: 'events',
-      writer: 'agent-1',
-      intent: intent.node.add({ subject: 'user:alice' }),
-      outcome: 'accepted',
-      patchSha: 'patch-1',
-    });
+  it('recovers exact write provenance only with explicit storage context', async () => {
+    const storage = MemoryStorage.create();
+    const warp = await openWarp({ storage, writer: 'agent-1' });
+    const timeline = await warp.timeline('events');
+    const receipt = await timeline.write(intent.node.add({ subject: 'user:alice' }));
 
-    expect(inspectReceipt(receipt)).toEqual({
+    const inspection = inspectReceipt(receipt, { storage });
+
+    expect(inspection).toMatchObject({
       operation: 'write',
       outcome: 'accepted',
       timeline: 'events',
       writer: 'agent-1',
       reason: undefined,
-      evidence: 'absent',
-      objectIds: ['patch-1'],
+      evidence: 'present',
+      substrate: { operation: 'write' },
     });
+    expect(inspection.objectIds).toHaveLength(1);
+    expect(inspection.substrate.operation).toBe('write');
+    if (inspection.substrate.operation !== 'write') {
+      throw new Error('write receipt diagnostics must expose write provenance');
+    }
+    expect(inspection.substrate.patchSha).toBe(inspection.objectIds[0]);
+    expect('patchSha' in receipt).toBe(false);
   });
 
-  it('does not invent object identities for rejected writes', () => {
+  it('does not invent object identities for unresolved writes', async () => {
+    const storage = MemoryStorage.create();
+    const warp = await openWarp({ storage, writer: 'agent-1' });
+    const timeline = await warp.timeline('events');
+    const receipt = await timeline.write(intent.node.remove({ subject: 'user:alice' }));
+
+    const inspection = inspectReceipt(receipt, { storage });
+
+    expect(receipt.outcome).not.toBe('accepted');
+    expect(inspection.objectIds).toEqual([]);
+    expect(inspection.evidence).toBe('absent');
+  });
+
+  it('recovers full bounded-read provenance without exposing it on evidence', async () => {
+    const storage = MemoryStorage.create();
+    const warp = await openWarp({ storage, writer: 'agent-1' });
+    const timeline = await warp.timeline('events');
+    await timeline.write(intent.node.add({ subject: 'user:alice' }));
+    await createBoundedReadBasis(storage, timeline.name);
+    const propertyWrite = await timeline.write(
+      intent.property.set({ subject: 'user:alice', key: 'role', value: 'admin' })
+    );
+    const result = await timeline.read(reading.property({ subject: 'user:alice', key: 'role' }));
+
+    const inspection = inspectReceipt(result.receipt, { storage });
+
+    expect(result.receipt.outcome).toBe('accepted');
+    expect(result.receipt.evidence).not.toHaveProperty('checkpointSha');
+    expect(result.receipt.evidence?.support).toContainEqual(propertyWrite.evidence?.support[0]);
+    expect(inspection.substrate.operation).toBe('read');
+    if (inspection.substrate.operation !== 'read') {
+      throw new Error('read receipt diagnostics must expose read provenance');
+    }
+    expect(inspection.substrate.identity?.checkpointSha).toBeTruthy();
+    expect(inspection.objectIds).toContain(inspection.substrate.identity?.checkpointSha);
+  });
+
+  it('recovers join object identities behind correlated support handles', async () => {
+    const storage = MemoryStorage.create();
+    const warp = await openWarp({ storage, writer: 'agent-1' });
+    const timeline = await warp.timeline('events');
+    await timeline.write(intent.node.add({ subject: 'user:alice' }));
+    const draft = await timeline.draft('try-admin-role');
+    const draftWrite = await draft.write(
+      intent.property.set({ subject: 'user:alice', key: 'role', value: 'admin' })
+    );
+    const preview = await timeline.previewJoin(draft);
+
+    const inspection = inspectReceipt(preview.receipt, { storage });
+
+    expect(preview.receipt.evidence?.support).toContainEqual(draftWrite.evidence?.support[0]);
+    expect('patchShas' in preview.receipt).toBe(false);
+    expect(inspection.substrate.operation).toBe('join');
+    if (inspection.substrate.operation !== 'join') {
+      throw new Error('join receipt diagnostics must expose join provenance');
+    }
+    expect(inspection.substrate.patchShas.length).toBeGreaterThan(0);
+    expect(preview.receipt.evidence?.support).toHaveLength(inspection.substrate.patchShas.length);
+    expect(inspection.objectIds).toEqual(inspection.substrate.patchShas);
+  });
+
+  it('rejects diagnostics requests made with a different storage handle', async () => {
+    const storage = MemoryStorage.create();
+    const otherStorage = MemoryStorage.create();
+    const warp = await openWarp({ storage, writer: 'agent-1' });
+    const timeline = await warp.timeline('events');
+    const receipt = await timeline.write(intent.node.add({ subject: 'user:alice' }));
+
+    expect(() => inspectReceipt(receipt, { storage: otherStorage })).toThrow(
+      'Receipt does not belong to the supplied storage'
+    );
+  });
+
+  it('requires an explicit diagnostics storage context', async () => {
+    const storage = MemoryStorage.create();
+    const warp = await openWarp({ storage, writer: 'agent-1' });
+    const timeline = await warp.timeline('events');
+    const receipt = await timeline.write(intent.node.add({ subject: 'user:alice' }));
+
+    expect(() => inspectReceipt(receipt, undefined as never)).toThrow(
+      'Receipt inspection requires an explicit storage context'
+    );
+  });
+
+  it('rejects receipts that were not issued by an openWarp runtime', () => {
+    const storage = MemoryStorage.create();
     const receipt = new WriteReceipt({
       timeline: 'events',
       writer: 'agent-1',
       intent: intent.node.add({ subject: 'user:alice' }),
       outcome: 'rejected',
-      reason: 'policy_rejected',
+      reason: 'not_admitted',
     });
 
-    expect(inspectReceipt(receipt).objectIds).toEqual([]);
+    expect(() => inspectReceipt(receipt, { storage })).toThrow(
+      'Receipt was not issued by an openWarp runtime'
+    );
+  });
+
+  it('binds raw receipt provenance exactly once', () => {
+    const storage = MemoryStorage.create();
+    const receipt = new WriteReceipt({
+      timeline: 'events',
+      writer: 'agent-1',
+      intent: intent.node.add({ subject: 'user:alice' }),
+      outcome: 'rejected',
+      reason: 'not_admitted',
+    });
+    const context = createApiRuntimeContext(storage, new NodeCryptoAdapter());
+    const provenance = { operation: 'write' as const, patchSha: undefined };
+
+    context.bindReceipt(receipt, provenance);
+
+    expect(() => context.bindReceipt(receipt, provenance)).toThrow(
+      'Receipt provenance is already bound'
+    );
   });
 });

--- a/test/unit/domain/ReceiptDiagnostics.test.ts
+++ b/test/unit/domain/ReceiptDiagnostics.test.ts
@@ -21,6 +21,20 @@ describe('receipt diagnostics', () => {
     ]);
 
     expect(new Set(ids).size).toBe(ids.length);
+    await expect(context.createOpaqueId('evidence', ['ab', 'c'])).resolves.toBe(ids[0]);
+  });
+
+  it('reserves recovery nonces across contexts sharing one storage', () => {
+    const storage = MemoryStorage.create();
+    const first = createApiRuntimeContext(storage, new NodeCryptoAdapter());
+    const reopened = createApiRuntimeContext(storage, new NodeCryptoAdapter());
+
+    const firstNonce = first.reserveRecoveryNonce();
+    const reopenedNonce = reopened.reserveRecoveryNonce();
+
+    expect(firstNonce).toMatch(/:1$/);
+    expect(reopenedNonce).toMatch(/:2$/);
+    expect(reopenedNonce).not.toBe(firstNonce);
   });
 
   it('recovers exact write provenance only with explicit storage context', async () => {

--- a/test/unit/domain/ReceiptDiagnostics.test.ts
+++ b/test/unit/domain/ReceiptDiagnostics.test.ts
@@ -3,27 +3,26 @@ import { describe, expect, it } from 'vitest';
 import { inspectReceipt } from '../../../diagnostics.ts';
 import { openWarp } from '../../../src/application/openWarp.ts';
 import { createApiRuntimeContext } from '../../../src/application/ReceiptProvenanceRegistry.ts';
-import { resolveWarpStorage } from '../../../src/application/WarpStorageRegistry.ts';
 import { intent } from '../../../src/domain/api/IntentBuilders.ts';
 import { reading } from '../../../src/domain/api/ReadingBuilders.ts';
 import WriteReceipt from '../../../src/domain/api/WriteReceipt.ts';
 import NodeCryptoAdapter from '../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
 import { MemoryStorage } from '../../../storage.ts';
-import { openMemoryRuntimeHostProduct } from '../../helpers/MemoryRuntimeHost.ts';
-
-async function createBoundedReadBasis(storage: MemoryStorage, graphName: string): Promise<void> {
-  const binding = resolveWarpStorage(storage);
-  const runtime = await openMemoryRuntimeHostProduct({
-    persistence: binding.history,
-    runtimeStorage: binding.runtimeStorage,
-    graphName,
-    writerId: 'agent-1',
-  });
-  await runtime.materialize();
-  await runtime.createCheckpoint();
-}
+import { createBoundedReadBasis } from '../../helpers/BoundedReadBasis.ts';
 
 describe('receipt diagnostics', () => {
+  it('uses collision-safe typed framing for opaque identity inputs', async () => {
+    const context = createApiRuntimeContext(MemoryStorage.create(), new NodeCryptoAdapter());
+    const ids = await Promise.all([
+      context.createOpaqueId('evidence', ['ab', 'c']),
+      context.createOpaqueId('evidence', ['a', 'bc']),
+      context.createOpaqueId('evidence', [1]),
+      context.createOpaqueId('evidence', ['1']),
+    ]);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
   it('recovers exact write provenance only with explicit storage context', async () => {
     const storage = MemoryStorage.create();
     const warp = await openWarp({ storage, writer: 'agent-1' });

--- a/test/unit/domain/ReceiptOutcome.test.ts
+++ b/test/unit/domain/ReceiptOutcome.test.ts
@@ -6,6 +6,11 @@ import JoinReceipt from '../../../src/domain/api/JoinReceipt.ts';
 import { RECEIPT_OUTCOMES } from '../../../src/domain/api/ReceiptOutcome.ts';
 import WriteReceipt from '../../../src/domain/api/WriteReceipt.ts';
 
+const EVIDENCE = Object.freeze({
+  basis: Object.freeze({ id: 'evidence:basis' }),
+  support: Object.freeze([]),
+});
+
 describe('receipt outcomes', () => {
   it('locks the canonical outcome axis to the approved five values', () => {
     expect([...RECEIPT_OUTCOMES]).toEqual([
@@ -33,6 +38,7 @@ describe('receipt outcomes', () => {
               draft,
               mode: 'join',
               outcome,
+              evidence: EVIDENCE,
             })
           : new JoinReceipt({
               timeline: 'events',
@@ -63,6 +69,7 @@ describe('receipt outcomes', () => {
           draft,
           mode: 'join',
           outcome: 'accepted',
+          evidence: EVIDENCE,
           // @ts-expect-error runtime validation accepts JavaScript callers.
           reason: 'accepted_with_reason',
         })
@@ -81,7 +88,7 @@ describe('receipt outcomes', () => {
     ).toThrow('joinReceipt.reason must be a non-empty string');
   });
 
-  it('represents rejected writes without inventing patch identities', () => {
+  it('represents rejected writes without inventing causal evidence', () => {
     const receipt = new WriteReceipt({
       timeline: 'events',
       writer: 'agent-1',
@@ -94,7 +101,35 @@ describe('receipt outcomes', () => {
       operation: 'write',
       outcome: 'rejected',
       reason: 'policy_rejected',
-      patchSha: undefined,
+      evidence: undefined,
     });
+  });
+
+  it.each([
+    [null, 'writeReceipt.evidence must be causal evidence'],
+    [
+      { basis: { id: 'evidence:basis' }, support: null },
+      'writeReceipt.evidence.support must be an array',
+    ],
+    [{ basis: null, support: [] }, 'writeReceipt.evidence.basis must be an evidence handle'],
+    [
+      { basis: { id: 'evidence:basis' }, support: [null] },
+      'writeReceipt.evidence.support[0] must be an evidence handle',
+    ],
+    [
+      { basis: { id: 'evidence:basis' }, support: [], tick: {} },
+      'writeReceipt.evidence.tick must be a Tick',
+    ],
+  ])('rejects malformed causal evidence %#', (evidence, message) => {
+    expect(
+      () =>
+        new WriteReceipt({
+          timeline: 'events',
+          writer: 'agent-1',
+          intent: intent.node.add({ subject: 'user:alice' }),
+          outcome: 'accepted',
+          evidence: evidence as never,
+        })
+    ).toThrow(message);
   });
 });

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -15,9 +15,8 @@ import { requireTimelineRuntime } from '../../../src/domain/api/TimelineRuntime.
 import { requireTickCoordinate } from '../../../src/domain/api/TickRuntime.ts';
 import Warp from '../../../src/domain/api/Warp.ts';
 import { MAX_WRITER_ID_LENGTH } from '../../../src/domain/utils/RefLayout.ts';
-import { openMemoryRuntimeHostProduct as openRuntimeHostProduct } from '../../helpers/MemoryRuntimeHost.ts';
-import { resolveWarpStorage } from '../../../src/application/WarpStorageRegistry.ts';
 import { MemoryStorage } from '../../../storage.ts';
+import { createBoundedReadBasis } from '../../helpers/BoundedReadBasis.ts';
 
 const FORBIDDEN_ROOT_SUBSTRATE_EXPORTS = Object.freeze([
   'openWarpGraph',
@@ -134,18 +133,6 @@ function collectExportedDeclarationName(statement: ts.Statement, exportedNames: 
   ) {
     exportedNames.add(statement.name.text);
   }
-}
-
-async function createBoundedReadBasis(storage: MemoryStorage, graphName: string): Promise<void> {
-  const binding = resolveWarpStorage(storage);
-  const runtime = await openRuntimeHostProduct({
-    persistence: binding.history,
-    runtimeStorage: binding.runtimeStorage,
-    graphName,
-    writerId: 'agent-1',
-  });
-  await runtime.materialize();
-  await runtime.createCheckpoint();
 }
 
 describe('v19 Warp facade', () => {

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -12,6 +12,7 @@ import ReadReceipt from '../../../src/domain/api/ReadReceipt.ts';
 import ReadingResult from '../../../src/domain/api/ReadingResult.ts';
 import Timeline from '../../../src/domain/api/Timeline.ts';
 import { requireTimelineRuntime } from '../../../src/domain/api/TimelineRuntime.ts';
+import { requireTickCoordinate } from '../../../src/domain/api/TickRuntime.ts';
 import Warp from '../../../src/domain/api/Warp.ts';
 import { MAX_WRITER_ID_LENGTH } from '../../../src/domain/utils/RefLayout.ts';
 import { openMemoryRuntimeHostProduct as openRuntimeHostProduct } from '../../helpers/MemoryRuntimeHost.ts';
@@ -135,10 +136,7 @@ function collectExportedDeclarationName(statement: ts.Statement, exportedNames: 
   }
 }
 
-async function createBoundedReadBasis(
-  storage: MemoryStorage,
-  graphName: string
-): Promise<void> {
+async function createBoundedReadBasis(storage: MemoryStorage, graphName: string): Promise<void> {
   const binding = resolveWarpStorage(storage);
   const runtime = await openRuntimeHostProduct({
     persistence: binding.history,
@@ -294,7 +292,9 @@ describe('v19 Warp facade', () => {
     expect(nodeReceipt.outcome).toBe('accepted');
     expect(nodeReceipt.operation).toBe('write');
     expect(nodeReceipt.intent.kind).toBe('node.add');
-    expect(typeof nodeReceipt.patchSha).toBe('string');
+    expect(nodeReceipt.evidence?.basis.id).toMatch(/^evidence:/);
+    expect(nodeReceipt.evidence?.support).toHaveLength(1);
+    expect('patchSha' in nodeReceipt).toBe(false);
     expect(propertyReceipt.outcome).toBe('accepted');
     expect(propertyReceipt.intent.kind).toBe('property.set');
     expect(propertyReceipt.timeline).toBe('events');
@@ -358,7 +358,7 @@ describe('v19 Warp facade', () => {
     expect(receipt).toMatchObject({
       operation: 'write',
       outcome: 'obstructed',
-      patchSha: undefined,
+      evidence: undefined,
       reason: 'missing_write_basis',
     });
     expect(receipt.repairHints).toEqual([
@@ -419,10 +419,8 @@ describe('v19 Warp facade', () => {
     expect(propertyResult.receipt.reading.kind).toBe('property.get');
     expect(propertyResult.receipt.timeline).toBe('events');
     expect(propertyResult.receipt.writer).toBe('agent-1');
-    expect(propertyResult.receipt.evidence).toMatchObject({
-      kind: 'checkpoint-tail-read',
-      worldline: 'events',
-    });
+    expect(propertyResult.receipt.evidence?.basis.id).toMatch(/^evidence:/);
+    expect(propertyResult.receipt.evidence?.tick).toBeUndefined();
 
     expect(existsResult).toBeInstanceOf(ReadingResult);
     expect(existsResult.value).toBe(true);
@@ -436,7 +434,7 @@ describe('v19 Warp facade', () => {
     });
     expect(neighborhoodResult.receipt).toMatchObject({
       outcome: 'accepted',
-      evidence: { kind: 'checkpoint-tail-read' },
+      evidence: { basis: { id: expect.stringMatching(/^evidence:/) } },
     });
     const coordinate = await captureCoordinate(timeline);
     const coordinateRole = await coordinate.optic().node('user:alice').prop('role').read();
@@ -451,6 +449,13 @@ describe('v19 Warp facade', () => {
     ).resolves.toBe('admin');
 
     const tick = await timeline.tick();
+    const tickCoordinate = requireTickCoordinate(requireTimelineRuntime(timeline), tick);
+    const serializedTick = JSON.stringify(tick);
+    expect(tick.id).toMatch(/^tick:/);
+    expect(serializedTick).not.toContain(tickCoordinate.checkpointSha);
+    for (const entry of tickCoordinate.frontierEntries) {
+      expect(serializedTick).not.toContain(entry.patchSha);
+    }
     const secondWarp = await openWarp({ storage, writer: 'agent-2' });
     const sameNamedForeignTimeline = await secondWarp.timeline('events');
     expect(() => sameNamedForeignTimeline.at(tick)).toThrow(
@@ -469,14 +474,16 @@ describe('v19 Warp facade', () => {
         key: 'role',
       })
     );
-    const historicalRole = await timeline.at(tick).readValue(
+    const historicalResult = await timeline.at(tick).read(
       reading.property({
         subject: 'user:alice',
         key: 'role',
       })
     );
+    const historicalRole = historicalResult.value;
     expect(currentRole).toBe('owner');
     expect(historicalRole).toBe('admin');
+    expect(historicalResult.receipt.evidence?.tick).toBe(tick);
   });
 
   it('returns an obstructed receipt instead of materializing a missing read basis', async () => {
@@ -554,12 +561,13 @@ describe('v19 Warp facade', () => {
     expect(preview.receipt).toBeInstanceOf(JoinReceipt);
     expect(preview.receipt.mode).toBe('preview');
     expect(preview.receipt.outcome).toBe('accepted');
-    expect(preview.receipt.patchShas).toContain(draftWrite.patchSha);
+    expect(preview.receipt.evidence?.support).toContainEqual(draftWrite.evidence?.support[0]);
+    expect('patchShas' in preview.receipt).toBe(false);
     expect(afterPreview.value).toBeNull();
     expect(joined).toBeInstanceOf(JoinResult);
     expect(joined.receipt.mode).toBe('join');
     expect(joined.receipt.outcome).toBe('accepted');
-    expect(joined.receipt.patchShas).toHaveLength(1);
+    expect(joined.receipt.evidence?.support).toHaveLength(1);
     expect(afterJoin.value).toBe('admin');
   });
 

--- a/test/unit/scripts/v19-public-api-boundary.test.ts
+++ b/test/unit/scripts/v19-public-api-boundary.test.ts
@@ -9,6 +9,8 @@ const ROOT_VALUE_EXPORTS = ['intent', 'openWarp', 'reading'] as const;
 const ROOT_TYPE_EXPORTS = [
   'DraftTimeline',
   'EdgeIntentFields',
+  'Evidence',
+  'EvidenceHandle',
   'Intent',
   'IntentBuilders',
   'IntentDescriptor',
@@ -27,7 +29,6 @@ const ROOT_TYPE_EXPORTS = [
   'OpenWarpOptions',
   'PropertyIntentFields',
   'PropertyReadingFields',
-  'ReadEvidence',
   'ReadOutcome',
   'ReadReceipt',
   'ReadReceiptOptions',
@@ -59,9 +60,8 @@ type ModuleSurface = {
 };
 
 function moduleSurface(relativePath = 'index.ts', source?: string): ModuleSurface {
-  const sourceFile = source === undefined
-    ? sourceFileFor(relativePath)
-    : parseSourceFile(relativePath, source);
+  const sourceFile =
+    source === undefined ? sourceFileFor(relativePath) : parseSourceFile(relativePath, source);
   const starExports: string[] = [];
   const typeExports: string[] = [];
   const valueExports: string[] = [];
@@ -199,10 +199,7 @@ describe('v19 public API boundary', () => {
   });
 
   it('classifies namespace re-exports as forbidden star exports', () => {
-    const surface = moduleSurface(
-      'namespace-export.ts',
-      "export * as graph from './graph.ts';"
-    );
+    const surface = moduleSurface('namespace-export.ts', "export * as graph from './graph.ts';");
 
     expect(surface.starExports).toEqual(["'./graph.ts'"]);
   });
@@ -242,7 +239,9 @@ describe('v19 public API boundary', () => {
     const surface = moduleSurface('diagnostics.ts');
     expect(surface.starExports).toEqual([]);
     expect(surface.valueExports).toEqual(['inspectReceipt']);
-    expect(surface.typeExports).toEqual(['ReceiptInspection']);
+    expect(surface.typeExports).toEqual(
+      sorted(['InspectReceiptOptions', 'ReceiptInspection', 'ReceiptSubstrateInspection'])
+    );
   });
 
   it('publishes only the supported v19 subpaths', () => {

--- a/test/unit/scripts/v19-root-declaration-gate.test.ts
+++ b/test/unit/scripts/v19-root-declaration-gate.test.ts
@@ -20,7 +20,16 @@ describe('v19 root declaration vocabulary gate', () => {
     writeFileSync(join(directory, 'index.d.ts'), "export type { Receipt } from './Receipt.ts';\n");
     writeFileSync(
       join(directory, 'Receipt.d.ts'),
-      'export type Receipt = { readonly patchShas: string[]; readonly objectId: string };\n'
+      [
+        'export type Receipt = {',
+        '  readonly patchShas: string[];',
+        '  readonly objectId: string;',
+        '  readonly rootObjectId: string;',
+        '  readonly sourceObjectIds: string[];',
+        '  readonly readObjectIdHex: string;',
+        '};',
+        '',
+      ].join('\n')
     );
 
     expect(findForbiddenRootDeclarationVocabulary(join(directory, 'index.d.ts'))).toEqual(
@@ -29,6 +38,21 @@ describe('v19 root declaration vocabulary gate', () => {
         expect.objectContaining({
           file: 'Receipt.d.ts',
           identifier: 'objectId',
+          token: 'object-id',
+        }),
+        expect.objectContaining({
+          file: 'Receipt.d.ts',
+          identifier: 'rootObjectId',
+          token: 'object-id',
+        }),
+        expect.objectContaining({
+          file: 'Receipt.d.ts',
+          identifier: 'sourceObjectIds',
+          token: 'object-id',
+        }),
+        expect.objectContaining({
+          file: 'Receipt.d.ts',
+          identifier: 'readObjectIdHex',
           token: 'object-id',
         }),
       ])

--- a/test/unit/scripts/v19-root-declaration-gate.test.ts
+++ b/test/unit/scripts/v19-root-declaration-gate.test.ts
@@ -1,0 +1,49 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { findForbiddenRootDeclarationVocabulary } from '../../../scripts/v19-root-declaration-gate.ts';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('v19 root declaration vocabulary gate', () => {
+  it('walks transitive declaration imports and reports substrate identifiers', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'git-warp-v19-dts-'));
+    temporaryDirectories.push(directory);
+    writeFileSync(join(directory, 'index.d.ts'), "export type { Receipt } from './Receipt.ts';\n");
+    writeFileSync(
+      join(directory, 'Receipt.d.ts'),
+      'export type Receipt = { readonly patchShas: string[]; readonly objectId: string };\n'
+    );
+
+    expect(findForbiddenRootDeclarationVocabulary(join(directory, 'index.d.ts'))).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ file: 'Receipt.d.ts', identifier: 'patchShas', token: 'sha' }),
+        expect.objectContaining({
+          file: 'Receipt.d.ts',
+          identifier: 'objectId',
+          token: 'object-id',
+        }),
+      ])
+    );
+  });
+
+  it('accepts storage-neutral receipt and evidence declarations', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'git-warp-v19-dts-'));
+    temporaryDirectories.push(directory);
+    writeFileSync(join(directory, 'index.d.ts'), "export type { Receipt } from './Receipt.ts';\n");
+    writeFileSync(
+      join(directory, 'Receipt.d.ts'),
+      'export type Receipt = { readonly evidence: { readonly id: string } };\n'
+    );
+
+    expect(findForbiddenRootDeclarationVocabulary(join(directory, 'index.d.ts'))).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #743

## Summary

- replace root-facing write, read, and join substrate identifiers with opaque, storage-neutral `Evidence` handles
- make `Tick.id` a deterministic opaque identifier while retaining its internal coordinate binding
- retain exact write/read/join provenance in a storage-authorized diagnostics registry
- require explicit storage context for `inspectReceipt()`
- add an AST-based gate over the transitive emitted root declaration graph
- update first-use docs, migration guidance, conformance tests, and consumer type proofs

This is an intentional breaking API change for the eventual v19.0.0 release.

## Source evidence

- Public evidence contains only opaque basis/support handles and an optional public tick. [cite: `src/domain/api/Evidence.ts#3-13@d5b4b47ded6303235fa4314dd22e76e93abecb01`]
- Write receipts require evidence and no longer expose a patch identifier. [cite: `src/domain/api/WriteReceipt.ts#16-31@d5b4b47ded6303235fa4314dd22e76e93abecb01`]
- Join receipts require or optionally carry evidence and no longer expose patch arrays. [cite: `src/domain/api/JoinReceipt.ts#18-40@d5b4b47ded6303235fa4314dd22e76e93abecb01`]
- Read receipts use the same storage-neutral evidence contract. [cite: `src/domain/api/ReadReceipt.ts#18-35@d5b4b47ded6303235fa4314dd22e76e93abecb01`]
- Tick identity is derived through the opaque-ID runtime boundary. [cite: `src/domain/api/TickRuntime.ts#48-57@d5b4b47ded6303235fa4314dd22e76e93abecb01`]
- Exact substrate provenance is storage-bound, immutable, and single-assignment. [cite: `src/application/ReceiptProvenanceRegistry.ts#13-64@d5b4b47ded6303235fa4314dd22e76e93abecb01`]
- Diagnostics require the issuing storage handle and recover exact object identities. [cite: `diagnostics.ts#11-90@d5b4b47ded6303235fa4314dd22e76e93abecb01`]
- The publication check executes the transitive declaration vocabulary gate. [cite: `scripts/check-dts-surface.ts#212-235@d5b4b47ded6303235fa4314dd22e76e93abecb01`]
- The gate walks emitted declaration imports and rejects Git/CAS vocabulary in reachable identifiers and literals. [cite: `scripts/v19-root-declaration-gate.ts#30-83@d5b4b47ded6303235fa4314dd22e76e93abecb01`]

## Validation

- `npm run test:local`: 577 files passed, 1 skipped; 7,374 tests passed, 2 skipped
- `npm run test:coverage:ci`: 588 files passed, 1 skipped; 7,419 tests passed, 2 skipped; 92.62% line threshold met
- `npx vitest run test/integration`: 19 files, 98 tests passed
- `PATH="$PWD/bin:$PATH" bats test/bats/`: 110 tests passed
- `npm run typecheck:surface`: zero errors and zero warnings
- source/test/consumer type checks, lint, Markdown, docs topology, source-backed references, contamination map, CAS invariants, and link checks passed
- `npm pack --dry-run` passed the full prepack pipeline
- IRONCLAD pre-push firewall passed all gates
- Graft export analysis reports the expected v19 major impact: `Evidence` and `EvidenceHandle` added; `ReadEvidence` removed
