### PR TITLE
Fix warm state-cache materialization hits

### DIFF
--- a/docs/topics/cas-first-memoized-materialization.md
+++ b/docs/topics/cas-first-memoized-materialization.md
@@ -47,9 +47,16 @@ The runtime asks `WarpStateCachePort` for an exact snapshot at that coordinate.
 On a hit, it returns the cached state without replaying writer patch streams and
 without republishing the same snapshot.
 
+The current payload records state but not the provenance index. A runtime may
+retain its resident provenance index when the cached state has the same hash and
+coordinate. A runtime restored only from the cache reports provenance as
+degraded instead of presenting an empty index as complete evidence.
+
 If no exact snapshot exists, the runtime asks for the best compatible
 predecessor. A predecessor hit lets materialization replay only the suffix after
 that cached coordinate, then publish a fresh snapshot for the current frontier.
+Until cache payloads carry provenance indexes, that derived snapshot retains a
+degraded provenance posture rather than claiming support for the cached prefix.
 
 ### 3. Fall back to replay and publish
 

--- a/src/domain/RuntimeHost.ts
+++ b/src/domain/RuntimeHost.ts
@@ -44,7 +44,10 @@ import RuntimeDetachedFactory from './warp/RuntimeDetachedFactory.ts';
 import BitmapNeighborProvider, { type LogicalIndex } from './services/index/BitmapNeighborProvider.ts';
 import { cloneState } from './services/JoinReducer.ts';
 import { diffStates, isEmptyDiff, type StateDiffResult } from './services/state/StateDiff.ts';
-import { buildAdjacency } from './services/controllers/MaterializeHelpers.ts';
+import {
+  buildAdjacency,
+  maxObservedLamportInState,
+} from './services/controllers/MaterializeHelpers.ts';
 import { selectProvenanceAfterMaterialization } from './services/controllers/MaterializeProvenancePolicy.ts';
 import WarpError from './errors/WarpError.ts';
 import QueryError from './errors/QueryError.ts';
