### PR TITLE
fix(materialize): stream session reduction

### DIFF
--- a/src/domain/artifacts/PatchEntry.ts
+++ b/src/domain/artifacts/PatchEntry.ts
@@ -1,5 +1,5 @@
 import WarpError from '../errors/WarpError.ts';
-import type Patch from '../types/Patch.ts';
+import Patch from '../types/Patch.ts';
 
 /**
  * A patch entry from a patch scan stream.
@@ -12,7 +12,7 @@ export default class PatchEntry {
   readonly sha: string;
 
   constructor({ patch, sha }: { patch: Patch; sha: string }) {
-    if (patch === null || patch === undefined) {
+    if (!(patch instanceof Patch)) {
       throw new WarpError('PatchEntry requires a patch', 'E_INVALID_ENTRY');
     }
     if (typeof sha !== 'string' || sha.length === 0) {

--- a/src/domain/orset/session/StateSession.ts
+++ b/src/domain/orset/session/StateSession.ts
@@ -118,14 +118,14 @@ export default class StateSession {
     await this.#edgeAlive.add(key, dot);
   }
 
-  async removeNodes(observedDots: ReadonlySet<string>): Promise<void> {
+  async removeNode(id: string, observedDots: ReadonlySet<string>): Promise<void> {
     this.#assertOpen();
-    await this.#nodeAlive.remove(observedDots);
+    await this.#nodeAlive.removeElement(id, observedDots);
   }
 
-  async removeEdges(observedDots: ReadonlySet<string>): Promise<void> {
+  async removeEdge(key: string, observedDots: ReadonlySet<string>): Promise<void> {
     this.#assertOpen();
-    await this.#edgeAlive.remove(observedDots);
+    await this.#edgeAlive.removeElement(key, observedDots);
   }
 
   scanNodes(): AsyncIterable<string> {

--- a/src/domain/orset/shadow/ShadowTrieORSet.ts
+++ b/src/domain/orset/shadow/ShadowTrieORSet.ts
@@ -60,6 +60,10 @@ export default class ShadowTrieORSet {
     await this.#cursor.remove(observedDots);
   }
 
+  async removeElement(element: string, observedDots: ReadonlySet<string>): Promise<void> {
+    await this.#cursor.removeElement(element, observedDots);
+  }
+
   async compact(includedVV: VersionVector): Promise<void> {
     await this.#cursor.compact(includedVV);
   }

--- a/src/domain/orset/trie/TrieCursor.ts
+++ b/src/domain/orset/trie/TrieCursor.ts
@@ -128,6 +128,21 @@ export default class TrieCursor {
     await this.#tombstoneBelow([], observedDots);
   }
 
+  async removeElement(element: string, observedDots: ReadonlySet<string>): Promise<void> {
+    validateElement(element);
+    if (observedDots.size === 0) {
+      return;
+    }
+    const located = await this.#locateEntry(element);
+    if (located === null) {
+      return;
+    }
+    const next = rewriteElementWithTombstones(located.leaf, element, observedDots);
+    if (next !== null) {
+      this.#markLoadedLeafMutation(located.path, new TrieLeaf(next, this.#geometry));
+    }
+  }
+
   async compact(includedVV: VersionVector): Promise<void> {
     const compactor = new TrieCompactor({
       geometry: this.#geometry,
@@ -254,6 +269,15 @@ export default class TrieCursor {
     const key = encodeDirtyPath(path);
     this.#workingLeaves.set(key, leaf);
     this.#dirtyLeaves.set(key, leaf);
+  }
+
+  #markLoadedLeafMutation(path: readonly number[], leaf: TrieLeaf): void {
+    this.#markLeafDirty(path, leaf);
+    let parentDepth = path.length - 1;
+    for (const nibble of [...path].reverse()) {
+      this.#rebindParentBranch(path.slice(0, parentDepth), nibble);
+      parentDepth -= 1;
+    }
   }
 
   #clearLeafAt(path: readonly number[]): void {
@@ -404,36 +428,60 @@ export default class TrieCursor {
   // -- read path -------------------------------------------------------------
 
   async #lookupEntry(element: string): Promise<TrieLeafEntry | null> {
+    const located = await this.#locateEntry(element);
+    return located?.entry ?? null;
+  }
+
+  async #locateEntry(element: string): Promise<LocatedEntry | null> {
     await this.#loadRootIfNeeded();
     if (!this.#hasRoot()) {
       return null;
     }
     const routeKey = RouteKey.fromElement(element);
     const nibbleBits = nibbleBitsOf(this.#geometry.nibbleBits);
-    return await this.#descendForLookup(routeKey, element, nibbleBits);
+    return await this.#descendForLookup({ routeKey, element, nibbleBits });
   }
 
-  async #descendForLookup(
-    routeKey: RouteKey,
-    element: string,
-    nibbleBits: NibbleBits,
-  ): Promise<TrieLeafEntry | null> {
-    const maxDepth = Math.floor(256 / nibbleBits);
+  async #descendForLookup(target: LookupTarget): Promise<LocatedEntry | null> {
+    const maxDepth = Math.floor(256 / target.nibbleBits);
     let path: readonly number[] = [];
     for (let depth = 0; depth < maxDepth; depth += 1) {
-      const step = await this.#stepLookup({ routeKey, path, depth, nibbleBits });
+      const step = await this.#stepLookup({
+        routeKey: target.routeKey,
+        path,
+        depth,
+        nibbleBits: target.nibbleBits,
+      });
       if (step.kind === "missing") {
         return null;
       }
       if (step.kind === "leaf") {
-        return findEntryInLeaf({ leaf: step.leaf, routeKey, depth: depth + 1, nibbleBits, element });
+        return locateEntryInLeaf({
+          leaf: step.leaf,
+          path: step.path,
+          depth: depth + 1,
+          ...target,
+        });
       }
       path = step.nextPath;
     }
+    return this.#locateTerminalEntry(path, target, maxDepth);
+  }
+
+  #locateTerminalEntry(
+    path: readonly number[],
+    target: LookupTarget,
+    depth: number,
+  ): LocatedEntry | null {
     const terminal = this.#leafAt(path);
     return terminal === null
       ? null
-      : findEntryInLeaf({ leaf: terminal, routeKey, depth: maxDepth, nibbleBits, element });
+      : locateEntryInLeaf({
+          leaf: terminal,
+          path,
+          depth,
+          ...target,
+        });
   }
 
   async #stepLookup(args: {
@@ -466,7 +514,7 @@ export default class TrieCursor {
     const nextPath = [...parentPath, nibble];
     if (kind === "leaf") {
       const leaf = this.#leafAt(nextPath);
-      return leaf === null ? { kind: "missing" } : { kind: "leaf", leaf };
+      return leaf === null ? { kind: "missing" } : { kind: "leaf", leaf, path: nextPath };
     }
     return { kind: "branch", nextPath };
   }
@@ -694,7 +742,7 @@ export default class TrieCursor {
     if (next === null) {
       return;
     }
-    this.#markLeafDirty(leafPath, new TrieLeaf(next, this.#geometry));
+    this.#markLoadedLeafMutation(leafPath, new TrieLeaf(next, this.#geometry));
   }
 
   // -- leaf walk (scan/elements) ---------------------------------------------
@@ -791,6 +839,39 @@ function rewriteLeafWithTombstones(
   return changed ? out : null;
 }
 
+function rewriteElementWithTombstones(
+  leaf: TrieLeaf,
+  element: string,
+  observedDots: ReadonlySet<string>,
+): TrieLeafEntry[] | null {
+  let changed = false;
+  const out: TrieLeafEntry[] = [];
+  for (const entry of leaf.entries()) {
+    if (entry.element !== element) {
+      out.push(entry);
+      continue;
+    }
+    const result = tombstoneEntry(entry, observedDots);
+    if (result.changed) {
+      changed = true;
+    }
+    out.push(result.entry);
+  }
+  return changed ? out : null;
+}
+
+function locateEntryInLeaf(args: {
+  readonly leaf: TrieLeaf;
+  readonly path: readonly number[];
+  readonly routeKey: RouteKey;
+  readonly depth: number;
+  readonly nibbleBits: NibbleBits;
+  readonly element: string;
+}): LocatedEntry | null {
+  const entry = findEntryInLeaf(args);
+  return entry === null ? null : { entry, leaf: args.leaf, path: args.path };
+}
+
 // -- helper: yield elements from a leaf -------------------------------------
 
 function* liveElementsOf(leaf: TrieLeaf): Iterable<string> {
@@ -813,8 +894,20 @@ function elementStateOfEntry(entry: TrieLeafEntry): ORSetElementState {
 
 type LookupStep =
   | { readonly kind: "missing" }
-  | { readonly kind: "leaf"; readonly leaf: TrieLeaf }
+  | { readonly kind: "leaf"; readonly leaf: TrieLeaf; readonly path: readonly number[] }
   | { readonly kind: "branch"; readonly nextPath: readonly number[] };
+
+type LocatedEntry = Readonly<{
+  entry: TrieLeafEntry;
+  leaf: TrieLeaf;
+  path: readonly number[];
+}>;
+
+type LookupTarget = Readonly<{
+  routeKey: RouteKey;
+  element: string;
+  nibbleBits: NibbleBits;
+}>;
 
 // -- non-Error catch escape hatch ------------------------------------------
 

--- a/src/domain/services/JoinReducerSession.ts
+++ b/src/domain/services/JoinReducerSession.ts
@@ -54,6 +54,13 @@ type ReplayDiffSnapshot =
 
 type ReplayMode = "fast" | "diff" | "receipt";
 
+type SessionPatch = Readonly<{
+  patch: PatchLike; // nosemgrep: ts-no-like-types -- 0025C
+  sha: string;
+}>;
+
+type SessionPatchSource = Iterable<SessionPatch> | AsyncIterable<SessionPatch>;
+
 export class ReducerSessionFrame {
   readonly session: StateSession;
   readonly prop: Map<string, LWWRegister<ReducerPropValue>>;
@@ -125,21 +132,21 @@ export async function applyWithReceiptInSession(
 }
 
 export function reducePatchesInSession(
-  patches: ReadonlyArray<{ readonly patch: PatchLike; readonly sha: string }>, // nosemgrep: ts-no-like-types -- 0025C
+  patches: SessionPatchSource,
   frame: ReducerSessionFrame,
 ): Promise<ReducerSessionFrame>;
 export function reducePatchesInSession(
-  patches: ReadonlyArray<{ readonly patch: PatchLike; readonly sha: string }>, // nosemgrep: ts-no-like-types -- 0025C
+  patches: SessionPatchSource,
   frame: ReducerSessionFrame,
   options: { readonly receipts: true },
 ): Promise<{ frame: ReducerSessionFrame; receipts: TickReceipt[] }>;
 export function reducePatchesInSession(
-  patches: ReadonlyArray<{ readonly patch: PatchLike; readonly sha: string }>, // nosemgrep: ts-no-like-types -- 0025C
+  patches: SessionPatchSource,
   frame: ReducerSessionFrame,
   options: { readonly trackDiff: true },
 ): Promise<{ frame: ReducerSessionFrame; diff: PatchDiff }>;
 export async function reducePatchesInSession(
-  patches: ReadonlyArray<{ readonly patch: PatchLike; readonly sha: string }>, // nosemgrep: ts-no-like-types -- 0025C
+  patches: SessionPatchSource,
   frame: ReducerSessionFrame,
   options?: { readonly receipts?: boolean; readonly trackDiff?: boolean },
 ): Promise<
@@ -147,7 +154,7 @@ export async function reducePatchesInSession(
 > {
   if (options?.receipts === true) {
     const receipts: TickReceipt[] = [];
-    for (const { patch, sha } of patches) {
+    for await (const { patch, sha } of patches) {
       receipts.push(await applyWithReceiptInSession(frame, patch, sha));
     }
     return { frame, receipts };
@@ -155,13 +162,13 @@ export async function reducePatchesInSession(
 
   if (options?.trackDiff === true) {
     let merged = createEmptyDiff();
-    for (const { patch, sha } of patches) {
+    for await (const { patch, sha } of patches) {
       merged = mergeDiffs(merged, await applyWithDiffInSession(frame, patch, sha));
     }
     return { frame, diff: merged };
   }
 
-  for (const { patch, sha } of patches) {
+  for await (const { patch, sha } of patches) {
     await applyFastInSession(frame, patch, sha);
   }
   return frame;
@@ -340,7 +347,7 @@ async function mutateInSession(
     return;
   }
   if (op instanceof NodeRemove) {
-    await frame.session.removeNodes(new Set(op.observedDots));
+    await frame.session.removeNode(op.node, new Set(op.observedDots));
     return;
   }
   if (op instanceof EdgeAdd) {
@@ -353,7 +360,8 @@ async function mutateInSession(
     return;
   }
   if (op instanceof EdgeRemove) {
-    await frame.session.removeEdges(new Set(op.observedDots));
+    const edgeKey = encodeEdgeKey(op.from, op.to, op.label);
+    await frame.session.removeEdge(edgeKey, new Set(op.observedDots));
     return;
   }
   if (op instanceof PropSet) {
@@ -532,7 +540,7 @@ async function mergeLiveNodesInto(
       await target.addNode(nodeState.element, Dot.decode(encodedDot));
     }
     if (nodeState.tombstonedDots.size > 0) {
-      await target.removeNodes(nodeState.tombstonedDots);
+      await target.removeNode(nodeState.element, nodeState.tombstonedDots);
     }
   }
 }
@@ -549,7 +557,7 @@ async function mergeLiveEdgesInto(
       await target.addEdge(edgeState.element, Dot.decode(encodedDot));
     }
     if (edgeState.tombstonedDots.size > 0) {
-      await target.removeEdges(edgeState.tombstonedDots);
+      await target.removeEdge(edgeState.element, edgeState.tombstonedDots);
     }
   }
 }

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -32,7 +32,7 @@ import MaterializePatchStreamReducer, {
   type MaterializePatchStreamOptions,
   type MaterializePatchStreamReduction,
 } from './MaterializePatchStreamReducer.ts';
-import { summarizeMaterializePatches } from './MaterializePatchSummary.ts';
+import { MaterializePatchSummaryAccumulator } from './MaterializePatchSummary.ts';
 import {
   shouldPublishMaterializeSnapshot,
   type MaterializeSnapshotPublicationOptions,
@@ -313,14 +313,23 @@ export default class MaterializeController {
         ...(provenanceBase === undefined ? {} : { provenanceBase }),
       });
     }
-    const patches: PatchWithSha[] = [];
-    for await (const entry of stream) {
-      patches.push(entry);
-    }
-    const reduced = await this._reducePatches(patches, base, opts);
+    const summary = new MaterializePatchSummaryAccumulator(provenanceBase);
+    const recordingStream = async function* (): AsyncIterable<PatchWithSha> {
+      for await (const entry of stream) {
+        summary.record(entry);
+        yield entry;
+      }
+    };
+    const reduced = await reduceSessionBackedState({
+      openStateSession: this._deps.openStateSession,
+      patches: recordingStream(),
+      receipts: opts.receipts,
+      wantDiff: opts.wantDiff,
+      ...(base === undefined ? {} : { baseState: base }),
+    });
     return {
       reduced,
-      summary: summarizeMaterializePatches(patches, provenanceBase),
+      summary: summary.toSummary(),
     };
   }
 

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -46,6 +46,7 @@ import type { WarpStateSnapshotProvenancePosture } from '../../../ports/WarpStat
 import type PatchCollector from '../../capabilities/PatchCollector.ts';
 import type { PatchWithSha } from '../../capabilities/PatchCollector.ts';
 import type DetachedGraphFactory from '../../capabilities/DetachedGraphFactory.ts';
+import PatchEntry from '../../artifacts/PatchEntry.ts';
 import type WarpState from '../state/WarpState.ts';
 import type { TickReceipt } from '../../types/TickReceipt.ts';
 import type { PatchDiff } from '../../types/PatchDiff.ts';
@@ -291,7 +292,7 @@ export default class MaterializeController {
     }
     const sessionArgs = {
       openStateSession,
-      patches,
+      patches: patches.map((entry) => new PatchEntry(entry)),
       receipts: opts.receipts,
       wantDiff: opts.wantDiff,
       ...(base === undefined ? {} : { baseState: base }),
@@ -314,10 +315,10 @@ export default class MaterializeController {
       });
     }
     const summary = new MaterializePatchSummaryAccumulator(provenanceBase);
-    const recordingStream = async function* (): AsyncIterable<PatchWithSha> {
+    const recordingStream = async function* (): AsyncIterable<PatchEntry> {
       for await (const entry of stream) {
         summary.record(entry);
-        yield entry;
+        yield new PatchEntry(entry);
       }
     };
     const reduced = await reduceSessionBackedState({

--- a/src/domain/services/controllers/MaterializeSessionBridge.ts
+++ b/src/domain/services/controllers/MaterializeSessionBridge.ts
@@ -1,11 +1,11 @@
 import ORSet from "../../crdt/ORSet.ts";
 import VersionVector from "../../crdt/VersionVector.ts";
 import { Dot } from "../../crdt/Dot.ts";
+import type PatchEntry from "../../artifacts/PatchEntry.ts";
 import type StateSession from "../../orset/session/StateSession.ts";
 import type { PatchDiff } from "../../types/PatchDiff.ts";
 import type { TickReceipt } from "../../types/TickReceipt.ts";
 import WarpStateClass from "../state/WarpState.ts";
-import type { PatchLike } from "../JoinReducer.ts"; // nosemgrep: ts-no-like-types -- 0025C
 import {
   ReducerSessionFrame,
   reducePatchesInSession,
@@ -24,14 +24,9 @@ export type MaterializeSessionOpener = (
   init: MaterializeSessionOpen,
 ) => Promise<StateSession>;
 
-type MaterializeSessionPatch = Readonly<{
-  patch: PatchLike; // nosemgrep: ts-no-like-types -- 0025C
-  sha: string;
-}>;
-
 type MaterializeSessionPatchSource =
-  | Iterable<MaterializeSessionPatch>
-  | AsyncIterable<MaterializeSessionPatch>;
+  | Iterable<PatchEntry>
+  | AsyncIterable<PatchEntry>;
 
 export async function reduceSessionBackedState(args: {
   readonly openStateSession: MaterializeSessionOpener;

--- a/src/domain/services/controllers/MaterializeSessionBridge.ts
+++ b/src/domain/services/controllers/MaterializeSessionBridge.ts
@@ -24,12 +24,18 @@ export type MaterializeSessionOpener = (
   init: MaterializeSessionOpen,
 ) => Promise<StateSession>;
 
+type MaterializeSessionPatch = Readonly<{
+  patch: PatchLike; // nosemgrep: ts-no-like-types -- 0025C
+  sha: string;
+}>;
+
+type MaterializeSessionPatchSource =
+  | Iterable<MaterializeSessionPatch>
+  | AsyncIterable<MaterializeSessionPatch>;
+
 export async function reduceSessionBackedState(args: {
   readonly openStateSession: MaterializeSessionOpener;
-  readonly patches: ReadonlyArray<{
-    readonly patch: PatchLike; // nosemgrep: ts-no-like-types -- 0025C
-    readonly sha: string;
-  }>;
+  readonly patches: MaterializeSessionPatchSource;
   readonly baseState?: WarpStateClass;
   readonly receipts: boolean;
   readonly wantDiff: boolean;
@@ -113,6 +119,7 @@ async function seedSessionWithORSet(args: {
   readonly source: ORSet;
 }): Promise<void> {
   for (const [element, dots] of args.source.entriesIter()) {
+    const tombstones = new Set<string>();
     for (const encodedDot of dots) {
       const dot = Dot.decode(encodedDot);
       if (args.kind === "node") {
@@ -120,18 +127,18 @@ async function seedSessionWithORSet(args: {
       } else {
         await args.session.addEdge(element, dot);
       }
+      if (args.source.isTombstoned(encodedDot)) {
+        tombstones.add(encodedDot);
+      }
     }
-  }
-
-  if (args.source.tombstones.size === 0) {
-    return;
-  }
-
-  const tombstones = new Set(args.source.tombstones);
-  if (args.kind === "node") {
-    await args.session.removeNodes(tombstones);
-  } else {
-    await args.session.removeEdges(tombstones);
+    if (tombstones.size === 0) {
+      continue;
+    }
+    if (args.kind === "node") {
+      await args.session.removeNode(element, tombstones);
+    } else {
+      await args.session.removeEdge(element, tombstones);
+    }
   }
 }
 

--- a/test/helpers/FixturePatchJournal.ts
+++ b/test/helpers/FixturePatchJournal.ts
@@ -1,7 +1,7 @@
 import PatchEntry from '../../src/domain/artifacts/PatchEntry.ts';
 import SyncError from '../../src/domain/errors/SyncError.ts';
 import WarpStream from '../../src/domain/stream/WarpStream.ts';
-import type Patch from '../../src/domain/types/Patch.ts';
+import Patch from '../../src/domain/types/Patch.ts';
 import { DEFAULT_COMMIT_MESSAGE_CODEC } from '../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts';
 import type CommitMessageCodecPort from '../../src/ports/CommitMessageCodecPort.ts';
 import type { PatchCommitMessage } from '../../src/ports/CommitMessageCodecPort.ts';
@@ -43,7 +43,7 @@ export default class FixturePatchJournal extends PatchJournalPort {
     if (patch === undefined) {
       throw new Error(`Fixture patch not found: ${handle}`);
     }
-    return Promise.resolve(patch);
+    return Promise.resolve(patch instanceof Patch ? patch : new Patch(patch));
   }
 
   override scanPatchRange(

--- a/test/unit/domain/artifacts/PatchEntry.test.ts
+++ b/test/unit/domain/artifacts/PatchEntry.test.ts
@@ -22,7 +22,14 @@ describe('PatchEntry', () => {
   });
 
   it('rejects null patch', () => {
-    expect(() => new PatchEntry({ patch: (null as any), sha: 'abc' })).toThrow('requires a patch');
+    // @ts-expect-error exercising runtime validation
+    expect(() => new PatchEntry({ patch: null, sha: 'abc' })).toThrow('requires a patch');
+  });
+
+  it('rejects structural patch lookalikes', () => {
+    const patch = { schema: 2, writer: 'w1', lamport: 1, context: {}, ops: [] };
+    // @ts-expect-error exercising runtime validation
+    expect(() => new PatchEntry({ patch, sha: 'abc' })).toThrow('requires a patch');
   });
 
   it('rejects empty sha', () => {

--- a/test/unit/domain/orset/session/StateSession.semilattice.property.test.ts
+++ b/test/unit/domain/orset/session/StateSession.semilattice.property.test.ts
@@ -81,12 +81,16 @@ async function seedSessionFromORSet(
   set: ORSet,
 ): Promise<void> {
   for (const [element, dots] of set.entriesIter()) {
+    const tombstones = new Set<string>();
     for (const encodedDot of dots) {
       await session.addNode(element, Dot.decode(encodedDot));
+      if (set.isTombstoned(encodedDot)) {
+        tombstones.add(encodedDot);
+      }
     }
-  }
-  if (set.tombstones.size > 0) {
-    await session.removeNodes(new Set(set.tombstones));
+    if (tombstones.size > 0) {
+      await session.removeNode(element, tombstones);
+    }
   }
 }
 

--- a/test/unit/domain/orset/session/StateSession.test.ts
+++ b/test/unit/domain/orset/session/StateSession.test.ts
@@ -200,8 +200,8 @@ describe("StateSession", () => {
 
       await session.addNode("node:1", nodeDot);
       await session.addEdge("edge:1", edgeDot);
-      await session.removeNodes(new Set([Dot.encode(nodeDot)]));
-      await session.removeEdges(new Set([Dot.encode(edgeDot)]));
+      await session.removeNode("node:1", new Set([Dot.encode(nodeDot)]));
+      await session.removeEdge("edge:1", new Set([Dot.encode(edgeDot)]));
       await session.compact(VersionVector.from({ alice: 2 }));
 
       const closeResult = await session.close();
@@ -227,8 +227,8 @@ describe("StateSession", () => {
 
       await session.addNode("node:1", nodeDot);
       await session.addEdge("edge:1", edgeDot);
-      await session.removeNodes(new Set([Dot.encode(nodeDot)]));
-      await session.removeEdges(new Set([Dot.encode(edgeDot)]));
+      await session.removeNode("node:1", new Set([Dot.encode(nodeDot)]));
+      await session.removeEdge("edge:1", new Set([Dot.encode(edgeDot)]));
 
       expect(await session.nodeContains("node:1")).toBe(false);
       expect(await session.edgeContains("edge:1")).toBe(false);

--- a/test/unit/domain/orset/shadow/ShadowTrieORSet.test.ts
+++ b/test/unit/domain/orset/shadow/ShadowTrieORSet.test.ts
@@ -165,6 +165,33 @@ describe("ShadowTrieORSet", () => {
       );
     });
 
+    it("targets removal by element even when another element carries the same dot", async () => {
+      const { engine } = makeEngine();
+      const sharedDot = new Dot("alice", 1);
+
+      await engine.add("node:target", sharedDot);
+      await engine.add("node:other", sharedDot);
+      await engine.removeElement("node:target", new Set([Dot.encode(sharedDot)]));
+
+      expect(await engine.contains("node:target")).toBe(false);
+      expect(await engine.contains("node:other")).toBe(true);
+    });
+
+    it("treats empty, unknown, and unobserved targeted removals as no-ops", async () => {
+      const { engine } = makeEngine();
+      const dot = new Dot("alice", 1);
+      await engine.add("node:target", dot);
+
+      await engine.removeElement("node:target", new Set());
+      await engine.removeElement("node:missing", new Set([Dot.encode(dot)]));
+      await engine.removeElement(
+        "node:target",
+        new Set([Dot.encode(new Dot("alice", 2))]),
+      );
+
+      expect(await engine.contains("node:target")).toBe(true);
+    });
+
     it("treats remove of an empty observed-dot set as a no-op", async () => {
       const { engine } = makeEngine();
 
@@ -205,6 +232,62 @@ describe("ShadowTrieORSet", () => {
       for (const id of ids) {
         expect(await engine.contains(id)).toBe(true);
       }
+    });
+
+    it("reads only the target route when removing from a persisted split trie", async () => {
+      const tiny = new TrieGeometry({
+        fanout: 16,
+        nibbleBits: 4,
+        leafCapacity: 2,
+        leafFloor: 1,
+      });
+      const store = new InMemoryTrieStore();
+      const { engine } = makeEngine({ geometry: tiny, store });
+      const ids = Array.from({ length: 128 }, (_, index) => `node:${index}`);
+      for (let index = 0; index < ids.length; index += 1) {
+        const id = ids[index];
+        if (id !== undefined) {
+          await engine.add(id, new Dot("writer", index + 1));
+        }
+      }
+      const flushed = await engine.flush();
+      expect(flushed.rootOid).not.toBeNull();
+      if (flushed.rootOid === null) {
+        throw new Error("rootOid must exist after split-trie flush");
+      }
+
+      const target = "node:63";
+      const targetDot = new Dot("writer", 64);
+      const lookup = makeEngine({ rootOid: flushed.rootOid, store, geometry: tiny }).engine;
+      const beforeLookup = store.readCounts();
+      expect(await lookup.contains(target)).toBe(true);
+      const afterLookup = store.readCounts();
+      const lookupReads = {
+        leaf: afterLookup.leaf - beforeLookup.leaf,
+        branch: afterLookup.branch - beforeLookup.branch,
+      };
+
+      const removal = makeEngine({ rootOid: flushed.rootOid, store, geometry: tiny }).engine;
+      const beforeRemoval = store.readCounts();
+      await removal.removeElement(target, new Set([Dot.encode(targetDot)]));
+      const afterRemoval = store.readCounts();
+      const removalReads = {
+        leaf: afterRemoval.leaf - beforeRemoval.leaf,
+        branch: afterRemoval.branch - beforeRemoval.branch,
+      };
+
+      expect(removalReads).toEqual(lookupReads);
+      expect(removalReads.leaf + removalReads.branch).toBeLessThan(10);
+
+      const removed = await removal.flush();
+      expect(removed.rootOid).not.toBeNull();
+      if (removed.rootOid === null) {
+        throw new Error("rootOid must exist after targeted removal flush");
+      }
+      const reopened = makeEngine({ rootOid: removed.rootOid, store, geometry: tiny }).engine;
+      expect(await reopened.contains(target)).toBe(false);
+      expect(await reopened.contains("node:62")).toBe(true);
+      expect(await reopened.contains("node:64")).toBe(true);
     });
 
     it("returns a clean flush result when no writes occurred", async () => {

--- a/test/unit/domain/services/GCSession.test.ts
+++ b/test/unit/domain/services/GCSession.test.ts
@@ -50,8 +50,8 @@ describe("GCMetrics.fromSession", () => {
     await session.addNode("node:1", nodeDot1);
     await session.addNode("node:2", nodeDot2);
     await session.addEdge("edge:1", edgeDot1);
-    await session.removeNodes(new Set([encodeDot(nodeDot2)]));
-    await session.removeEdges(new Set([encodeDot(edgeDot1)]));
+    await session.removeNode("node:2", new Set([encodeDot(nodeDot2)]));
+    await session.removeEdge("edge:1", new Set([encodeDot(edgeDot1)]));
 
     const syncMetrics = GCMetrics.fromState(syncState);
     const sessionMetrics = await GCMetrics.fromSession(session);
@@ -81,8 +81,8 @@ describe("executeGCInSession", () => {
 
     await session.addNode("node:1", compactableDot);
     await session.addNode("node:2", retainedDot);
-    await session.removeNodes(new Set([encodeDot(compactableDot)]));
-    await session.removeNodes(new Set([encodeDot(retainedDot)]));
+    await session.removeNode("node:1", new Set([encodeDot(compactableDot)]));
+    await session.removeNode("node:2", new Set([encodeDot(retainedDot)]));
 
     const result = await executeGCInSession(
       session,
@@ -132,8 +132,8 @@ describe("executeGCInSession", () => {
 
     await session.addNode("node:1", nodeDot);
     await session.addEdge("edge:1", edgeDot);
-    await session.removeNodes(new Set([encodeDot(nodeDot)]));
-    await session.removeEdges(new Set([encodeDot(edgeDot)]));
+    await session.removeNode("node:1", new Set([encodeDot(nodeDot)]));
+    await session.removeEdge("edge:1", new Set([encodeDot(edgeDot)]));
 
     const result = await executeGCInSession(
       session,

--- a/test/unit/domain/services/JoinReducer.stateSession.test.ts
+++ b/test/unit/domain/services/JoinReducer.stateSession.test.ts
@@ -169,6 +169,41 @@ describe("JoinReducer session-backed path", () => {
       );
     });
 
+    it("removes only the named checkpoint entry when synthetic dots are shared", async () => {
+      const { ReducerSessionFrame, reducePatchesInSession } =
+        await loadJoinReducerSessionModule();
+      const { session } = await openSession();
+      const checkpointDot = new Dot("__checkpoint__", 1);
+      const encodedDot = Dot.encode(checkpointDot);
+      const targetEdge = "node:target\x00node:other\x00knows";
+      const retainedEdge = "node:other\x00node:target\x00knows";
+      await session.addNode("node:target", checkpointDot);
+      await session.addNode("node:other", checkpointDot);
+      await session.addEdge(targetEdge, checkpointDot);
+      await session.addEdge(retainedEdge, checkpointDot);
+      const frame = new ReducerSessionFrame({
+        session,
+        prop: new Map(),
+        observedFrontier: VersionVector.empty(),
+        edgeBirthEvent: new Map(),
+      });
+
+      await reducePatchesInSession([
+        {
+          patch: makePatch("alice", 1, [
+            nodeRemove("node:target", [encodedDot]),
+            edgeRemove("node:target", "node:other", "knows", [encodedDot]),
+          ]),
+          sha: "c".repeat(40),
+        },
+      ], frame);
+
+      expect(await session.nodeContains("node:target")).toBe(false);
+      expect(await session.nodeContains("node:other")).toBe(true);
+      expect(await session.edgeContains(targetEdge)).toBe(false);
+      expect(await session.edgeContains(retainedEdge)).toBe(true);
+    });
+
     it("matches the legacy sync reducer in receipt mode", async () => {
       const { ReducerSessionFrame, reducePatchesInSession } =
         await loadJoinReducerSessionModule();
@@ -444,8 +479,14 @@ describe("JoinReducer session-backed path", () => {
 
       await rightOpen.session.addNode("node:shared", sharedNodeDot);
       await rightOpen.session.addEdge("node:a\x00node:b\x00knows", sharedEdgeDot);
-      await rightOpen.session.removeNodes(new Set([Dot.encode(sharedNodeDot)]));
-      await rightOpen.session.removeEdges(new Set([Dot.encode(sharedEdgeDot)]));
+      await rightOpen.session.removeNode(
+        "node:shared",
+        new Set([Dot.encode(sharedNodeDot)]),
+      );
+      await rightOpen.session.removeEdge(
+        "node:a\x00node:b\x00knows",
+        new Set([Dot.encode(sharedEdgeDot)]),
+      );
 
       const left = new ReducerSessionFrame({
         session: leftOpen.session,

--- a/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
@@ -75,6 +75,12 @@ function edgeAddPatchRecord(args: {
 function snapshotRecord(coordinate: Coordinate) {
   const state = createEmptyState();
   state.nodeAlive.add("node:base", Dot.create("seed", 1));
+  const removedNodeDot = Dot.create("seed", 2);
+  state.nodeAlive.add("node:removed", removedNodeDot);
+  state.nodeAlive.remove(new Set([Dot.encode(removedNodeDot)]));
+  const removedEdgeDot = Dot.create("seed", 3);
+  state.edgeAlive.add("node:base\0node:removed\0related", removedEdgeDot);
+  state.edgeAlive.remove(new Set([Dot.encode(removedEdgeDot)]));
   return {
     snapshotId: "snapshot-base",
     coordinate,
@@ -256,6 +262,10 @@ describe("MaterializeController — state session integration", () => {
     );
     expect(result.state.nodeAlive.contains("node:base")).toBe(true);
     expect(result.state.nodeAlive.contains("node:suffix")).toBe(true);
+    expect(result.state.nodeAlive.contains("node:removed")).toBe(false);
+    expect(result.state.nodeAlive.isTombstoned(Dot.encode(Dot.create("seed", 2)))).toBe(true);
+    expect(result.state.edgeAlive.contains("node:base\0node:removed\0related")).toBe(false);
+    expect(result.state.edgeAlive.isTombstoned(Dot.encode(Dot.create("seed", 3)))).toBe(true);
   });
 
   it("fails fast on materializeAt when the controller is on the session-backed runtime line", async () => {

--- a/test/unit/domain/services/controllers/MaterializePatchStreamReducer.test.ts
+++ b/test/unit/domain/services/controllers/MaterializePatchStreamReducer.test.ts
@@ -15,6 +15,7 @@ import MaterializeController, {
   type MaterializePersistence,
 } from '../../../../../src/domain/services/controllers/MaterializeController.ts';
 import MaterializePatchStreamReducer from '../../../../../src/domain/services/controllers/MaterializePatchStreamReducer.ts';
+import { createEmptyDiff } from '../../../../../src/domain/types/PatchDiff.ts';
 import StateSession from '../../../../../src/domain/orset/session/StateSession.ts';
 import PageCache from '../../../../../src/domain/orset/trie/PageCache.ts';
 import TrieGeometry from '../../../../../src/domain/orset/trie/TrieGeometry.ts';
@@ -66,7 +67,7 @@ describe('MaterializeController patch streams', () => {
     ['plain', { receipts: false, wantDiff: false }],
     ['receipt', { receipts: true, wantDiff: false }],
     ['diff', { receipts: false, wantDiff: true }],
-  ] as const)('reduces session-backed patches incrementally in %s mode', async (_mode, options) => {
+  ] as const)('reduces session-backed patches incrementally in %s mode', async (mode, options) => {
     const collector = new StreamingOnlyPatchCollector(
       Array.from({ length: 128 }, (_, index) => patchEntry(index + 1)),
     );
@@ -92,6 +93,16 @@ describe('MaterializeController patch streams', () => {
     expect(result.provenanceIndex.patchesFor('node-128')).toEqual(['sha-128']);
     expect(result.provenanceIndex.has('poisoned-node')).toBe(false);
     expect(collector.writerLoadCount).toBe(0);
+    if (mode === 'receipt') {
+      expect(result.receipts).toHaveLength(128);
+      expect(result.diff).toBeUndefined();
+    } else if (mode === 'diff') {
+      expect(result.receipts).toBeUndefined();
+      expect(result.diff).toEqual(createEmptyDiff());
+    } else {
+      expect(result.receipts).toBeUndefined();
+      expect(result.diff).toBeUndefined();
+    }
   });
 });
 

--- a/test/unit/domain/services/controllers/MaterializePatchStreamReducer.test.ts
+++ b/test/unit/domain/services/controllers/MaterializePatchStreamReducer.test.ts
@@ -15,10 +15,15 @@ import MaterializeController, {
   type MaterializePersistence,
 } from '../../../../../src/domain/services/controllers/MaterializeController.ts';
 import MaterializePatchStreamReducer from '../../../../../src/domain/services/controllers/MaterializePatchStreamReducer.ts';
+import StateSession from '../../../../../src/domain/orset/session/StateSession.ts';
+import PageCache from '../../../../../src/domain/orset/trie/PageCache.ts';
+import TrieGeometry from '../../../../../src/domain/orset/trie/TrieGeometry.ts';
 import Patch from '../../../../../src/domain/types/Patch.ts';
+import cborCodec from '../../../../../src/infrastructure/codecs/CborCodec.ts';
 import type CodecValue from '../../../../../src/domain/types/codec/CodecValue.ts';
 import type LogFields from '../../../../../src/domain/types/log/LogFields.ts';
 import InMemoryCheckpointStore from '../../../../helpers/InMemoryCheckpointStore.ts';
+import { InMemoryTrieStore } from '../../../../helpers/trieHelpers.ts';
 
 describe('MaterializePatchStreamReducer', () => {
   it('reduces each patch before requesting the next stream item', async () => {
@@ -54,6 +59,38 @@ describe('MaterializeController patch streams', () => {
     expect(result.provenanceIndex.patchesFor('node-001')).toEqual(['sha-001']);
     expect(result.provenanceIndex.patchesFor('node-003')).toEqual(['sha-003']);
     expect(collector.streamedWriters).toEqual(['writer-a']);
+    expect(collector.writerLoadCount).toBe(0);
+  });
+
+  it.each([
+    ['plain', { receipts: false, wantDiff: false }],
+    ['receipt', { receipts: true, wantDiff: false }],
+    ['diff', { receipts: false, wantDiff: true }],
+  ] as const)('reduces session-backed patches incrementally in %s mode', async (_mode, options) => {
+    const collector = new StreamingOnlyPatchCollector(
+      Array.from({ length: 128 }, (_, index) => patchEntry(index + 1)),
+    );
+    const store = new InMemoryTrieStore();
+    const controller = new MaterializeController({
+      ...materializeDeps(collector),
+      openStateSession: async ({ nodeAliveRootOid, edgeAliveRootOid }) =>
+        await StateSession.open({
+          nodeAliveRootOid,
+          edgeAliveRootOid,
+          store,
+          codec: cborCodec,
+          geometry: TrieGeometry.default16way(),
+          pageCache: new PageCache({ maxResident: 16 }),
+        }),
+    });
+
+    const result = await controller.materialize(options);
+
+    expect(result.patchCount).toBe(128);
+    expect(result.maxObservedLamport).toBe(128);
+    expect(result.provenanceIndex.patchesFor('node-001')).toEqual(['sha-001']);
+    expect(result.provenanceIndex.patchesFor('node-128')).toEqual(['sha-128']);
+    expect(result.provenanceIndex.has('poisoned-node')).toBe(false);
     expect(collector.writerLoadCount).toBe(0);
   });
 });
@@ -135,7 +172,10 @@ class StreamingOnlyPatchCollector extends PatchCollector {
   }
 
   async getFrontier(): Promise<Map<string, string>> {
-    return new Map([['writer-a', 'sha-003']]);
+    const last = this.#entries.at(-1);
+    return last === undefined
+      ? new Map()
+      : new Map([['writer-a', last.sha]]);
   }
 }
 


### PR DESCRIPTION
## Summary

- stream session-backed patch reduction directly from the async patch source
- accumulate materialization provenance and lamport summaries during consumption
- route node and edge removals by target identity through one trie path
- rebuild dirty ancestors so targeted updates persist without scanning siblings
- cover shared checkpoint dots, all reduction modes, bounded route reads, and reopen persistence

## Root cause

The session-backed materialization path collected every streamed patch into an array before replay. Removal then discarded the node or edge identity and walked the complete trie looking for matching dots. Besides defeating bounded materialization, that global walk could remove unrelated checkpoint entries because checkpoint reconstruction intentionally shares a synthetic dot.

## Scope

Refs #738. This is a prerequisite slice and does **not** complete the issue. `MaterializeSessionBridge` still projects the complete session back into `WarpState`, builds complete adjacency, opens from null roots, and discards the roots returned by `StateSession.close()`. Those retained-root and bounded-projection changes remain required before #738 can close.

## Validation

- `npm run lint`
- `npm run build`
- `npm run typecheck`
- `npm run typecheck:policy`
- `npm run typecheck:surface`
- `npm run test:local` (6,992 passed, 2 skipped in pre-push)
- `npm run test:coverage:ci` (7,095 passed, 2 skipped; 92.78% lines)
- Graft structural diff/review and publication-surface audit
- Git/CAS invariant gate