@@ -739,11 +742,7 @@ export default class RuntimeHost {
    * Extracts the maximum Lamport timestamp from a WarpState.
    */
   _maxLamportFromState(state: WarpState): number {
-    let max = 0;
-    for (const v of state.observedFrontier.values()) {
-      if (v > max) { max = v; }
-    }
-    return max;
+    return maxObservedLamportInState(state);
   }
 
   /**

--- a/src/domain/RuntimeHost.ts
+++ b/src/domain/RuntimeHost.ts
@@ -45,6 +45,7 @@ import BitmapNeighborProvider, { type LogicalIndex } from './services/index/Bitm
 import { cloneState } from './services/JoinReducer.ts';
 import { diffStates, isEmptyDiff, type StateDiffResult } from './services/state/StateDiff.ts';
 import { buildAdjacency } from './services/controllers/MaterializeHelpers.ts';
+import { selectProvenanceAfterMaterialization } from './services/controllers/MaterializeProvenancePolicy.ts';
 import WarpError from './errors/WarpError.ts';
 import QueryError from './errors/QueryError.ts';
 import { requireCommitMessageCodec } from './services/codec/CommitMessageCodecRequirement.ts';
@@ -826,6 +827,14 @@ export default class RuntimeHost {
    */
   // eslint-disable-next-line max-lines-per-function -- side-effect callback must apply all post-materialize state in one method
   async _onMaterialized(result: MaterializeResult): Promise<void> {
+    const provenance = selectProvenanceAfterMaterialization({
+      index: this._provenanceIndex,
+      degraded: this._provenanceDegraded,
+      stateHash: this._materializedGraph?.stateHash,
+      frontier: this._cachedFrontier,
+      ceiling: this._cachedCeiling,
+    }, result);
+
     // 1. Cache state + lamport
     this._cachedState = result.state;
     this._stateDirty = false;
@@ -841,8 +850,8 @@ export default class RuntimeHost {
         incoming: new Map(result.adjacency.incoming),
       },
     };
-    this._provenanceIndex = result.provenanceIndex;
-    this._provenanceDegraded = result.provenanceDegraded;
+    this._provenanceIndex = provenance.index;
+    this._provenanceDegraded = provenance.degraded;
     this._cachedCeiling = result.ceiling;
     this._cachedFrontier = result.frontier ? new Map(result.frontier) : null;
 

--- a/src/domain/RuntimeHost.ts
+++ b/src/domain/RuntimeHost.ts
@@ -59,6 +59,7 @@ import type CryptoPort from '../ports/CryptoPort.ts';
 import type CodecPort from '../ports/CodecPort.ts';
 import type TrustCryptoPort from '../ports/TrustCryptoPort.ts';
 import type WarpStateCachePort from '../ports/WarpStateCachePort.ts';
+import type { WarpStateCoordinate } from '../ports/WarpStateCachePort.ts';
 import type AssetStoragePort from '../ports/AssetStoragePort.ts';
 import type AuditLogPort from '../ports/AuditLogPort.ts';
 import type PatchJournalPort from '../ports/PatchJournalPort.ts';
@@ -78,6 +79,7 @@ import type { TickReceipt } from './types/TickReceipt.ts';
 import type PropertyIndexReader from './services/index/PropertyIndexReader.ts';
 import type QueryCapability from './capabilities/QueryCapability.ts';
 import type AdjacencyMap from './capabilities/AdjacencyMap.ts';
+import type { MaterializedStateUpdateOptions } from './capabilities/MaterializedStateUpdate.ts';
 
 import {
   normalizeTrustConfig,
@@ -157,7 +159,7 @@ function canUseCachedMaterializedGraph(
 }
 
 function resolveMaterializedStateDiff(
-  optionsOrDiff: PatchDiff | { diff?: PatchDiff | null } | undefined,
+  optionsOrDiff: PatchDiff | MaterializedStateUpdateOptions | undefined,
 ): PatchDiff | undefined {
   if (optionsOrDiff === null || optionsOrDiff === undefined) {
     return undefined;
@@ -166,6 +168,15 @@ function resolveMaterializedStateDiff(
     return optionsOrDiff;
   }
   return optionsOrDiff.diff ?? undefined;
+}
+
+function resolveMaterializedStateCoordinate(
+  optionsOrDiff: PatchDiff | MaterializedStateUpdateOptions | undefined,
+): WarpStateCoordinate | null {
+  if (optionsOrDiff === null || optionsOrDiff === undefined || 'edgesAdded' in optionsOrDiff) {
+    return null;
+  }
+  return optionsOrDiff.coordinate ?? null;
 }
 
 type Subscriber = {
@@ -501,15 +512,18 @@ export default class RuntimeHost {
 
   async _setMaterializedState(
     state: WarpState,
-    optionsOrDiff?: PatchDiff | { diff?: PatchDiff | null },
+    optionsOrDiff?: PatchDiff | MaterializedStateUpdateOptions,
   ): Promise<MaterializedGraph> {
     const stateHash = await computeStateHash(state, { crypto: this._crypto, codec: this._codec });
     const adjacency = this._buildAdjacency(state);
     const diff = resolveMaterializedStateDiff(optionsOrDiff);
+    const coordinate = resolveMaterializedStateCoordinate(optionsOrDiff);
     this._cachedState = state;
     this._stateDirty = false;
     this._versionVector = state.observedFrontier.clone();
     this._materializedGraph = { state, stateHash, adjacency };
+    this._cachedCeiling = coordinate?.ceiling ?? null;
+    this._cachedFrontier = coordinate === null ? null : new Map(coordinate.frontier);
     this._buildViewFromResult({ state, stateHash, diff });
     this._notifyAfterMaterialize(state);
     return this._materializedGraph;

--- a/src/domain/capabilities/MaterializedStateUpdate.ts
+++ b/src/domain/capabilities/MaterializedStateUpdate.ts
@@ -1,0 +1,8 @@
+import type { WarpStateCoordinate } from '../../ports/WarpStateCachePort.ts';
+import type { PatchDiff } from '../types/PatchDiff.ts';
+
+/** Metadata that keeps an installed materialized state tied to its causal basis. */
+export type MaterializedStateUpdateOptions = Readonly<{
+  diff?: PatchDiff | null;
+  coordinate?: WarpStateCoordinate | null;
+}>;

--- a/src/domain/services/controllers/CheckpointController.ts
+++ b/src/domain/services/controllers/CheckpointController.ts
@@ -27,7 +27,6 @@ import type GCExecuteResult from '../GCExecuteResult.ts';
 import type { ProvenanceIndex } from '../provenance/ProvenanceIndex.ts';
 import type {
   WarpStateCoordinate,
-  WarpStateSnapshotProvenancePosture,
   WarpStateSnapshotRecord,
 } from '../../../ports/WarpStateCachePort.ts';
 import type WarpStateCachePort from '../../../ports/WarpStateCachePort.ts';
@@ -138,7 +137,6 @@ export default class CheckpointController {
       const stored = await stateCache.put(await this._buildSnapshotRecord({
         state,
         coordinate,
-        provenancePosture: 'full',
       }));
       const pinned = await stateCache.pin(stored.snapshotId);
       await stateCache.publishCheckpointHead(h._graphName, pinned.snapshotId);
@@ -197,14 +195,13 @@ export default class CheckpointController {
   private async _buildSnapshotRecord(params: {
     state: WarpState;
     coordinate: WarpStateCoordinate;
-    provenancePosture: WarpStateSnapshotProvenancePosture;
   }): Promise<WarpStateSnapshotRecord> {
     const stateHash = await this._computeStateHash(params.state, params.coordinate);
     return {
       snapshotId: `snapshot:${stateHash}`,
       coordinate: params.coordinate,
       retention: 'evictable',
-      provenancePosture: params.provenancePosture,
+      provenancePosture: 'degraded',
       stateHash,
       payloadRef: `snapshot:${stateHash}`,
       createdAt: 'checkpoint-create',

--- a/src/domain/services/controllers/MaterializeCheckpointStrategy.ts
+++ b/src/domain/services/controllers/MaterializeCheckpointStrategy.ts
@@ -30,7 +30,7 @@ export default class MaterializeCheckpointStrategy {
       targetFrontier: frontier,
       patchLoader,
     });
-    return await this.runtime.wrapState(state, null, null);
+    return await this.runtime.wrapState(state, null, null, 'degraded');
   }
 
   private async buildTargetFrontier(): Promise<Map<string, string>> {

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -42,6 +42,7 @@ import type CodecPort from '../../../ports/CodecPort.ts';
 import type CryptoPort from '../../../ports/CryptoPort.ts';
 import type CheckpointStorePort from '../../../ports/CheckpointStorePort.ts';
 import type WarpStateCachePort from '../../../ports/WarpStateCachePort.ts';
+import type { WarpStateSnapshotProvenancePosture } from '../../../ports/WarpStateCachePort.ts';
 import type PatchCollector from '../../capabilities/PatchCollector.ts';
 import type { PatchWithSha } from '../../capabilities/PatchCollector.ts';
 import type DetachedGraphFactory from '../../capabilities/DetachedGraphFactory.ts';
@@ -52,7 +53,6 @@ import AdjacencyMap from '../../capabilities/AdjacencyMap.ts';
 import type {
   MaterializeResultBuildInput,
   MaterializeStrategyRuntime,
-  MaterializeWrappedStateProvenance,
 } from './MaterializeStrategyRuntime.ts';
 
 export type MaterializePersistence = {
@@ -225,7 +225,7 @@ export default class MaterializeController {
     state: WarpState,
     ceiling: number | null,
     frontier: Map<string, string> | null,
-    provenance: MaterializeWrappedStateProvenance,
+    provenance: WarpStateSnapshotProvenancePosture,
     options?: MaterializeSnapshotPublicationOptions,
   ): Promise<MaterializeResult> {
     const stateHash = await computeHash(this._deps, state);

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -17,6 +17,7 @@ import {
   normalizeFrontierInput,
   normalizeExplicitCeiling,
   buildAdjacency,
+  maxObservedLamportInState,
   type MaterializeAdjacency,
 } from './MaterializeHelpers.ts';
 import {
@@ -225,7 +226,6 @@ export default class MaterializeController {
       await this._publishSnapshot({
         state,
         stateHash,
-        degraded: false,
         ceiling,
         frontier,
       });
@@ -235,7 +235,7 @@ export default class MaterializeController {
       stateHash,
       adjacency: new AdjacencyMap({ outgoing: adjacency.outgoing, incoming: adjacency.incoming }),
       patchCount: 0,
-      maxObservedLamport: 0,
+      maxObservedLamport: maxObservedLamportInState(state),
       provenanceIndex: new ProvenanceIndex(),
       provenanceDegraded: false,
       frontier,
@@ -250,7 +250,6 @@ export default class MaterializeController {
       await this._publishSnapshot({
         state: params.reduced.state,
         stateHash,
-        degraded: params.degraded,
         ceiling: params.ceiling,
         frontier: params.frontier,
       });
@@ -262,7 +261,10 @@ export default class MaterializeController {
       receipts: params.reduced.receipts,
       diff: params.reduced.diff,
       patchCount: params.summary.patchCount,
-      maxObservedLamport: params.summary.maxObservedLamport,
+      maxObservedLamport: Math.max(
+        params.summary.maxObservedLamport,
+        maxObservedLamportInState(params.reduced.state),
+      ),
       provenanceIndex: params.summary.provenance,
       provenanceDegraded: params.degraded,
       frontier: params.frontier,
@@ -332,7 +334,6 @@ export default class MaterializeController {
   private async _publishSnapshot(args: {
     state: WarpState;
     stateHash: string;
-    degraded: boolean;
     ceiling: number | null;
     frontier: Map<string, string> | null;
   }): Promise<void> {
@@ -347,7 +348,7 @@ export default class MaterializeController {
         ceiling: args.ceiling,
       },
       retention: 'evictable',
-      provenancePosture: args.degraded ? 'degraded' : 'full',
+      provenancePosture: 'degraded',
       stateHash: args.stateHash,
       payloadRef: `snapshot:${args.stateHash}`,
       createdAt: 'materialize-controller',

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -52,6 +52,7 @@ import AdjacencyMap from '../../capabilities/AdjacencyMap.ts';
 import type {
   MaterializeResultBuildInput,
   MaterializeStrategyRuntime,
+  MaterializeWrappedStateProvenance,
 } from './MaterializeStrategyRuntime.ts';
 
 export type MaterializePersistence = {
@@ -211,13 +212,20 @@ export default class MaterializeController {
     frontier?: Map<string, string> | null,
     options?: MaterializeSnapshotPublicationOptions,
   ): Promise<MaterializeResult> {
-    return await this._wrapState(createEmptyState(), ceiling ?? null, frontier ?? null, options);
+    return await this._wrapState(
+      createEmptyState(),
+      ceiling ?? null,
+      frontier ?? null,
+      'full',
+      options,
+    );
   }
 
   private async _wrapState(
     state: WarpState,
     ceiling: number | null,
     frontier: Map<string, string> | null,
+    provenance: MaterializeWrappedStateProvenance,
     options?: MaterializeSnapshotPublicationOptions,
   ): Promise<MaterializeResult> {
     const stateHash = await computeHash(this._deps, state);
@@ -237,7 +245,7 @@ export default class MaterializeController {
       patchCount: 0,
       maxObservedLamport: maxObservedLamportInState(state),
       provenanceIndex: new ProvenanceIndex(),
-      provenanceDegraded: false,
+      provenanceDegraded: provenance === 'degraded',
       frontier,
       ceiling,
     };
@@ -321,8 +329,8 @@ export default class MaterializeController {
       deps: this._deps,
       emptyResult: async (ceiling, frontier, options) =>
         await this._emptyResult(ceiling, frontier, options),
-      wrapState: async (state, ceiling, frontier, options) =>
-        await this._wrapState(state, ceiling, frontier, options),
+      wrapState: async (state, ceiling, frontier, provenance, options) =>
+        await this._wrapState(state, ceiling, frontier, provenance, options),
       reducePatches: async (patches, base, opts) => await this._reducePatches(patches, base, opts),
       reducePatchStream: async (stream, base, opts, provenanceBase) =>
         await this._reducePatchStream(stream, base, opts, provenanceBase),

--- a/src/domain/services/controllers/MaterializeCoordinateStrategy.ts
+++ b/src/domain/services/controllers/MaterializeCoordinateStrategy.ts
@@ -142,7 +142,7 @@ export default class MaterializeCoordinateStrategy {
     return await this.runtime.buildResult({
       reduced: reduction.reduced,
       summary: reduction.summary,
-      degraded: predecessor.provenancePosture === 'degraded',
+      degraded: true,
       ceiling: opts.coordinate.ceiling,
       frontier: opts.coordinate.frontier,
     });

--- a/src/domain/services/controllers/MaterializeHelpers.ts
+++ b/src/domain/services/controllers/MaterializeHelpers.ts
@@ -107,6 +107,15 @@ export function maxLamportInPatches(patches: Array<{ patch: { lamport?: number }
   return max;
 }
 
+/** Returns the greatest Lamport time already folded into a materialized state. */
+export function maxObservedLamportInState(state: WarpState): number {
+  let max = 0;
+  for (const lamport of state.observedFrontier.values()) {
+    max = Math.max(max, lamport);
+  }
+  return max;
+}
+
 // ── Adjacency building ──────────────────────────────────────────────
 
 type NeighborEdge = { neighborId: string; label: string };

--- a/src/domain/services/controllers/MaterializeLiveStrategy.ts
+++ b/src/domain/services/controllers/MaterializeLiveStrategy.ts
@@ -287,7 +287,7 @@ export default class MaterializeLiveStrategy {
     return await this.runtime.buildResult({
       reduced: reduction.reduced,
       summary: reduction.summary,
-      degraded: predecessor.provenancePosture === 'degraded',
+      degraded: true,
       ceiling: opts.coordinate.ceiling,
       frontier: opts.coordinate.frontier,
     });

--- a/src/domain/services/controllers/MaterializeLiveStrategy.ts
+++ b/src/domain/services/controllers/MaterializeLiveStrategy.ts
@@ -239,12 +239,15 @@ export default class MaterializeLiveStrategy {
     stateCache: WarpStateCachePort,
     opts: { coordinate: WarpStateCoordinate; receipts: boolean; wantDiff: boolean },
   ): Promise<MaterializeResult | null> {
-    if (opts.receipts || opts.wantDiff) {
+    if (opts.receipts) {
       return null;
     }
     const exactResult = await this.tryResolveExactSnapshot(stateCache, opts);
     if (exactResult !== null) {
       return exactResult;
+    }
+    if (opts.wantDiff) {
+      return null;
     }
     return await this.tryResolvePredecessorSnapshot(stateCache, opts);
   }

--- a/src/domain/services/controllers/MaterializeLiveStrategy.ts
+++ b/src/domain/services/controllers/MaterializeLiveStrategy.ts
@@ -126,16 +126,17 @@ export default class MaterializeLiveStrategy {
     opts: MaterializeLiveOptions,
     frontier: Map<string, string> | null,
   ): Promise<MaterializeResult> {
+    const provenanceBase = checkpoint.provenanceIndex;
     const reduction = await this.runtime.reducePatchStream(
       this.streamPatchesSinceCheckpoint(checkpoint, frontier),
       checkpoint.state,
       opts,
-      checkpoint.provenanceIndex,
+      provenanceBase,
     );
     return await this.runtime.buildResult({
       reduced: reduction.reduced,
       summary: reduction.summary,
-      degraded: false,
+      degraded: provenanceBase === undefined,
       ceiling: null,
       frontier,
     });

--- a/src/domain/services/controllers/MaterializeProvenancePolicy.ts
+++ b/src/domain/services/controllers/MaterializeProvenancePolicy.ts
@@ -31,7 +31,6 @@ function shouldPreserveResidentProvenance(
     return false;
   }
   return [
-    !resident.degraded,
     materialized.patchCount === 0,
     materialized.stateHash === resident.stateHash,
     materialized.ceiling === resident.ceiling,

--- a/src/domain/services/controllers/MaterializeProvenancePolicy.ts
+++ b/src/domain/services/controllers/MaterializeProvenancePolicy.ts
@@ -1,0 +1,59 @@
+import { frontiersEqual } from './MaterializeHelpers.ts';
+import type { ProvenanceIndex } from '../provenance/ProvenanceIndex.ts';
+
+type ResidentProvenanceBasis = Readonly<{
+  index: ProvenanceIndex | null;
+  degraded: boolean;
+  stateHash: string | null | undefined;
+  frontier: Map<string, string> | null;
+  ceiling: number | null;
+}>;
+
+type MaterializedProvenanceBasis = Readonly<{
+  patchCount: number;
+  stateHash: string;
+  frontier: Map<string, string> | null;
+  ceiling: number | null;
+  provenanceIndex: ProvenanceIndex;
+  provenanceDegraded: boolean;
+}>;
+
+type ProvenanceSelection = Readonly<{
+  index: ProvenanceIndex;
+  degraded: boolean;
+}>;
+
+function shouldPreserveResidentProvenance(
+  resident: ResidentProvenanceBasis,
+  materialized: MaterializedProvenanceBasis,
+): boolean {
+  if (materialized.frontier === null) {
+    return false;
+  }
+  return [
+    !resident.degraded,
+    materialized.patchCount === 0,
+    materialized.stateHash === resident.stateHash,
+    materialized.ceiling === resident.ceiling,
+    frontiersEqual(resident.frontier, materialized.frontier),
+  ].every(Boolean);
+}
+
+export function selectProvenanceAfterMaterialization(
+  resident: ResidentProvenanceBasis,
+  materialized: MaterializedProvenanceBasis,
+): ProvenanceSelection {
+  if (
+    resident.index !== null
+    && shouldPreserveResidentProvenance(resident, materialized)
+  ) {
+    return {
+      index: resident.index,
+      degraded: resident.degraded,
+    };
+  }
+  return {
+    index: materialized.provenanceIndex,
+    degraded: materialized.provenanceDegraded,
+  };
+}

--- a/src/domain/services/controllers/MaterializeSnapshotCacheResult.ts
+++ b/src/domain/services/controllers/MaterializeSnapshotCacheResult.ts
@@ -1,6 +1,6 @@
 import AdjacencyMap from '../../capabilities/AdjacencyMap.ts';
 import { ProvenanceIndex } from '../provenance/ProvenanceIndex.ts';
-import { buildAdjacency } from './MaterializeHelpers.ts';
+import { buildAdjacency, maxObservedLamportInState } from './MaterializeHelpers.ts';
 import type WarpState from '../state/WarpState.ts';
 import type { MaterializeResult } from './MaterializeController.ts';
 import type {
@@ -45,9 +45,10 @@ export function snapshotToMaterializeResult(snapshot: UsableSnapshotRecord): Mat
     stateHash: snapshot.stateHash,
     adjacency: new AdjacencyMap({ outgoing: adjacency.outgoing, incoming: adjacency.incoming }),
     patchCount: 0,
-    maxObservedLamport: 0,
+    maxObservedLamport: maxObservedLamportInState(snapshot.state),
     provenanceIndex: new ProvenanceIndex(),
-    provenanceDegraded: snapshot.provenancePosture === 'degraded',
+    // State-cache payloads do not yet carry the provenance index itself.
+    provenanceDegraded: true,
     frontier: snapshot.coordinate.frontier,
     ceiling: snapshot.coordinate.ceiling,
   };

--- a/src/domain/services/controllers/MaterializeStrategyRuntime.ts
+++ b/src/domain/services/controllers/MaterializeStrategyRuntime.ts
@@ -7,6 +7,7 @@ import type {
 } from './MaterializePatchStreamReducer.ts';
 import type { MaterializePatchSummary } from './MaterializePatchSummary.ts';
 import type { MaterializeSnapshotPublicationOptions } from './MaterializeSnapshotPublication.ts';
+import type { WarpStateSnapshotProvenancePosture } from '../../../ports/WarpStateCachePort.ts';
 import type {
   MaterializeDeps,
   MaterializeResult,
@@ -37,8 +38,6 @@ export type MaterializeResultBuildInput = {
   frontier: Map<string, string> | null;
 };
 
-export type MaterializeWrappedStateProvenance = 'full' | 'degraded';
-
 export type MaterializeStrategyRuntime = {
   deps: MaterializeDeps;
   emptyResult(
@@ -50,7 +49,7 @@ export type MaterializeStrategyRuntime = {
     state: WarpState,
     ceiling: number | null,
     frontier: Map<string, string> | null,
-    provenance: MaterializeWrappedStateProvenance,
+    provenance: WarpStateSnapshotProvenancePosture,
     options?: MaterializeSnapshotPublicationOptions,
   ): Promise<MaterializeResult>;
   reducePatches(

--- a/src/domain/services/controllers/MaterializeStrategyRuntime.ts
+++ b/src/domain/services/controllers/MaterializeStrategyRuntime.ts
@@ -37,6 +37,8 @@ export type MaterializeResultBuildInput = {
   frontier: Map<string, string> | null;
 };
 
+export type MaterializeWrappedStateProvenance = 'full' | 'degraded';
+
 export type MaterializeStrategyRuntime = {
   deps: MaterializeDeps;
   emptyResult(
@@ -48,6 +50,7 @@ export type MaterializeStrategyRuntime = {
     state: WarpState,
     ceiling: number | null,
     frontier: Map<string, string> | null,
+    provenance: MaterializeWrappedStateProvenance,
     options?: MaterializeSnapshotPublicationOptions,
   ): Promise<MaterializeResult>;
   reducePatches(

--- a/src/domain/services/controllers/PatchController.ts
+++ b/src/domain/services/controllers/PatchController.ts
@@ -36,6 +36,7 @@ import type { LogicalIndex } from '../index/logicalIndexHelpers.ts';
 import type PropertyIndexReader from '../index/PropertyIndexReader.ts';
 import type { PatchCommitResult } from '../../types/PatchCommitResult.ts';
 import type { AuditReceiptService } from '../audit/AuditReceiptService.ts';
+import type { MaterializedStateUpdateOptions } from '../../capabilities/MaterializedStateUpdate.ts';
 import { E_NO_STATE_MSG, E_STALE_STATE_MSG } from './QueryStateMessages.ts';
 
 // ── PatchHost ─────────────────────────────────────────────────────────────────
@@ -47,7 +48,7 @@ type MaterializedAdjacency = {
 };
 type SetMaterializedState = (
   state: WarpState,
-  optionsOrDiff?: PatchDiff | { diff?: PatchDiff | null },
+  optionsOrDiff?: PatchDiff | MaterializedStateUpdateOptions,
 ) => Promise<{
   state: WarpState;
   stateHash: string;
@@ -75,6 +76,7 @@ export interface PatchHost extends PatchDiscoveryHost {
   _provenanceIndex: {
     addPatch: (sha: string, reads: string[] | undefined, writes: string[] | undefined) => void;
   } | null | undefined;
+  _cachedFrontier: Map<string, string> | null | undefined;
   _lastFrontier: Map<string, string> | null | undefined;
   _auditService: Pick<AuditReceiptService, 'commit'> | null | undefined;
   _auditSkipCount: number;
@@ -275,7 +277,16 @@ export default class PatchController {
         const result = applyWithDiff(h._cachedState, committed, sha);
         diff = result.diff;
       }
-      await h._setMaterializedState(h._cachedState, { diff });
+      const materializedFrontier = h._cachedFrontier === null || h._cachedFrontier === undefined
+        ? null
+        : new Map(h._cachedFrontier);
+      materializedFrontier?.set(writerId, sha);
+      await h._setMaterializedState(h._cachedState, {
+        diff,
+        ...(materializedFrontier === null
+          ? {}
+          : { coordinate: { frontier: materializedFrontier, ceiling: null } }),
+      });
       if (h._provenanceIndex) {
         h._provenanceIndex.addPatch(
           sha,

--- a/src/domain/services/controllers/SyncController.ts
+++ b/src/domain/services/controllers/SyncController.ts
@@ -304,7 +304,9 @@ export default class SyncController {
     const result = applySyncResponseImpl(
       response, this._host._cachedState, currentFrontier,
     ) as { state: WarpState; frontier: Map<string, string>; applied: number };
-    await this._host._setMaterializedState(result.state);
+    await this._host._setMaterializedState(result.state, {
+      coordinate: { frontier: result.frontier, ceiling: null },
+    });
     this._host._lastFrontier = result.frontier;
     this._host._patchesSinceGC += result.applied;
     const skippedWriters: SkippedWriter[] = Array.isArray(response.skippedWriters)

--- a/src/domain/services/controllers/SyncControllerTypes.ts
+++ b/src/domain/services/controllers/SyncControllerTypes.ts
@@ -11,6 +11,7 @@ import type SyncTrustGate from '../sync/SyncTrustGate.ts';
 import type SyncCapability from '../../capabilities/SyncCapability.ts';
 import type SnapshotWarpState from '../snapshot/SnapshotWarpState.ts';
 import type SyncSecret from '../sync/SyncSecret.ts';
+import type { MaterializedStateUpdateOptions } from '../../capabilities/MaterializedStateUpdate.ts';
 
 /**
  * The host interface that SyncController depends on.
@@ -32,7 +33,10 @@ export interface SyncHost {
   _patchesSinceCheckpoint: number;
   _maxObservedLamport: number;
   materialize: () => Promise<SnapshotWarpState>;
-  _setMaterializedState: (state: WarpState) => Promise<object>;
+  _setMaterializedState: (
+    state: WarpState,
+    options?: MaterializedStateUpdateOptions,
+  ) => Promise<object>;
   discoverWriters: () => Promise<string[]>;
   _createSyncTrustGate?: (
     trust: { mode?: 'off' | 'log-only' | 'enforce'; pin?: string | null } | undefined | null,

--- a/src/domain/warp/RuntimeHostProduct.ts
+++ b/src/domain/warp/RuntimeHostProduct.ts
@@ -23,6 +23,7 @@ import type { VerifyResult } from '../services/MaterializedViewService.ts';
 import type LogicalTraversal from '../services/query/LogicalTraversal.ts';
 import type { LoadedCheckpoint } from '../services/state/checkpointLoad.ts';
 import type { PatchDiff } from '../types/PatchDiff.ts';
+import type { MaterializedStateUpdateOptions } from '../capabilities/MaterializedStateUpdate.ts';
 import type { ProvenanceIndex } from '../services/provenance/ProvenanceIndex.ts';
 import type ProvenancePayload from '../services/provenance/ProvenancePayload.ts';
 import type SyncController from '../services/controllers/SyncController.ts';
@@ -172,7 +173,7 @@ export type RuntimeHostProduct = RuntimeGraphHostProduct & {
   readonly _commitMessageCodec: CommitMessageCodecPort;
   _setMaterializedState(
     state: WarpState,
-    optionsOrDiff?: PatchDiff | { diff?: PatchDiff | null },
+    optionsOrDiff?: PatchDiff | MaterializedStateUpdateOptions,
   ): Promise<RuntimeHostMaterializedGraph>;
   _materializeGraph(options?: { ceiling?: number | null }): Promise<RuntimeHostMaterializedGraph>;
   _materializeCoordinateGraph(options: RuntimeHostCoordinateGraphOptions): Promise<RuntimeHostMaterializedGraph>;

--- a/src/ports/WarpStateCachePort.ts
+++ b/src/ports/WarpStateCachePort.ts
@@ -12,6 +12,7 @@ export type WarpStateSnapshotRecord = {
   snapshotId: string;
   coordinate: WarpStateCoordinate;
   retention: WarpStateSnapshotRetention;
+  /** `full` is valid only when the retained payload includes its provenance index. */
   provenancePosture: WarpStateSnapshotProvenancePosture;
   stateHash: string;
   payloadRef: string;

--- a/test/unit/domain/RuntimeHost.snapshotCache.test.ts
+++ b/test/unit/domain/RuntimeHost.snapshotCache.test.ts
@@ -78,6 +78,7 @@ describe('RuntimeHost snapshot cache', () => {
 
     const first = await runtime.materialize();
     expect(runtime._cachedViewHash).not.toBeNull();
+    expect(Reflect.get(runtime, '_cachedIndexTree')).not.toBeNull();
     expect(stateCache.publications).toHaveLength(1);
 
     const second = await runtime.materialize();

--- a/test/unit/domain/RuntimeHost.snapshotCache.test.ts
+++ b/test/unit/domain/RuntimeHost.snapshotCache.test.ts
@@ -96,4 +96,27 @@ describe('RuntimeHost snapshot cache', () => {
     expect(applyViewDiff).toHaveBeenCalledTimes(viewDiffsAfterFirstRead);
     expect(second).toEqual(first);
   });
+
+  it('advances the cached causal basis after eager patch application', async () => {
+    const persistence = new InMemoryGraphAdapter();
+    const stateCache = new RecordingStateCache();
+    const runtime = await openMemoryRuntimeHostProduct({
+      persistence,
+      graphName: 'runtime-snapshot-basis',
+      writerId: 'writer-1',
+      stateCache,
+    });
+
+    await runtime.patch((patch) => {
+      patch.addNode('node:one');
+    });
+    await runtime.materialize();
+
+    const patchId = await runtime.patch((patch) => {
+      patch.addNode('node:two');
+    });
+
+    expect(Reflect.get(runtime, '_cachedFrontier')).toEqual(new Map([['writer-1', patchId]]));
+    expect(Reflect.get(runtime, '_cachedCeiling')).toBe(null);
+  });
 });

--- a/test/unit/domain/RuntimeHost.snapshotCache.test.ts
+++ b/test/unit/domain/RuntimeHost.snapshotCache.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { openMemoryRuntimeHostProduct } from '../../helpers/MemoryRuntimeHost.ts';
+import InMemoryGraphAdapter from '../../helpers/InMemoryGraphAdapter.ts';
+import WarpStateCachePort, {
+  type WarpStateCoordinate,
+  type WarpStateSnapshotRecord,
+} from '../../../src/ports/WarpStateCachePort.ts';
+
+function coordinatesEqual(
+  left: WarpStateCoordinate,
+  right: WarpStateCoordinate,
+): boolean {
+  if (left.ceiling !== right.ceiling || left.frontier.size !== right.frontier.size) {
+    return false;
+  }
+  for (const [writerId, objectId] of right.frontier) {
+    if (left.frontier.get(writerId) !== objectId) {
+      return false;
+    }
+  }
+  return true;
+}
+
+class RecordingStateCache extends WarpStateCachePort {
+  readonly exactLookups: WarpStateCoordinate[] = [];
+  readonly publications: WarpStateSnapshotRecord[] = [];
+
+  getExact(coordinate: WarpStateCoordinate): Promise<WarpStateSnapshotRecord | null> {
+    this.exactLookups.push(coordinate);
+    return Promise.resolve(
+      this.publications.find((snapshot) => coordinatesEqual(snapshot.coordinate, coordinate)) ?? null,
+    );
+  }
+
+  getBestCompatiblePredecessor(
+    _coordinate: WarpStateCoordinate,
+  ): Promise<WarpStateSnapshotRecord | null> {
+    return Promise.resolve(null);
+  }
+
+  put(snapshot: WarpStateSnapshotRecord): Promise<WarpStateSnapshotRecord> {
+    this.publications.push(snapshot);
+    return Promise.resolve(snapshot);
+  }
+
+  pin(_snapshotId: string): Promise<WarpStateSnapshotRecord> {
+    return Promise.reject(new Error('unused'));
+  }
+
+  publishCheckpointHead(_graphName: string, _snapshotId: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  resolveCheckpointHead(_graphName: string): Promise<WarpStateSnapshotRecord | null> {
+    return Promise.resolve(null);
+  }
+
+  pruneEvictable(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe('RuntimeHost snapshot cache', () => {
+  it('uses the exact retained snapshot on an unchanged second materialization', async () => {
+    const persistence = new InMemoryGraphAdapter();
+    const stateCache = new RecordingStateCache();
+    const runtime = await openMemoryRuntimeHostProduct({
+      persistence,
+      graphName: 'runtime-snapshot-warm-hit',
+      writerId: 'writer-1',
+      stateCache,
+    });
+
+    await runtime.patch((patch) => {
+      patch.addNode('node:one');
+    });
+
+    const first = await runtime.materialize();
+    expect(runtime._cachedViewHash).not.toBeNull();
+    expect(stateCache.publications).toHaveLength(1);
+
+    const second = await runtime.materialize();
+
+    expect(stateCache.exactLookups).toHaveLength(2);
+    expect(stateCache.publications).toHaveLength(1);
+    expect(second).toEqual(first);
+  });
+});

--- a/test/unit/domain/RuntimeHost.snapshotCache.test.ts
+++ b/test/unit/domain/RuntimeHost.snapshotCache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { openMemoryRuntimeHostProduct } from '../../helpers/MemoryRuntimeHost.ts';
 import InMemoryGraphAdapter from '../../helpers/InMemoryGraphAdapter.ts';
@@ -75,8 +75,12 @@ describe('RuntimeHost snapshot cache', () => {
     const patchId = await runtime.patch((patch) => {
       patch.addNode('node:one');
     });
+    const buildView = vi.spyOn(runtime._viewService, 'build');
+    const applyViewDiff = vi.spyOn(runtime._viewService, 'applyDiff');
 
     const first = await runtime.materialize();
+    const viewBuildsAfterFirstRead = buildView.mock.calls.length;
+    const viewDiffsAfterFirstRead = applyViewDiff.mock.calls.length;
     expect(runtime._cachedViewHash).not.toBeNull();
     expect(Reflect.get(runtime, '_cachedIndexTree')).not.toBeNull();
     expect(runtime.provenanceIndex?.patchesFor('node:one')).toEqual([patchId]);
@@ -87,6 +91,9 @@ describe('RuntimeHost snapshot cache', () => {
     expect(stateCache.exactLookups).toHaveLength(2);
     expect(stateCache.publications).toHaveLength(1);
     expect(runtime.provenanceIndex?.patchesFor('node:one')).toEqual([patchId]);
+    expect(Reflect.get(runtime, '_provenanceDegraded')).toBe(false);
+    expect(buildView).toHaveBeenCalledTimes(viewBuildsAfterFirstRead);
+    expect(applyViewDiff).toHaveBeenCalledTimes(viewDiffsAfterFirstRead);
     expect(second).toEqual(first);
   });
 });

--- a/test/unit/domain/RuntimeHost.snapshotCache.test.ts
+++ b/test/unit/domain/RuntimeHost.snapshotCache.test.ts
@@ -72,19 +72,21 @@ describe('RuntimeHost snapshot cache', () => {
       stateCache,
     });
 
-    await runtime.patch((patch) => {
+    const patchId = await runtime.patch((patch) => {
       patch.addNode('node:one');
     });
 
     const first = await runtime.materialize();
     expect(runtime._cachedViewHash).not.toBeNull();
     expect(Reflect.get(runtime, '_cachedIndexTree')).not.toBeNull();
+    expect(runtime.provenanceIndex?.patchesFor('node:one')).toEqual([patchId]);
     expect(stateCache.publications).toHaveLength(1);
 
     const second = await runtime.materialize();
 
     expect(stateCache.exactLookups).toHaveLength(2);
     expect(stateCache.publications).toHaveLength(1);
+    expect(runtime.provenanceIndex?.patchesFor('node:one')).toEqual([patchId]);
     expect(second).toEqual(first);
   });
 });

--- a/test/unit/domain/services/SyncController.test.ts
+++ b/test/unit/domain/services/SyncController.test.ts
@@ -390,7 +390,9 @@ describe('SyncController', () => {
       await ctrl.applySyncResponse({ type: 'sync-response', frontier: {}, patches: [] as any[] });
 
       expect((host['_setMaterializedState'] as any)).toHaveBeenCalledOnce();
-      expect((host['_setMaterializedState'] as any)).toHaveBeenCalledWith(newState);
+      expect((host['_setMaterializedState'] as any)).toHaveBeenCalledWith(newState, {
+        coordinate: { frontier: newFrontier, ceiling: null },
+      });
       // _materializedGraph should be rebuilt (not null)
       expect(host['_materializedGraph']).not.toBeNull();
     });

--- a/test/unit/domain/services/controllers/CheckpointController.snapshotCache.test.ts
+++ b/test/unit/domain/services/controllers/CheckpointController.snapshotCache.test.ts
@@ -186,7 +186,10 @@ describe('CheckpointController — unified snapshot cache', () => {
 
     expect(snapshotCache.put).toHaveBeenCalledTimes(1);
     expect(snapshotCache.put).toHaveBeenCalledWith(
-      expect.objectContaining({ state: host._cachedState }),
+      expect.objectContaining({
+        provenancePosture: 'degraded',
+        state: host._cachedState,
+      }),
     );
     expect(snapshotCache.pin).toHaveBeenCalledWith('snapshot-new');
     expect(snapshotCache.publishCheckpointHead).toHaveBeenCalledWith('test-graph', 'snapshot-new');

--- a/test/unit/domain/services/controllers/MaterializeController.snapshotCache.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.snapshotCache.test.ts
@@ -238,7 +238,7 @@ describe('MaterializeController — unified snapshot cache', () => {
     expect(result.frontier).toEqual(target.frontier);
   });
 
-  it('bypasses live snapshot hits when diff materialization is requested', async () => {
+  it('uses an exact live snapshot hit when diff materialization is requested', async () => {
     const { controller, stateCache, patches } = createControllerFixtures();
     const target: Coordinate = {
       frontier: new Map([['writer-1', 'tip-7']]),
@@ -254,7 +254,36 @@ describe('MaterializeController — unified snapshot cache', () => {
 
     const result = await controller.materialize({ wantDiff: true });
 
-    expect(stateCache.getExact).not.toHaveBeenCalled();
+    expect(stateCache.getExact).toHaveBeenCalledWith(target);
+    expect(stateCache.getBestCompatiblePredecessor).not.toHaveBeenCalled();
+    expect(patches.collectForFrontier).not.toHaveBeenCalled();
+    expect(patches.loadCheckpoint).not.toHaveBeenCalled();
+    expect(stateCache.put).not.toHaveBeenCalled();
+    expect(result.patchCount).toBe(0);
+    expect(result.frontier).toEqual(target.frontier);
+  });
+
+  it('replays with a diff after an exact snapshot miss', async () => {
+    const { controller, stateCache, patches } = createControllerFixtures();
+    const target: Coordinate = {
+      frontier: new Map([['writer-1', 'tip-7']]),
+      ceiling: null,
+    };
+
+    stateCache.getExact.mockResolvedValue(null);
+    stateCache.getBestCompatiblePredecessor.mockResolvedValue(
+      snapshotRecord('snapshot-live-predecessor', {
+        frontier: new Map([['writer-1', 'tip-5']]),
+        ceiling: null,
+      }, 'full'),
+    );
+    patches.collectForFrontier.mockResolvedValue([
+      patchRecord(7, 'sha-7'),
+    ]);
+
+    const result = await controller.materialize({ wantDiff: true });
+
+    expect(stateCache.getExact).toHaveBeenCalledWith(target);
     expect(stateCache.getBestCompatiblePredecessor).not.toHaveBeenCalled();
     expect(patches.collectForFrontier).toHaveBeenCalledWith(
       target.frontier,

--- a/test/unit/domain/services/controllers/MaterializeController.snapshotCache.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.snapshotCache.test.ts
@@ -55,6 +55,16 @@ function snapshotRecord(
   };
 }
 
+function snapshotRecordWithObservedLamport(
+  snapshotId: string,
+  coordinate: Coordinate,
+  lamport: number,
+): SnapshotRecord {
+  const snapshot = snapshotRecord(snapshotId, coordinate, 'full');
+  snapshot.state.observedFrontier.set('writer-1', lamport);
+  return snapshot;
+}
+
 async function* streamFromPromise<T>(items: Promise<T[]>): AsyncIterable<T> {
   for (const item of await items) {
     yield item;
@@ -175,13 +185,13 @@ describe('MaterializeController — unified snapshot cache', () => {
       frontier: new Map([['writer-1', 'tip-7']]),
       ceiling: null,
     };
-    const predecessor = snapshotRecord(
+    const predecessor = snapshotRecordWithObservedLamport(
       'snapshot-live-predecessor',
       {
         frontier: new Map([['writer-1', 'tip-5']]),
         ceiling: null,
       },
-      'full',
+      40,
     );
 
     stateCache.getExact.mockResolvedValue(null);
@@ -203,6 +213,8 @@ describe('MaterializeController — unified snapshot cache', () => {
     expect(patches.loadCheckpoint).not.toHaveBeenCalled();
     expect(patches.loadWriterPatches).not.toHaveBeenCalled();
     expect(result.patchCount).toBe(2);
+    expect(result.maxObservedLamport).toBe(40);
+    expect(result.provenanceDegraded).toBe(true);
     expect(result.frontier).toEqual(target.frontier);
   });
 
@@ -229,7 +241,7 @@ describe('MaterializeController — unified snapshot cache', () => {
         snapshotId: 'snapshot:state-hash-1',
         coordinate: target,
         retention: 'evictable',
-        provenancePosture: 'full',
+        provenancePosture: 'degraded',
         stateHash: 'state-hash-1',
         state: result.state,
       }),
@@ -246,7 +258,7 @@ describe('MaterializeController — unified snapshot cache', () => {
     };
 
     stateCache.getExact.mockResolvedValue(
-      snapshotRecord('snapshot-live-exact', target, 'full'),
+      snapshotRecordWithObservedLamport('snapshot-live-exact', target, 41),
     );
     patches.collectForFrontier.mockResolvedValue([
       patchRecord(7, 'sha-7'),
@@ -260,6 +272,8 @@ describe('MaterializeController — unified snapshot cache', () => {
     expect(patches.loadCheckpoint).not.toHaveBeenCalled();
     expect(stateCache.put).not.toHaveBeenCalled();
     expect(result.patchCount).toBe(0);
+    expect(result.maxObservedLamport).toBe(41);
+    expect(result.provenanceDegraded).toBe(true);
     expect(result.frontier).toEqual(target.frontier);
   });
 
@@ -433,7 +447,7 @@ describe('MaterializeController — unified snapshot cache', () => {
     expect(stateCache.put).not.toHaveBeenCalled();
     expect(patches.collectForFrontier).not.toHaveBeenCalled();
     expect(result.patchCount).toBe(0);
-    expect(result.provenanceDegraded).toBe(false);
+    expect(result.provenanceDegraded).toBe(true);
   });
 
   it('replays only the suffix after the best compatible predecessor snapshot', async () => {
@@ -467,6 +481,7 @@ describe('MaterializeController — unified snapshot cache', () => {
     );
     expect(patches.collectForFrontier).not.toHaveBeenCalled();
     expect(result.patchCount).toBe(1);
+    expect(result.provenanceDegraded).toBe(true);
   });
 
   it('bypasses coordinate snapshot hits when receipts are requested', async () => {

--- a/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
@@ -251,7 +251,7 @@ describe("MaterializeController — state session integration", () => {
       expect.objectContaining({
         coordinate: target,
         retention: "evictable",
-        provenancePosture: "full",
+        provenancePosture: "degraded",
       }),
     );
     expect(result.state.nodeAlive.contains("node:base")).toBe(true);

--- a/test/unit/domain/services/controllers/MaterializeController.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.test.ts
@@ -399,7 +399,7 @@ describe('MaterializeController', () => {
       expect(Array.isArray(result.receipts)).toBe(true);
     });
 
-    it('builds provenance index from checkpoint provenanceIndex + new patches', async () => {
+    it('preserves full provenance from a checkpoint index and new patches', async () => {
       const { ctrl, patches } = setup();
       const ckPI = new ProvenanceIndex();
       ckPI.addPatch('old-sha', ['r1'], ['w1']);
@@ -416,10 +416,14 @@ describe('MaterializeController', () => {
 
       const result = await ctrl.materialize({});
 
-      expect(result.provenanceIndex).toBeInstanceOf(ProvenanceIndex);
+      expect(result.provenanceIndex.patchesFor('r1')).toEqual(['old-sha']);
+      expect(result.provenanceIndex.patchesFor('w1')).toEqual(['old-sha']);
+      expect(result.provenanceIndex.patchesFor('r2')).toEqual(['new-sha']);
+      expect(result.provenanceIndex.patchesFor('w2')).toEqual(['new-sha']);
+      expect(result.provenanceDegraded).toBe(false);
     });
 
-    it('creates fresh provenance index when checkpoint lacks one', async () => {
+    it('marks provenance degraded when the checkpoint lacks its prefix index', async () => {
       const { ctrl, patches } = setup();
       const checkpoint = {
         schema: 5,
@@ -429,11 +433,39 @@ describe('MaterializeController', () => {
         // no provenanceIndex
       };
       patches.loadCheckpoint.mockResolvedValue(checkpoint);
-      patches.loadPatchesSince.mockResolvedValue([fakePatchEntry({ sha: 'sha1' })]);
+      patches.loadPatchesSince.mockResolvedValue([
+        fakePatchEntry({ sha: 'new-sha', reads: ['r2'], writes: ['w2'] }),
+      ]);
 
       const result = await ctrl.materialize({});
 
       expect(result.provenanceIndex).toBeInstanceOf(ProvenanceIndex);
+      expect(result.provenanceIndex.patchesFor('r2')).toEqual(['new-sha']);
+      expect(result.provenanceIndex.patchesFor('w2')).toEqual(['new-sha']);
+      expect(result.provenanceDegraded).toBe(true);
+    });
+  });
+
+  describe('materializeAt() — explicit checkpoint', () => {
+    it('marks provenance degraded because state-only replay omits its support index', async () => {
+      const checkpointStore = {
+        loadCheckpoint: vi.fn().mockResolvedValue({
+          state: emptyState(),
+          frontier: new Map(),
+          stateHash: 'checkpoint-hash',
+          schema: 5,
+          appliedVV: null,
+          provenanceIndex: null,
+          indexShardHandles: null,
+        }),
+      };
+      const { ctrl } = setup({ depsOverrides: { checkpointStore } });
+
+      const result = await ctrl.materializeAt('checkpoint-sha');
+
+      expect(result.provenanceIndex).toBeInstanceOf(ProvenanceIndex);
+      expect(result.provenanceIndex.size).toBe(0);
+      expect(result.provenanceDegraded).toBe(true);
     });
   });
 

--- a/test/unit/domain/services/controllers/MaterializeProvenancePolicy.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeProvenancePolicy.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectProvenanceAfterMaterialization } from '../../../../../src/domain/services/controllers/MaterializeProvenancePolicy.ts';
+import { ProvenanceIndex } from '../../../../../src/domain/services/provenance/ProvenanceIndex.ts';
+
+type ResidentBasis = Parameters<typeof selectProvenanceAfterMaterialization>[0];
+type MaterializedBasis = Parameters<typeof selectProvenanceAfterMaterialization>[1];
+
+const FRONTIER = new Map([['writer-1', 'tip-1']]);
+
+function provenance(entity: string, patch: string): ProvenanceIndex {
+  return new ProvenanceIndex().addPatch(patch, [], [entity]);
+}
+
+function residentBasis(index: ProvenanceIndex): ResidentBasis {
+  return {
+    index,
+    degraded: false,
+    stateHash: 'state-1',
+    frontier: FRONTIER,
+    ceiling: null,
+  };
+}
+
+function materializedBasis(index: ProvenanceIndex): MaterializedBasis {
+  return {
+    patchCount: 0,
+    stateHash: 'state-1',
+    frontier: new Map(FRONTIER),
+    ceiling: null,
+    provenanceIndex: index,
+    provenanceDegraded: true,
+  };
+}
+
+describe('selectProvenanceAfterMaterialization', () => {
+  it('preserves a basis-equivalent resident index and its degraded posture', () => {
+    const residentIndex = provenance('node:resident', 'patch-resident');
+    const cachedIndex = new ProvenanceIndex();
+    const resident = { ...residentBasis(residentIndex), degraded: true };
+
+    const selection = selectProvenanceAfterMaterialization(
+      resident,
+      materializedBasis(cachedIndex),
+    );
+
+    expect(selection.index).toBe(residentIndex);
+    expect(selection.degraded).toBe(true);
+  });
+
+  const rejectionCases: ReadonlyArray<{
+    label: string;
+    resident?: Partial<ResidentBasis>;
+    materialized?: Partial<MaterializedBasis>;
+  }> = [
+    { label: 'a missing resident index', resident: { index: null } },
+    { label: 'replayed patches', materialized: { patchCount: 1 } },
+    { label: 'a different state', materialized: { stateHash: 'state-2' } },
+    { label: 'a different ceiling', materialized: { ceiling: 7 } },
+    {
+      label: 'a different frontier',
+      materialized: { frontier: new Map([['writer-1', 'tip-2']]) },
+    },
+    { label: 'an unanchored materialization', materialized: { frontier: null } },
+  ];
+
+  it.each(rejectionCases)('uses materialized provenance for $label', ({ resident, materialized }) => {
+    const residentIndex = provenance('node:resident', 'patch-resident');
+    const cachedIndex = provenance('node:cached', 'patch-cached');
+
+    const selection = selectProvenanceAfterMaterialization(
+      { ...residentBasis(residentIndex), ...resident },
+      { ...materializedBasis(cachedIndex), ...materialized },
+    );
+
+    expect(selection.index).toBe(cachedIndex);
+    expect(selection.degraded).toBe(true);
+  });
+});

--- a/test/unit/domain/services/controllers/PatchController.test.ts
+++ b/test/unit/domain/services/controllers/PatchController.test.ts
@@ -114,6 +114,7 @@ function createMockHost(overrides = {}) {
     _patchJournal: null,
     _patchInProgress: false,
     _provenanceIndex: null,
+    _cachedFrontier: null,
     _lastFrontier: null,
     _auditService: null,
     _auditSkipCount: 0,
@@ -502,6 +503,8 @@ describe('PatchController', () => {
       const state = createStateWithNode('n1');
       host['_cachedState'] = state;
       host['_stateDirty'] = false;
+      host['_cachedFrontier'] = new Map([['bob', 'sha-bob']]);
+      host['_lastFrontier'] = new Map([['bob', 'sha-bob']]);
 
       const diff = { nodesAdded: ['n2'], nodesRemoved: [], edgesAdded: [], edgesRemoved: [], propsChanged: [] };
       applyWithDiffMock.mockReturnValue({ diff });
@@ -513,7 +516,16 @@ describe('PatchController', () => {
 
       expect(applyWithDiffMock).toHaveBeenCalledWith(state, patch, 'sha-1');
       const setMat = (host['_setMaterializedState'] as any);
-      expect(setMat).toHaveBeenCalledWith(state, { diff });
+      expect(setMat).toHaveBeenCalledWith(state, {
+        diff,
+        coordinate: {
+          frontier: new Map([
+            ['alice', 'sha-1'],
+            ['bob', 'sha-bob'],
+          ]),
+          ceiling: null,
+        },
+      });
     });
 
     it('uses applyWithReceipt when audit service is present', async () => {

--- a/test/unit/domain/services/controllers/SyncController.test.ts
+++ b/test/unit/domain/services/controllers/SyncController.test.ts
@@ -501,7 +501,8 @@ describe('SyncController', () => {
 
     it('calls _setMaterializedState with new state (B105)', async () => {
       const newState = fakeState();
-      applySyncResponseMock.mockReturnValue({ state: newState, frontier: new Map(), applied: 1 });
+      const newFrontier = new Map([['alice', 'sha-2']]);
+      applySyncResponseMock.mockReturnValue({ state: newState, frontier: newFrontier, applied: 1 });
 
       const host = createMockHost({
         _cachedState: fakeState(),
@@ -511,7 +512,9 @@ describe('SyncController', () => {
 
       await ctrl.applySyncResponse((validSyncResponse() as any));
 
-      expect((host['_setMaterializedState'] as any)).toHaveBeenCalledWith(newState);
+      expect((host['_setMaterializedState'] as any)).toHaveBeenCalledWith(newState, {
+        coordinate: { frontier: newFrontier, ceiling: null },
+      });
     });
 
     it('does not advance frontier/counters when _setMaterializedState rejects', async () => {


### PR DESCRIPTION
Refs #734.
Refs #738.
Refs #739.

## Summary

- Honor exact live state-cache hits even when `RuntimeHost` requests a diff for its resident bitmap view.
- Keep exact misses on the replay path when a diff is required, rather than applying a predecessor snapshot against the wrong resident basis.
- Preserve basis-equivalent resident provenance across unchanged warm hits.
- Derive maximum observed Lamport time from restored state, including snapshot, predecessor, and checkpoint bases.
- Mark state-only cache and checkpoint payloads as provenance-degraded until the retained payload actually includes its provenance index.
- Preserve the checkpoint prefix index when present and fail closed when checkpoint or `materializeAt()` replay omits it.
- Keep eager patch and sync state installs tied to their updated causal coordinates so the next provenance decision compares the correct basis.
- Skip duplicate snapshot publication and bitmap/property view reconstruction on an unchanged second materialization.

## Root Cause

`RuntimeHost.materialize()` requests a diff after its bitmap index has been built. `MaterializeLiveStrategy` treated `wantDiff` as a reason to bypass the state cache entirely, so every subsequent materialization replayed patch history even when an exact retained snapshot existed.

Simply allowing the exact hit exposed two metadata hazards in the existing snapshot result: it replaced a valid resident provenance index with an empty index, and it reported maximum observed Lamport time as zero. The fix makes exact-hit reuse conditional only at the cache lookup layer, then preserves resident provenance only when hash, frontier, ceiling, and zero-replay facts prove the basis is unchanged. Restored Lamport truth comes from the state itself.

The same provenance comparison also depends on the basis metadata attached to the resident state. Eager patch and sync installation now advance `_cachedFrontier` and `_cachedCeiling` together with `_materializedGraph`; calls without a known coordinate clear that metadata rather than retaining a stale basis.

## Evidence Contract

The current state-cache payload stores `WarpState`, not `ProvenanceIndex`. Cache-only restoration therefore reports degraded provenance instead of presenting an empty index as complete support. An unchanged resident runtime may keep its existing index, but its degraded/full posture is never upgraded by the cache hit.

The same rule now covers checkpoint replay. A checkpoint carrying a prefix provenance index retains full posture and extends that index with suffix patches. A cache-backed checkpoint without that index, and the state-only `materializeAt()` path, report degraded provenance.

Materialized state installation accepts an explicit causal coordinate. Patch and sync controllers supply the coordinate they actually installed; unknown or legacy bases fail closed to `null`, preventing a later materialization from preserving provenance against stale coordinate metadata.

## Validation

- `npm run test:local`: 563 files passed, 6,952 tests passed, 2 skipped.
- `npm run test:coverage:ci`: 575 files passed, 1 skipped; 7,026 tests passed, 2 skipped; 92.72% line coverage.
- Changed executable statements: 31/31 covered.
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm run typecheck:consumer`
- `npm run lint:semgrep`
- `npm run lint:sludge`
- `npm run lint:docs-topology`
- `npm run typecheck:surface`
- Pre-push IRONCLAD M9 firewall passed at `4c2392e0e298`.

## Scope

This removes redundant replay for exact warm hits and fixes the causal metadata contract around those hits. It does **not** close #738 or #739: full `WarpState` hydration remains, and bounded CAS page-backed observer reads, shared checkpoint/materialization bundles, cache diagnostics, and removal of remaining WARP-local cache policy are still required.
