### PR TITLE
Read retained properties through git-cas 6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Raised the coverage ratchet from `92.10%` to `92.62%` after adding targeted
   coverage for bounded query node paging and memory-budget rejection paths and
   removing retired compatibility surfaces.
-- Upgraded `@git-stunts/git-cas` to `^6.2.0` so Git-backed materializations can
+- Upgraded `@git-stunts/git-cas` to `^6.5.0` so Git-backed materializations can
   use managed `CacheSet` retention and opaque page and bundle handles.
 - Moved shadow-trie leaf and branch storage from unretained raw Git blobs and
   trees to bounded git-cas pages and composable bundle handles. Production

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Live exact node-property reads now retain collision-safe property shards as
+  an independently addressed materialization root. Each node uses its full
+  BLAKE3 route key and a deterministic schema-v2 entry-bag envelope; writes and
+  reads enforce a 16 MiB shard ceiling, while reads also bound CBOR structure
+  before decoding. Git-backed runtimes resolve one shard through exact `git-cas`
+  bundle lookup and release the acquisition without replaying patches, hydrating
+  `WarpState`, or populating a WARP-owned property cache. Newly built property
+  roots, once assembled, remain pinned by the operation workspace until final
+  promotion.
+  The flat property-root profile also rejects more than 100,000 shards before
+  asset staging. Materialization descriptor/cache schema v3 replaces incomplete
+  v2 entries and removes the
+  corresponding legacy cache anchor through git-cas only after successful v3
+  retention. Schema-v3 materializations require the property root to be either
+  retained or explicitly empty; they reject `unavailable` property roots.
 - Exact state-cache hits now retain and reopen coordinate-keyed materialization
   descriptors through the `git-cas` cache API. Repeated materialization,
   including through a fresh runtime adapter, resumes the retained node/edge

--- a/docs/topics/cas-first-memoized-materialization.md
+++ b/docs/topics/cas-first-memoized-materialization.md
@@ -213,13 +213,11 @@ lost payload bytes, or run Git garbage collection.
   (100,000 by default). The profile preflights this count before staging any
   shard assets. A hierarchical property root is required to exceed that ceiling
   without widening a repository-wide safety limit.
-- Individual staged shards remain unanchored until git-cas assembles and the
-  workspace checkpoints their property bundle. Supported operation therefore
-  relies on Git's ordinary unreachable-object grace period; concurrent
-  immediate-expiry pruning is outside the current write contract. A git-cas
-  scoped staging workspace is tracked in
-  [git-cas issue 75](https://github.com/git-stunts/git-cas/issues/75) to shorten
-  that interval without moving CAS lifecycle ownership into git-warp.
+- Staged pages and bundles are immediately retained by the active git-cas
+  workspace. Each checkpoint atomically replaces the workspace's active staged
+  roots; promotion transfers the final materialization into the cache policy,
+  and release closes the staging workspace. git-warp never owns raw CAS-object
+  reachability or relies on Git's unreachable-object grace period.
 - `WarpStateCachePort` remains a legacy full-snapshot compatibility cache with
   a WARP-owned index. Ordinary bounded observers cannot rely on it as their
   final storage contract.

--- a/docs/topics/cas-first-memoized-materialization.md
+++ b/docs/topics/cas-first-memoized-materialization.md
@@ -102,17 +102,34 @@ The bounded-memory read path is optic/worldline/query work over a sharded or
 streamed basis. The state cache is the replay-skipping compatibility bridge for
 legacy materialization and checkpoint flows.
 
-`RuntimeHost.hasNode()` is the first compatibility read to consume the
-handle-first path directly when the runtime uses the built-in trie-backed state
-session and matching materialization reader. On an exact retained-coordinate
-hit, it acquires the materialization, opens only the node-liveness trie through
-a bounded page cache, answers one membership question, and releases the
-acquisition. It does not hydrate `WarpState`, build adjacency, publish a state
-snapshot, or populate `_cachedState`. A cold handle miss still performs the
-current materialization path before retaining and reading the new root. A
-custom state-session opener owns its root storage and encoding, so git-warp does
-not pair it with the default reader and instead preserves the compatibility
-fallback.
+`RuntimeHost.hasNode()` and `RuntimeHost.getNodeProps()` consume the handle-first
+path directly when the runtime uses the built-in trie-backed state session and
+matching materialization reader. On an exact retained-coordinate hit, node
+liveness opens only the required trie path through a bounded page cache. A
+property read uses the node's full BLAKE3 route key to resolve one per-node
+property shard by exact bundle member path. The schema-v2 shard envelope stores
+the property bag as sorted key/value entries, preserving legal keys such as
+`__proto__` without treating them as object structure. Writes reject an encoded
+shard over 16 MiB; reads enforce the same byte ceiling plus CBOR container,
+depth, and item limits before general decoding. The reader owns no cache.
+
+Both exact paths release the acquisition without hydrating `WarpState`, building
+adjacency, publishing a state snapshot, or populating `_cachedState`. A cold
+handle miss still performs the current materialization path before retaining and
+reading the new roots. Once assembled, a newly built property root joins the
+operation's expiring git-cas workspace before state hashing and final promotion,
+so the completed root remains reachable throughout promotion. A custom
+state-session opener owns its root storage and
+encoding, so git-warp does not pair it with the default reader and instead
+preserves the compatibility fallback.
+
+The property-root contract advances the retained-materialization descriptor and
+coordinate cache key to schema v3. A v3 exact miss leaves any corresponding v2
+entry anchored until replacement succeeds. Successful v3 retention then removes
+the incompatible v2 anchor through the git-cas cache API. A v2 descriptor may
+still be structurally valid, but it cannot satisfy the v3 root profile because
+its property root may be unavailable. New v3 descriptors reject an unavailable
+property root; an empty graph records the root as explicitly empty.
 
 ## `git-cas` Encapsulation
 
@@ -175,16 +192,31 @@ lost payload bytes, or run Git garbage collection.
 
 ## Current Limitations
 
-- RuntimeHost exact node-liveness reads consume the handle-first result when
-  the built-in trie session and reader pair is active. Custom session openers,
-  properties, neighborhoods, list reads, checkpoint creation, and other
-  compatibility operations still own process-resident whole state.
+- RuntimeHost exact node-liveness and node-property reads consume the
+  handle-first result when the built-in trie session and reader pair is active.
+  Custom session openers, neighborhoods, list reads, checkpoint creation, and
+  other compatibility operations still own process-resident whole state.
 - Exact state-cache hits bypass replay, but full materialization still hydrates
   a full `WarpState`, scans retained node/edge tries, and builds full adjacency.
-- Retained materialization descriptors currently carry node/edge trie roots;
-  property, frontier, edge-birth, adjacency, provenance-support, and roaring
-  roots are explicitly marked unavailable until their paged representations
-  land.
+- Retained materialization descriptors currently carry node/edge trie roots and
+  a per-node property-shard root. Frontier, edge-birth, adjacency,
+  provenance-support, and roaring roots remain explicitly unavailable until
+  their paged representations land. Cold property-root construction still
+  projects a complete `WarpState`; only exact retained reads avoid that state.
+- One node's complete encoded property bag must currently fit within the 16 MiB
+  shard limit. Property-key pagination or a property trie is not yet available.
+- The first property-root profile stores one bundle member per property-bearing
+  node and therefore inherits the configured git-cas bundle-member ceiling
+  (100,000 by default). The profile preflights this count before staging any
+  shard assets. A hierarchical property root is required to exceed that ceiling
+  without widening a repository-wide safety limit.
+- Individual staged shards remain unanchored until git-cas assembles and the
+  workspace checkpoints their property bundle. Supported operation therefore
+  relies on Git's ordinary unreachable-object grace period; concurrent
+  immediate-expiry pruning is outside the current write contract. A git-cas
+  scoped staging workspace is tracked in
+  [git-cas issue 75](https://github.com/git-stunts/git-cas/issues/75) to shorten
+  that interval without moving CAS lifecycle ownership into git-warp.
 - `WarpStateCachePort` remains a legacy full-snapshot compatibility cache with
   a WARP-owned index. Ordinary bounded observers cannot rely on it as their
   final storage contract.

--- a/docs/topics/cas-first-memoized-materialization.md
+++ b/docs/topics/cas-first-memoized-materialization.md
@@ -113,12 +113,15 @@ the property bag as sorted key/value entries, preserving legal keys such as
 shard over 16 MiB; reads enforce the same byte ceiling plus CBOR container,
 depth, and item limits before general decoding. The reader owns no cache.
 
-Both exact paths release the acquisition without hydrating `WarpState`, building
-adjacency, publishing a state snapshot, or populating `_cachedState`. A cold
-handle miss still performs the current materialization path before retaining and
-reading the new roots. Once assembled, a newly built property root joins the
-operation's expiring git-cas workspace before state hashing and final promotion,
-so the completed root remains reachable throughout promotion. A custom
+Both exact paths release their operation borrow without hydrating `WarpState`,
+building adjacency, publishing a state snapshot, or populating `_cachedState`.
+The runtime storage adapter keeps one git-cas acquisition for the current
+coordinate, retires it after in-flight readers finish when the coordinate
+changes, and releases it from `RuntimeHost.close()`. A cold handle miss still
+performs the current materialization path before retaining and reading the new
+roots. Once assembled, a newly built property root joins the operation's
+expiring git-cas workspace before state hashing and final promotion, so the
+completed root remains reachable throughout promotion. A custom
 state-session opener owns its root storage and
 encoding, so git-warp does not pair it with the default reader and instead
 preserves the compatibility fallback.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@git-stunts/alfred": "^0.10.4",
-        "@git-stunts/git-cas": "^6.3.0",
+        "@git-stunts/git-cas": "^6.4.0",
         "@git-stunts/plumbing": "^3.1.0",
         "@git-stunts/trailer-codec": "^2.1.1",
         "@noble/hashes": "^2.2.0",
@@ -489,9 +489,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@git-stunts/git-cas": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@git-stunts/git-cas/-/git-cas-6.3.0.tgz",
-      "integrity": "sha512-Cl/WPjj60LvjXl3BqSb1M3a0tx2xpx6KxGEC1TXKekNzgn5so/t43LG7Qz2XuXle+YmXWoCi8H94cJYvfgI8Yw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@git-stunts/git-cas/-/git-cas-6.4.0.tgz",
+      "integrity": "sha512-xLtNBCpXolGGusV8efsr/cRlhjrRrFFKZQVwgx/gNtonPVzDor6AyidtILM88ss6M6bJLapGUgOaoimr/y3gZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@flyingrobots/bijou": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "dependencies": {
         "@git-stunts/alfred": "^0.10.4",
-        "@git-stunts/git-cas": "^6.4.0",
+        "@git-stunts/git-cas": "^6.5.0",
         "@git-stunts/plumbing": "^3.1.0",
         "@git-stunts/trailer-codec": "^2.1.1",
         "@noble/hashes": "^2.2.0",
@@ -489,9 +489,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@git-stunts/git-cas": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@git-stunts/git-cas/-/git-cas-6.4.0.tgz",
-      "integrity": "sha512-xLtNBCpXolGGusV8efsr/cRlhjrRrFFKZQVwgx/gNtonPVzDor6AyidtILM88ss6M6bJLapGUgOaoimr/y3gZA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@git-stunts/git-cas/-/git-cas-6.5.0.tgz",
+      "integrity": "sha512-KfKperNdXu3xWw07tpo1yYpLTynhwAP60PhYiZ5MRsSydPdNspQzJmi6Pv0Jz+6WULD883/NJCR0V1IUhBwOBw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@flyingrobots/bijou": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "dependencies": {
     "@git-stunts/alfred": "^0.10.4",
-    "@git-stunts/git-cas": "^6.3.0",
+    "@git-stunts/git-cas": "^6.4.0",
     "@git-stunts/plumbing": "^3.1.0",
     "@git-stunts/trailer-codec": "^2.1.1",
     "@noble/hashes": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   },
   "dependencies": {
     "@git-stunts/alfred": "^0.10.4",
-    "@git-stunts/git-cas": "^6.4.0",
+    "@git-stunts/git-cas": "^6.5.0",
     "@git-stunts/plumbing": "^3.1.0",
     "@git-stunts/trailer-codec": "^2.1.1",
     "@noble/hashes": "^2.2.0",

--- a/src/domain/RuntimeHost.ts
+++ b/src/domain/RuntimeHost.ts
@@ -402,6 +402,7 @@ export default class RuntimeHost {
       persistence: this._persistence,
       checkpointStore,
       materializations,
+      propertyStore: indexStore,
       ...(options.materializationRead === undefined
         ? {}
         : { materializationRead: options.materializationRead }),
@@ -427,6 +428,10 @@ export default class RuntimeHost {
 
   _readLiveNodePresence(nodeId: string): Promise<boolean | null> {
     return this._materializeController.readLiveNodePresence(nodeId);
+  }
+
+  _readLiveNodeProperties(nodeId: string) {
+    return this._materializeController.readLiveNodeProperties(nodeId);
   }
 
   /**

--- a/src/domain/RuntimeHost.ts
+++ b/src/domain/RuntimeHost.ts
@@ -68,6 +68,7 @@ import type CommitMessageCodecPort from '../ports/CommitMessageCodecPort.ts';
 import type CheckpointStorePort from '../ports/CheckpointStorePort.ts';
 import type IndexStorePort from '../ports/IndexStorePort.ts';
 import type IntentStorePort from '../ports/IntentStorePort.ts';
+import type MaterializationStorePort from '../ports/MaterializationStorePort.ts';
 import type RuntimeStorageProviderPort from '../ports/RuntimeStorageProviderPort.ts';
 import type { EffectPipeline } from './services/EffectPipeline.ts';
 import type WarpState from './services/state/WarpState.ts';
@@ -256,6 +257,8 @@ export default class RuntimeHost {
   _intentStore: IntentStorePort;
   _stateHashService: StateHashService | null;
   _auditService: AuditReceiptService | null;
+  _materializations: MaterializationStorePort;
+  _closePromise: Promise<void> | null;
 
   /**
    * Constructs a RuntimeHost instance with injected dependencies and configuration.
@@ -424,6 +427,8 @@ export default class RuntimeHost {
     this._checkpointStore = checkpointStore;
     this._indexStore = indexStore;
     this._auditService = auditService || null;
+    this._materializations = materializations;
+    this._closePromise = null;
   }
 
   _readLiveNodePresence(nodeId: string): Promise<boolean | null> {
@@ -432,6 +437,12 @@ export default class RuntimeHost {
 
   _readLiveNodeProperties(nodeId: string) {
     return this._materializeController.readLiveNodeProperties(nodeId);
+  }
+
+  /** Releases local runtime resources without changing admitted history. */
+  close(): Promise<void> {
+    this._closePromise ??= this._materializations.close();
+    return this._closePromise;
   }
 
   /**

--- a/src/domain/materialization/MaterializationPropertyProfile.ts
+++ b/src/domain/materialization/MaterializationPropertyProfile.ts
@@ -1,0 +1,43 @@
+import RouteKey from '../orset/route/RouteKey.ts';
+import IndexError from '../errors/IndexError.ts';
+
+/** Maximum encoded size of one node-property shard retained for bounded reads. */
+export const MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES = 16 * 1024 * 1024;
+
+/** Maximum members admitted by the first flat property-root bundle profile. */
+export const MAX_MATERIALIZATION_PROPERTY_SHARDS = 100_000;
+
+/** Decoder limits applied before a retained property shard reaches the CBOR codec. */
+export const MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS = Object.freeze({
+  maxBytes: MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES,
+  maxContainerEntries: 100_000,
+  maxDepth: 64,
+  maxItems: 1_000_000,
+});
+
+/** Full BLAKE3 routing key used by the retained property-root profile. */
+export function materializationPropertyShardKey(nodeId: string): string {
+  return RouteKey.fromElement(nodeId).toHex();
+}
+
+/** Exact bundle-member path for one node's retained property shard. */
+export function materializationPropertyShardPath(nodeId: string): string {
+  return `props_${materializationPropertyShardKey(nodeId)}.cbor`;
+}
+
+/** Fails before asset staging when the flat property-root profile cannot admit the graph. */
+export function requireMaterializationPropertyShardCount(count: number): void {
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw propertyShardCountError(count, 'must be a non-negative safe integer');
+  }
+  if (count > MAX_MATERIALIZATION_PROPERTY_SHARDS) {
+    throw propertyShardCountError(count, 'exceeds the flat property-root limit');
+  }
+}
+
+function propertyShardCountError(count: number, reason: string): IndexError {
+  return new IndexError(`Materialization property shard count ${reason}`, {
+    code: 'E_INDEX_SHARD_COUNT_LIMIT',
+    context: { actual: count, maximum: MAX_MATERIALIZATION_PROPERTY_SHARDS },
+  });
+}

--- a/src/domain/materialization/MaterializationPropertyProfile.ts
+++ b/src/domain/materialization/MaterializationPropertyProfile.ts
@@ -10,9 +10,11 @@ export const MAX_MATERIALIZATION_PROPERTY_SHARDS = 100_000;
 /** Structural and byte limits every retained property shard must satisfy. */
 export const MATERIALIZATION_PROPERTY_SHARD_LIMITS = Object.freeze({
   maxBytes: MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES,
-  maxContainerEntries: 100_000,
-  maxDepth: 64,
-  maxItems: 1_000_000,
+  structureLimits: Object.freeze({
+    maxContainerEntries: 100_000,
+    maxDepth: 64,
+    maxItems: 1_000_000,
+  }),
 });
 
 /** Full BLAKE3 routing key used by the retained property-root profile. */

--- a/src/domain/materialization/MaterializationPropertyProfile.ts
+++ b/src/domain/materialization/MaterializationPropertyProfile.ts
@@ -7,8 +7,8 @@ export const MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES = 16 * 1024 * 1024;
 /** Maximum members admitted by the first flat property-root bundle profile. */
 export const MAX_MATERIALIZATION_PROPERTY_SHARDS = 100_000;
 
-/** Decoder limits applied before a retained property shard reaches the CBOR codec. */
-export const MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS = Object.freeze({
+/** Structural and byte limits every retained property shard must satisfy. */
+export const MATERIALIZATION_PROPERTY_SHARD_LIMITS = Object.freeze({
   maxBytes: MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES,
   maxContainerEntries: 100_000,
   maxDepth: 64,

--- a/src/domain/materialization/MaterializationRoot.ts
+++ b/src/domain/materialization/MaterializationRoot.ts
@@ -28,6 +28,15 @@ export default class MaterializationRoot {
   static unavailable(): MaterializationRoot {
     return new MaterializationRoot('unavailable', null);
   }
+
+  equals(other: MaterializationRoot): boolean {
+    if (!(other instanceof MaterializationRoot) || other.status !== this.status) {
+      return false;
+    }
+    return this.handle === null
+      ? other.handle === null
+      : other.handle !== null && this.handle.equals(other.handle);
+  }
 }
 
 function rootError(message: string): WarpError {

--- a/src/domain/materialization/MaterializationRoots.ts
+++ b/src/domain/materialization/MaterializationRoots.ts
@@ -65,6 +65,11 @@ export default class MaterializationRoots {
       MATERIALIZATION_ROOT_NAMES.map((name) => rootEntry(name, this.roots[name])),
     );
   }
+
+  equals(other: MaterializationRoots): boolean {
+    return other instanceof MaterializationRoots
+      && MATERIALIZATION_ROOT_NAMES.every((name) => this.roots[name].equals(other.roots[name]));
+  }
 }
 
 function rootEntry(

--- a/src/domain/materialization/TrieMaterializationReader.ts
+++ b/src/domain/materialization/TrieMaterializationReader.ts
@@ -1,4 +1,5 @@
 import type CodecPort from '../../ports/CodecPort.ts';
+import type IndexStorePort from '../../ports/IndexStorePort.ts';
 import MaterializationReadPort from '../../ports/MaterializationReadPort.ts';
 import BundleHandle from '../storage/BundleHandle.ts';
 import WarpError from '../errors/WarpError.ts';
@@ -6,6 +7,13 @@ import PageCache from '../orset/trie/PageCache.ts';
 import TrieCursor from '../orset/trie/TrieCursor.ts';
 import TrieGeometry from '../orset/trie/TrieGeometry.ts';
 import type TrieStorePort from '../orset/trie/TrieStorePort.ts';
+import { decodeCurrentPropertyShard } from '../services/index/PropertyIndexReader.ts';
+import type { PropValue } from '../types/PropValue.ts';
+import {
+  materializationPropertyShardKey,
+  materializationPropertyShardPath,
+  MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS,
+} from './MaterializationPropertyProfile.ts';
 
 const MAX_RESIDENT_READ_PAGES = 256;
 
@@ -14,11 +22,13 @@ export default class TrieMaterializationReader extends MaterializationReadPort {
   readonly #store: TrieStorePort;
   readonly #codec: CodecPort;
   readonly #geometry: TrieGeometry;
+  readonly #indexStore: IndexStorePort | null;
 
   constructor(options: {
     readonly store: TrieStorePort;
     readonly codec: CodecPort;
     readonly geometry?: TrieGeometry;
+    readonly indexStore?: IndexStorePort;
   }) {
     super();
     requireOptions(options);
@@ -27,6 +37,9 @@ export default class TrieMaterializationReader extends MaterializationReadPort {
     this.#geometry = options.geometry === undefined
       ? TrieGeometry.default16way()
       : requireGeometry(options.geometry);
+    this.#indexStore = options.indexStore === undefined
+      ? null
+      : requireIndexStore(options.indexStore);
     Object.freeze(this);
   }
 
@@ -45,6 +58,29 @@ export default class TrieMaterializationReader extends MaterializationReadPort {
       pageCache: new PageCache({ maxResident: MAX_RESIDENT_READ_PAGES }),
     });
     return await cursor.contains(nodeId);
+  }
+
+  override async getNodeProperties(
+    propertiesRoot: BundleHandle,
+    nodeId: string,
+  ): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+    if (!(propertiesRoot instanceof BundleHandle)) {
+      throw readerError('properties root must be a BundleHandle');
+    }
+    if (this.#indexStore === null) {
+      return undefined;
+    }
+    const path = materializationPropertyShardPath(nodeId);
+    const handle = await this.#indexStore.readShardHandle(propertiesRoot, path);
+    if (handle === null) {
+      return null;
+    }
+    const shard = decodeCurrentPropertyShard(
+      await this.#indexStore.decodeShard(handle, MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS),
+      path,
+      materializationPropertyShardKey,
+    );
+    return shard.get(nodeId) ?? null;
   }
 }
 
@@ -89,6 +125,18 @@ function requireGeometry(geometry: TrieGeometry): TrieGeometry {
     throw readerError('geometry must be a TrieGeometry instance');
   }
   return geometry;
+}
+
+function requireIndexStore(indexStore: IndexStorePort): IndexStorePort {
+  if (
+    indexStore === null
+    || typeof indexStore !== 'object'
+    || typeof indexStore.readShardHandle !== 'function'
+    || typeof indexStore.decodeShard !== 'function'
+  ) {
+    throw readerError('indexStore must provide exact shard read operations');
+  }
+  return indexStore;
 }
 
 function readerError(message: string): WarpError {

--- a/src/domain/materialization/TrieMaterializationReader.ts
+++ b/src/domain/materialization/TrieMaterializationReader.ts
@@ -12,7 +12,7 @@ import type { PropValue } from '../types/PropValue.ts';
 import {
   materializationPropertyShardKey,
   materializationPropertyShardPath,
-  MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS,
+  MATERIALIZATION_PROPERTY_SHARD_LIMITS,
 } from './MaterializationPropertyProfile.ts';
 
 const MAX_RESIDENT_READ_PAGES = 256;
@@ -74,7 +74,7 @@ export default class TrieMaterializationReader extends MaterializationReadPort {
     const encoded = await this.#indexStore.decodeShardAt(
       propertiesRoot,
       path,
-      MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS,
+      MATERIALIZATION_PROPERTY_SHARD_LIMITS,
     );
     if (encoded === null) {
       return null;

--- a/src/domain/materialization/TrieMaterializationReader.ts
+++ b/src/domain/materialization/TrieMaterializationReader.ts
@@ -71,12 +71,16 @@ export default class TrieMaterializationReader extends MaterializationReadPort {
       return undefined;
     }
     const path = materializationPropertyShardPath(nodeId);
-    const handle = await this.#indexStore.readShardHandle(propertiesRoot, path);
-    if (handle === null) {
+    const encoded = await this.#indexStore.decodeShardAt(
+      propertiesRoot,
+      path,
+      MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS,
+    );
+    if (encoded === null) {
       return null;
     }
     const shard = decodeCurrentPropertyShard(
-      await this.#indexStore.decodeShard(handle, MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS),
+      encoded,
       path,
       materializationPropertyShardKey,
     );
@@ -131,8 +135,7 @@ function requireIndexStore(indexStore: IndexStorePort): IndexStorePort {
   if (
     indexStore === null
     || typeof indexStore !== 'object'
-    || typeof indexStore.readShardHandle !== 'function'
-    || typeof indexStore.decodeShard !== 'function'
+    || typeof indexStore.decodeShardAt !== 'function'
   ) {
     throw readerError('indexStore must provide exact shard read operations');
   }

--- a/src/domain/orset/route/RouteKey.ts
+++ b/src/domain/orset/route/RouteKey.ts
@@ -100,8 +100,8 @@ export default class RouteKey {
   /**
    * Return the route key as a lowercase hex string.
    *
-   * Useful for logging and test assertions. Not for storage — storage
-   * uses the raw bytes.
+   * This is the canonical textual form for deterministic path names,
+   * diagnostics, and test assertions. Trie storage uses the raw bytes.
    */
   toHex(): string {
     let out = "";

--- a/src/domain/orset/session/StateSession.ts
+++ b/src/domain/orset/session/StateSession.ts
@@ -101,10 +101,12 @@ export default class StateSession {
     const nodeFlusher = new TrieFlusher({
       store: init.store,
       codec: init.codec,
+      ...(init.workspace === undefined ? {} : { staging: init.workspace }),
     });
     const edgeFlusher = new TrieFlusher({
       store: init.store,
       codec: init.codec,
+      ...(init.workspace === undefined ? {} : { staging: init.workspace }),
     });
 
     return new StateSession({
@@ -439,9 +441,9 @@ function isPinnedWorkspaceWitness(
   witness: Awaited<ReturnType<MaterializationWorkspacePort["checkpoint"]>>,
 ): witness is StorageRetentionWitness {
   return witness instanceof StorageRetentionWitness &&
-    witness.policy === "pinned" &&
+    witness.policy === "evictable" &&
     witness.reachability === "anchored" &&
-    witness.root.kind === "cache-set";
+    witness.root.kind === "root-set";
 }
 
 function requireFinalRetentionWitness(

--- a/src/domain/orset/trie/TrieFlusher.ts
+++ b/src/domain/orset/trie/TrieFlusher.ts
@@ -11,6 +11,7 @@ import type TrieBranch from "./TrieBranch.ts";
 import type { TrieBranchEntries } from "./TrieBranchEntries.ts";
 import TrieLeaf from "./TrieLeaf.ts";
 import type TrieStorePort from "./TrieStorePort.ts";
+import type ArtifactStagingPort from "../../../ports/ArtifactStagingPort.ts";
 
 const PENDING_OID_PREFIX = "pending:";
 
@@ -20,6 +21,7 @@ const PENDING_OID_PREFIX = "pending:";
 export interface TrieFlusherInit {
   readonly store: TrieStorePort;
   readonly codec: CodecPort;
+  readonly staging?: ArtifactStagingPort;
 }
 
 /**
@@ -65,10 +67,12 @@ export interface TrieFlusherInit {
 export default class TrieFlusher {
   readonly #store: TrieStorePort;
   readonly #codec: CodecPort;
+  readonly #staging: ArtifactStagingPort | undefined;
 
   constructor(init: TrieFlusherInit) {
     this.#store = init.store;
     this.#codec = init.codec;
+    this.#staging = init.staging;
   }
 
   async flush(dirty: DirtyPageSet): Promise<FlushResult> {
@@ -169,7 +173,7 @@ export default class TrieFlusher {
     path: readonly number[],
   ): Promise<string> {
     try {
-      return await this.#store.writeLeaf(bytes);
+      return await this.#store.writeLeaf(bytes, this.#staging);
     } catch (raw) {
       if (!(raw instanceof Error)) {
         throw flushNonErrorCaught(String(raw));
@@ -188,7 +192,7 @@ export default class TrieFlusher {
     path: readonly number[],
   ): Promise<string> {
     try {
-      return await this.#store.writeBranch(entries);
+      return await this.#store.writeBranch(entries, this.#staging);
     } catch (raw) {
       if (!(raw instanceof Error)) {
         throw flushNonErrorCaught(String(raw));

--- a/src/domain/orset/trie/TrieStorePort.ts
+++ b/src/domain/orset/trie/TrieStorePort.ts
@@ -1,22 +1,23 @@
 import type { TrieBranchEntries } from "./TrieBranchEntries.ts";
+import type ArtifactStagingPort from "../../../ports/ArtifactStagingPort.ts";
 
 /**
- * Storage port for the shadow-trie ORSet's Git-native backing.
+ * Storage port for the shadow-trie ORSet's content-addressed backing.
  *
- * The shadow trie stores its structure as native Git objects: branch
- * nodes are Git trees, leaf nodes are Git blobs. This port is the
- * minimum contract required for the trie cursor, codec, and session
- * layers to exchange those two kinds of object with a concrete
- * backend without knowing anything about Git transports, packfiles,
- * or reference plumbing.
+ * Branch nodes are immutable bundles and leaf nodes are immutable pages.
+ * This port is the minimum contract required for the trie cursor, codec,
+ * and session layers to exchange those two artifact kinds with a concrete
+ * backend without knowing anything about its object model or retention
+ * plumbing. Writes may join an existing staging scope so a complete trie
+ * remains reachable until its final owner is installed.
  *
  * ## Four methods, nothing more
  *
- * - `readLeaf(oid)` — read a leaf blob's raw bytes.
- * - `readBranch(oid)` — read a branch tree as its nibble-indexed
+ * - `readLeaf(root)` — read a leaf page's raw bytes.
+ * - `readBranch(root)` — read a branch bundle as its nibble-indexed
  *   child map.
- * - `writeLeaf(data)` — write a leaf blob and return its OID.
- * - `writeBranch(children)` — write a branch tree and return its OID.
+ * - `writeLeaf(data, staging?)` — write or stage a page and return its handle.
+ * - `writeBranch(children, staging?)` — write or stage a bundle and return its handle.
  *
  * That is the entire port. No batch reads, no batch writes, no
  * page caching, no geometry configuration, no checkpoint envelope
@@ -78,7 +79,7 @@ export default interface TrieStorePort {
    * Throws `TrieStoreError` with code `E_TRIE_STORE_WRITE` if the
    * backing store rejects the write.
    */
-  writeLeaf(data: Uint8Array): Promise<string>;
+  writeLeaf(data: Uint8Array, staging?: ArtifactStagingPort): Promise<string>;
 
   /**
    * Write a branch bundle from its nibble-indexed child map and return
@@ -87,5 +88,5 @@ export default interface TrieStorePort {
    * Throws `TrieStoreError` with code `E_TRIE_STORE_WRITE` if the
    * backing store rejects the write.
    */
-  writeBranch(children: TrieBranchEntries): Promise<string>;
+  writeBranch(children: TrieBranchEntries, staging?: ArtifactStagingPort): Promise<string>;
 }

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -168,7 +168,6 @@ export default class MaterializeController {
   readLiveNodeProperties(nodeId: string): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
     return this._liveStrategy.readNodeProperties(nodeId);
   }
-
   /** Coordinate materialization — explicit frontier. */
   async materializeCoordinate(
     opts: {

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -36,6 +36,7 @@ import PatchEntry from '../../artifacts/PatchEntry.ts';
 import type WarpState from '../state/WarpState.ts';
 import type { TickReceipt } from '../../types/TickReceipt.ts';
 import type { PatchDiff } from '../../types/PatchDiff.ts';
+import type { PropValue } from '../../types/PropValue.ts';
 import AdjacencyMap from '../../capabilities/AdjacencyMap.ts';
 import MaterializationCoordinate from '../../materialization/MaterializationCoordinate.ts';
 import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
@@ -164,6 +165,9 @@ export default class MaterializeController {
   readLiveNodePresence(nodeId: string): Promise<boolean | null> {
     return this._liveStrategy.readNodePresence(nodeId);
   }
+  readLiveNodeProperties(nodeId: string): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+    return this._liveStrategy.readNodeProperties(nodeId);
+  }
 
   /** Coordinate materialization — explicit frontier. */
   async materializeCoordinate(
@@ -273,8 +277,13 @@ export default class MaterializeController {
       if (params.materialization.stateHash !== stateHash) {
         throw materializationResumeError('retained handle state hash does not match resumed state');
       }
-      params.reduced.acceptMaterialization?.(params.materialization.retention);
-      return params.materialization;
+      if (
+        params.reduced.roots === undefined
+        || params.materialization.roots.equals(params.reduced.roots)
+      ) {
+        params.reduced.acceptMaterialization?.(params.materialization.retention);
+        return params.materialization;
+      }
     }
     if (params.reduced.roots === undefined || params.frontier === null) {
       await this._acceptSessionWithoutMaterialization(params.reduced);
@@ -337,11 +346,17 @@ export default class MaterializeController {
       const reduced = await reduceSessionBackedState({
         openStateSession,
         materializations: this._deps.materializations,
+        ...(this._deps.propertyStore === undefined
+          ? {}
+          : { propertyStore: this._deps.propertyStore }),
         logger: this._deps.logger,
         coordinate,
         patches: [],
         baseState: snapshot.state,
         ...(retainedRoots === null ? {} : { roots: retainedRoots }),
+        ...(retainedRoots === null || retained === null
+          ? {}
+          : { propertyRoot: retained.roots.properties }),
         receipts: false,
         wantDiff: options.wantDiff,
       });
@@ -377,6 +392,9 @@ export default class MaterializeController {
     const sessionArgs = {
       openStateSession,
       materializations: this._deps.materializations,
+      ...(this._deps.propertyStore === undefined
+        ? {}
+        : { propertyStore: this._deps.propertyStore }),
       logger: this._deps.logger,
       coordinate: new MaterializationCoordinate(coordinate),
       patches: patches.map((entry) => new PatchEntry(entry)),
@@ -412,6 +430,9 @@ export default class MaterializeController {
     const reduced = await reduceSessionBackedState({
       openStateSession: this._deps.openStateSession,
       materializations: this._deps.materializations,
+      ...(this._deps.propertyStore === undefined
+        ? {}
+        : { propertyStore: this._deps.propertyStore }),
       logger: this._deps.logger,
       coordinate: new MaterializationCoordinate(coordinate),
       patches: recordingStream(),

--- a/src/domain/services/controllers/MaterializeDeps.ts
+++ b/src/domain/services/controllers/MaterializeDeps.ts
@@ -2,6 +2,7 @@ import type CheckpointStorePort from '../../../ports/CheckpointStorePort.ts';
 import type CodecPort from '../../../ports/CodecPort.ts';
 import type CryptoPort from '../../../ports/CryptoPort.ts';
 import type LoggerPort from '../../../ports/LoggerPort.ts';
+import type IndexStorePort from '../../../ports/IndexStorePort.ts';
 import type MaterializationReadPort from '../../../ports/MaterializationReadPort.ts';
 import type MaterializationStorePort from '../../../ports/MaterializationStorePort.ts';
 import type WarpStateCachePort from '../../../ports/WarpStateCachePort.ts';
@@ -22,6 +23,7 @@ export type MaterializeDeps = {
   checkpointStore: CheckpointStorePort;
   materializations: MaterializationStorePort;
   materializationRead?: MaterializationReadPort;
+  propertyStore?: IndexStorePort;
   getStateCache?: () => WarpStateCachePort | null;
   openStateSession?: MaterializeSessionOpener;
   patches: PatchCollector;

--- a/src/domain/services/controllers/MaterializeLiveStrategy.ts
+++ b/src/domain/services/controllers/MaterializeLiveStrategy.ts
@@ -15,6 +15,7 @@ import type {
 import type WarpStateCachePort from '../../../ports/WarpStateCachePort.ts';
 import type MaterializationReadPort from '../../../ports/MaterializationReadPort.ts';
 import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
+import type { PropValue } from '../../types/PropValue.ts';
 import type {
   WarpStateCoordinate,
 } from '../../../ports/WarpStateCachePort.ts';
@@ -84,6 +85,25 @@ export default class MaterializeLiveStrategy {
     }
     await resolution.release();
     return presence;
+  }
+
+  async readNodeProperties(
+    nodeId: string,
+  ): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+    const reader = this.runtime.deps.materializationRead;
+    if (reader === undefined) {
+      return undefined;
+    }
+    const resolution = await this.resolveMaterialization();
+    let properties: Readonly<Record<string, PropValue>> | null | undefined;
+    try {
+      properties = await readNodeProperties(reader, resolution.materialization, nodeId);
+    } catch (raw) {
+      await releaseAcquisitionAfterFailure(resolution, this.runtime.deps.logger);
+      throw raw;
+    }
+    await resolution.release();
+    return properties;
   }
 
   private async resolveRetainedMaterialization(
@@ -365,6 +385,51 @@ async function readNodePresence(
     throw resolutionError('retained node-liveness root has no handle');
   }
   return await reader.hasNode(root.handle, nodeId);
+}
+
+async function readNodeProperties(
+  reader: MaterializationReadPort,
+  materialization: MaterializationHandle | null,
+  nodeId: string,
+): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+  if (materialization === null) {
+    return null;
+  }
+  const presence = await readNodePresence(reader, materialization, nodeId);
+  if (presence === false) {
+    return null;
+  }
+  if (presence === null) {
+    return undefined;
+  }
+  return await readPropertiesRoot(reader, materialization, nodeId);
+}
+
+async function readPropertiesRoot(
+  reader: MaterializationReadPort,
+  materialization: MaterializationHandle,
+  nodeId: string,
+): Promise<Readonly<Record<string, PropValue>> | undefined> {
+  const propertiesRoot = materialization.roots.properties;
+  if (propertiesRoot.status === 'unavailable') {
+    return undefined;
+  }
+  if (propertiesRoot.status === 'empty') {
+    return Object.freeze({});
+  }
+  return await readRetainedPropertiesRoot(reader, propertiesRoot, nodeId);
+}
+
+async function readRetainedPropertiesRoot(
+  reader: MaterializationReadPort,
+  propertiesRoot: MaterializationHandle['roots']['properties'],
+  nodeId: string,
+): Promise<Readonly<Record<string, PropValue>> | undefined> {
+  if (propertiesRoot.handle === null) {
+    throw resolutionError('retained properties root has no handle');
+  }
+  const properties = await reader.getNodeProperties(propertiesRoot.handle, nodeId);
+  return properties === undefined ? undefined : properties ?? Object.freeze({});
 }
 
 function emptyResolution(): LiveMaterializationResolution {

--- a/src/domain/services/controllers/MaterializeSessionBridge.ts
+++ b/src/domain/services/controllers/MaterializeSessionBridge.ts
@@ -6,6 +6,7 @@ import type StateSession from "../../orset/session/StateSession.ts";
 import type MaterializationStorePort from "../../../ports/MaterializationStorePort.ts";
 import type MaterializationWorkspacePort from "../../../ports/MaterializationWorkspacePort.ts";
 import type LoggerPort from "../../../ports/LoggerPort.ts";
+import type IndexStorePort from "../../../ports/IndexStorePort.ts";
 import type MaterializationCoordinate from "../../materialization/MaterializationCoordinate.ts";
 import type StorageRetentionWitness from "../../storage/StorageRetentionWitness.ts";
 import MaterializationRoot from "../../materialization/MaterializationRoot.ts";
@@ -23,6 +24,15 @@ import {
   type MaterializeAdjacency,
 } from "./MaterializeHelpers.ts";
 import { releaseWorkspaceAfterFailure } from "./MaterializationWorkspaceCleanup.ts";
+import PropertyIndexBuilder from "../index/PropertyIndexBuilder.ts";
+import WarpStream from "../../stream/WarpStream.ts";
+import type { IndexShard } from "../../artifacts/IndexShard.ts";
+import {
+  materializationPropertyShardKey,
+  MAX_MATERIALIZATION_PROPERTY_SHARDS,
+  MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES,
+  requireMaterializationPropertyShardCount,
+} from "../../materialization/MaterializationPropertyProfile.ts";
 
 export type MaterializeSessionOpen = {
   readonly nodeAliveRootOid: string | null;
@@ -42,6 +52,8 @@ export async function reduceSessionBackedState(args: {
   readonly openStateSession: MaterializeSessionOpener;
   readonly materializations: MaterializationStorePort;
   readonly logger?: LoggerPort;
+  readonly propertyStore?: IndexStorePort;
+  readonly propertyRoot?: MaterializationRoot;
   readonly coordinate: MaterializationCoordinate;
   readonly patches: MaterializeSessionPatchSource;
   readonly baseState?: WarpStateClass;
@@ -59,6 +71,13 @@ export async function reduceSessionBackedState(args: {
 }> {
   const workspace = await args.materializations.openWorkspace(args.coordinate);
   try {
+    let reducedPatchCount = 0;
+    const patches = (async function* (): AsyncIterable<PatchEntry> {
+      for await (const patch of args.patches) {
+        reducedPatchCount += 1;
+        yield patch;
+      }
+    })();
     const frame = await openReducerSessionFrame(
       args.openStateSession,
       workspace,
@@ -72,7 +91,7 @@ export async function reduceSessionBackedState(args: {
       readonly diff?: PatchDiff;
     };
     if (args.receipts) {
-      const result = await reducePatchesInSession(args.patches, frame, {
+      const result = await reducePatchesInSession(patches, frame, {
         receipts: true,
       });
       const adjacency = await buildAdjacencyFromSession(result.frame.session);
@@ -82,7 +101,7 @@ export async function reduceSessionBackedState(args: {
         receipts: result.receipts,
       };
     } else if (args.wantDiff) {
-      const result = await reducePatchesInSession(args.patches, frame, {
+      const result = await reducePatchesInSession(patches, frame, {
         trackDiff: true,
       });
       const adjacency = await buildAdjacencyFromSession(result.frame.session);
@@ -92,7 +111,7 @@ export async function reduceSessionBackedState(args: {
         diff: result.diff,
       };
     } else {
-      const result = await reducePatchesInSession(args.patches, frame);
+      const result = await reducePatchesInSession(patches, frame);
       const adjacency = await buildAdjacencyFromSession(result.session);
       reduced = {
         state: await projectFrameToState(result),
@@ -101,7 +120,13 @@ export async function reduceSessionBackedState(args: {
     }
 
     const close = await frame.session.prepareClose();
-    const roots = materializationRootsFromSession(close.roots);
+    const properties = await resolvePropertyRoot(
+      reduced.state,
+      args.propertyStore,
+      reducedPatchCount === 0 ? args.propertyRoot : undefined,
+    );
+    await retainPreparedPropertyRoot(workspace, close.roots, properties);
+    const roots = materializationRootsFromSession(close.roots, properties);
     return {
       ...reduced,
       roots,
@@ -162,6 +187,7 @@ export function materializationSessionOpen(
 
 function materializationRootsFromSession(
   roots: MaterializeSessionOpen,
+  properties: MaterializationRoot,
 ): MaterializationRoots {
   return new MaterializationRoots({
     adjacency: MaterializationRoot.unavailable(),
@@ -169,9 +195,69 @@ function materializationRootsFromSession(
     edgeBirths: MaterializationRoot.unavailable(),
     frontier: MaterializationRoot.unavailable(),
     nodeAlive: sessionMaterializationRoot(roots.nodeAliveRootOid),
-    properties: MaterializationRoot.unavailable(),
+    properties,
     provenanceSupport: MaterializationRoot.unavailable(),
     roaringIndexes: MaterializationRoot.unavailable(),
+  });
+}
+
+async function materializePropertyRoot(
+  state: WarpStateClass,
+  store: IndexStorePort | undefined,
+): Promise<MaterializationRoot> {
+  if (store === undefined) {
+    return MaterializationRoot.unavailable();
+  }
+  const builder = new PropertyIndexBuilder({
+    schemaVersion: 2,
+    shardKey: materializationPropertyShardKey,
+  });
+  let propertyCount = 0;
+  for (const entry of state.nodeProperties()) {
+    if (state.nodeAlive.contains(entry.nodeId)) {
+      builder.addProperty(entry.nodeId, entry.key, entry.register.value);
+      propertyCount += 1;
+    }
+  }
+  if (propertyCount === 0) {
+    return MaterializationRoot.empty();
+  }
+  const shardCount = builder.shardCount();
+  requireMaterializationPropertyShardCount(shardCount);
+  const handle = await store.writeShards(
+    WarpStream.from<IndexShard>(builder.yieldShards()),
+    {
+      expectedShardCount: shardCount,
+      maxShardCount: MAX_MATERIALIZATION_PROPERTY_SHARDS,
+      maxShardBytes: MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES,
+    },
+  );
+  return MaterializationRoot.retained(handle);
+}
+
+async function resolvePropertyRoot(
+  state: WarpStateClass,
+  store: IndexStorePort | undefined,
+  existing: MaterializationRoot | undefined,
+): Promise<MaterializationRoot> {
+  if (existing !== undefined && existing.status !== "unavailable") {
+    return existing;
+  }
+  return await materializePropertyRoot(state, store);
+}
+
+async function retainPreparedPropertyRoot(
+  workspace: MaterializationWorkspacePort,
+  roots: MaterializeSessionOpen,
+  properties: MaterializationRoot,
+): Promise<void> {
+  if (properties.status !== 'retained' || properties.handle === null) {
+    return;
+  }
+  await workspace.checkpoint({
+    nodeAliveRoot: roots.nodeAliveRootOid,
+    edgeAliveRoot: roots.edgeAliveRootOid,
+    propertiesRoot: properties.handle.toString(),
   });
 }
 
@@ -223,9 +309,9 @@ async function projectFrameToState(
   return new WarpStateClass({
     nodeAlive: await projectORSet(frame.session.scanNodeElementStates()),
     edgeAlive: await projectORSet(frame.session.scanEdgeElementStates()),
-    prop: new Map(frame.prop),
-    observedFrontier: frame.observedFrontier.clone(),
-    edgeBirthEvent: new Map(frame.edgeBirthEvent),
+    prop: frame.prop,
+    observedFrontier: frame.observedFrontier,
+    edgeBirthEvent: frame.edgeBirthEvent,
   });
 }
 

--- a/src/domain/services/controllers/MaterializeSessionBridge.ts
+++ b/src/domain/services/controllers/MaterializeSessionBridge.ts
@@ -233,10 +233,7 @@ async function materializePropertyRoot(
       memberStorage: 'page',
       maxShardCount: MAX_MATERIALIZATION_PROPERTY_SHARDS,
       maxShardBytes: MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxBytes,
-      maxContainerEntries:
-        MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxContainerEntries,
-      maxDepth: MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxDepth,
-      maxItems: MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxItems,
+      structureLimits: MATERIALIZATION_PROPERTY_SHARD_LIMITS.structureLimits,
       staging: workspace,
     },
   );

--- a/src/domain/services/controllers/MaterializeSessionBridge.ts
+++ b/src/domain/services/controllers/MaterializeSessionBridge.ts
@@ -123,6 +123,7 @@ export async function reduceSessionBackedState(args: {
     const properties = await resolvePropertyRoot(
       reduced.state,
       args.propertyStore,
+      workspace,
       reducedPatchCount === 0 ? args.propertyRoot : undefined,
     );
     await retainPreparedPropertyRoot(workspace, close.roots, properties);
@@ -204,6 +205,7 @@ function materializationRootsFromSession(
 async function materializePropertyRoot(
   state: WarpStateClass,
   store: IndexStorePort | undefined,
+  workspace: MaterializationWorkspacePort,
 ): Promise<MaterializationRoot> {
   if (store === undefined) {
     return MaterializationRoot.unavailable();
@@ -228,8 +230,10 @@ async function materializePropertyRoot(
     WarpStream.from<IndexShard>(builder.yieldShards()),
     {
       expectedShardCount: shardCount,
+      memberStorage: 'page',
       maxShardCount: MAX_MATERIALIZATION_PROPERTY_SHARDS,
       maxShardBytes: MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES,
+      staging: workspace,
     },
   );
   return MaterializationRoot.retained(handle);
@@ -238,12 +242,13 @@ async function materializePropertyRoot(
 async function resolvePropertyRoot(
   state: WarpStateClass,
   store: IndexStorePort | undefined,
+  workspace: MaterializationWorkspacePort,
   existing: MaterializationRoot | undefined,
 ): Promise<MaterializationRoot> {
   if (existing !== undefined && existing.status !== "unavailable") {
     return existing;
   }
-  return await materializePropertyRoot(state, store);
+  return await materializePropertyRoot(state, store, workspace);
 }
 
 async function retainPreparedPropertyRoot(

--- a/src/domain/services/controllers/MaterializeSessionBridge.ts
+++ b/src/domain/services/controllers/MaterializeSessionBridge.ts
@@ -29,8 +29,8 @@ import WarpStream from "../../stream/WarpStream.ts";
 import type { IndexShard } from "../../artifacts/IndexShard.ts";
 import {
   materializationPropertyShardKey,
+  MATERIALIZATION_PROPERTY_SHARD_LIMITS,
   MAX_MATERIALIZATION_PROPERTY_SHARDS,
-  MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES,
   requireMaterializationPropertyShardCount,
 } from "../../materialization/MaterializationPropertyProfile.ts";
 
@@ -232,7 +232,11 @@ async function materializePropertyRoot(
       expectedShardCount: shardCount,
       memberStorage: 'page',
       maxShardCount: MAX_MATERIALIZATION_PROPERTY_SHARDS,
-      maxShardBytes: MAX_MATERIALIZATION_PROPERTY_SHARD_BYTES,
+      maxShardBytes: MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxBytes,
+      maxContainerEntries:
+        MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxContainerEntries,
+      maxDepth: MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxDepth,
+      maxItems: MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxItems,
       staging: workspace,
     },
   );

--- a/src/domain/services/controllers/QueryReads.ts
+++ b/src/domain/services/controllers/QueryReads.ts
@@ -133,11 +133,24 @@ export async function hasNodeImpl(host: QueryReadHost, nodeId: string): Promise<
 }
 
 export async function getNodePropsImpl(host: QueryReadHost, nodeId: string): Promise<PropertyBag | null> {
+  if (!isLegacyNodePropertyProjectionTarget(nodeId)) { return null; }
+  const retained = await tryRetainedNodeProps(host, nodeId);
+  if (retained !== undefined) { return retained; }
   await host._ensureFreshState();
   const indexed = await tryIndexedNodeProps(host, nodeId);
   if (indexed !== undefined) { return indexed; }
   if (host._cachedState === null) { return null; }
   return linearNodeProps(host._cachedState, nodeId);
+}
+
+async function tryRetainedNodeProps(
+  host: QueryReadHost,
+  nodeId: string,
+): Promise<PropertyBag | null | undefined> {
+  if (host._readLiveNodeProperties === undefined) { return undefined; }
+  const retained = await host._readLiveNodeProperties(nodeId);
+  if (retained === undefined) { return undefined; }
+  return retained === null ? null : createSnapshotPropertyValues(retained);
 }
 
 function hasIndexForNode(host: QueryReadHost, nodeId: string): boolean {
@@ -156,7 +169,6 @@ async function tryIndexedNodeProps(host: QueryReadHost, nodeId: string): Promise
 }
 
 function linearNodeProps(state: WarpState, nodeId: string): PropertyBag | null {
-  if (!isLegacyNodePropertyProjectionTarget(nodeId)) { return null; }
   const owner = state.getNodeRecord(nodeId);
   if (owner === null) { return null; }
   return nodePropertyBagFromRecords(NodePropertyProjection.forNodeRecord(state, owner));

--- a/src/domain/services/controllers/ReadGraphHost.ts
+++ b/src/domain/services/controllers/ReadGraphHost.ts
@@ -8,6 +8,7 @@ import type PropertyIndexReader from '../index/PropertyIndexReader.ts';
 import type { LogicalIndex } from '../index/logicalIndexHelpers.ts';
 import type { ProvenanceIndex } from '../provenance/ProvenanceIndex.ts';
 import type Patch from '../../types/Patch.ts';
+import type { PropValue } from '../../types/PropValue.ts';
 
 export type ReadAdjacencyMaps = {
   outgoing: Map<string, readonly NeighborEdge[]> | ReadonlyMap<string, readonly NeighborEdge[]>;
@@ -29,6 +30,9 @@ export type FreshStateHost = {
 
 export type QueryReadHost = FreshStateHost & {
   _readLiveNodePresence?(nodeId: string): Promise<boolean | null>;
+  _readLiveNodeProperties?(
+    nodeId: string,
+  ): Promise<Readonly<Record<string, PropValue>> | null | undefined>;
   _propertyReader: PropertyIndexReader | null;
   _logicalIndex: LogicalIndex | null;
   _materializedGraph: MaterializedReadGraph | null;

--- a/src/domain/services/index/PropertyIndexBuilder.ts
+++ b/src/domain/services/index/PropertyIndexBuilder.ts
@@ -9,6 +9,9 @@
 
 import computeShardKey from '../../utils/shardKey.ts';
 import { PropertyShard } from '../../artifacts/PropertyShard.ts';
+import WarpError from '../../errors/WarpError.ts';
+
+type PropertyIndexSchemaVersion = 1 | 2;
 
 /**
  * Creates a null-prototype object typed as Record<string, unknown>. // nosemgrep: ts-no-record-string-unknown-outside-adapters -- 0025B; nosemgrep: ts-no-unknown-outside-adapters -- 0025B
@@ -20,16 +23,16 @@ function createNullProtoRecord(): Record<string, unknown> { // nosemgrep: ts-no-
 export default class PropertyIndexBuilder {
   private readonly _shards: Map<string, Map<string, Record<string, unknown>>>; // nosemgrep: ts-no-record-string-unknown-outside-adapters -- 0025B; nosemgrep: ts-no-unknown-outside-adapters -- 0025B
   private readonly _shardKey: (nodeId: string) => string;
-  private readonly _schemaVersion: number;
+  private readonly _schemaVersion: PropertyIndexSchemaVersion;
 
   constructor(options: {
-    readonly schemaVersion?: number;
+    readonly schemaVersion?: PropertyIndexSchemaVersion;
     readonly shardKey?: (nodeId: string) => string;
   } = {}) {
     /** shardKey → (nodeId → props) */
     this._shards = new Map();
     this._shardKey = options.shardKey ?? computeShardKey;
-    this._schemaVersion = options.schemaVersion ?? 1;
+    this._schemaVersion = requirePropertyIndexSchemaVersion(options.schemaVersion);
   }
 
   /**
@@ -66,4 +69,20 @@ export default class PropertyIndexBuilder {
       yield new PropertyShard({ shardKey, schemaVersion: this._schemaVersion, entries });
     }
   }
+}
+
+function requirePropertyIndexSchemaVersion(
+  value: PropertyIndexSchemaVersion | undefined,
+): PropertyIndexSchemaVersion {
+  if (value === undefined) {
+    return 1;
+  }
+  if (typeof value !== 'number' || (value !== 1 && value !== 2)) {
+    throw new WarpError(
+      'Unsupported property index schema version',
+      'E_INDEX_SHARD_SCHEMA',
+      { context: { value } },
+    );
+  }
+  return value;
 }

--- a/src/domain/services/index/PropertyIndexBuilder.ts
+++ b/src/domain/services/index/PropertyIndexBuilder.ts
@@ -19,17 +19,24 @@ function createNullProtoRecord(): Record<string, unknown> { // nosemgrep: ts-no-
 
 export default class PropertyIndexBuilder {
   private readonly _shards: Map<string, Map<string, Record<string, unknown>>>; // nosemgrep: ts-no-record-string-unknown-outside-adapters -- 0025B; nosemgrep: ts-no-unknown-outside-adapters -- 0025B
+  private readonly _shardKey: (nodeId: string) => string;
+  private readonly _schemaVersion: number;
 
-  constructor() {
+  constructor(options: {
+    readonly schemaVersion?: number;
+    readonly shardKey?: (nodeId: string) => string;
+  } = {}) {
     /** shardKey → (nodeId → props) */
     this._shards = new Map();
+    this._shardKey = options.shardKey ?? computeShardKey;
+    this._schemaVersion = options.schemaVersion ?? 1;
   }
 
   /**
    * Adds a property for a node.
    */
   addProperty(nodeId: string, key: string, value: unknown): void { // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
-    const shardKey = computeShardKey(nodeId);
+    const shardKey = this._shardKey(nodeId);
     let shard = this._shards.get(shardKey);
     if (!shard) {
       shard = new Map();
@@ -43,6 +50,11 @@ export default class PropertyIndexBuilder {
     nodeProps[key] = value;
   }
 
+  /** Number of physical property shards that will be emitted. */
+  shardCount(): number {
+    return this._shards.size;
+  }
+
   /**
    * Yields PropertyShard instances without encoding.
    */
@@ -51,7 +63,7 @@ export default class PropertyIndexBuilder {
       const entries = [...shard.entries()]
         .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
         .map(([nodeId, props]): [string, Record<string, unknown>] => [nodeId, props]); // nosemgrep: ts-no-record-string-unknown-outside-adapters -- 0025B; nosemgrep: ts-no-unknown-outside-adapters -- 0025B
-      yield new PropertyShard({ shardKey, entries });
+      yield new PropertyShard({ shardKey, schemaVersion: this._schemaVersion, entries });
     }
   }
 }

--- a/src/domain/services/index/PropertyIndexReader.ts
+++ b/src/domain/services/index/PropertyIndexReader.ts
@@ -16,7 +16,7 @@ import type AssetHandle from '../../storage/AssetHandle.ts';
 import { isPropValue, type PropValue } from '../../types/PropValue.ts';
 import type CodecValue from '../../types/codec/CodecValue.ts';
 
-export type IndexedPropertyBag = { [key: string]: PropValue };
+export type IndexedPropertyBag = Readonly<{ [key: string]: PropValue }>;
 type PropertyShard = ReadonlyMap<string, IndexedPropertyBag>;
 type PropertyShardSchemaVersion = 1 | 2;
 export type DecodedPropertyShardArtifact = Readonly<{

--- a/src/domain/services/index/PropertyIndexReader.ts
+++ b/src/domain/services/index/PropertyIndexReader.ts
@@ -16,26 +16,254 @@ import type AssetHandle from '../../storage/AssetHandle.ts';
 import { isPropValue, type PropValue } from '../../types/PropValue.ts';
 import type CodecValue from '../../types/codec/CodecValue.ts';
 
-type IndexedPropertyBag = { [key: string]: PropValue };
-type PropertyShard = { [nodeId: string]: IndexedPropertyBag };
-type PropertyShardEntry = readonly [string, IndexedPropertyBag];
-
-function createNullRecord(): PropertyShard {
-  return {};
-}
+export type IndexedPropertyBag = { [key: string]: PropValue };
+type PropertyShard = ReadonlyMap<string, IndexedPropertyBag>;
+type PropertyShardSchemaVersion = 1 | 2;
+export type DecodedPropertyShardArtifact = Readonly<{
+  readonly schemaVersion: PropertyShardSchemaVersion;
+  readonly entries: PropertyShard;
+}>;
+type PropertyShardDecodeContext = {
+  readonly data: Map<string, IndexedPropertyBag>;
+  readonly path: string;
+  readonly schemaVersion: PropertyShardSchemaVersion;
+};
+type PropertyShardPayload = Readonly<{
+  readonly schemaVersion: PropertyShardSchemaVersion;
+  readonly entries: ReadonlyArray<CodecValue>;
+}>;
+type PropertyShardKeyResolver = (
+  nodeId: string,
+  schemaVersion: PropertyShardSchemaVersion,
+) => string;
 
 function isIndexedPropertyBag(value: CodecValue): value is IndexedPropertyBag {
-  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+  if (!isCodecRecord(value)) {
     return false;
   }
-  return Object.values(value).every((entry) => isPropValue(entry));
+  return Object.entries(value).every(
+    ([key, entry]) => isValidPropertyKey(key) && isPropValue(entry),
+  );
 }
 
-function isPropertyShardEntry(value: CodecValue): value is PropertyShardEntry {
-  return Array.isArray(value)
-    && value.length === 2
-    && typeof value[0] === 'string'
-    && isIndexedPropertyBag(value[1]);
+function isValidPropertyKey(value: string): boolean {
+  return value.length > 0 && !value.includes('\0');
+}
+
+/** Validates one decoded property shard without retaining it beyond the caller. */
+export function decodePropertyShard(
+  decoded: CodecValue,
+  path: string,
+  shardKeyForNode: PropertyShardKeyResolver = computeShardKey,
+): PropertyShard {
+  return decodeRoutedPropertyShardArtifact(decoded, path, shardKeyForNode).entries;
+}
+
+/** Validates one current-profile property shard and requires schema v2. */
+export function decodeCurrentPropertyShard(
+  decoded: CodecValue,
+  path: string,
+  shardKeyForNode: PropertyShardKeyResolver,
+): PropertyShard {
+  const artifact = decodeRoutedPropertyShardArtifact(decoded, path, shardKeyForNode);
+  if (artifact.schemaVersion !== 2) {
+    throw malformedPropertyShard(path, 'retained property root requires current schema');
+  }
+  return artifact.entries;
+}
+
+/** Decodes one property artifact and validates its physical routing profile. */
+export function decodeRoutedPropertyShardArtifact(
+  decoded: CodecValue,
+  path: string,
+  shardKeyForNode: PropertyShardKeyResolver = computeShardKey,
+): DecodedPropertyShardArtifact {
+  const artifact = decodePropertyShardArtifact(decoded, path);
+  validatePropertyShardRouting(artifact, path, shardKeyForNode);
+  return artifact;
+}
+
+function validatePropertyShardRouting(
+  artifact: DecodedPropertyShardArtifact,
+  path: string,
+  shardKeyForNode: PropertyShardKeyResolver,
+): void {
+  for (const nodeId of artifact.entries.keys()) {
+    if (path !== `props_${shardKeyForNode(nodeId, artifact.schemaVersion)}.cbor`) {
+      throw malformedPropertyShard(path, 'node entry belongs to another shard');
+    }
+  }
+}
+
+/** Decodes a property artifact without assuming a specific physical routing profile. */
+export function decodePropertyShardArtifact(
+  decoded: CodecValue,
+  path: string,
+): DecodedPropertyShardArtifact {
+  const payload = decodePropertyShardPayload(decoded, path);
+  const data = new Map<string, IndexedPropertyBag>();
+  const context = { data, path, schemaVersion: payload.schemaVersion };
+  for (const entry of payload.entries) {
+    addPropertyShardEntry(context, entry);
+  }
+  return Object.freeze({ schemaVersion: payload.schemaVersion, entries: data });
+}
+
+function decodePropertyShardPayload(decoded: CodecValue, path: string): PropertyShardPayload {
+  if (Array.isArray(decoded)) {
+    return Object.freeze({ schemaVersion: 1, entries: decoded });
+  }
+  return decodeCurrentPropertyShardPayload(decoded, path);
+}
+
+function decodeCurrentPropertyShardPayload(
+  decoded: CodecValue,
+  path: string,
+): PropertyShardPayload {
+  if (!isCodecRecord(decoded)) {
+    throw malformedPropertyShard(path, 'expected a legacy entry array or current schema envelope');
+  }
+  if (!hasPropertyShardEnvelopeKeys(decoded)) {
+    throw malformedPropertyShard(path, 'invalid current property shard envelope');
+  }
+  const { entries, schemaVersion } = decoded;
+  if (schemaVersion !== 2) {
+    throw malformedPropertyShard(path, 'unsupported property shard schema version');
+  }
+  if (!Array.isArray(entries)) {
+    throw malformedPropertyShard(path, 'current property shard entries must be an array');
+  }
+  return Object.freeze({ schemaVersion: 2, entries });
+}
+
+function hasPropertyShardEnvelopeKeys(
+  decoded: { readonly [key: string]: CodecValue },
+): boolean {
+  const keys = Object.keys(decoded).sort();
+  return keys.length === 2 && keys[0] === 'entries' && keys[1] === 'schemaVersion';
+}
+
+function isCodecRecord(
+  value: CodecValue,
+): value is { readonly [key: string]: CodecValue } {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  if (isNonRecordCodecValue(value)) {
+    return false;
+  }
+  const prototype = Reflect.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isNonRecordCodecValue(value: object): boolean {
+  return Array.isArray(value) || value instanceof Uint8Array || value instanceof Date;
+}
+
+function addPropertyShardEntry(
+  context: PropertyShardDecodeContext,
+  candidate: CodecValue,
+): void {
+  const [nodeId, bag] = decodePropertyShardEntry(candidate, context.path);
+  if (context.data.has(nodeId)) {
+    throw malformedPropertyShard(context.path, 'duplicate node entry');
+  }
+  context.data.set(nodeId, decodePropertyBag(bag, context.path, context.schemaVersion));
+}
+
+function decodePropertyShardEntry(
+  candidate: CodecValue,
+  path: string,
+): readonly [string, CodecValue] {
+  if (!isPropertyShardTuple(candidate) || !isValidNodeId(candidate[0])) {
+    throw malformedPropertyShard(path, 'invalid node entry');
+  }
+  return [candidate[0], candidate[1]];
+}
+
+function isPropertyShardTuple(
+  candidate: CodecValue,
+): candidate is [string, CodecValue] {
+  return Array.isArray(candidate)
+    && candidate.length === 2
+    && typeof candidate[0] === 'string';
+}
+
+function isValidNodeId(nodeId: string): boolean {
+  return nodeId.length > 0 && !nodeId.includes('\0');
+}
+
+function decodePropertyBag(
+  candidate: CodecValue,
+  path: string,
+  schemaVersion: PropertyShardSchemaVersion,
+): IndexedPropertyBag {
+  if (schemaVersion === 1) {
+    if (!isIndexedPropertyBag(candidate)) {
+      throw malformedPropertyShard(path, 'legacy property bag must be an object');
+    }
+    return createPropertyBag(Object.entries(candidate), path);
+  }
+  if (!Array.isArray(candidate)) {
+    throw malformedPropertyShard(path, 'current property bag must be an entry array');
+  }
+  return decodePropertyBagEntries(candidate, path);
+}
+
+function decodePropertyBagEntries(
+  entries: CodecValue[],
+  path: string,
+): IndexedPropertyBag {
+  return createPropertyBag(entries, path);
+}
+
+function createPropertyBag(
+  entries: ReadonlyArray<CodecValue | readonly [string, PropValue]>,
+  path: string,
+): IndexedPropertyBag {
+  const bag: IndexedPropertyBag = {};
+  Reflect.setPrototypeOf(bag, null);
+  for (const candidate of entries) {
+    addPropertyBagEntry(bag, candidate, path);
+  }
+  return Object.freeze(bag);
+}
+
+function addPropertyBagEntry(
+  bag: IndexedPropertyBag,
+  candidate: CodecValue,
+  path: string,
+): void {
+  if (!isDecodedPropertyBagEntry(candidate)) {
+    throw malformedPropertyShard(path, 'invalid property entry');
+  }
+  const [key, value] = candidate;
+  if (Object.hasOwn(bag, key)) {
+    throw malformedPropertyShard(path, 'duplicate property entry');
+  }
+  Object.defineProperty(bag, key, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function isDecodedPropertyBagEntry(
+  candidate: CodecValue,
+): candidate is [string, PropValue] {
+  return Array.isArray(candidate)
+    && candidate.length === 2
+    && typeof candidate[0] === 'string'
+    && isValidPropertyKey(candidate[0])
+    && isPropValue(candidate[1]);
+}
+
+function malformedPropertyShard(path: string, reason: string): IndexError {
+  return new IndexError(`PropertyIndexReader: invalid shard '${path}' (${reason})`, {
+    code: 'E_INDEX_SHARD_MALFORMED',
+    context: { path, reason },
+  });
 }
 
 export default class PropertyIndexReader {
@@ -82,7 +310,7 @@ export default class PropertyIndexReader {
     if (!shard) {
       return null;
     }
-    return shard[nodeId] ?? null;
+    return shard.get(nodeId) ?? null;
   }
 
   /**
@@ -93,7 +321,7 @@ export default class PropertyIndexReader {
     if (!props) {
       return undefined;
     }
-    return props[key];
+    return Object.hasOwn(props, key) ? props[key] : undefined;
   }
 
   private async _loadShard(nodeId: string): Promise<PropertyShard | null> {
@@ -143,24 +371,7 @@ export default class PropertyIndexReader {
   }
 
   private _parseShard(decoded: CodecValue, path: string): PropertyShard {
-    if (!Array.isArray(decoded)) {
-      const shape = decoded === null ? 'null' : typeof decoded;
-      throw new IndexError(
-        `PropertyIndexReader: invalid shard format for '${path}' (expected array, got ${shape})`,
-        { code: 'E_INDEX_SHARD_MALFORMED', context: { path, shape } },
-      );
-    }
-
-    const data = createNullRecord();
-    for (const entry of decoded) {
-      if (!isPropertyShardEntry(entry)) {
-        throw new IndexError(
-          `PropertyIndexReader: invalid shard property bag for '${path}'`,
-          { code: 'E_INDEX_SHARD_MALFORMED', context: { path } },
-        );
-      }
-      data[entry[0]] = entry[1];
-    }
+    const data = decodePropertyShard(decoded, path);
     this._cache.set(path, data);
     return data;
   }

--- a/src/domain/warp/RuntimeHostBoot.ts
+++ b/src/domain/warp/RuntimeHostBoot.ts
@@ -359,6 +359,7 @@ export async function resolveRuntimeHostConstructionOptions(
       store,
       codec: resolvedCodec,
       geometry,
+      indexStore: resolvedIndexStore,
     });
   }
 

--- a/src/infrastructure/adapters/BoundedCborValidation.ts
+++ b/src/infrastructure/adapters/BoundedCborValidation.ts
@@ -1,0 +1,202 @@
+import IndexError from '../../domain/errors/IndexError.ts';
+
+export type CborStructureLimits = Readonly<{
+  maxContainerEntries: number;
+  maxDepth: number;
+  maxItems: number;
+}>;
+
+const ARGUMENT_WIDTHS = new Map<number, number>([
+  [24, 1],
+  [25, 2],
+  [26, 4],
+  [27, 8],
+]);
+const STRICT_UTF8 = new TextDecoder('utf-8', { fatal: true });
+
+class CborStructureReader {
+  readonly #bytes: Uint8Array;
+  readonly #limits: CborStructureLimits;
+  #offset = 0;
+  #items = 0;
+
+  constructor(bytes: Uint8Array, limits: CborStructureLimits) {
+    this.#bytes = bytes;
+    this.#limits = limits;
+  }
+
+  readDocument(): void {
+    this.#readItem(0);
+    if (this.#offset !== this.#bytes.byteLength) {
+      throw malformedCbor('trailing bytes after the top-level value');
+    }
+  }
+
+  #readItem(depth: number): void {
+    this.#requireItemBudget(depth);
+    const initial = this.#readByte();
+    const major = initial >>> 5;
+    const additional = initial & 0x1f;
+    if (major === 7) {
+      this.#readSimple(additional);
+      return;
+    }
+    const argument = this.#readArgument(additional);
+    this.#readMajorValue(major, argument, depth);
+  }
+
+  #requireItemBudget(depth: number): void {
+    if (depth > this.#limits.maxDepth) {
+      throw malformedCbor('nesting depth exceeds the configured maximum');
+    }
+    this.#items += 1;
+    if (this.#items > this.#limits.maxItems) {
+      throw malformedCbor('decoded item count exceeds the configured maximum');
+    }
+  }
+
+  #readMajorValue(major: number, argument: bigint, depth: number): void {
+    if (major <= 1) {
+      return;
+    }
+    if (major <= 3) {
+      this.#skip(this.#toLength(argument));
+      return;
+    }
+    if (major <= 5) {
+      this.#readContainer(major, this.#toLength(argument), depth);
+      return;
+    }
+    if (major === 6) {
+      this.#readItem(depth + 1);
+      return;
+    }
+    throw malformedCbor('unsupported major type');
+  }
+
+  #readContainer(major: number, length: number, depth: number): void {
+    if (length > this.#limits.maxContainerEntries) {
+      throw malformedCbor('container entry count exceeds the configured maximum');
+    }
+    if (major === 4) {
+      this.#readItems(length, depth);
+      return;
+    }
+    this.#readMapEntries(length, depth);
+  }
+
+  #readMapEntries(length: number, depth: number): void {
+    const decodedKeys = new Set<string>();
+    for (let index = 0; index < length; index += 1) {
+      const keyStart = this.#offset;
+      const initial = this.#bytes[keyStart];
+      if (initial === undefined) {
+        throw malformedCbor('value is truncated');
+      }
+      if (initial >>> 5 !== 3) {
+        throw malformedCbor('map key must be a UTF-8 text string');
+      }
+      this.#readItem(depth + 1);
+      const payloadStart = keyStart + encodedHeaderWidth(initial);
+      const decodedKey = decodeTextKey(this.#bytes, payloadStart, this.#offset);
+      if (decodedKeys.has(decodedKey)) {
+        throw malformedCbor('map contains a duplicate text key');
+      }
+      decodedKeys.add(decodedKey);
+      this.#readItem(depth + 1);
+    }
+  }
+
+  #readItems(length: number, depth: number): void {
+    for (let index = 0; index < length; index += 1) {
+      this.#readItem(depth + 1);
+    }
+  }
+
+  #readSimple(additional: number): void {
+    if (additional < 24) {
+      return;
+    }
+    const width = ARGUMENT_WIDTHS.get(additional);
+    if (width === undefined) {
+      throw malformedCbor('reserved or break simple value is not supported');
+    }
+    this.#skip(width);
+  }
+
+  #readArgument(additional: number): bigint {
+    if (additional === 0x1f) {
+      throw malformedCbor('indefinite-length values are not supported');
+    }
+    if (additional < 24) {
+      return BigInt(additional);
+    }
+    const width = ARGUMENT_WIDTHS.get(additional);
+    if (width === undefined) {
+      throw malformedCbor('reserved additional information');
+    }
+    return this.#readUnsigned(width);
+  }
+
+  #readUnsigned(width: number): bigint {
+    let value = 0n;
+    for (let index = 0; index < width; index += 1) {
+      value = (value << 8n) | BigInt(this.#readByte());
+    }
+    return value;
+  }
+
+  #toLength(value: bigint): number {
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw malformedCbor('declared length exceeds the safe integer range');
+    }
+    return Number(value);
+  }
+
+  #readByte(): number {
+    const value = this.#bytes[this.#offset];
+    if (value === undefined) {
+      throw malformedCbor('value is truncated');
+    }
+    this.#offset += 1;
+    return value;
+  }
+
+  #skip(length: number): void {
+    if (length > this.#bytes.byteLength - this.#offset) {
+      throw malformedCbor('value is truncated');
+    }
+    this.#offset += length;
+  }
+}
+
+/** Rejects dangerous CBOR structure declarations before the general decoder allocates them. */
+export function validateBoundedCbor(
+  bytes: Uint8Array,
+  limits: CborStructureLimits,
+): void {
+  new CborStructureReader(bytes, limits).readDocument();
+}
+
+function decodeTextKey(bytes: Uint8Array, start: number, end: number): string {
+  try {
+    return STRICT_UTF8.decode(bytes.subarray(start, end));
+  } catch {
+    throw malformedCbor('map contains an invalid UTF-8 text key');
+  }
+}
+
+function encodedHeaderWidth(initial: number): number {
+  const additional = initial & 0x1f;
+  if (additional < 24) {
+    return 1;
+  }
+  return 1 + (ARGUMENT_WIDTHS.get(additional) ?? 0);
+}
+
+function malformedCbor(reason: string): IndexError {
+  return new IndexError(`Index shard CBOR is malformed: ${reason}`, {
+    code: 'E_INDEX_SHARD_MALFORMED',
+    context: { reason },
+  });
+}

--- a/src/infrastructure/adapters/CborCheckpointStoreAdapter.ts
+++ b/src/infrastructure/adapters/CborCheckpointStoreAdapter.ts
@@ -48,7 +48,7 @@ interface CheckpointHistory {
 }
 
 export type GitCasCheckpointFacade = {
-  readonly bundles: Pick<BundleCapability, 'putOrdered' | 'iterateMembers'>;
+  readonly bundles: Pick<BundleCapability, 'putOrdered' | 'iterateMemberReferences'>;
   readonly publications: Pick<PublicationCapability, 'commit'>;
 };
 
@@ -265,7 +265,7 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
   ): Promise<CheckpointLayout> {
     const artifacts = new Map<string, CheckpointArtifact>();
     const indexShardHandles = new Map<string, AssetHandle>();
-    for await (const member of this._cas.bundles.iterateMembers({
+    for await (const member of this._cas.bundles.iterateMemberReferences({
       handle: bundleHandle.toString(),
     })) {
       if (member.handle.kind !== 'asset') {

--- a/src/infrastructure/adapters/CborIndexShardWriter.ts
+++ b/src/infrastructure/adapters/CborIndexShardWriter.ts
@@ -4,6 +4,7 @@ import IndexError from '../../domain/errors/IndexError.ts';
 import BundleHandle from '../../domain/storage/BundleHandle.ts';
 import WarpStream from '../../domain/stream/WarpStream.ts';
 import type AssetStoragePort from '../../ports/AssetStoragePort.ts';
+import type ArtifactStagingPort from '../../ports/ArtifactStagingPort.ts';
 import type CodecPort from '../../ports/CodecPort.ts';
 import type { IndexShardWriteOptions } from '../../ports/IndexStorePort.ts';
 import type { CborStructureLimits } from './BoundedCborValidation.ts';
@@ -24,7 +25,7 @@ type ValidatedWriteLimits = Readonly<{
   memberStorage: 'asset' | 'page';
   maxShardBytes: number | undefined;
   maxShardCount: number | undefined;
-  staging: IndexShardWriteOptions['staging'];
+  staging: ArtifactStagingPort | undefined;
   structureLimits: CborStructureLimits | undefined;
 }>;
 
@@ -124,7 +125,7 @@ function validatedWriteLimits(options: IndexShardWriteOptions): ValidatedWriteLi
     maxShardCount: optionalNonNegativeInteger(options.maxShardCount, 'maxShardCount'),
     maxShardBytes: optionalPositiveInteger(options.maxShardBytes, 'maxShardBytes'),
     staging: validatedStaging(options.staging),
-    structureLimits: optionalCborStructureLimits(options),
+    structureLimits: optionalCborStructureLimits(options.structureLimits),
   });
   if (limits.memberStorage === 'page') {
     requirePageShardLimit(limits.maxShardBytes);
@@ -133,12 +134,12 @@ function validatedWriteLimits(options: IndexShardWriteOptions): ValidatedWriteLi
 }
 
 function validatedStaging(
-  value: IndexShardWriteOptions['staging'],
-): IndexShardWriteOptions['staging'] {
+  value: unknown,
+): ArtifactStagingPort | undefined {
   if (value === undefined) {
     return undefined;
   }
-  if (typeof value.stagePage !== 'function' || typeof value.stageOrderedBundle !== 'function') {
+  if (!isArtifactStagingPort(value)) {
     throw new IndexError('Index shard staging must provide page and bundle operations', {
       code: 'E_INDEX_INVALID_STORAGE',
     });
@@ -146,7 +147,25 @@ function validatedStaging(
   return value;
 }
 
-function validatedMemberStorage(value: IndexShardWriteOptions['memberStorage']): 'asset' | 'page' {
+function isArtifactStagingPort(value: unknown): value is ArtifactStagingPort {
+  if (value === null) {
+    return false;
+  }
+  if (typeof value !== 'object') {
+    return false;
+  }
+  return hasCallableProperty(value, 'stagePage')
+    && hasCallableProperty(value, 'stageOrderedBundle');
+}
+
+function hasCallableProperty(
+  value: object,
+  property: 'stagePage' | 'stageOrderedBundle',
+): boolean {
+  return property in value && typeof Reflect.get(value, property) === 'function';
+}
+
+function validatedMemberStorage(value: unknown): 'asset' | 'page' {
   if (value === undefined || value === 'asset') {
     return 'asset';
   }

--- a/src/infrastructure/adapters/CborIndexShardWriter.ts
+++ b/src/infrastructure/adapters/CborIndexShardWriter.ts
@@ -6,8 +6,10 @@ import WarpStream from '../../domain/stream/WarpStream.ts';
 import type AssetStoragePort from '../../ports/AssetStoragePort.ts';
 import type CodecPort from '../../ports/CodecPort.ts';
 import type { IndexShardWriteOptions } from '../../ports/IndexStorePort.ts';
+import type { CborStructureLimits } from './BoundedCborValidation.ts';
 import { IndexShardEncodeTransform } from './IndexShardEncodeTransform.ts';
 import {
+  optionalCborStructureLimits,
   optionalNonNegativeInteger,
   optionalPositiveInteger,
 } from './IndexShardLimitValidation.ts';
@@ -23,6 +25,7 @@ type ValidatedWriteLimits = Readonly<{
   maxShardBytes: number | undefined;
   maxShardCount: number | undefined;
   staging: IndexShardWriteOptions['staging'];
+  structureLimits: CborStructureLimits | undefined;
 }>;
 
 export async function writeCborIndexShards(args: {
@@ -56,6 +59,9 @@ async function collectEncodedShardMembers(args: {
     ...(args.limits.maxShardBytes === undefined
       ? {}
       : { maxBytes: args.limits.maxShardBytes }),
+    ...(args.limits.structureLimits === undefined
+      ? {}
+      : { structureLimits: args.limits.structureLimits }),
   });
   for await (const [path, bytes] of args.shardStream.pipe(encoder)) {
     requireShardCountWithinLimit(members.length + 1, args.limits.maxShardCount);
@@ -118,6 +124,7 @@ function validatedWriteLimits(options: IndexShardWriteOptions): ValidatedWriteLi
     maxShardCount: optionalNonNegativeInteger(options.maxShardCount, 'maxShardCount'),
     maxShardBytes: optionalPositiveInteger(options.maxShardBytes, 'maxShardBytes'),
     staging: validatedStaging(options.staging),
+    structureLimits: optionalCborStructureLimits(options),
   });
   if (limits.memberStorage === 'page') {
     requirePageShardLimit(limits.maxShardBytes);

--- a/src/infrastructure/adapters/CborIndexShardWriter.ts
+++ b/src/infrastructure/adapters/CborIndexShardWriter.ts
@@ -1,0 +1,200 @@
+import type { BundleCapability, PageCapability } from '@git-stunts/git-cas';
+import type { IndexShard } from '../../domain/artifacts/IndexShard.ts';
+import IndexError from '../../domain/errors/IndexError.ts';
+import BundleHandle from '../../domain/storage/BundleHandle.ts';
+import WarpStream from '../../domain/stream/WarpStream.ts';
+import type AssetStoragePort from '../../ports/AssetStoragePort.ts';
+import type CodecPort from '../../ports/CodecPort.ts';
+import type { IndexShardWriteOptions } from '../../ports/IndexStorePort.ts';
+import { IndexShardEncodeTransform } from './IndexShardEncodeTransform.ts';
+import {
+  optionalNonNegativeInteger,
+  optionalPositiveInteger,
+} from './IndexShardLimitValidation.ts';
+
+type IndexWriteFacade = Readonly<{
+  bundles: Pick<BundleCapability, 'putOrdered'>;
+  pages: Pick<PageCapability, 'put'>;
+}>;
+
+type ValidatedWriteLimits = Readonly<{
+  expectedShardCount: number | undefined;
+  memberStorage: 'asset' | 'page';
+  maxShardBytes: number | undefined;
+  maxShardCount: number | undefined;
+  staging: IndexShardWriteOptions['staging'];
+}>;
+
+export async function writeCborIndexShards(args: {
+  shardStream: WarpStream<IndexShard>;
+  options: IndexShardWriteOptions;
+  codec: CodecPort;
+  assets: AssetStoragePort;
+  cas: IndexWriteFacade;
+}): Promise<BundleHandle> {
+  const limits = validatedWriteLimits(args.options);
+  requireExpectedShardCountWithinLimit(limits.expectedShardCount, limits.maxShardCount);
+  const members = await collectEncodedShardMembers({ ...args, limits });
+  requireExpectedShardCount(members.length, limits.expectedShardCount);
+  members.sort(([left], [right]) => compareStrings(left, right));
+  return await putShardBundle(args.cas, members, limits);
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+async function collectEncodedShardMembers(args: {
+  shardStream: WarpStream<IndexShard>;
+  codec: CodecPort;
+  assets: AssetStoragePort;
+  cas: IndexWriteFacade;
+  limits: ValidatedWriteLimits;
+}): Promise<Array<[string, string]>> {
+  const members: Array<[string, string]> = [];
+  const encoder = new IndexShardEncodeTransform(args.codec, {
+    ...(args.limits.maxShardBytes === undefined
+      ? {}
+      : { maxBytes: args.limits.maxShardBytes }),
+  });
+  for await (const [path, bytes] of args.shardStream.pipe(encoder)) {
+    requireShardCountWithinLimit(members.length + 1, args.limits.maxShardCount);
+    requireShardSize(path, bytes.byteLength, args.limits.maxShardBytes);
+    members.push([path, await stageEncodedShard(path, bytes, args)]);
+  }
+  return members;
+}
+
+async function stageEncodedShard(
+  path: string,
+  bytes: Uint8Array,
+  args: {
+    assets: AssetStoragePort;
+    cas: IndexWriteFacade;
+    limits: ValidatedWriteLimits;
+  },
+): Promise<string> {
+  if (args.limits.memberStorage === 'page') {
+    const maxBytes = requirePageShardLimit(args.limits.maxShardBytes);
+    return args.limits.staging === undefined
+      ? (await args.cas.pages.put({ source: bytes, maxBytes })).handle.toString()
+      : await args.limits.staging.stagePage(bytes, { maxBytes });
+  }
+  const staged = await args.assets.stage(WarpStream.from([bytes]), {
+    slug: `index-shard-${path}`,
+    filename: path,
+    expectedSize: bytes.byteLength,
+  });
+  return staged.handle.toString();
+}
+
+async function putShardBundle(
+  cas: IndexWriteFacade,
+  members: Array<[string, string]>,
+  limits: ValidatedWriteLimits,
+): Promise<BundleHandle> {
+  if (limits.staging !== undefined) {
+    return await limits.staging.stageOrderedBundle(
+      members,
+      limits.maxShardCount === undefined ? {} : { maxMembers: limits.maxShardCount },
+    );
+  }
+  const bundle = await cas.bundles.putOrdered({
+    members,
+    ...(limits.maxShardCount === undefined
+      ? {}
+      : { limits: { maxMembers: limits.maxShardCount } }),
+  });
+  return new BundleHandle(bundle.handle.toString());
+}
+
+function validatedWriteLimits(options: IndexShardWriteOptions): ValidatedWriteLimits {
+  const limits = Object.freeze({
+    expectedShardCount: optionalNonNegativeInteger(
+      options.expectedShardCount,
+      'expectedShardCount',
+    ),
+    memberStorage: validatedMemberStorage(options.memberStorage),
+    maxShardCount: optionalNonNegativeInteger(options.maxShardCount, 'maxShardCount'),
+    maxShardBytes: optionalPositiveInteger(options.maxShardBytes, 'maxShardBytes'),
+    staging: validatedStaging(options.staging),
+  });
+  if (limits.memberStorage === 'page') {
+    requirePageShardLimit(limits.maxShardBytes);
+  }
+  return limits;
+}
+
+function validatedStaging(
+  value: IndexShardWriteOptions['staging'],
+): IndexShardWriteOptions['staging'] {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value.stagePage !== 'function' || typeof value.stageOrderedBundle !== 'function') {
+    throw new IndexError('Index shard staging must provide page and bundle operations', {
+      code: 'E_INDEX_INVALID_STORAGE',
+    });
+  }
+  return value;
+}
+
+function validatedMemberStorage(value: IndexShardWriteOptions['memberStorage']): 'asset' | 'page' {
+  if (value === undefined || value === 'asset') {
+    return 'asset';
+  }
+  if (value === 'page') {
+    return value;
+  }
+  throw new IndexError('Index shard memberStorage must be asset or page', {
+    code: 'E_INDEX_INVALID_STORAGE',
+    context: { value },
+  });
+}
+
+function requirePageShardLimit(value: number | undefined): number {
+  if (value === undefined) {
+    throw new IndexError('Page-backed index shards require maxShardBytes', {
+      code: 'E_INDEX_INVALID_LIMIT',
+      context: { name: 'maxShardBytes' },
+    });
+  }
+  return value;
+}
+
+function requireShardSize(path: string, actual: number, maximum: number | undefined): void {
+  if (maximum !== undefined && actual > maximum) {
+    throw new IndexError(`Index shard exceeds the configured maximum: ${path}`, {
+      code: 'E_INDEX_SHARD_TOO_LARGE',
+      context: { path, actual, maximum },
+    });
+  }
+}
+
+function requireExpectedShardCountWithinLimit(
+  expected: number | undefined,
+  maximum: number | undefined,
+): void {
+  if (expected !== undefined) {
+    requireShardCountWithinLimit(expected, maximum);
+  }
+}
+
+function requireShardCountWithinLimit(actual: number, maximum: number | undefined): void {
+  if (maximum !== undefined && actual > maximum) {
+    throw shardCountError(actual, maximum, 'exceeds the configured maximum');
+  }
+}
+
+function requireExpectedShardCount(actual: number, expected: number | undefined): void {
+  if (expected !== undefined && actual !== expected) {
+    throw shardCountError(actual, expected, 'does not match the expected count');
+  }
+}
+
+function shardCountError(actual: number, maximum: number, reason: string): IndexError {
+  return new IndexError(`Index shard count ${reason}`, {
+    code: 'E_INDEX_SHARD_COUNT_LIMIT',
+    context: { actual, maximum },
+  });
+}

--- a/src/infrastructure/adapters/CborIndexStoreAdapter.ts
+++ b/src/infrastructure/adapters/CborIndexStoreAdapter.ts
@@ -28,10 +28,8 @@ import { validateBoundedCbor } from './BoundedCborValidation.ts';
 import { decodeRoutedPropertyShardArtifact } from '../../domain/services/index/PropertyIndexReader.ts';
 import { writeCborIndexShards } from './CborIndexShardWriter.ts';
 import {
-  invalidLimit,
+  optionalCborStructureLimits,
   optionalPositiveInteger,
-  requiredNonNegativeInteger,
-  requiredPositiveInteger,
 } from './IndexShardLimitValidation.ts';
 
 export type GitCasIndexFacade = {
@@ -323,28 +321,10 @@ function validateRequestedStructure(
   bytes: Uint8Array,
   options: IndexShardDecodeOptions,
 ): void {
-  const configured = [
-    options.maxContainerEntries,
-    options.maxDepth,
-    options.maxItems,
-  ].filter((value) => value !== undefined).length;
-  if (configured === 0) {
-    return;
+  const limits = optionalCborStructureLimits(options);
+  if (limits !== undefined) {
+    validateBoundedCbor(bytes, limits);
   }
-  if (configured !== 3) {
-    throw invalidLimit('CBOR structure limits');
-  }
-  const maxContainerEntries = requiredPositiveInteger(
-    options.maxContainerEntries,
-    'maxContainerEntries',
-  );
-  const maxDepth = requiredNonNegativeInteger(options.maxDepth, 'maxDepth');
-  const maxItems = requiredPositiveInteger(options.maxItems, 'maxItems');
-  validateBoundedCbor(bytes, {
-    maxContainerEntries,
-    maxDepth,
-    maxItems,
-  });
 }
 
 function shardTooLarge(actual: number, maximum: number): IndexError {

--- a/src/infrastructure/adapters/CborIndexStoreAdapter.ts
+++ b/src/infrastructure/adapters/CborIndexStoreAdapter.ts
@@ -1,4 +1,4 @@
-import type { BundleCapability } from '@git-stunts/git-cas';
+import type { BundleCapability, BundleMember, PageCapability } from '@git-stunts/git-cas';
 import IndexStorePort, {
   type IndexShardDecodeOptions,
   type IndexShardWriteOptions,
@@ -14,25 +14,26 @@ import { LabelShard } from '../../domain/artifacts/LabelShard.ts';
 import { PropertyShard } from '../../domain/artifacts/PropertyShard.ts';
 import { ReceiptShard } from '../../domain/artifacts/ReceiptShard.ts';
 import type { IndexShard } from '../../domain/artifacts/IndexShard.ts';
-import { IndexShardEncodeTransform } from './IndexShardEncodeTransform.ts';
 import AssetHandle from '../../domain/storage/AssetHandle.ts';
-import BundleHandle from '../../domain/storage/BundleHandle.ts';
+import type BundleHandle from '../../domain/storage/BundleHandle.ts';
 import IndexError from '../../domain/errors/IndexError.ts';
 import { collectAsyncIterable } from '../../domain/utils/streamUtils.ts';
 import computeShardKey from '../../domain/utils/shardKey.ts';
 import { materializationPropertyShardKey } from '../../domain/materialization/MaterializationPropertyProfile.ts';
 import { validateBoundedCbor } from './BoundedCborValidation.ts';
 import { decodeRoutedPropertyShardArtifact } from '../../domain/services/index/PropertyIndexReader.ts';
+import { writeCborIndexShards } from './CborIndexShardWriter.ts';
+import {
+  invalidLimit,
+  optionalPositiveInteger,
+  requiredNonNegativeInteger,
+  requiredPositiveInteger,
+} from './IndexShardLimitValidation.ts';
 
 export type GitCasIndexFacade = {
   readonly bundles: Pick<BundleCapability, 'getMember' | 'putOrdered' | 'iterateMembers'>;
+  readonly pages: Pick<PageCapability, 'get' | 'put'>;
 };
-
-type ValidatedIndexShardWriteLimits = Readonly<{
-  expectedShardCount: number | undefined;
-  maxShardBytes: number | undefined;
-  maxShardCount: number | undefined;
-}>;
 
 function classifyMeta(match: RegExpMatchArray, data: unknown): MetaShard {
   const d = data as { nodeToGlobal: Array<[string, number]>; nextLocalId: number; alive: Uint8Array };
@@ -100,9 +101,10 @@ const SHARD_CLASSIFIERS: ReadonlyArray<{ pattern: RegExp; classify: (match: RegE
  *
  * Owns the codec while configured asset and bundle capabilities own
  * persistence. Domain services produce IndexShard streams; the adapter
- * encodes and stages assets, then assembles their opaque handles into
- * ordered bundles. On read, the adapter decodes assets and
- * constructs IndexShard subclass instances.
+ * encodes and stages immutable members, then assembles their opaque handles
+ * into ordered bundles. General indexes use assets; bounded exact-read roots
+ * may use pages to avoid creating an asset manifest per shard. On read, the
+ * adapter decodes members and constructs IndexShard subclass instances.
  *
  * Write pipeline reuses existing infrastructure transforms:
  *   WarpStream<IndexShard>
@@ -133,29 +135,13 @@ export class CborIndexStoreAdapter extends IndexStorePort {
     shardStream: WarpStream<IndexShard>,
     options: IndexShardWriteOptions = {},
   ): Promise<BundleHandle> {
-    const { expectedShardCount, maxShardBytes, maxShardCount } = validatedWriteLimits(options);
-    requireExpectedShardCountWithinLimit(expectedShardCount, maxShardCount);
-    const members: Array<[string, string]> = [];
-    const encoder = new IndexShardEncodeTransform(this._codec, {
-      ...(maxShardBytes === undefined ? {} : { maxBytes: maxShardBytes }),
+    return await writeCborIndexShards({
+      shardStream,
+      options,
+      codec: this._codec,
+      assets: this._assets,
+      cas: this._cas,
     });
-    for await (const [path, bytes] of shardStream.pipe(encoder)) {
-      requireShardCountWithinLimit(members.length + 1, maxShardCount);
-      requireShardSize(path, bytes.byteLength, maxShardBytes);
-      const staged = await this._assets.stage(WarpStream.from([bytes]), {
-        slug: `index-shard-${path}`,
-        filename: path,
-        expectedSize: bytes.byteLength,
-      });
-      members.push([path, staged.handle.toString()]);
-    }
-    requireExpectedShardCount(members.length, expectedShardCount);
-    members.sort(([left], [right]) => compareStrings(left, right));
-    const bundle = await this._cas.bundles.putOrdered({
-      members,
-      ...(maxShardCount === undefined ? {} : { limits: { maxMembers: maxShardCount } }),
-    });
-    return new BundleHandle(bundle.handle.toString());
   }
 
   override scanShards(indexHandle: BundleHandle): WarpStream<IndexShard> {
@@ -227,6 +213,52 @@ export class CborIndexStoreAdapter extends IndexStorePort {
     validateRequestedStructure(bytes, options);
     return this._codec.decode<TDecoded>(bytes);
   }
+
+  override async decodeShardAt<TDecoded extends CodecValue = CodecValue>(
+    indexHandle: BundleHandle,
+    path: string,
+    options: IndexShardDecodeOptions = {},
+  ): Promise<TDecoded | null> {
+    const member = await this._cas.bundles.getMember({
+      handle: indexHandle.toString(),
+      path,
+    });
+    if (member === null) {
+      return null;
+    }
+    const maxBytes = optionalPositiveInteger(options.maxBytes, 'maxBytes');
+    const bytes = await readMemberBytes({
+      member,
+      path,
+      maxBytes,
+      cas: this._cas,
+      assets: this._assets,
+    });
+    validateRequestedStructure(bytes, options);
+    return this._codec.decode<TDecoded>(bytes);
+  }
+}
+
+async function readMemberBytes(args: {
+  member: BundleMember;
+  path: string;
+  maxBytes: number | undefined;
+  cas: GitCasIndexFacade;
+  assets: AssetStoragePort;
+}): Promise<Uint8Array> {
+  if (args.member.handle.kind === 'page') {
+    return await args.cas.pages.get({
+      handle: args.member.handle.toString(),
+      ...(args.maxBytes === undefined ? {} : { maxBytes: args.maxBytes }),
+    });
+  }
+  if (args.member.handle.kind !== 'asset') {
+    throw invalidBundleMember(args.path, args.member.handle.kind);
+  }
+  const source = args.assets.open(new AssetHandle(args.member.handle.toString()));
+  return args.maxBytes === undefined
+    ? await collectAsyncIterable(source)
+    : await collectBoundedShard(source, args.maxBytes);
 }
 
 async function collectBoundedShard(
@@ -280,10 +312,6 @@ function requireShardChunkCount(actual: number): void {
   }
 }
 
-function compareStrings(left: string, right: string): number {
-  return left < right ? -1 : left > right ? 1 : 0;
-}
-
 function validateRequestedStructure(
   bytes: Uint8Array,
   options: IndexShardDecodeOptions,
@@ -312,55 +340,6 @@ function validateRequestedStructure(
   });
 }
 
-function requireShardSize(path: string, actual: number, maximum: number | undefined): void {
-  if (maximum !== undefined && actual > maximum) {
-    throw new IndexError(`Index shard exceeds the configured maximum: ${path}`, {
-      code: 'E_INDEX_SHARD_TOO_LARGE',
-      context: { path, actual, maximum },
-    });
-  }
-}
-
-function validatedWriteLimits(
-  options: IndexShardWriteOptions,
-): ValidatedIndexShardWriteLimits {
-  const expectedShardCount = optionalNonNegativeInteger(
-    options.expectedShardCount,
-    'expectedShardCount',
-  );
-  const maxShardCount = optionalNonNegativeInteger(options.maxShardCount, 'maxShardCount');
-  const maxShardBytes = optionalPositiveInteger(options.maxShardBytes, 'maxShardBytes');
-  return Object.freeze({ expectedShardCount, maxShardBytes, maxShardCount });
-}
-
-function requireExpectedShardCountWithinLimit(
-  expected: number | undefined,
-  maximum: number | undefined,
-): void {
-  if (expected !== undefined) {
-    requireShardCountWithinLimit(expected, maximum);
-  }
-}
-
-function requireShardCountWithinLimit(actual: number, maximum: number | undefined): void {
-  if (maximum !== undefined && actual > maximum) {
-    throw shardCountError(actual, maximum, 'exceeds the configured maximum');
-  }
-}
-
-function requireExpectedShardCount(actual: number, expected: number | undefined): void {
-  if (expected !== undefined && actual !== expected) {
-    throw shardCountError(actual, expected, 'does not match the expected count');
-  }
-}
-
-function shardCountError(actual: number, maximum: number, reason: string): IndexError {
-  return new IndexError(`Index shard count ${reason}`, {
-    code: 'E_INDEX_SHARD_COUNT_LIMIT',
-    context: { actual, maximum },
-  });
-}
-
 function shardTooLarge(actual: number, maximum: number): IndexError {
   return new IndexError('Index shard exceeds the configured maximum', {
     code: 'E_INDEX_SHARD_TOO_LARGE',
@@ -368,57 +347,18 @@ function shardTooLarge(actual: number, maximum: number): IndexError {
   });
 }
 
-function optionalPositiveInteger(value: number | undefined, name: string): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (!Number.isSafeInteger(value) || value <= 0) {
-    throw invalidLimit(name);
-  }
-  return value;
-}
-
-function optionalNonNegativeInteger(value: number | undefined, name: string): number | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-  if (!Number.isSafeInteger(value) || value < 0) {
-    throw invalidLimit(name);
-  }
-  return value;
-}
-
-function requiredPositiveInteger(value: number | undefined, name: string): number {
-  const checked = optionalPositiveInteger(value, name);
-  if (checked === undefined) {
-    throw invalidLimit(name);
-  }
-  return checked;
-}
-
-function requiredNonNegativeInteger(value: number | undefined, name: string): number {
-  const checked = optionalNonNegativeInteger(value, name);
-  if (checked === undefined) {
-    throw invalidLimit(name);
-  }
-  return checked;
-}
-
-function invalidLimit(name: string): IndexError {
-  return new IndexError(`Index shard ${name} must be a safe integer within range`, {
-    code: 'E_INDEX_INVALID_LIMIT',
-    context: { name },
-  });
-}
-
 function requireAssetMember(path: string, kind: string, token: string): AssetHandle {
   if (kind !== 'asset') {
-    throw new IndexError(`Index bundle member is not an asset: ${path}`, {
-      code: 'E_INDEX_INVALID_BUNDLE_MEMBER',
-      context: { path, kind },
-    });
+    throw invalidBundleMember(path, kind);
   }
   return new AssetHandle(token);
+}
+
+function invalidBundleMember(path: string, kind: string): IndexError {
+  return new IndexError(`Index bundle member is not a readable shard: ${path}`, {
+    code: 'E_INDEX_INVALID_BUNDLE_MEMBER',
+    context: { path, kind },
+  });
 }
 
 function requireUniqueBundleMember(seenPaths: Set<string>, path: string): void {

--- a/src/infrastructure/adapters/CborIndexStoreAdapter.ts
+++ b/src/infrastructure/adapters/CborIndexStoreAdapter.ts
@@ -1,5 +1,8 @@
 import type { BundleCapability } from '@git-stunts/git-cas';
-import IndexStorePort from '../../ports/IndexStorePort.ts';
+import IndexStorePort, {
+  type IndexShardDecodeOptions,
+  type IndexShardWriteOptions,
+} from '../../ports/IndexStorePort.ts';
 import type AssetStoragePort from '../../ports/AssetStoragePort.ts';
 import type CodecPort from '../../ports/CodecPort.ts';
 import type CodecValue from '../../domain/types/codec/CodecValue.ts';
@@ -16,10 +19,20 @@ import AssetHandle from '../../domain/storage/AssetHandle.ts';
 import BundleHandle from '../../domain/storage/BundleHandle.ts';
 import IndexError from '../../domain/errors/IndexError.ts';
 import { collectAsyncIterable } from '../../domain/utils/streamUtils.ts';
+import computeShardKey from '../../domain/utils/shardKey.ts';
+import { materializationPropertyShardKey } from '../../domain/materialization/MaterializationPropertyProfile.ts';
+import { validateBoundedCbor } from './BoundedCborValidation.ts';
+import { decodeRoutedPropertyShardArtifact } from '../../domain/services/index/PropertyIndexReader.ts';
 
 export type GitCasIndexFacade = {
-  readonly bundles: Pick<BundleCapability, 'putOrdered' | 'iterateMembers'>;
+  readonly bundles: Pick<BundleCapability, 'getMember' | 'putOrdered' | 'iterateMembers'>;
 };
+
+type ValidatedIndexShardWriteLimits = Readonly<{
+  expectedShardCount: number | undefined;
+  maxShardBytes: number | undefined;
+  maxShardCount: number | undefined;
+}>;
 
 function classifyMeta(match: RegExpMatchArray, data: unknown): MetaShard {
   const d = data as { nodeToGlobal: Array<[string, number]>; nextLocalId: number; alive: Uint8Array };
@@ -46,9 +59,21 @@ function classifyLabel(_match: RegExpMatchArray, data: unknown): LabelShard {
 }
 
 function classifyProperty(match: RegExpMatchArray, data: unknown): PropertyShard {
+  const path = match[0];
+  const decoded = decodeRoutedPropertyShardArtifact(
+    data as CodecValue, // nosemgrep: ts-no-unsafe-type-assertion -- validated by decoder
+    path,
+    (nodeId, schemaVersion) => schemaVersion === 2
+      ? materializationPropertyShardKey(nodeId)
+      : computeShardKey(nodeId),
+  );
   return new PropertyShard({
     shardKey: match[1] as string,
-    entries: data as Array<[string, Record<string, unknown>]>,
+    schemaVersion: decoded.schemaVersion,
+    entries: Array.from(
+      decoded.entries,
+      ([nodeId, properties]): [string, Record<string, unknown>] => [nodeId, properties],
+    ),
   });
 }
 
@@ -104,9 +129,19 @@ export class CborIndexStoreAdapter extends IndexStorePort {
     this._cas = cas;
   }
 
-  override async writeShards(shardStream: WarpStream<IndexShard>): Promise<BundleHandle> {
+  override async writeShards(
+    shardStream: WarpStream<IndexShard>,
+    options: IndexShardWriteOptions = {},
+  ): Promise<BundleHandle> {
+    const { expectedShardCount, maxShardBytes, maxShardCount } = validatedWriteLimits(options);
+    requireExpectedShardCountWithinLimit(expectedShardCount, maxShardCount);
     const members: Array<[string, string]> = [];
-    for await (const [path, bytes] of shardStream.pipe(new IndexShardEncodeTransform(this._codec))) {
+    const encoder = new IndexShardEncodeTransform(this._codec, {
+      ...(maxShardBytes === undefined ? {} : { maxBytes: maxShardBytes }),
+    });
+    for await (const [path, bytes] of shardStream.pipe(encoder)) {
+      requireShardCountWithinLimit(members.length + 1, maxShardCount);
+      requireShardSize(path, bytes.byteLength, maxShardBytes);
       const staged = await this._assets.stage(WarpStream.from([bytes]), {
         slug: `index-shard-${path}`,
         filename: path,
@@ -114,8 +149,12 @@ export class CborIndexStoreAdapter extends IndexStorePort {
       });
       members.push([path, staged.handle.toString()]);
     }
-    members.sort(([left], [right]) => left.localeCompare(right));
-    const bundle = await this._cas.bundles.putOrdered({ members });
+    requireExpectedShardCount(members.length, expectedShardCount);
+    members.sort(([left], [right]) => compareStrings(left, right));
+    const bundle = await this._cas.bundles.putOrdered({
+      members,
+      ...(maxShardCount === undefined ? {} : { limits: { maxMembers: maxShardCount } }),
+    });
     return new BundleHandle(bundle.handle.toString());
   }
 
@@ -160,16 +199,216 @@ export class CborIndexStoreAdapter extends IndexStorePort {
     return Object.freeze(Object.fromEntries(entries));
   }
 
+  override async readShardHandle(
+    indexHandle: BundleHandle,
+    path: string,
+  ): Promise<AssetHandle | null> {
+    const member = await this._cas.bundles.getMember({
+      handle: indexHandle.toString(),
+      path,
+    });
+    return member === null
+      ? null
+      : requireAssetMember(path, member.handle.kind, member.handle.toString());
+  }
+
   override openShard(shardHandle: AssetHandle): AsyncIterable<Uint8Array> {
     return this._assets.open(shardHandle);
   }
 
   override async decodeShard<TDecoded extends CodecValue = CodecValue>(
     shardHandle: AssetHandle,
+    options: IndexShardDecodeOptions = {},
   ): Promise<TDecoded> {
-    const bytes = await collectAsyncIterable(this._assets.open(shardHandle));
+    const maxBytes = optionalPositiveInteger(options.maxBytes, 'maxBytes');
+    const bytes = maxBytes === undefined
+      ? await collectAsyncIterable(this._assets.open(shardHandle))
+      : await collectBoundedShard(this._assets.open(shardHandle), maxBytes);
+    validateRequestedStructure(bytes, options);
     return this._codec.decode<TDecoded>(bytes);
   }
+}
+
+async function collectBoundedShard(
+  source: AsyncIterable<Uint8Array>,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for await (const chunk of source) {
+    total = appendBoundedShardChunk(chunks, chunk, { total, maxBytes });
+  }
+  return joinShardChunks(chunks, total);
+}
+
+function appendBoundedShardChunk(
+  chunks: Uint8Array[],
+  chunk: Uint8Array,
+  bounds: { readonly total: number; readonly maxBytes: number },
+): number {
+  if (chunk.byteLength === 0) {
+    return bounds.total;
+  }
+  if (chunk.byteLength > bounds.maxBytes - bounds.total) {
+    throw shardTooLarge(bounds.total + chunk.byteLength, bounds.maxBytes);
+  }
+  requireShardChunkCount(chunks.length + 1);
+  chunks.push(chunk);
+  return bounds.total + chunk.byteLength;
+}
+
+function joinShardChunks(chunks: Uint8Array[], total: number): Uint8Array {
+  if (chunks.length === 1) {
+    return chunks[0]!;
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+function requireShardChunkCount(actual: number): void {
+  const maximum = 4096;
+  if (actual > maximum) {
+    throw new IndexError('Index shard stream exceeds the configured chunk maximum', {
+      code: 'E_INDEX_SHARD_CHUNK_LIMIT',
+      context: { actual, maximum },
+    });
+  }
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function validateRequestedStructure(
+  bytes: Uint8Array,
+  options: IndexShardDecodeOptions,
+): void {
+  const configured = [
+    options.maxContainerEntries,
+    options.maxDepth,
+    options.maxItems,
+  ].filter((value) => value !== undefined).length;
+  if (configured === 0) {
+    return;
+  }
+  if (configured !== 3) {
+    throw invalidLimit('CBOR structure limits');
+  }
+  const maxContainerEntries = requiredPositiveInteger(
+    options.maxContainerEntries,
+    'maxContainerEntries',
+  );
+  const maxDepth = requiredNonNegativeInteger(options.maxDepth, 'maxDepth');
+  const maxItems = requiredPositiveInteger(options.maxItems, 'maxItems');
+  validateBoundedCbor(bytes, {
+    maxContainerEntries,
+    maxDepth,
+    maxItems,
+  });
+}
+
+function requireShardSize(path: string, actual: number, maximum: number | undefined): void {
+  if (maximum !== undefined && actual > maximum) {
+    throw new IndexError(`Index shard exceeds the configured maximum: ${path}`, {
+      code: 'E_INDEX_SHARD_TOO_LARGE',
+      context: { path, actual, maximum },
+    });
+  }
+}
+
+function validatedWriteLimits(
+  options: IndexShardWriteOptions,
+): ValidatedIndexShardWriteLimits {
+  const expectedShardCount = optionalNonNegativeInteger(
+    options.expectedShardCount,
+    'expectedShardCount',
+  );
+  const maxShardCount = optionalNonNegativeInteger(options.maxShardCount, 'maxShardCount');
+  const maxShardBytes = optionalPositiveInteger(options.maxShardBytes, 'maxShardBytes');
+  return Object.freeze({ expectedShardCount, maxShardBytes, maxShardCount });
+}
+
+function requireExpectedShardCountWithinLimit(
+  expected: number | undefined,
+  maximum: number | undefined,
+): void {
+  if (expected !== undefined) {
+    requireShardCountWithinLimit(expected, maximum);
+  }
+}
+
+function requireShardCountWithinLimit(actual: number, maximum: number | undefined): void {
+  if (maximum !== undefined && actual > maximum) {
+    throw shardCountError(actual, maximum, 'exceeds the configured maximum');
+  }
+}
+
+function requireExpectedShardCount(actual: number, expected: number | undefined): void {
+  if (expected !== undefined && actual !== expected) {
+    throw shardCountError(actual, expected, 'does not match the expected count');
+  }
+}
+
+function shardCountError(actual: number, maximum: number, reason: string): IndexError {
+  return new IndexError(`Index shard count ${reason}`, {
+    code: 'E_INDEX_SHARD_COUNT_LIMIT',
+    context: { actual, maximum },
+  });
+}
+
+function shardTooLarge(actual: number, maximum: number): IndexError {
+  return new IndexError('Index shard exceeds the configured maximum', {
+    code: 'E_INDEX_SHARD_TOO_LARGE',
+    context: { actual, maximum },
+  });
+}
+
+function optionalPositiveInteger(value: number | undefined, name: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw invalidLimit(name);
+  }
+  return value;
+}
+
+function optionalNonNegativeInteger(value: number | undefined, name: string): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw invalidLimit(name);
+  }
+  return value;
+}
+
+function requiredPositiveInteger(value: number | undefined, name: string): number {
+  const checked = optionalPositiveInteger(value, name);
+  if (checked === undefined) {
+    throw invalidLimit(name);
+  }
+  return checked;
+}
+
+function requiredNonNegativeInteger(value: number | undefined, name: string): number {
+  const checked = optionalNonNegativeInteger(value, name);
+  if (checked === undefined) {
+    throw invalidLimit(name);
+  }
+  return checked;
+}
+
+function invalidLimit(name: string): IndexError {
+  return new IndexError(`Index shard ${name} must be a safe integer within range`, {
+    code: 'E_INDEX_INVALID_LIMIT',
+    context: { name },
+  });
 }
 
 function requireAssetMember(path: string, kind: string, token: string): AssetHandle {

--- a/src/infrastructure/adapters/CborIndexStoreAdapter.ts
+++ b/src/infrastructure/adapters/CborIndexStoreAdapter.ts
@@ -271,8 +271,11 @@ async function collectBoundedShard(
   maxBytes: number,
 ): Promise<Uint8Array> {
   const chunks: Uint8Array[] = [];
+  let chunkCount = 0;
   let total = 0;
   for await (const chunk of source) {
+    chunkCount += 1;
+    requireShardChunkCount(chunkCount);
     total = appendBoundedShardChunk(chunks, chunk, { total, maxBytes });
   }
   return joinShardChunks(chunks, total);
@@ -289,7 +292,6 @@ function appendBoundedShardChunk(
   if (chunk.byteLength > bounds.maxBytes - bounds.total) {
     throw shardTooLarge(bounds.total + chunk.byteLength, bounds.maxBytes);
   }
-  requireShardChunkCount(chunks.length + 1);
   chunks.push(chunk);
   return bounds.total + chunk.byteLength;
 }
@@ -321,7 +323,7 @@ function validateRequestedStructure(
   bytes: Uint8Array,
   options: IndexShardDecodeOptions,
 ): void {
-  const limits = optionalCborStructureLimits(options);
+  const limits = optionalCborStructureLimits(options.structureLimits);
   if (limits !== undefined) {
     validateBoundedCbor(bytes, limits);
   }

--- a/src/infrastructure/adapters/CborIndexStoreAdapter.ts
+++ b/src/infrastructure/adapters/CborIndexStoreAdapter.ts
@@ -1,4 +1,8 @@
-import type { BundleCapability, BundleMember, PageCapability } from '@git-stunts/git-cas';
+import type {
+  BundleCapability,
+  BundleMemberReference,
+  PageCapability,
+} from '@git-stunts/git-cas';
 import IndexStorePort, {
   type IndexShardDecodeOptions,
   type IndexShardWriteOptions,
@@ -31,7 +35,10 @@ import {
 } from './IndexShardLimitValidation.ts';
 
 export type GitCasIndexFacade = {
-  readonly bundles: Pick<BundleCapability, 'getMember' | 'putOrdered' | 'iterateMembers'>;
+  readonly bundles: Pick<
+    BundleCapability,
+    'getMemberReference' | 'putOrdered' | 'iterateMemberReferences'
+  >;
   readonly pages: Pick<PageCapability, 'get' | 'put'>;
 };
 
@@ -148,7 +155,7 @@ export class CborIndexStoreAdapter extends IndexStorePort {
     const adapter = this;
     return WarpStream.from((async function* () {
       const seenPaths = new Set<string>();
-      for await (const member of adapter._cas.bundles.iterateMembers({
+      for await (const member of adapter._cas.bundles.iterateMemberReferences({
         handle: indexHandle.toString(),
       })) {
         requireUniqueBundleMember(seenPaths, member.path);
@@ -173,7 +180,7 @@ export class CborIndexStoreAdapter extends IndexStorePort {
   ): Promise<Readonly<Record<string, AssetHandle>>> {
     const entries: Array<[string, AssetHandle]> = [];
     const seenPaths = new Set<string>();
-    for await (const member of this._cas.bundles.iterateMembers({
+    for await (const member of this._cas.bundles.iterateMemberReferences({
       handle: indexHandle.toString(),
     })) {
       requireUniqueBundleMember(seenPaths, member.path);
@@ -189,7 +196,7 @@ export class CborIndexStoreAdapter extends IndexStorePort {
     indexHandle: BundleHandle,
     path: string,
   ): Promise<AssetHandle | null> {
-    const member = await this._cas.bundles.getMember({
+    const member = await this._cas.bundles.getMemberReference({
       handle: indexHandle.toString(),
       path,
     });
@@ -219,7 +226,7 @@ export class CborIndexStoreAdapter extends IndexStorePort {
     path: string,
     options: IndexShardDecodeOptions = {},
   ): Promise<TDecoded | null> {
-    const member = await this._cas.bundles.getMember({
+    const member = await this._cas.bundles.getMemberReference({
       handle: indexHandle.toString(),
       path,
     });
@@ -240,7 +247,7 @@ export class CborIndexStoreAdapter extends IndexStorePort {
 }
 
 async function readMemberBytes(args: {
-  member: BundleMember;
+  member: BundleMemberReference;
   path: string;
   maxBytes: number | undefined;
   cas: GitCasIndexFacade;

--- a/src/infrastructure/adapters/GitCasMaterializationBundle.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationBundle.ts
@@ -1,6 +1,6 @@
 import type {
-  BundleMember,
   BundleMemberInput,
+  BundleMemberReference,
   PageHandle,
 } from '@git-stunts/git-cas';
 import WarpError from '../../domain/errors/WarpError.ts';
@@ -39,7 +39,7 @@ export function* materializationMembers(
 }
 
 export async function decodeMaterializationMembers(
-  members: AsyncIterable<BundleMember>,
+  members: AsyncIterable<BundleMemberReference>,
 ): Promise<DecodedMaterializationMembers> {
   const accumulator = createMemberAccumulator();
   for await (const member of members) {
@@ -58,7 +58,7 @@ function createMemberAccumulator(): MaterializationMemberAccumulator {
 
 function collectMaterializationMember(
   accumulator: MaterializationMemberAccumulator,
-  member: BundleMember,
+  member: BundleMemberReference,
 ): void {
   accumulator.memberCount += 1;
   if (accumulator.memberCount > MATERIALIZATION_MEMBER_COUNT) {
@@ -73,7 +73,7 @@ function collectMaterializationMember(
 
 function collectDescriptorMember(
   accumulator: MaterializationMemberAccumulator,
-  member: BundleMember,
+  member: BundleMemberReference,
 ): void {
   if (accumulator.descriptor !== null) {
     throw storageError('materialization bundle has duplicate descriptor members');
@@ -86,7 +86,7 @@ function collectDescriptorMember(
 
 function collectRootMember(
   accumulator: MaterializationMemberAccumulator,
-  member: BundleMember,
+  member: BundleMemberReference,
 ): void {
   const rootName = parseRootName(member.path);
   if (rootName === null) {

--- a/src/infrastructure/adapters/GitCasMaterializationBundle.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationBundle.ts
@@ -1,0 +1,137 @@
+import type {
+  BundleMember,
+  BundleMemberInput,
+  PageHandle,
+} from '@git-stunts/git-cas';
+import WarpError from '../../domain/errors/WarpError.ts';
+import type MaterializationRoot from '../../domain/materialization/MaterializationRoot.ts';
+import {
+  MATERIALIZATION_ROOT_NAMES,
+  type default as MaterializationRoots,
+  type MaterializationRootName,
+} from '../../domain/materialization/MaterializationRoots.ts';
+import BundleHandle from '../../domain/storage/BundleHandle.ts';
+
+const DESCRIPTOR_PATH = 'meta/descriptor';
+const MATERIALIZATION_MEMBER_COUNT = MATERIALIZATION_ROOT_NAMES.length + 1;
+
+export type DecodedMaterializationMembers = Readonly<{
+  descriptor: PageHandle;
+  retainedRoots: ReadonlyMap<MaterializationRootName, BundleHandle>;
+}>;
+
+type MaterializationMemberAccumulator = {
+  descriptor: PageHandle | null;
+  memberCount: number;
+  roots: Map<MaterializationRootName, BundleHandle>;
+};
+
+export function* materializationMembers(
+  descriptorHandle: string,
+  roots: MaterializationRoots,
+): Generator<[string, BundleMemberInput]> {
+  yield [DESCRIPTOR_PATH, descriptorHandle];
+  for (const [name, root] of roots.entries()) {
+    if (root.status === 'retained') {
+      yield [`roots/${name}`, requireRetainedHandle(root, name).toString()];
+    }
+  }
+}
+
+export async function decodeMaterializationMembers(
+  members: AsyncIterable<BundleMember>,
+): Promise<DecodedMaterializationMembers> {
+  const accumulator = createMemberAccumulator();
+  for await (const member of members) {
+    collectMaterializationMember(accumulator, member);
+  }
+  return finishMaterializationMembers(accumulator);
+}
+
+function createMemberAccumulator(): MaterializationMemberAccumulator {
+  return {
+    descriptor: null,
+    memberCount: 0,
+    roots: new Map<MaterializationRootName, BundleHandle>(),
+  };
+}
+
+function collectMaterializationMember(
+  accumulator: MaterializationMemberAccumulator,
+  member: BundleMember,
+): void {
+  accumulator.memberCount += 1;
+  if (accumulator.memberCount > MATERIALIZATION_MEMBER_COUNT) {
+    throw storageError('materialization bundle has too many members');
+  }
+  if (member.path === DESCRIPTOR_PATH) {
+    collectDescriptorMember(accumulator, member);
+    return;
+  }
+  collectRootMember(accumulator, member);
+}
+
+function collectDescriptorMember(
+  accumulator: MaterializationMemberAccumulator,
+  member: BundleMember,
+): void {
+  if (accumulator.descriptor !== null) {
+    throw storageError('materialization bundle has duplicate descriptor members');
+  }
+  if (member.handle.kind !== 'page') {
+    throw storageError('materialization bundle has no descriptor page');
+  }
+  accumulator.descriptor = member.handle;
+}
+
+function collectRootMember(
+  accumulator: MaterializationMemberAccumulator,
+  member: BundleMember,
+): void {
+  const rootName = parseRootName(member.path);
+  if (rootName === null) {
+    throw storageError(`materialization bundle has an unexpected member: ${member.path}`);
+  }
+  if (accumulator.roots.has(rootName)) {
+    throw storageError(`materialization bundle has duplicate ${rootName} root members`);
+  }
+  if (member.handle.kind !== 'bundle') {
+    throw storageError(`materialization bundle has no ${rootName} root bundle`);
+  }
+  accumulator.roots.set(rootName, new BundleHandle(member.handle.toString()));
+}
+
+function finishMaterializationMembers(
+  accumulator: MaterializationMemberAccumulator,
+): DecodedMaterializationMembers {
+  if (accumulator.descriptor === null) {
+    throw storageError('materialization bundle has no descriptor page');
+  }
+  return Object.freeze({
+    descriptor: accumulator.descriptor,
+    retainedRoots: new Map(accumulator.roots),
+  });
+}
+
+function requireRetainedHandle(
+  root: MaterializationRoot,
+  name: MaterializationRootName,
+): BundleHandle {
+  if (root.handle === null) {
+    throw storageError(`${name} retained root has no bundle handle`);
+  }
+  return root.handle;
+}
+
+function parseRootName(path: string): MaterializationRootName | null {
+  const prefix = 'roots/';
+  if (!path.startsWith(prefix)) {
+    return null;
+  }
+  const candidate = path.slice(prefix.length);
+  return MATERIALIZATION_ROOT_NAMES.find((name) => name === candidate) ?? null;
+}
+
+function storageError(message: string): WarpError {
+  return new WarpError(`Materialization storage ${message}`, 'E_MATERIALIZATION_STORAGE');
+}

--- a/src/infrastructure/adapters/GitCasMaterializationDescriptor.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationDescriptor.ts
@@ -9,7 +9,7 @@ import MaterializationRoots, {
 import type BundleHandle from '../../domain/storage/BundleHandle.ts';
 import WarpError from '../../domain/errors/WarpError.ts';
 
-export const MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION = 2;
+export const MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION = 3;
 
 export type DecodedMaterializationDescriptor = Readonly<{
   coordinate: MaterializationCoordinate;
@@ -121,7 +121,16 @@ function decodeRootStatuses(
   for (const name of MATERIALIZATION_ROOT_NAMES) {
     requireRootStatus(statuses, name);
   }
+  requireCurrentPropertyRoot(statuses);
   return statuses;
+}
+
+function requireCurrentPropertyRoot(
+  statuses: ReadonlyMap<MaterializationRootName, MaterializationRootStatus>,
+): void {
+  if (statuses.get('properties') === 'unavailable') {
+    throw descriptorError('current materialization descriptor requires a property root');
+  }
 }
 
 function decodeRootStatusEntry(

--- a/src/infrastructure/adapters/GitCasMaterializationLease.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationLease.ts
@@ -39,8 +39,9 @@ export default class GitCasMaterializationLease {
         }
         released = true;
         this.#borrowers -= 1;
+        const completedLease = this.#borrowers === 0;
         this.#releaseIfReady();
-        if (this.#retirement !== null) {
+        if (completedLease && this.#retirement !== null) {
           await this.#retirement.promise;
         }
       },

--- a/src/infrastructure/adapters/GitCasMaterializationLease.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationLease.ts
@@ -1,0 +1,75 @@
+import type { CacheAcquisition } from '@git-stunts/git-cas';
+import WarpError from '../../domain/errors/WarpError.ts';
+import type MaterializationCoordinate from '../../domain/materialization/MaterializationCoordinate.ts';
+import type MaterializationHandle from '../../domain/materialization/MaterializationHandle.ts';
+import type { MaterializationAcquisition } from '../../ports/MaterializationStorePort.ts';
+
+/** One runtime-owned git-cas acquisition with operation-scoped borrows. */
+export default class GitCasMaterializationLease {
+  readonly coordinate: MaterializationCoordinate;
+  readonly #acquisition: CacheAcquisition;
+  readonly #materialization: MaterializationHandle;
+  #borrowers = 0;
+  #retired = false;
+  #releasing = false;
+  #retirement: PromiseWithResolvers<void> | null = null;
+
+  constructor(options: Readonly<{
+    acquisition: CacheAcquisition;
+    coordinate: MaterializationCoordinate;
+    materialization: MaterializationHandle;
+  }>) {
+    this.#acquisition = options.acquisition;
+    this.coordinate = options.coordinate;
+    this.#materialization = options.materialization;
+  }
+
+  acquire(): MaterializationAcquisition {
+    if (this.#retired) {
+      throw leaseError('retired lease cannot be acquired');
+    }
+    this.#borrowers += 1;
+    let released = false;
+    return Object.freeze({
+      materialization: this.#materialization,
+      acquiredAt: this.#acquisition.acquiredAt,
+      release: async () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        this.#borrowers -= 1;
+        this.#releaseIfReady();
+        if (this.#retirement !== null) {
+          await this.#retirement.promise;
+        }
+      },
+    });
+  }
+
+  retire(): Promise<void> {
+    this.#retired = true;
+    this.#retirement ??= Promise.withResolvers<void>();
+    this.#releaseIfReady();
+    return this.#retirement.promise;
+  }
+
+  #releaseIfReady(): void {
+    if (!this.#retired || this.#borrowers !== 0 || this.#releasing) {
+      return;
+    }
+    const retirement = this.#retirement;
+    if (retirement === null) {
+      throw leaseError('retired lease is missing its completion');
+    }
+    this.#releasing = true;
+    void this.#acquisition.release().then(
+      () => retirement.resolve(),
+      retirement.reject,
+    );
+  }
+}
+
+function leaseError(message: string): WarpError {
+  return new WarpError(`Git-cas materialization ${message}`, 'E_MATERIALIZATION_STORAGE');
+}

--- a/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
@@ -41,10 +41,12 @@ const CACHE_NAMESPACE = 'git-warp/materializations';
 const WORKSPACE_CACHE_NAMESPACE = 'git-warp/materialization-workspaces';
 const DESCRIPTOR_PATH = 'meta/descriptor';
 const MAX_DESCRIPTOR_BYTES = 1024 * 1024;
+const LEGACY_MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION = 2;
 // A root-list change also requires a descriptor schema-version change.
 const MATERIALIZATION_MEMBER_COUNT = MATERIALIZATION_ROOT_NAMES.length + 1;
 
 type MaterializationCacheSet = Pick<CacheSet, 'acquire' | 'put' | 'remove'>;
+type MaterializationCachePut = Awaited<ReturnType<MaterializationCacheSet['put']>>;
 
 export type GitCasMaterializationFacade = {
   readonly bundles: Pick<BundleCapability, 'iterateMembers' | 'putOrdered'>;
@@ -150,14 +152,20 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
   ): Promise<StorageRetentionWitness> {
     const cache = await this.#cas.caches.open({ namespace: CACHE_NAMESPACE });
     const cacheKey = await this.#cacheKey(coordinate);
+    const expectedHandle = bundle.handle.toString();
     const stored = await cache.put(cacheKey, bundle.handle, { retention: 'evictable' });
-    if (!stored.accepted || stored.hit === null || stored.witness === null) {
-      throw storageError('git-cas did not retain the materialization bundle');
+    const retention = requireStoredMaterialization(stored, expectedHandle);
+    const acquisition = await cache.acquire(cacheKey);
+    if (acquisition === null) {
+      throw storageError('git-cas lost the retained materialization before legacy cleanup');
     }
-    if (stored.hit.handle.toString() !== bundle.handle.toString()) {
-      throw storageError('git-cas retained an unexpected materialization handle');
+    try {
+      requireExpectedAcquisition(acquisition, expectedHandle);
+      await this.#removeLegacyEntry(cache, coordinate);
+      return adaptGitCasRetentionWitness(retention.toJSON());
+    } finally {
+      await acquisition.release();
     }
-    return adaptGitCasRetentionWitness(stored.witness.toJSON());
   }
 
   override async acquireExact(
@@ -210,9 +218,12 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
     });
   }
 
-  async #cacheKey(coordinate: MaterializationCoordinate): Promise<string> {
+  async #cacheKey(
+    coordinate: MaterializationCoordinate,
+    schemaVersion = MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION,
+  ): Promise<string> {
     const encoded = this.#codec.encode({
-      schemaVersion: MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION,
+      schemaVersion,
       laneName: this.#laneName,
       coordinate: materializationCoordinateData(coordinate),
     });
@@ -220,7 +231,18 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
       await this.#crypto.hash('sha256', encoded),
       'coordinate digest',
     );
-    return `v${MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION}:${digest}`;
+    return `v${String(schemaVersion)}:${digest}`;
+  }
+
+  async #removeLegacyEntry(
+    cache: MaterializationCacheSet,
+    coordinate: MaterializationCoordinate,
+  ): Promise<void> {
+    const key = await this.#cacheKey(
+      coordinate,
+      LEGACY_MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION,
+    );
+    await cache.remove(key);
   }
 
   async #readDescriptor(handle: PageHandle): Promise<DecodedMaterializationDescriptor> {
@@ -352,6 +374,28 @@ function requireRetainedHandle(
   return root.handle;
 }
 
+function requireStoredMaterialization(
+  stored: MaterializationCachePut,
+  expectedHandle: string,
+): Exclude<MaterializationCachePut['witness'], null> {
+  if (!stored.accepted || stored.hit === null || stored.witness === null) {
+    throw storageError('git-cas did not retain the materialization bundle');
+  }
+  if (stored.hit.handle.toString() !== expectedHandle) {
+    throw storageError('git-cas retained an unexpected materialization handle');
+  }
+  return stored.witness;
+}
+
+function requireExpectedAcquisition(
+  acquisition: CacheAcquisition,
+  expectedHandle: string,
+): void {
+  if (acquisition.hit.handle.toString() !== expectedHandle) {
+    throw storageError('git-cas acquired an unexpected materialization before legacy cleanup');
+  }
+}
+
 function parseRootName(path: string): MaterializationRootName | null {
   const prefix = 'roots/';
   if (!path.startsWith(prefix)) {
@@ -368,6 +412,13 @@ function requireRetainRequest(request: RetainMaterializationRequest): void {
   requireCoordinate(request.coordinate);
   if (!(request.roots instanceof MaterializationRoots)) {
     throw storageError('retain request roots have an invalid runtime identity');
+  }
+  requireCurrentPropertyRoot(request.roots);
+}
+
+function requireCurrentPropertyRoot(roots: MaterializationRoots): void {
+  if (roots.properties.status === 'unavailable') {
+    throw storageError('current materialization profile requires a property root');
   }
 }
 

--- a/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
@@ -25,6 +25,7 @@ import { adaptGitCasRetentionWitness } from './GitCasRetentionWitnessAdapter.ts'
 import GitCasMaterializationWorkspace, {
   type GitCasStagingWorkspace,
 } from './GitCasMaterializationWorkspace.ts';
+import GitCasMaterializationLease from './GitCasMaterializationLease.ts';
 import {
   decodeMaterializationDescriptor,
   MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION,
@@ -49,7 +50,7 @@ type MaterializationCacheSet = Pick<CacheSet, 'acquire' | 'put' | 'remove' | 're
 type MaterializationCachePut = Awaited<ReturnType<MaterializationCacheSet['put']>>;
 
 export type GitCasMaterializationFacade = {
-  readonly bundles: Pick<BundleCapability, 'iterateMembers' | 'putOrdered'>;
+  readonly bundles: Pick<BundleCapability, 'iterateMemberReferences' | 'putOrdered'>;
   readonly caches: {
     open(options: { readonly namespace: string }): Promise<MaterializationCacheSet>;
   };
@@ -68,6 +69,12 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
   readonly #codec: CodecPort;
   readonly #crypto: CryptoPort;
   readonly #laneName: string;
+  #currentLease: GitCasMaterializationLease | null = null;
+  #leaseMutation: Promise<void> = Promise.resolve();
+  readonly #retirements = new Set<Promise<void>>();
+  #retirementFailure: Readonly<{ cause: unknown }> | null = null;
+  #closed = false;
+  #closePromise: Promise<void> | null = null;
 
   constructor(options: {
     readonly cas: GitCasMaterializationFacade;
@@ -203,6 +210,46 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
     coordinate: MaterializationCoordinate,
   ): Promise<MaterializationAcquisition | null> {
     requireCoordinate(coordinate);
+    return await this.#withLeaseMutation(
+      async () => await this.#acquireExactLocked(coordinate),
+    );
+  }
+
+  override close(): Promise<void> {
+    this.#closePromise ??= this.#close();
+    return this.#closePromise;
+  }
+
+  async #acquireExactLocked(
+    coordinate: MaterializationCoordinate,
+  ): Promise<MaterializationAcquisition | null> {
+    if (this.#closed) {
+      throw storageError('adapter is closed');
+    }
+    if (this.#currentLease?.coordinate.equals(coordinate) === true) {
+      return this.#currentLease.acquire();
+    }
+
+    const next = await this.#openLease(coordinate);
+    if (next === null) {
+      return null;
+    }
+    return this.#replaceCurrentLease(next);
+  }
+
+  #replaceCurrentLease(next: GitCasMaterializationLease): MaterializationAcquisition {
+    const previous = this.#currentLease;
+    this.#currentLease = next;
+    const acquisition = next.acquire();
+    if (previous !== null) {
+      this.#retireLease(previous);
+    }
+    return acquisition;
+  }
+
+  async #openLease(
+    coordinate: MaterializationCoordinate,
+  ): Promise<GitCasMaterializationLease | null> {
     const cache = await this.#cas.caches.open({ namespace: CACHE_NAMESPACE });
     const acquisition = await cache.acquire(await this.#cacheKey(coordinate));
     if (acquisition === null) {
@@ -217,10 +264,55 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
         acquisition.evidence,
         coordinate,
       );
-      return materializationAcquisition(acquisition, materialization);
+      return new GitCasMaterializationLease({
+        acquisition,
+        coordinate,
+        materialization,
+      });
     } catch (raw) {
       await releaseCacheAcquisitionAfterFailure(acquisition);
       throw raw;
+    }
+  }
+
+  async #close(): Promise<void> {
+    await this.#withLeaseMutation(() => {
+      this.#closed = true;
+      if (this.#currentLease !== null) {
+        this.#retireLease(this.#currentLease);
+        this.#currentLease = null;
+      }
+      return Promise.resolve();
+    });
+    await Promise.allSettled([...this.#retirements]);
+    if (this.#retirementFailure !== null) {
+      throw this.#retirementFailure.cause;
+    }
+  }
+
+  #retireLease(lease: GitCasMaterializationLease): void {
+    const retirement = lease.retire();
+    this.#retirements.add(retirement);
+    void retirement.then(
+      () => {
+        this.#retirements.delete(retirement);
+      },
+      (cause: unknown) => {
+        this.#retirements.delete(retirement);
+        this.#retirementFailure ??= Object.freeze({ cause });
+      },
+    );
+  }
+
+  async #withLeaseMutation<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.#leaseMutation;
+    const turn = Promise.withResolvers<void>();
+    this.#leaseMutation = turn.promise;
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      turn.resolve();
     }
   }
 
@@ -285,23 +377,10 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
   }
 
   async #readMembers(bundle: BundleHandle): Promise<DecodedMaterializationMembers> {
-    return await decodeMaterializationMembers(this.#cas.bundles.iterateMembers({
+    return await decodeMaterializationMembers(this.#cas.bundles.iterateMemberReferences({
       handle: bundle.toString(),
     }));
   }
-}
-
-function materializationAcquisition(
-  acquisition: CacheAcquisition,
-  materialization: MaterializationHandle,
-): MaterializationAcquisition {
-  return Object.freeze({
-    materialization,
-    acquiredAt: acquisition.acquiredAt,
-    release: async () => {
-      await acquisition.release();
-    },
-  });
 }
 
 async function releaseCacheAcquisitionAfterFailure(

--- a/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
@@ -1,21 +1,16 @@
 import type {
   BundleCapability,
-  BundleMember,
-  BundleMemberInput,
   CacheAcquisition,
   CacheHit,
   CacheSet,
   PageHandle,
   PageCapability,
-  StagedBundle,
+  WorkspaceRetainedBundle,
+  WorkspaceRetainedPage,
 } from '@git-stunts/git-cas';
 import MaterializationCoordinate from '../../domain/materialization/MaterializationCoordinate.ts';
 import MaterializationHandle from '../../domain/materialization/MaterializationHandle.ts';
-import type MaterializationRoot from '../../domain/materialization/MaterializationRoot.ts';
-import MaterializationRoots, {
-  MATERIALIZATION_ROOT_NAMES,
-  type MaterializationRootName,
-} from '../../domain/materialization/MaterializationRoots.ts';
+import MaterializationRoots from '../../domain/materialization/MaterializationRoots.ts';
 import BundleHandle from '../../domain/storage/BundleHandle.ts';
 import type StorageRetentionWitness from '../../domain/storage/StorageRetentionWitness.ts';
 import WarpError from '../../domain/errors/WarpError.ts';
@@ -27,7 +22,9 @@ import MaterializationStorePort, {
   type RetainMaterializationRequest,
 } from '../../ports/MaterializationStorePort.ts';
 import { adaptGitCasRetentionWitness } from './GitCasRetentionWitnessAdapter.ts';
-import GitCasMaterializationWorkspace from './GitCasMaterializationWorkspace.ts';
+import GitCasMaterializationWorkspace, {
+  type GitCasStagingWorkspace,
+} from './GitCasMaterializationWorkspace.ts';
 import {
   decodeMaterializationDescriptor,
   MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION,
@@ -36,16 +33,19 @@ import {
   materializationRootsFromDescriptor,
   type DecodedMaterializationDescriptor,
 } from './GitCasMaterializationDescriptor.ts';
+import {
+  decodeMaterializationMembers,
+  materializationMembers,
+  type DecodedMaterializationMembers,
+} from './GitCasMaterializationBundle.ts';
 
 const CACHE_NAMESPACE = 'git-warp/materializations';
-const WORKSPACE_CACHE_NAMESPACE = 'git-warp/materialization-workspaces';
-const DESCRIPTOR_PATH = 'meta/descriptor';
+const WORKSPACE_NAMESPACE = 'git-warp/materializations';
+const WORKSPACE_TTL_MS = 2 * 60 * 60 * 1000;
 const MAX_DESCRIPTOR_BYTES = 1024 * 1024;
 const LEGACY_MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION = 2;
-// A root-list change also requires a descriptor schema-version change.
-const MATERIALIZATION_MEMBER_COUNT = MATERIALIZATION_ROOT_NAMES.length + 1;
 
-type MaterializationCacheSet = Pick<CacheSet, 'acquire' | 'put' | 'remove'>;
+type MaterializationCacheSet = Pick<CacheSet, 'acquire' | 'put' | 'remove' | 'ref'>;
 type MaterializationCachePut = Awaited<ReturnType<MaterializationCacheSet['put']>>;
 
 export type GitCasMaterializationFacade = {
@@ -54,17 +54,12 @@ export type GitCasMaterializationFacade = {
     open(options: { readonly namespace: string }): Promise<MaterializationCacheSet>;
   };
   readonly pages: Pick<PageCapability, 'get' | 'put'>;
-};
-
-type DecodedMaterializationMembers = Readonly<{
-  descriptor: PageHandle;
-  retainedRoots: ReadonlyMap<MaterializationRootName, BundleHandle>;
-}>;
-
-type MaterializationMemberAccumulator = {
-  descriptor: PageHandle | null;
-  memberCount: number;
-  roots: Map<MaterializationRootName, BundleHandle>;
+  readonly workspaces: {
+    open(options: {
+      readonly namespace: string;
+      readonly ttlMs?: number;
+    }): Promise<GitCasStagingWorkspace>;
+  };
 };
 
 /** git-cas-backed retained materialization lifecycle. */
@@ -95,25 +90,43 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
     coordinate: MaterializationCoordinate,
   ): Promise<MaterializationWorkspacePort> {
     requireCoordinate(coordinate);
-    const cache = await this.#cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
+    const workspace = await this.#cas.workspaces.open({
+      namespace: WORKSPACE_NAMESPACE,
+      ttlMs: WORKSPACE_TTL_MS,
+    });
     return new GitCasMaterializationWorkspace({
-      bundles: this.#cas.bundles,
-      cache,
-      key: `workspace:${this.#laneName}:${globalThis.crypto.randomUUID()}`,
-      promote: async (request) => {
+      workspace,
+      promote: async (activeWorkspace, request) => {
         if (!request.coordinate.equals(coordinate)) {
           throw storageError('workspace promotion coordinate does not match its open coordinate');
         }
-        return await this.retain(request);
+        return await this.#promoteWorkspace(activeWorkspace, request);
       },
     });
   }
 
   override async retain(request: RetainMaterializationRequest): Promise<MaterializationHandle> {
     requireRetainRequest(request);
+    const workspace = await this.openWorkspace(request.coordinate);
+    try {
+      return await workspace.promote(request);
+    } finally {
+      await workspace.release();
+    }
+  }
+
+  async #promoteWorkspace(
+    workspace: GitCasStagingWorkspace,
+    request: RetainMaterializationRequest,
+  ): Promise<MaterializationHandle> {
+    requireRetainRequest(request);
     const stateHash = requireNonEmpty(request.stateHash, 'stateHash');
-    const bundle = await this.#writeBundle(request, stateHash);
-    const retention = await this.#retainBundle(bundle, request.coordinate);
+    const bundle = await this.#stageWorkspaceBundle(workspace, request, stateHash);
+    const retention = await this.#promoteWorkspaceBundle(
+      workspace,
+      bundle,
+      request.coordinate,
+    );
     return new MaterializationHandle({
       laneName: this.#laneName,
       bundle: new BundleHandle(bundle.handle.toString()),
@@ -124,10 +137,11 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
     });
   }
 
-  async #writeBundle(
+  async #stageWorkspaceBundle(
+    workspace: GitCasStagingWorkspace,
     request: RetainMaterializationRequest,
     stateHash: string,
-  ): Promise<StagedBundle> {
+  ): Promise<WorkspaceRetainedBundle> {
     const descriptorBytes = this.#codec.encode(materializationDescriptorData({
       coordinate: request.coordinate,
       stateHash,
@@ -136,33 +150,50 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
     }));
     requireDescriptorSize(descriptorBytes);
 
-    const descriptorPage = await this.#cas.pages.put({
+    const descriptorPage = await workspace.pages.put({
       source: descriptorBytes,
       maxBytes: MAX_DESCRIPTOR_BYTES,
     });
-    const bundle = await this.#cas.bundles.putOrdered({
+    requireWorkspaceStage(descriptorPage);
+    const bundle = await workspace.bundles.putOrdered({
       members: materializationMembers(descriptorPage.handle.toString(), request.roots),
     });
+    requireWorkspaceStage(bundle);
     return bundle;
   }
 
-  async #retainBundle(
-    bundle: StagedBundle,
+  async #promoteWorkspaceBundle(
+    workspace: GitCasStagingWorkspace,
+    bundle: WorkspaceRetainedBundle,
     coordinate: MaterializationCoordinate,
   ): Promise<StorageRetentionWitness> {
     const cache = await this.#cas.caches.open({ namespace: CACHE_NAMESPACE });
     const cacheKey = await this.#cacheKey(coordinate);
     const expectedHandle = bundle.handle.toString();
-    const stored = await cache.put(cacheKey, bundle.handle, { retention: 'evictable' });
-    const retention = requireStoredMaterialization(stored, expectedHandle);
-    const acquisition = await cache.acquire(cacheKey);
+    const promoted = await workspace.promoteToCache({
+      cache,
+      key: cacheKey,
+      handle: bundle.handle,
+      options: { retention: 'evictable' },
+    });
+    const retention = requireStoredMaterialization(promoted.destination, expectedHandle);
+    await this.#cleanLegacyAfterPromotion({ cache, cacheKey, expectedHandle, coordinate });
+    return adaptGitCasRetentionWitness(retention.toJSON());
+  }
+
+  async #cleanLegacyAfterPromotion(args: {
+    cache: MaterializationCacheSet;
+    cacheKey: string;
+    expectedHandle: string;
+    coordinate: MaterializationCoordinate;
+  }): Promise<void> {
+    const acquisition = await args.cache.acquire(args.cacheKey);
     if (acquisition === null) {
       throw storageError('git-cas lost the retained materialization before legacy cleanup');
     }
     try {
-      requireExpectedAcquisition(acquisition, expectedHandle);
-      await this.#removeLegacyEntry(cache, coordinate);
-      return adaptGitCasRetentionWitness(retention.toJSON());
+      requireExpectedAcquisition(acquisition, args.expectedHandle);
+      await this.#removeLegacyEntry(args.cache, args.coordinate);
     } finally {
       await acquisition.release();
     }
@@ -254,13 +285,9 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
   }
 
   async #readMembers(bundle: BundleHandle): Promise<DecodedMaterializationMembers> {
-    const accumulator = createMemberAccumulator();
-    for await (const member of this.#cas.bundles.iterateMembers({
+    return await decodeMaterializationMembers(this.#cas.bundles.iterateMembers({
       handle: bundle.toString(),
-    })) {
-      collectMaterializationMember(accumulator, member);
-    }
-    return finishMaterializationMembers(accumulator);
+    }));
   }
 }
 
@@ -287,91 +314,20 @@ async function releaseCacheAcquisitionAfterFailure(
   }
 }
 
-function* materializationMembers(
-  descriptorHandle: string,
-  roots: MaterializationRoots,
-): Generator<[string, BundleMemberInput]> {
-  yield [DESCRIPTOR_PATH, descriptorHandle];
-  for (const [name, root] of roots.entries()) {
-    if (root.status === 'retained') {
-      yield [`roots/${name}`, requireRetainedHandle(root, name).toString()];
-    }
-  }
-}
-
-function createMemberAccumulator(): MaterializationMemberAccumulator {
-  return {
-    descriptor: null,
-    memberCount: 0,
-    roots: new Map<MaterializationRootName, BundleHandle>(),
-  };
-}
-
-function collectMaterializationMember(
-  accumulator: MaterializationMemberAccumulator,
-  member: BundleMember,
+function requireWorkspaceStage(
+  staged: WorkspaceRetainedPage | WorkspaceRetainedBundle,
 ): void {
-  accumulator.memberCount += 1;
-  if (accumulator.memberCount > MATERIALIZATION_MEMBER_COUNT) {
-    throw storageError('materialization bundle has too many members');
+  const valid = [
+    staged.state === 'retained',
+    staged.retention.policy === 'evictable',
+    staged.retention.reachability === 'anchored',
+    staged.retention.protection === 'workspace',
+    staged.witness.handle.toString() === staged.handle.toString(),
+    staged.witness.root.kind === 'root-set',
+  ];
+  if (valid.includes(false)) {
+    throw storageError('git-cas did not retain a staged materialization artifact');
   }
-  if (member.path === DESCRIPTOR_PATH) {
-    collectDescriptorMember(accumulator, member);
-    return;
-  }
-  collectRootMember(accumulator, member);
-}
-
-function collectDescriptorMember(
-  accumulator: MaterializationMemberAccumulator,
-  member: BundleMember,
-): void {
-  if (accumulator.descriptor !== null) {
-    throw storageError('materialization bundle has duplicate descriptor members');
-  }
-  if (member.handle.kind !== 'page') {
-    throw storageError('materialization bundle has no descriptor page');
-  }
-  accumulator.descriptor = member.handle;
-}
-
-function collectRootMember(
-  accumulator: MaterializationMemberAccumulator,
-  member: BundleMember,
-): void {
-  const rootName = parseRootName(member.path);
-  if (rootName === null) {
-    throw storageError(`materialization bundle has an unexpected member: ${member.path}`);
-  }
-  if (accumulator.roots.has(rootName)) {
-    throw storageError(`materialization bundle has duplicate ${rootName} root members`);
-  }
-  if (member.handle.kind !== 'bundle') {
-    throw storageError(`materialization bundle has no ${rootName} root bundle`);
-  }
-  accumulator.roots.set(rootName, new BundleHandle(member.handle.toString()));
-}
-
-function finishMaterializationMembers(
-  accumulator: MaterializationMemberAccumulator,
-): DecodedMaterializationMembers {
-  if (accumulator.descriptor === null) {
-    throw storageError('materialization bundle has no descriptor page');
-  }
-  return Object.freeze({
-    descriptor: accumulator.descriptor,
-    retainedRoots: new Map(accumulator.roots),
-  });
-}
-
-function requireRetainedHandle(
-  root: MaterializationRoot,
-  name: MaterializationRootName,
-): BundleHandle {
-  if (root.handle === null) {
-    throw storageError(`${name} retained root has no bundle handle`);
-  }
-  return root.handle;
 }
 
 function requireStoredMaterialization(
@@ -394,15 +350,6 @@ function requireExpectedAcquisition(
   if (acquisition.hit.handle.toString() !== expectedHandle) {
     throw storageError('git-cas acquired an unexpected materialization before legacy cleanup');
   }
-}
-
-function parseRootName(path: string): MaterializationRootName | null {
-  const prefix = 'roots/';
-  if (!path.startsWith(prefix)) {
-    return null;
-  }
-  const candidate = path.slice(prefix.length);
-  return MATERIALIZATION_ROOT_NAMES.find((name) => name === candidate) ?? null;
 }
 
 function requireRetainRequest(request: RetainMaterializationRequest): void {

--- a/src/infrastructure/adapters/GitCasMaterializationWorkspace.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationWorkspace.ts
@@ -255,6 +255,9 @@ function workspaceMembers(
   if (roots.nodeAliveRoot !== null) {
     members.push(['roots/node-alive', parseRoot(roots.nodeAliveRoot)]);
   }
+  if (roots.propertiesRoot !== undefined && roots.propertiesRoot !== null) {
+    members.push(['roots/properties', parseRoot(roots.propertiesRoot)]);
+  }
   return members;
 }
 

--- a/src/infrastructure/adapters/GitCasMaterializationWorkspace.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationWorkspace.ts
@@ -1,236 +1,146 @@
 import {
   BundleHandle as GitCasBundleHandle,
-  type BundleCapability,
-  type BundleMemberInput,
+  type ApplicationHandleInput,
   type CacheSet,
   type RetentionWitness,
+  type StagingWorkspace,
+  type WorkspaceCheckpointResult,
+  type WorkspaceRetainedBundle,
+  type WorkspaceRetainedPage,
 } from '@git-stunts/git-cas';
 import type MaterializationHandle from '../../domain/materialization/MaterializationHandle.ts';
+import BundleHandle from '../../domain/storage/BundleHandle.ts';
 import type StorageRetentionWitness from '../../domain/storage/StorageRetentionWitness.ts';
 import WarpError from '../../domain/errors/WarpError.ts';
+import type {
+  StagedBundleMember,
+  StageOrderedBundleOptions,
+  StagePageOptions,
+} from '../../ports/ArtifactStagingPort.ts';
 import MaterializationWorkspacePort, {
   type MaterializationWorkspaceRoots,
   type PromoteMaterializationRequest,
 } from '../../ports/MaterializationWorkspacePort.ts';
 import { adaptGitCasRetentionWitness } from './GitCasRetentionWitnessAdapter.ts';
 
-const WORKSPACE_TTL_MS = 2 * 60 * 60 * 1000;
-const WORKSPACE_RENEWAL_MS = WORKSPACE_TTL_MS / 2;
-
-type WorkspaceCache = Pick<CacheSet, 'put' | 'remove'>;
-type WorkspaceTarget = Parameters<WorkspaceCache['put']>[1];
-type ActiveLeaseTarget = Readonly<{
-  input: WorkspaceTarget;
-  token: string;
-}>;
-
-export type MaterializationWorkspaceLease = Readonly<{
-  cancel(): void;
-}>;
-
-export type MaterializationWorkspaceLeaseScheduler = Readonly<{
-  schedule(
-    task: () => Promise<void>,
-    delayMs: number,
-  ): MaterializationWorkspaceLease;
+export type GitCasStagingWorkspace = Pick<
+  StagingWorkspace,
+  'pages' | 'bundles' | 'checkpoint' | 'release'
+> & Readonly<{
+  promoteToCache(options: {
+    cache: Pick<CacheSet, 'ref' | 'put'>;
+    key: string;
+    handle: ApplicationHandleInput;
+    options?: Parameters<CacheSet['put']>[2];
+  }): ReturnType<StagingWorkspace['promoteToCache']>;
 }>;
 
 export type GitCasMaterializationWorkspaceOptions = Readonly<{
-  bundles: Pick<BundleCapability, 'putOrdered'>;
-  cache: WorkspaceCache;
-  key: string;
-  clock?: { readonly now: () => Date };
-  leaseTtlMs?: number;
-  leaseRenewalMs?: number;
-  leaseScheduler?: MaterializationWorkspaceLeaseScheduler;
-  promote: (request: PromoteMaterializationRequest) => Promise<MaterializationHandle>;
-}>;
-
-const SYSTEM_LEASE_SCHEDULER: MaterializationWorkspaceLeaseScheduler = Object.freeze({
-  schedule(task: () => Promise<void>, delayMs: number): MaterializationWorkspaceLease {
-    const timer = setTimeout(() => {
-      void task().catch(() => undefined);
-    }, delayMs);
-    timer.unref();
-    return Object.freeze({ cancel: () => clearTimeout(timer) });
-  },
-});
-
-/** CacheSet-backed reachability for one in-progress materialization. */
-export default class GitCasMaterializationWorkspace extends MaterializationWorkspacePort {
-  readonly #bundles: Pick<BundleCapability, 'putOrdered'>;
-  readonly #cache: WorkspaceCache;
-  readonly #clock: { readonly now: () => Date };
-  readonly #key: string;
-  readonly #leaseRenewalMs: number;
-  readonly #leaseScheduler: MaterializationWorkspaceLeaseScheduler;
-  readonly #leaseTtlMs: number;
-  readonly #promoteMaterialization: (
+  workspace: GitCasStagingWorkspace;
+  promote: (
+    workspace: GitCasStagingWorkspace,
     request: PromoteMaterializationRequest,
   ) => Promise<MaterializationHandle>;
-  #installationAttempted = false;
-  #leaseTarget: ActiveLeaseTarget | null = null;
-  #leaseFailure: WarpError | null = null;
-  #leaseTimer: MaterializationWorkspaceLease | null = null;
+}>;
+
+/** git-cas-owned retention scope for one in-progress materialization. */
+export default class GitCasMaterializationWorkspace extends MaterializationWorkspacePort {
+  readonly #workspace: GitCasStagingWorkspace;
+  readonly #promoteMaterialization: GitCasMaterializationWorkspaceOptions['promote'];
   #promoting = false;
-  #promotionDone: Promise<void> | null = null;
-  #releasePending = false;
+  #promoted = false;
   #releaseRequested = false;
   #released = false;
+  #releasePromise: Promise<void> | null = null;
   #tail: Promise<void> = Promise.resolve();
 
   constructor(options: GitCasMaterializationWorkspaceOptions) {
     super();
     requireWorkspaceOptions(options);
-    this.#bundles = options.bundles;
-    this.#cache = options.cache;
-    this.#key = requireNonEmpty(options.key, 'key');
-    this.#clock = options.clock ?? { now: () => new Date() };
-    this.#leaseTtlMs = options.leaseTtlMs ?? WORKSPACE_TTL_MS;
-    this.#leaseRenewalMs = options.leaseRenewalMs ?? WORKSPACE_RENEWAL_MS;
-    this.#leaseScheduler = options.leaseScheduler ?? SYSTEM_LEASE_SCHEDULER;
+    this.#workspace = options.workspace;
     this.#promoteMaterialization = options.promote;
+  }
+
+  override stagePage(
+    source: Uint8Array,
+    options: StagePageOptions,
+  ): Promise<string> {
+    this.#assertMutable('stage a page');
+    return this.#serialize(async () => {
+      const staged = await this.#workspace.pages.put({
+        source,
+        maxBytes: options.maxBytes,
+      });
+      requireRetainedStage(staged, staged.handle.toString());
+      return staged.handle.toString();
+    });
+  }
+
+  override stageOrderedBundle(
+    members: Iterable<StagedBundleMember>,
+    options: StageOrderedBundleOptions = {},
+  ): Promise<BundleHandle> {
+    this.#assertMutable('stage a bundle');
+    return this.#serialize(async () => {
+      const staged = await this.#workspace.bundles.putOrdered({
+        members,
+        ...(options.maxMembers === undefined
+          ? {}
+          : { limits: { maxMembers: options.maxMembers } }),
+      });
+      requireRetainedStage(staged, staged.handle.toString());
+      return new BundleHandle(staged.handle.toString());
+    });
   }
 
   override checkpoint(
     roots: MaterializationWorkspaceRoots,
   ): Promise<StorageRetentionWitness | null> {
-    if (this.#releasePending || this.#releaseRequested || this.#promoting) {
-      return Promise.reject(workspaceError('cannot checkpoint a releasing workspace'));
-    }
-    return this.#serialize(async () => await this.#checkpoint(roots));
-  }
-
-  override async release(): Promise<void> {
-    this.#releasePending = true;
-    await this.#promotionDone;
-    this.#releaseRequested = true;
-    this.#cancelLeaseTimer();
-    await this.#serialize(async () => await this.#release());
+    this.#assertMutable('checkpoint');
+    return this.#serialize(async () => {
+      const members = workspaceMembers(roots);
+      if (members.length === 0) {
+        return null;
+      }
+      const staged = await this.#workspace.bundles.putOrdered({ members });
+      requireRetainedStage(staged, staged.handle.toString());
+      const checkpoint = await this.#workspace.checkpoint({ handles: [staged.handle] });
+      return requireCheckpointWitness(checkpoint, staged.handle.toString());
+    });
   }
 
   override promote(
     request: PromoteMaterializationRequest,
   ): Promise<MaterializationHandle> {
-    if (this.#releasePending || this.#releaseRequested || this.#promoting) {
-      return Promise.reject(workspaceError('cannot promote a releasing workspace'));
-    }
+    this.#assertMutable('promote');
     this.#promoting = true;
-    const operation = this.#serialize(() => this.#assertLeaseHealthy())
-      .then(async () => await this.#promoteMaterialization(request))
-      .then(async (materialization) => await this.#finishPromotion(materialization));
-    const done = operation.then(
-      () => undefined,
-      () => undefined,
+    const operation = this.#serialize(
+      async () => await this.#promoteMaterialization(this.#workspace, request),
     );
-    this.#promotionDone = done;
-    return operation.finally(() => {
-      this.#promoting = false;
-      if (this.#promotionDone === done) {
-        this.#promotionDone = null;
-      }
-    });
-  }
-
-  async #checkpoint(
-    roots: MaterializationWorkspaceRoots,
-  ): Promise<StorageRetentionWitness | null> {
-    this.#assertLeaseHealthy();
-    const members = workspaceMembers(roots);
-    if (members.length === 0) {
-      return null;
-    }
-    const bundle = await this.#bundles.putOrdered({ members });
-    const targetToken = bundle.handle.toString();
-    const witness = await this.#retain(bundle.handle, targetToken);
-    const target = Object.freeze({ input: bundle.handle, token: targetToken });
-    this.#leaseTarget = target;
-    this.#scheduleLeaseRenewal(target);
-    return adaptGitCasRetentionWitness(witness.toJSON());
-  }
-
-  async #retain(
-    target: WorkspaceTarget,
-    expectedHandle: string,
-  ): Promise<RetentionWitness> {
-    this.#installationAttempted = true;
-    const retained = await this.#cache.put(this.#key, target, {
-      retention: 'pinned',
-      expiresAt: this.#expiresAt(),
-    });
-    return requireAcceptedCheckpoint(retained, expectedHandle);
-  }
-
-  async #finishPromotion(
-    materialization: MaterializationHandle,
-  ): Promise<MaterializationHandle> {
-    return await this.#serialize(() => {
-      this.#leaseFailure = null;
-      this.#cancelLeaseTimer();
+    return operation.then((materialization) => {
+      this.#promoted = true;
       return materialization;
+    }).finally(() => {
+      this.#promoting = false;
     });
   }
 
-  async #release(): Promise<void> {
-    if (this.#released) {
-      return;
-    }
-    if (this.#installationAttempted) {
-      await this.#cache.remove(this.#key);
-    }
-    this.#released = true;
-  }
-
-  #expiresAt(): string {
-    const now = this.#clock.now();
-    if (!(now instanceof Date) || Number.isNaN(now.getTime())) {
-      throw workspaceError('clock returned an invalid Date');
-    }
-    return new Date(now.getTime() + this.#leaseTtlMs).toISOString();
-  }
-
-  #scheduleLeaseRenewal(target: ActiveLeaseTarget): void {
-    this.#cancelLeaseTimer();
-    if (!this.#leaseIsActive()) {
-      return;
-    }
-    this.#leaseTimer = this.#leaseScheduler.schedule(
-      async () => await this.#renewLease(target),
-      this.#leaseRenewalMs,
-    );
-  }
-
-  async #renewLease(target: ActiveLeaseTarget): Promise<void> {
-    this.#leaseTimer = null;
-    await this.#serialize(async () => {
-      if (!this.#leaseIsActive()) {
-        return;
-      }
-      if (this.#leaseTarget !== target) {
-        return;
-      }
-      try {
-        await this.#retain(target.input, target.token);
-        this.#scheduleLeaseRenewal(target);
-      } catch (raw) {
-        this.#leaseFailure = workspaceError(`lease renewal failed: ${errorMessage(raw)}`);
-        this.#cancelLeaseTimer();
+  override release(): Promise<void> {
+    this.#releaseRequested = true;
+    this.#releasePromise ??= this.#serialize(async () => {
+      if (!this.#released) {
+        await this.#workspace.release();
+        this.#released = true;
       }
     });
+    return this.#releasePromise;
   }
 
-  #cancelLeaseTimer(): void {
-    this.#leaseTimer?.cancel();
-    this.#leaseTimer = null;
-  }
-
-  #leaseIsActive(): boolean {
-    return !this.#releaseRequested && !this.#released;
-  }
-
-  #assertLeaseHealthy(): void {
-    if (this.#leaseFailure !== null) {
-      throw this.#leaseFailure;
+  #assertMutable(operation: string): void {
+    if (
+      this.#releaseRequested || this.#released || this.#promoting || this.#promoted
+    ) {
+      throw workspaceError(`cannot ${operation} on a closed workspace`);
     }
   }
 
@@ -246,9 +156,9 @@ export default class GitCasMaterializationWorkspace extends MaterializationWorks
 
 function workspaceMembers(
   roots: MaterializationWorkspaceRoots,
-): Array<[string, BundleMemberInput]> {
+): Array<[string, string]> {
   requireRoots(roots);
-  const members: Array<[string, BundleMemberInput]> = [];
+  const members: Array<[string, string]> = [];
   if (roots.edgeAliveRoot !== null) {
     members.push(['roots/edge-alive', parseRoot(roots.edgeAliveRoot)]);
   }
@@ -269,6 +179,56 @@ function parseRoot(token: string): string {
   }
 }
 
+function requireRetainedStage(
+  staged: WorkspaceRetainedPage | WorkspaceRetainedBundle,
+  expectedHandle: string,
+): StorageRetentionWitness {
+  if (
+    staged.state !== 'retained' ||
+    staged.retention.policy !== 'evictable' ||
+    staged.retention.reachability !== 'anchored' ||
+    staged.retention.protection !== 'workspace'
+  ) {
+    throw workspaceError('git-cas returned an unretained staged artifact');
+  }
+  return requireWorkspaceWitness(staged.witness, expectedHandle);
+}
+
+function requireCheckpointWitness(
+  checkpoint: WorkspaceCheckpointResult,
+  expectedHandle: string,
+): StorageRetentionWitness {
+  const exact = [
+    checkpoint.handles.length === 1,
+    checkpoint.handles[0]?.toString() === expectedHandle,
+    checkpoint.witnesses.length === 1,
+  ];
+  if (exact.includes(false)) {
+    throw workspaceError('git-cas checkpoint did not retain the exact workspace root');
+  }
+  const witness = checkpoint.witnesses[0];
+  if (witness === undefined) {
+    throw workspaceError('git-cas checkpoint omitted retention evidence');
+  }
+  return requireWorkspaceWitness(witness, expectedHandle);
+}
+
+function requireWorkspaceWitness(
+  witness: RetentionWitness,
+  expectedHandle: string,
+): StorageRetentionWitness {
+  const adapted = adaptGitCasRetentionWitness(witness.toJSON());
+  if (
+    adapted.handle.toString() !== expectedHandle ||
+    adapted.policy !== 'evictable' ||
+    adapted.reachability !== 'anchored' ||
+    adapted.root.kind !== 'root-set'
+  ) {
+    throw workspaceError('git-cas returned invalid workspace retention evidence');
+  }
+  return adapted;
+}
+
 function requireRoots(value: MaterializationWorkspaceRoots): void {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     throw workspaceError('checkpoint roots must be an object');
@@ -276,92 +236,36 @@ function requireRoots(value: MaterializationWorkspaceRoots): void {
 }
 
 function requireWorkspaceOptions(options: GitCasMaterializationWorkspaceOptions): void {
-  requireOptionsObject(options);
-  requireBundles(options.bundles);
-  requireCache(options.cache);
-  requireClock(options.clock);
-  requireLeaseTiming(options.leaseTtlMs, options.leaseRenewalMs);
-  requireLeaseScheduler(options.leaseScheduler);
-  requirePromote(options.promote);
-}
-
-function requireAcceptedCheckpoint(
-  retained: Awaited<ReturnType<WorkspaceCache['put']>>,
-  expectedHandle: string,
-): RetentionWitness {
-  if (!retained.accepted || retained.hit === null || retained.witness === null) {
-    throw workspaceError('git-cas did not retain the workspace checkpoint');
-  }
-  if (retained.hit.handle.toString() !== expectedHandle) {
-    throw workspaceError('git-cas retained an unexpected workspace handle');
-  }
-  return retained.witness;
-}
-
-function requireOptionsObject(options: GitCasMaterializationWorkspaceOptions): void {
   if (options === null || typeof options !== 'object' || Array.isArray(options)) {
     throw workspaceError('options must be an object');
   }
+  requireObject(options.workspace, 'git-cas workspace dependency');
+  requireObject(options.workspace.pages, 'git-cas workspace dependency pages');
+  requireObject(options.workspace.bundles, 'git-cas workspace dependency bundles');
+  requireMethod(options.workspace.pages, 'put', 'git-cas workspace pages');
+  requireMethod(options.workspace.bundles, 'putOrdered', 'git-cas workspace bundles');
+  requireMethod(options.workspace, 'checkpoint', 'git-cas workspace');
+  requireMethod(options.workspace, 'promoteToCache', 'git-cas workspace');
+  requireMethod(options.workspace, 'release', 'git-cas workspace');
+  requireFunction(options.promote, 'promote dependency');
 }
 
-function requireBundles(bundles: Pick<BundleCapability, 'putOrdered'>): void {
-  if (typeof bundles?.putOrdered !== 'function') {
-    throw workspaceError('bundles dependency is required');
+function requireObject(value: unknown, field: string): asserts value is object {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw workspaceError(`${field} is required`);
   }
 }
 
-function requireCache(cache: WorkspaceCache): void {
-  if (typeof cache?.put !== 'function' || typeof cache?.remove !== 'function') {
-    throw workspaceError('cache dependency is required');
+function requireMethod(value: object, method: string, field: string): void {
+  if (typeof Reflect.get(value, method) !== 'function') {
+    throw workspaceError(`${field} must provide ${method}()`);
   }
 }
 
-function requireClock(clock: { readonly now: () => Date } | undefined): void {
-  if (clock !== undefined && typeof clock.now !== 'function') {
-    throw workspaceError('clock must provide now()');
+function requireFunction(value: unknown, field: string): void {
+  if (typeof value !== 'function') {
+    throw workspaceError(`${field} is required`);
   }
-}
-
-function requireLeaseTiming(ttlMs: number | undefined, renewalMs: number | undefined): void {
-  const ttl = ttlMs ?? WORKSPACE_TTL_MS;
-  const renewal = renewalMs ?? WORKSPACE_RENEWAL_MS;
-  requirePositiveLeaseTtl(ttl);
-  requireLeaseRenewalBelowTtl(renewal, ttl);
-}
-
-function requirePositiveLeaseTtl(ttl: number): void {
-  if (!Number.isSafeInteger(ttl) || ttl <= 0) {
-    throw workspaceError('leaseTtlMs must be a positive safe integer');
-  }
-}
-
-function requireLeaseRenewalBelowTtl(renewal: number, ttl: number): void {
-  if (!Number.isSafeInteger(renewal) || renewal <= 0 || renewal >= ttl) {
-    throw workspaceError('leaseRenewalMs must be a positive safe integer below leaseTtlMs');
-  }
-}
-
-function requireLeaseScheduler(
-  scheduler: MaterializationWorkspaceLeaseScheduler | undefined,
-): void {
-  if (scheduler !== undefined && typeof scheduler.schedule !== 'function') {
-    throw workspaceError('leaseScheduler must provide schedule()');
-  }
-}
-
-function requirePromote(
-  promote: ((request: PromoteMaterializationRequest) => Promise<MaterializationHandle>) | undefined,
-): void {
-  if (typeof promote !== 'function') {
-    throw workspaceError('promote dependency is required');
-  }
-}
-
-function requireNonEmpty(value: string, field: string): string {
-  if (typeof value !== 'string' || value.length === 0) {
-    throw workspaceError(`${field} must be a non-empty string`);
-  }
-  return value;
 }
 
 function errorMessage(raw: unknown): string {

--- a/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
+++ b/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
@@ -46,7 +46,7 @@ export type GitCasFacade = Pick<
   readonly assets: Pick<AssetCapability, 'put' | 'adopt' | 'open'>;
   readonly bundles: Pick<
     BundleCapability,
-    'getMember' | 'putOrdered' | 'iterateMembers'
+    'getMemberReference' | 'putOrdered' | 'iterateMemberReferences'
   >;
   readonly caches: GitCasMaterializationFacade['caches'];
   readonly pages: GitCasMaterializationFacade['pages'];

--- a/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
+++ b/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
@@ -50,6 +50,7 @@ export type GitCasFacade = Pick<
   >;
   readonly caches: GitCasMaterializationFacade['caches'];
   readonly pages: GitCasMaterializationFacade['pages'];
+  readonly workspaces: GitCasMaterializationFacade['workspaces'];
   readonly publications: Pick<PublicationCapability, 'commit'>;
   readonly rootSets: {
     open(options: { readonly ref: string }): Promise<GitCasRootSetClient>;

--- a/src/infrastructure/adapters/GitCasTrieStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasTrieStoreAdapter.ts
@@ -1,7 +1,7 @@
 import {
   BundleHandle,
   type BundleCapability,
-  type BundleMember,
+  type BundleMemberReference,
   type PageCapability,
 } from '@git-stunts/git-cas';
 import TrieStoreError from '../../domain/errors/TrieStoreError.ts';
@@ -28,7 +28,7 @@ const MISSING_CODES = new Set([
 export type GitCasTrieFacade = {
   readonly bundles: Pick<
     BundleCapability,
-    'getMember' | 'iterateMembers' | 'putOrdered'
+    'getMemberReference' | 'iterateMemberReferences' | 'putOrdered'
   >;
   readonly pages: Pick<PageCapability, 'get' | 'put'>;
 };
@@ -51,9 +51,9 @@ export default class GitCasTrieStoreAdapter implements TrieStorePort {
 
   async readLeaf(root: string): Promise<Uint8Array> {
     const bundle = parseReadRoot(root);
-    let member: BundleMember | null;
+    let member: BundleMemberReference | null;
     try {
-      member = await this.#cas.bundles.getMember({
+      member = await this.#cas.bundles.getMemberReference({
         handle: bundle,
         path: LEAF_PATH,
       });
@@ -80,7 +80,7 @@ export default class GitCasTrieStoreAdapter implements TrieStorePort {
     const bundle = parseReadRoot(root);
     const entries = new Map<number, string>();
     try {
-      for await (const member of this.#cas.bundles.iterateMembers({ handle: bundle })) {
+      for await (const member of this.#cas.bundles.iterateMemberReferences({ handle: bundle })) {
         collectBranchMember(entries, member, root);
       }
     } catch (raw) {
@@ -131,7 +131,7 @@ export default class GitCasTrieStoreAdapter implements TrieStorePort {
 
 function collectBranchMember(
   entries: Map<number, string>,
-  member: BundleMember,
+  member: BundleMemberReference,
   root: string,
 ): void {
   const name = branchMemberName(member.path, root);

--- a/src/infrastructure/adapters/GitCasTrieStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasTrieStoreAdapter.ts
@@ -2,12 +2,12 @@ import {
   BundleHandle,
   type BundleCapability,
   type BundleMember,
-  type BundleMemberInput,
   type PageCapability,
 } from '@git-stunts/git-cas';
 import TrieStoreError from '../../domain/errors/TrieStoreError.ts';
 import type { TrieBranchEntries } from '../../domain/orset/trie/TrieBranchEntries.ts';
 import type TrieStorePort from '../../domain/orset/trie/TrieStorePort.ts';
+import type ArtifactStagingPort from '../../ports/ArtifactStagingPort.ts';
 import { parseNibbleName } from './trieNibbleName.ts';
 
 const BRANCH_PREFIX = 'children/';
@@ -92,14 +92,19 @@ export default class GitCasTrieStoreAdapter implements TrieStorePort {
     return entries;
   }
 
-  async writeLeaf(data: Uint8Array): Promise<string> {
+  async writeLeaf(data: Uint8Array, staging?: ArtifactStagingPort): Promise<string> {
     try {
-      const page = await this.#cas.pages.put({
-        source: data,
-        maxBytes: MAX_TRIE_LEAF_BYTES,
-      });
+      const pageHandle = staging === undefined
+        ? (await this.#cas.pages.put({
+          source: data,
+          maxBytes: MAX_TRIE_LEAF_BYTES,
+        })).handle.toString()
+        : await staging.stagePage(data, { maxBytes: MAX_TRIE_LEAF_BYTES });
+      if (staging !== undefined) {
+        return (await staging.stageOrderedBundle([[LEAF_PATH, pageHandle]])).toString();
+      }
       const bundle = await this.#cas.bundles.putOrdered({
-        members: [[LEAF_PATH, page.handle]],
+        members: [[LEAF_PATH, pageHandle]],
       });
       return bundle.handle.toString();
     } catch (raw) {
@@ -107,9 +112,15 @@ export default class GitCasTrieStoreAdapter implements TrieStorePort {
     }
   }
 
-  async writeBranch(children: TrieBranchEntries): Promise<string> {
+  async writeBranch(
+    children: TrieBranchEntries,
+    staging?: ArtifactStagingPort,
+  ): Promise<string> {
     const members = branchMembers(children);
     try {
+      if (staging !== undefined) {
+        return (await staging.stageOrderedBundle(members)).toString();
+      }
       const bundle = await this.#cas.bundles.putOrdered({ members });
       return bundle.handle.toString();
     } catch (raw) {
@@ -145,12 +156,12 @@ function branchMemberName(path: string, root: string): string {
   return name;
 }
 
-function branchMembers(children: TrieBranchEntries): Array<[string, BundleMemberInput]> {
+function branchMembers(children: TrieBranchEntries): Array<[string, string]> {
   const ordered = [...children].sort(([left], [right]) => left - right);
   const width = nibbleNameWidth(ordered);
   return ordered.map(([nibble, child]) => [
     `${BRANCH_PREFIX}${formatNibble(nibble, width)}`,
-    parseChildRoot(child),
+    parseChildRoot(child).toString(),
   ]);
 }
 

--- a/src/infrastructure/adapters/IndexShardEncodeTransform.ts
+++ b/src/infrastructure/adapters/IndexShardEncodeTransform.ts
@@ -8,9 +8,14 @@ import type { IndexShard } from '../../domain/artifacts/IndexShard.ts';
 import type CodecPort from '../../ports/CodecPort.ts';
 import WarpError from '../../domain/errors/WarpError.ts';
 import { requirePropertyShardEncodedSize } from './PropertyShardEncodedSizeGuard.ts';
+import {
+  validateBoundedCbor,
+  type CborStructureLimits,
+} from './BoundedCborValidation.ts';
 
 type IndexShardEncodeOptions = Readonly<{
   maxBytes?: number;
+  structureLimits?: CborStructureLimits;
 }>;
 
 /**
@@ -26,6 +31,7 @@ type IndexShardEncodeOptions = Readonly<{
 export class IndexShardEncodeTransform extends Transform<IndexShard, [string, Uint8Array]> {
   private readonly _codec: CodecPort;
   private readonly _maxBytes: number | undefined;
+  private readonly _structureLimits: CborStructureLimits | undefined;
 
   constructor(codec: CodecPort, options: IndexShardEncodeOptions = {}) {
     super();
@@ -34,6 +40,7 @@ export class IndexShardEncodeTransform extends Transform<IndexShard, [string, Ui
     }
     this._codec = codec;
     this._maxBytes = options.maxBytes;
+    this._structureLimits = options.structureLimits;
   }
 
   override async *apply(source: AsyncIterable<IndexShard>): AsyncIterable<[string, Uint8Array]> {
@@ -47,49 +54,51 @@ export class IndexShardEncodeTransform extends Transform<IndexShard, [string, Ui
    */
   private _encode(shard: IndexShard): [string, Uint8Array] {
     if (shard instanceof MetaShard) {
-      return [
+      return this._encodePayload(
         `meta_${shard.shardKey}.cbor`,
-        this._codec.encode({
+        {
           nodeToGlobal: shard.nodeToGlobal,
           nextLocalId: shard.nextLocalId,
           alive: shard.alive,
-        }),
-      ];
+        },
+      );
     }
     if (shard instanceof EdgeShard) {
-      return [
+      return this._encodePayload(
         `${shard.direction}_${shard.shardKey}.cbor`,
-        this._codec.encode(shard.buckets),
-      ];
+        shard.buckets,
+      );
     }
     if (shard instanceof LabelShard) {
-      return [
-        'labels.cbor',
-        this._codec.encode(shard.labels),
-      ];
+      return this._encodePayload('labels.cbor', shard.labels);
     }
     if (shard instanceof PropertyShard) {
       const path = `props_${shard.shardKey}.cbor`;
       if (this._maxBytes !== undefined) {
         requirePropertyShardEncodedSize(shard, path, this._maxBytes);
       }
-      return [
-        path,
-        this._codec.encode(propertyShardPayload(shard)),
-      ];
+      return this._encodePayload(path, propertyShardPayload(shard));
     }
     if (shard instanceof ReceiptShard) {
-      return [
+      return this._encodePayload(
         'receipt.cbor',
-        this._codec.encode({
+        {
           version: shard.version,
           nodeCount: shard.nodeCount,
           labelCount: shard.labelCount,
           shardCount: shard.shardCount,
-        }),
-      ];
+        },
+      );
     }
     throw new WarpError('Unknown IndexShard type', 'E_UNKNOWN_SHARD');
+  }
+
+  private _encodePayload(path: string, payload: unknown): [string, Uint8Array] {
+    const bytes = this._codec.encode(payload);
+    if (this._structureLimits !== undefined) {
+      validateBoundedCbor(bytes, this._structureLimits);
+    }
+    return [path, bytes];
   }
 }
 

--- a/src/infrastructure/adapters/IndexShardEncodeTransform.ts
+++ b/src/infrastructure/adapters/IndexShardEncodeTransform.ts
@@ -7,6 +7,11 @@ import { ReceiptShard } from '../../domain/artifacts/ReceiptShard.ts';
 import type { IndexShard } from '../../domain/artifacts/IndexShard.ts';
 import type CodecPort from '../../ports/CodecPort.ts';
 import WarpError from '../../domain/errors/WarpError.ts';
+import { requirePropertyShardEncodedSize } from './PropertyShardEncodedSizeGuard.ts';
+
+type IndexShardEncodeOptions = Readonly<{
+  maxBytes?: number;
+}>;
 
 /**
  * Stream transform that maps IndexShard instances to [path, bytes] entries.
@@ -20,13 +25,15 @@ import WarpError from '../../domain/errors/WarpError.ts';
  */
 export class IndexShardEncodeTransform extends Transform<IndexShard, [string, Uint8Array]> {
   private readonly _codec: CodecPort;
+  private readonly _maxBytes: number | undefined;
 
-  constructor(codec: CodecPort) {
+  constructor(codec: CodecPort, options: IndexShardEncodeOptions = {}) {
     super();
     if (codec === null || codec === undefined) {
       throw new WarpError('IndexShardEncodeTransform requires a codec', 'E_INVALID_DEPENDENCY');
     }
     this._codec = codec;
+    this._maxBytes = options.maxBytes;
   }
 
   override async *apply(source: AsyncIterable<IndexShard>): AsyncIterable<[string, Uint8Array]> {
@@ -62,9 +69,13 @@ export class IndexShardEncodeTransform extends Transform<IndexShard, [string, Ui
       ];
     }
     if (shard instanceof PropertyShard) {
+      const path = `props_${shard.shardKey}.cbor`;
+      if (this._maxBytes !== undefined) {
+        requirePropertyShardEncodedSize(shard, path, this._maxBytes);
+      }
       return [
-        `props_${shard.shardKey}.cbor`,
-        this._codec.encode(shard.entries),
+        path,
+        this._codec.encode(propertyShardPayload(shard)),
       ];
     }
     if (shard instanceof ReceiptShard) {
@@ -80,4 +91,32 @@ export class IndexShardEncodeTransform extends Transform<IndexShard, [string, Ui
     }
     throw new WarpError('Unknown IndexShard type', 'E_UNKNOWN_SHARD');
   }
+}
+
+function propertyShardPayload(
+  shard: PropertyShard,
+): PropertyShard['entries'] | {
+  readonly schemaVersion: 2;
+  readonly entries: Array<[string, Array<[string, unknown]>]>; // nosemgrep: ts-no-unknown-outside-adapters -- 0025B
+} {
+  if (shard.schemaVersion === 1) {
+    return shard.entries;
+  }
+  if (shard.schemaVersion !== 2) {
+    throw new WarpError(
+      `Unsupported property shard schema version: ${String(shard.schemaVersion)}`,
+      'E_INDEX_SHARD_SCHEMA',
+    );
+  }
+  return {
+    schemaVersion: 2,
+    entries: shard.entries.map(([nodeId, properties]) => [
+      nodeId,
+      Object.entries(properties).sort(([left], [right]) => compareStrings(left, right)),
+    ]),
+  };
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }

--- a/src/infrastructure/adapters/IndexShardLimitValidation.ts
+++ b/src/infrastructure/adapters/IndexShardLimitValidation.ts
@@ -1,4 +1,35 @@
 import IndexError from '../../domain/errors/IndexError.ts';
+import type { CborStructureLimits } from './BoundedCborValidation.ts';
+
+type OptionalCborStructureLimits = Readonly<{
+  maxContainerEntries?: number;
+  maxDepth?: number;
+  maxItems?: number;
+}>;
+
+export function optionalCborStructureLimits(
+  options: OptionalCborStructureLimits,
+): CborStructureLimits | undefined {
+  const configured = [
+    options.maxContainerEntries,
+    options.maxDepth,
+    options.maxItems,
+  ].filter((value) => value !== undefined).length;
+  if (configured === 0) {
+    return undefined;
+  }
+  if (configured !== 3) {
+    throw invalidLimit('CBOR structure limits');
+  }
+  return Object.freeze({
+    maxContainerEntries: positiveInteger(
+      options.maxContainerEntries!,
+      'maxContainerEntries',
+    ),
+    maxDepth: nonNegativeInteger(options.maxDepth!, 'maxDepth'),
+    maxItems: positiveInteger(options.maxItems!, 'maxItems'),
+  });
+}
 
 export function optionalPositiveInteger(
   value: number | undefined,
@@ -7,10 +38,7 @@ export function optionalPositiveInteger(
   if (value === undefined) {
     return undefined;
   }
-  if (!Number.isSafeInteger(value) || value <= 0) {
-    throw invalidLimit(name);
-  }
-  return value;
+  return positiveInteger(value, name);
 }
 
 export function optionalNonNegativeInteger(
@@ -20,26 +48,21 @@ export function optionalNonNegativeInteger(
   if (value === undefined) {
     return undefined;
   }
-  if (!Number.isSafeInteger(value) || value < 0) {
+  return nonNegativeInteger(value, name);
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
     throw invalidLimit(name);
   }
   return value;
 }
 
-export function requiredPositiveInteger(value: number | undefined, name: string): number {
-  const checked = optionalPositiveInteger(value, name);
-  if (checked === undefined) {
+function nonNegativeInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
     throw invalidLimit(name);
   }
-  return checked;
-}
-
-export function requiredNonNegativeInteger(value: number | undefined, name: string): number {
-  const checked = optionalNonNegativeInteger(value, name);
-  if (checked === undefined) {
-    throw invalidLimit(name);
-  }
-  return checked;
+  return value;
 }
 
 export function invalidLimit(name: string): IndexError {

--- a/src/infrastructure/adapters/IndexShardLimitValidation.ts
+++ b/src/infrastructure/adapters/IndexShardLimitValidation.ts
@@ -1,0 +1,50 @@
+import IndexError from '../../domain/errors/IndexError.ts';
+
+export function optionalPositiveInteger(
+  value: number | undefined,
+  name: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw invalidLimit(name);
+  }
+  return value;
+}
+
+export function optionalNonNegativeInteger(
+  value: number | undefined,
+  name: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw invalidLimit(name);
+  }
+  return value;
+}
+
+export function requiredPositiveInteger(value: number | undefined, name: string): number {
+  const checked = optionalPositiveInteger(value, name);
+  if (checked === undefined) {
+    throw invalidLimit(name);
+  }
+  return checked;
+}
+
+export function requiredNonNegativeInteger(value: number | undefined, name: string): number {
+  const checked = optionalNonNegativeInteger(value, name);
+  if (checked === undefined) {
+    throw invalidLimit(name);
+  }
+  return checked;
+}
+
+export function invalidLimit(name: string): IndexError {
+  return new IndexError(`Index shard ${name} must be a safe integer within range`, {
+    code: 'E_INDEX_INVALID_LIMIT',
+    context: { name },
+  });
+}

--- a/src/infrastructure/adapters/IndexShardLimitValidation.ts
+++ b/src/infrastructure/adapters/IndexShardLimitValidation.ts
@@ -1,38 +1,54 @@
 import IndexError from '../../domain/errors/IndexError.ts';
 import type { CborStructureLimits } from './BoundedCborValidation.ts';
 
-type OptionalCborStructureLimits = Readonly<{
-  maxContainerEntries?: number;
-  maxDepth?: number;
-  maxItems?: number;
-}>;
-
 export function optionalCborStructureLimits(
-  options: OptionalCborStructureLimits,
+  value: unknown,
 ): CborStructureLimits | undefined {
-  const configured = [
-    options.maxContainerEntries,
-    options.maxDepth,
-    options.maxItems,
-  ].filter((value) => value !== undefined).length;
-  if (configured === 0) {
+  if (value === undefined) {
     return undefined;
   }
-  if (configured !== 3) {
-    throw invalidLimit('CBOR structure limits');
-  }
+  const limits = requireStructureLimitRecord(value);
+  requireCompleteStructureLimits(limits);
   return Object.freeze({
     maxContainerEntries: positiveInteger(
-      options.maxContainerEntries!,
+      limits['maxContainerEntries'],
       'maxContainerEntries',
     ),
-    maxDepth: nonNegativeInteger(options.maxDepth!, 'maxDepth'),
-    maxItems: positiveInteger(options.maxItems!, 'maxItems'),
+    maxDepth: nonNegativeInteger(limits['maxDepth'], 'maxDepth'),
+    maxItems: positiveInteger(limits['maxItems'], 'maxItems'),
   });
 }
 
+function requireStructureLimitRecord(
+  value: unknown,
+): Readonly<Record<string, unknown>> { // nosemgrep: ts-no-record-string-unknown-outside-adapters -- adapter validation boundary; nosemgrep: ts-no-unknown-outside-adapters -- adapter validation boundary
+  if (value === null || typeof value !== 'object') {
+    throw invalidLimit('CBOR structure limits');
+  }
+  return value as Readonly<Record<string, unknown>>; // nosemgrep: ts-no-record-string-unknown-outside-adapters -- adapter validation boundary; nosemgrep: ts-no-unknown-outside-adapters -- adapter validation boundary
+}
+
+function requireCompleteStructureLimits(
+  limits: Readonly<Record<string, unknown>>, // nosemgrep: ts-no-record-string-unknown-outside-adapters -- adapter validation boundary; nosemgrep: ts-no-unknown-outside-adapters -- adapter validation boundary
+): void {
+  if (
+    !hasOwnDefinedLimit(limits, 'maxContainerEntries')
+    || !hasOwnDefinedLimit(limits, 'maxDepth')
+    || !hasOwnDefinedLimit(limits, 'maxItems')
+  ) {
+    throw invalidLimit('CBOR structure limits');
+  }
+}
+
+function hasOwnDefinedLimit(
+  limits: Readonly<Record<string, unknown>>, // nosemgrep: ts-no-record-string-unknown-outside-adapters -- adapter validation boundary; nosemgrep: ts-no-unknown-outside-adapters -- adapter validation boundary
+  name: string,
+): boolean {
+  return Object.hasOwn(limits, name) && limits[name] !== undefined;
+}
+
 export function optionalPositiveInteger(
-  value: number | undefined,
+  value: unknown,
   name: string,
 ): number | undefined {
   if (value === undefined) {
@@ -42,7 +58,7 @@ export function optionalPositiveInteger(
 }
 
 export function optionalNonNegativeInteger(
-  value: number | undefined,
+  value: unknown,
   name: string,
 ): number | undefined {
   if (value === undefined) {
@@ -51,15 +67,15 @@ export function optionalNonNegativeInteger(
   return nonNegativeInteger(value, name);
 }
 
-function positiveInteger(value: number, name: string): number {
-  if (!Number.isSafeInteger(value) || value <= 0) {
+function positiveInteger(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
     throw invalidLimit(name);
   }
   return value;
 }
 
-function nonNegativeInteger(value: number, name: string): number {
-  if (!Number.isSafeInteger(value) || value < 0) {
+function nonNegativeInteger(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
     throw invalidLimit(name);
   }
   return value;

--- a/src/infrastructure/adapters/PropertyShardEncodedSizeGuard.ts
+++ b/src/infrastructure/adapters/PropertyShardEncodedSizeGuard.ts
@@ -1,0 +1,98 @@
+import { Buffer } from 'node:buffer';
+import type { PropertyShard } from '../../domain/artifacts/PropertyShard.ts';
+import IndexError from '../../domain/errors/IndexError.ts';
+
+class PropertyPayloadLowerBound {
+  readonly #maximum: number;
+  readonly #seen = new WeakSet<object>();
+  #consumed = 0;
+
+  constructor(maximum: number) {
+    this.#maximum = maximum;
+  }
+
+  get consumed(): number {
+    return this.#consumed;
+  }
+
+  get exceeded(): boolean {
+    return this.#consumed > this.#maximum;
+  }
+
+  consume(value: unknown): void {
+    if (this.exceeded) {
+      return;
+    }
+    if (typeof value === 'string') {
+      this.#consumeBytes(Buffer.byteLength(value, 'utf8') + 1);
+      return;
+    }
+    if (value instanceof Uint8Array) {
+      this.#consumeBytes(value.byteLength + 1);
+      return;
+    }
+    if (Array.isArray(value)) {
+      this.#consumeArray(value);
+      return;
+    }
+    this.#consumeObjectOrScalar(value);
+  }
+
+  #consumeObjectOrScalar(value: unknown): void {
+    if (value !== null && typeof value === 'object') {
+      this.#consumeRecord(value);
+      return;
+    }
+    this.#consumeBytes(1);
+  }
+
+  #consumeArray(value: readonly unknown[]): void {
+    this.#enter(value);
+    this.#consumeBytes(1);
+    for (const entry of value) {
+      this.consume(entry);
+    }
+    this.#seen.delete(value);
+  }
+
+  #consumeRecord(value: object): void {
+    this.#enter(value);
+    this.#consumeBytes(1);
+    for (const [key, entry] of Object.entries(value)) {
+      this.consume(key);
+      this.consume(entry);
+    }
+    this.#seen.delete(value);
+  }
+
+  #enter(value: object): void {
+    if (this.#seen.has(value)) {
+      throw new IndexError('Property shard contains a cyclic value', {
+        code: 'E_INDEX_SHARD_SCHEMA',
+      });
+    }
+    this.#seen.add(value);
+  }
+
+  #consumeBytes(count: number): void {
+    this.#consumed += count;
+  }
+}
+
+/** Rejects definitely oversized property payloads before the CBOR encoder allocates output. */
+export function requirePropertyShardEncodedSize(
+  shard: PropertyShard,
+  path: string,
+  maximum: number,
+): void {
+  const counter = new PropertyPayloadLowerBound(maximum);
+  counter.consume(shard.schemaVersion === 1
+    ? shard.entries
+    : { schemaVersion: shard.schemaVersion, entries: shard.entries });
+  if (counter.exceeded) {
+    throw new IndexError(`Index shard exceeds the configured maximum: ${path}`, {
+      code: 'E_INDEX_SHARD_TOO_LARGE',
+      context: { path, lowerBound: counter.consumed, maximum },
+    });
+  }
+}

--- a/src/ports/ArtifactStagingPort.ts
+++ b/src/ports/ArtifactStagingPort.ts
@@ -1,0 +1,24 @@
+import type BundleHandle from '../domain/storage/BundleHandle.ts';
+
+export type StagedBundleMember = [path: string, handle: string];
+
+export type StagePageOptions = Readonly<{
+  maxBytes: number;
+}>;
+
+export type StageOrderedBundleOptions = Readonly<{
+  maxMembers?: number;
+}>;
+
+/** Operation-scoped retention for immutable artifacts under construction. */
+export default abstract class ArtifactStagingPort {
+  abstract stagePage(
+    _source: Uint8Array,
+    _options: StagePageOptions,
+  ): Promise<string>;
+
+  abstract stageOrderedBundle(
+    _members: Iterable<StagedBundleMember>,
+    _options?: StageOrderedBundleOptions,
+  ): Promise<BundleHandle>;
+}

--- a/src/ports/IndexStorePort.ts
+++ b/src/ports/IndexStorePort.ts
@@ -3,11 +3,14 @@ import type { IndexShard } from '../domain/artifacts/IndexShard.ts';
 import type CodecValue from '../domain/types/codec/CodecValue.ts';
 import type AssetHandle from '../domain/storage/AssetHandle.ts';
 import type BundleHandle from '../domain/storage/BundleHandle.ts';
+import type ArtifactStagingPort from './ArtifactStagingPort.ts';
 
 export type IndexShardWriteOptions = Readonly<{
   expectedShardCount?: number;
+  memberStorage?: 'asset' | 'page';
   maxShardCount?: number;
   maxShardBytes?: number;
+  staging?: ArtifactStagingPort;
 }>;
 
 export type IndexShardDecodeOptions = Readonly<{
@@ -44,8 +47,9 @@ export default abstract class IndexStorePort {
   /**
    * Stages a stream of `IndexShard` records as an ordered bundle.
    *
-   * The adapter internally encodes and stages each shard as an asset,
-   * then assembles the opaque handles into a deterministic bundle.
+   * The adapter internally encodes each shard, stages it under the requested
+   * immutable member policy, then assembles the opaque handles into a
+   * deterministic bundle. Page members require an explicit byte limit.
    */
   abstract writeShards(
     _shardStream: WarpStream<IndexShard>,
@@ -96,4 +100,17 @@ export default abstract class IndexStorePort {
     _shardHandle: AssetHandle,
     _options?: IndexShardDecodeOptions,
   ): Promise<TDecoded>;
+
+  /**
+   * Resolves and decodes one bundle member by path without enumerating siblings.
+   *
+   * Unlike `readShardHandle`, this operation accepts either asset-backed or
+   * page-backed members while keeping the concrete member handle inside the
+   * storage adapter.
+   */
+  abstract decodeShardAt<TDecoded extends CodecValue = CodecValue>(
+    _indexHandle: BundleHandle,
+    _path: string,
+    _options?: IndexShardDecodeOptions,
+  ): Promise<TDecoded | null>;
 }

--- a/src/ports/IndexStorePort.ts
+++ b/src/ports/IndexStorePort.ts
@@ -4,6 +4,19 @@ import type CodecValue from '../domain/types/codec/CodecValue.ts';
 import type AssetHandle from '../domain/storage/AssetHandle.ts';
 import type BundleHandle from '../domain/storage/BundleHandle.ts';
 
+export type IndexShardWriteOptions = Readonly<{
+  expectedShardCount?: number;
+  maxShardCount?: number;
+  maxShardBytes?: number;
+}>;
+
+export type IndexShardDecodeOptions = Readonly<{
+  maxBytes?: number;
+  maxContainerEntries?: number;
+  maxDepth?: number;
+  maxItems?: number;
+}>;
+
 /**
  * IndexStorePort — domain-facing port for index shard persistence.
  *
@@ -34,7 +47,10 @@ export default abstract class IndexStorePort {
    * The adapter internally encodes and stages each shard as an asset,
    * then assembles the opaque handles into a deterministic bundle.
    */
-  abstract writeShards(_shardStream: WarpStream<IndexShard>): Promise<BundleHandle>;
+  abstract writeShards(
+    _shardStream: WarpStream<IndexShard>,
+    _options?: IndexShardWriteOptions,
+  ): Promise<BundleHandle>;
 
   /**
    * Scans all shards in an index bundle, yielding `IndexShard`
@@ -57,6 +73,12 @@ export default abstract class IndexStorePort {
     _indexHandle: BundleHandle,
   ): Promise<Readonly<Record<string, AssetHandle>>>;
 
+  /** Resolves one shard handle by path without enumerating or decoding siblings. */
+  abstract readShardHandle(
+    _indexHandle: BundleHandle,
+    _path: string,
+  ): Promise<AssetHandle | null>;
+
   /** Streams one encoded shard without opening unrelated index members. */
   abstract openShard(_shardHandle: AssetHandle): AsyncIterable<Uint8Array>;
 
@@ -72,5 +94,6 @@ export default abstract class IndexStorePort {
    */
   abstract decodeShard<TDecoded extends CodecValue = CodecValue>(
     _shardHandle: AssetHandle,
+    _options?: IndexShardDecodeOptions,
   ): Promise<TDecoded>;
 }

--- a/src/ports/IndexStorePort.ts
+++ b/src/ports/IndexStorePort.ts
@@ -5,7 +5,13 @@ import type AssetHandle from '../domain/storage/AssetHandle.ts';
 import type BundleHandle from '../domain/storage/BundleHandle.ts';
 import type ArtifactStagingPort from './ArtifactStagingPort.ts';
 
-export type IndexShardWriteOptions = Readonly<{
+export type IndexShardStructureLimitOptions = Readonly<{
+  maxContainerEntries?: number;
+  maxDepth?: number;
+  maxItems?: number;
+}>;
+
+export type IndexShardWriteOptions = IndexShardStructureLimitOptions & Readonly<{
   expectedShardCount?: number;
   memberStorage?: 'asset' | 'page';
   maxShardCount?: number;
@@ -13,11 +19,8 @@ export type IndexShardWriteOptions = Readonly<{
   staging?: ArtifactStagingPort;
 }>;
 
-export type IndexShardDecodeOptions = Readonly<{
+export type IndexShardDecodeOptions = IndexShardStructureLimitOptions & Readonly<{
   maxBytes?: number;
-  maxContainerEntries?: number;
-  maxDepth?: number;
-  maxItems?: number;
 }>;
 
 /**

--- a/src/ports/IndexStorePort.ts
+++ b/src/ports/IndexStorePort.ts
@@ -5,22 +5,40 @@ import type AssetHandle from '../domain/storage/AssetHandle.ts';
 import type BundleHandle from '../domain/storage/BundleHandle.ts';
 import type ArtifactStagingPort from './ArtifactStagingPort.ts';
 
+export type IndexShardStructureLimits = Readonly<{
+  maxContainerEntries: number;
+  maxDepth: number;
+  maxItems: number;
+}>;
+
+/** @deprecated Use `IndexShardStructureLimits` for complete structural policies. */
 export type IndexShardStructureLimitOptions = Readonly<{
   maxContainerEntries?: number;
   maxDepth?: number;
   maxItems?: number;
 }>;
 
-export type IndexShardWriteOptions = IndexShardStructureLimitOptions & Readonly<{
+type CommonIndexShardWriteOptions = Readonly<{
   expectedShardCount?: number;
-  memberStorage?: 'asset' | 'page';
   maxShardCount?: number;
-  maxShardBytes?: number;
   staging?: ArtifactStagingPort;
+  structureLimits?: IndexShardStructureLimits;
 }>;
 
-export type IndexShardDecodeOptions = IndexShardStructureLimitOptions & Readonly<{
+export type IndexShardWriteOptions = CommonIndexShardWriteOptions & (
+  | Readonly<{
+    memberStorage?: 'asset';
+    maxShardBytes?: number;
+  }>
+  | Readonly<{
+    memberStorage: 'page';
+    maxShardBytes: number;
+  }>
+);
+
+export type IndexShardDecodeOptions = Readonly<{
   maxBytes?: number;
+  structureLimits?: IndexShardStructureLimits;
 }>;
 
 /**

--- a/src/ports/MaterializationReadPort.ts
+++ b/src/ports/MaterializationReadPort.ts
@@ -1,6 +1,14 @@
 import type BundleHandle from '../domain/storage/BundleHandle.ts';
+import type { PropValue } from '../domain/types/PropValue.ts';
 
 /** Bounded reads over independently retained materialization roots. */
 export default abstract class MaterializationReadPort {
   abstract hasNode(_nodeAliveRoot: BundleHandle, _nodeId: string): Promise<boolean>;
+
+  getNodeProperties(
+    _propertiesRoot: BundleHandle,
+    _nodeId: string,
+  ): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+    return Promise.resolve(undefined);
+  }
 }

--- a/src/ports/MaterializationStorePort.ts
+++ b/src/ports/MaterializationStorePort.ts
@@ -22,4 +22,9 @@ export default abstract class MaterializationStorePort {
   abstract acquireExact(
     _coordinate: MaterializationCoordinate,
   ): Promise<MaterializationAcquisition | null>;
+
+  /** Releases runtime-local materialization resources without changing retained storage. */
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
 }

--- a/src/ports/MaterializationWorkspacePort.ts
+++ b/src/ports/MaterializationWorkspacePort.ts
@@ -2,6 +2,7 @@ import type MaterializationCoordinate from '../domain/materialization/Materializ
 import type MaterializationHandle from '../domain/materialization/MaterializationHandle.ts';
 import type MaterializationRoots from '../domain/materialization/MaterializationRoots.ts';
 import type StorageRetentionWitness from '../domain/storage/StorageRetentionWitness.ts';
+import ArtifactStagingPort from './ArtifactStagingPort.ts';
 
 export type MaterializationWorkspaceRoots = Readonly<{
   nodeAliveRoot: string | null;
@@ -19,7 +20,7 @@ export type PromoteMaterializationRequest = Readonly<{
  * Operation-scoped retention for materialization roots that are not yet
  * reachable from the final retained materialization handle.
  */
-export default abstract class MaterializationWorkspacePort {
+export default abstract class MaterializationWorkspacePort extends ArtifactStagingPort {
   abstract checkpoint(
     _roots: MaterializationWorkspaceRoots,
   ): Promise<StorageRetentionWitness | null>;

--- a/src/ports/MaterializationWorkspacePort.ts
+++ b/src/ports/MaterializationWorkspacePort.ts
@@ -6,6 +6,7 @@ import type StorageRetentionWitness from '../domain/storage/StorageRetentionWitn
 export type MaterializationWorkspaceRoots = Readonly<{
   nodeAliveRoot: string | null;
   edgeAliveRoot: string | null;
+  propertiesRoot?: string | null;
 }>;
 
 export type PromoteMaterializationRequest = Readonly<{

--- a/test/helpers/InMemoryGitCasFacade.ts
+++ b/test/helpers/InMemoryGitCasFacade.ts
@@ -53,7 +53,14 @@ const ENCRYPTED_ASSET_NONCE_BYTES = 12;
 /** Minimal high-level git-cas facade used to exercise production adapters in memory. */
 export default class InMemoryGitCasFacade {
   readonly assets: Pick<AssetCapability, 'put' | 'adopt' | 'open'>;
-  readonly bundles: Pick<BundleCapability, 'getMember' | 'putOrdered' | 'iterateMembers'>;
+  readonly bundles: Pick<
+    BundleCapability,
+    | 'getMember'
+    | 'getMemberReference'
+    | 'putOrdered'
+    | 'iterateMembers'
+    | 'iterateMemberReferences'
+  >;
   readonly caches: {
     open(options: {
       readonly namespace: string;
@@ -96,7 +103,11 @@ export default class InMemoryGitCasFacade {
     this.bundles = Object.freeze({
       putOrdered: async (request) => await this.#putBundle(request.members),
       getMember: async (request) => await this.#getBundleMember(request.handle, request.path),
+      getMemberReference: async (request) => (
+        await this.#getBundleMember(request.handle, request.path)
+      ),
       iterateMembers: (request) => this.#iterateBundleMembers(request.handle),
+      iterateMemberReferences: (request) => this.#iterateBundleMembers(request.handle),
     });
     this.caches = Object.freeze({
       open: async ({ namespace }) => await this.#openCache(namespace),

--- a/test/helpers/InMemoryGitCasFacade.ts
+++ b/test/helpers/InMemoryGitCasFacade.ts
@@ -16,13 +16,19 @@ import {
   type BundleMember,
   type CacheAcquisition,
   type CacheSet,
+  type CacheStoreResult,
   type PageHandleInput,
   type PageCapability,
   type PublicationCapability,
+  type WorkspaceCheckpointResult,
+  type WorkspaceReleaseResult,
+  type WorkspaceRetainedBundle,
+  type WorkspaceRetainedPage,
 } from '@git-stunts/git-cas';
 import AssetHandle from '../../src/domain/storage/AssetHandle.ts';
 import { collectAsyncIterable } from '../../src/domain/utils/streamUtils.ts';
 import type { GitTreeCommitOptions } from '../../src/infrastructure/adapters/GitTimelineHistoryAdapter.ts';
+import type { GitCasStagingWorkspace } from '../../src/infrastructure/adapters/GitCasMaterializationWorkspace.ts';
 import InMemoryBlobStorageAdapter from './InMemoryBlobStorageAdapter.ts';
 
 type PublicationHistory = {
@@ -51,10 +57,16 @@ export default class InMemoryGitCasFacade {
   readonly caches: {
     open(options: {
       readonly namespace: string;
-    }): Promise<Pick<CacheSet, 'acquire' | 'get' | 'put' | 'remove'>>;
+    }): Promise<Pick<CacheSet, 'acquire' | 'get' | 'put' | 'remove' | 'ref'>>;
   };
   readonly pages: Pick<PageCapability, 'get' | 'put'>;
   readonly publications: Pick<PublicationCapability, 'commit'>;
+  readonly workspaces: {
+    open(options: {
+      readonly namespace: string;
+      readonly ttlMs?: number;
+    }): Promise<GitCasStagingWorkspace>;
+  };
 
   readonly #history: PublicationHistory;
   readonly #storage: InMemoryBlobStorageAdapter;
@@ -64,8 +76,11 @@ export default class InMemoryGitCasFacade {
   readonly #cacheEntries = new Map<string, Map<string, CacheHit>>();
   readonly #pageBytes = new Map<string, Uint8Array>();
   readonly #publicationRoots = new Map<string, string>();
+  readonly #workspaceRoots = new Map<string, ReadonlySet<string>>();
   #cacheGeneration = 0;
   #nextCacheAcquisition = 1;
+  #nextWorkspace = 1;
+  #workspaceGeneration = 0;
 
   constructor(options: {
     history: PublicationHistory;
@@ -93,6 +108,9 @@ export default class InMemoryGitCasFacade {
     this.publications = Object.freeze({
       commit: async (request) => await this.#publish(request),
     });
+    this.workspaces = Object.freeze({
+      open: async (request) => await this.#openWorkspace(request),
+    });
   }
 
   readBundleMembers(handle: string): readonly [string, string][] {
@@ -113,6 +131,16 @@ export default class InMemoryGitCasFacade {
 
   readActiveCacheAcquisitionCount(): number {
     return this.#cacheAcquisitions.size;
+  }
+
+  readActiveWorkspaceCount(): number {
+    return this.#workspaceRoots.size;
+  }
+
+  readWorkspaceRoots(): readonly (readonly string[])[] {
+    return Object.freeze(
+      [...this.#workspaceRoots.values()].map((roots) => Object.freeze([...roots])),
+    );
   }
 
   replaceStoredPage(handle: string, bytes: Uint8Array): void {
@@ -303,10 +331,11 @@ export default class InMemoryGitCasFacade {
 
   async #openCache(
     namespace: string,
-  ): Promise<Pick<CacheSet, 'acquire' | 'get' | 'put' | 'remove'>> {
+  ): Promise<Pick<CacheSet, 'acquire' | 'get' | 'put' | 'remove' | 'ref'>> {
     const entries = this.#cacheEntries.get(namespace) ?? new Map<string, CacheHit>();
     this.#cacheEntries.set(namespace, entries);
     return Object.freeze({
+      ref: `refs/cas/caches/${namespace}`,
       acquire: async (key): Promise<CacheAcquisition | null> => {
         const hit = entries.get(key);
         if (hit === undefined) {
@@ -399,6 +428,108 @@ export default class InMemoryGitCasFacade {
     });
   }
 
+  async #openWorkspace(options: {
+    readonly namespace: string;
+    readonly ttlMs?: number;
+  }): Promise<GitCasStagingWorkspace> {
+    const id = `test-workspace-${String(this.#nextWorkspace)}`;
+    this.#nextWorkspace += 1;
+    const ref = `refs/cas/workspaces/${options.namespace}/${id}`;
+    const createdAt = new Date(0).toISOString();
+    const expiresAt = new Date(options.ttlMs ?? 60_000).toISOString();
+    let released = false;
+    let roots = new Map<string, ApplicationHandle>();
+
+    const install = (handles: Iterable<ApplicationHandleInput>): WorkspaceCheckpointResult => {
+      if (released) {
+        throw Object.assign(new Error('Workspace is released'), { code: 'WORKSPACE_RELEASED' });
+      }
+      roots = new Map(
+        [...handles].map((input) => {
+          const handle = parseApplicationHandle(input);
+          return [handle.toString(), handle];
+        }),
+      );
+      this.#workspaceGeneration += 1;
+      const generation = this.#workspaceGeneration.toString(16).padStart(40, '0');
+      this.#workspaceRoots.set(ref, new Set(roots.keys()));
+      const witnesses = [...roots.values()].map((handle, index) => new RetentionWitness({
+        handle,
+        policy: 'evictable',
+        reachability: 'anchored',
+        root: {
+          kind: 'root-set',
+          namespace: options.namespace,
+          ref,
+          generation,
+          path: `root-${index.toString(16).padStart(8, '0')}`,
+        },
+        observedAt: createdAt,
+      }));
+      return Object.freeze({
+        changed: true,
+        ref,
+        generation,
+        expiresAt,
+        handles: Object.freeze([...roots.values()]),
+        witnesses: Object.freeze(witnesses),
+      });
+    };
+
+    const retain = (handle: ApplicationHandle): RetentionWitness => {
+      const checkpoint = install([...roots.values(), handle]);
+      const witness = checkpoint.witnesses.find(
+        (candidate) => candidate.handle.toString() === handle.toString(),
+      );
+      if (witness === undefined) {
+        throw new Error('In-memory workspace omitted a staged handle');
+      }
+      return witness;
+    };
+
+    const release = async (): Promise<WorkspaceReleaseResult> => {
+      const changed = !released;
+      released = true;
+      this.#workspaceRoots.delete(ref);
+      return Object.freeze({
+        changed,
+        ref,
+        generation: changed
+          ? (++this.#workspaceGeneration).toString(16).padStart(40, '0')
+          : null,
+      });
+    };
+
+    return Object.freeze({
+      pages: Object.freeze({
+        put: async (request): Promise<WorkspaceRetainedPage> => {
+          const staged = await this.#putPage(request);
+          return retainedPage(staged, retain(staged.handle));
+        },
+      }),
+      bundles: Object.freeze({
+        put: async (request): Promise<WorkspaceRetainedBundle> => {
+          const staged = await this.#putBundle(request.members);
+          return retainedBundle(staged, retain(staged.handle));
+        },
+        putOrdered: async (request): Promise<WorkspaceRetainedBundle> => {
+          const staged = await this.#putBundle(request.members);
+          return retainedBundle(staged, retain(staged.handle));
+        },
+      }),
+      checkpoint: async ({ handles }) => install(handles),
+      promoteToCache: async ({ cache, key, handle, options: entryOptions }) => {
+        const target = parseApplicationHandle(handle);
+        if (!roots.has(target.toString())) {
+          install([...roots.values(), target]);
+        }
+        const destination: CacheStoreResult = await cache.put(key, target, entryOptions);
+        return Object.freeze({ destination, release: await release() });
+      },
+      release,
+    });
+  }
+
   async #publish(
     request: Parameters<PublicationCapability['commit']>[0],
   ): Promise<Awaited<ReturnType<PublicationCapability['commit']>>> {
@@ -440,6 +571,59 @@ export default class InMemoryGitCasFacade {
       witness,
     });
   }
+}
+
+function retainedPage(
+  staged: StagedPage,
+  witness: RetentionWitness,
+): WorkspaceRetainedPage {
+  const retention = Object.freeze({
+    policy: 'evictable' as const,
+    reachability: 'anchored' as const,
+    protection: 'workspace' as const,
+  });
+  return Object.freeze({
+    version: staged.version,
+    state: 'retained',
+    handle: staged.handle,
+    page: staged.page,
+    retention,
+    witness,
+    observedAt: staged.observedAt,
+    toJSON: () => Object.freeze({
+      ...staged.toJSON(),
+      state: 'retained' as const,
+      retention,
+      witness: witness.toJSON(),
+    }),
+  });
+}
+
+function retainedBundle(
+  staged: StagedBundle,
+  witness: RetentionWitness,
+): WorkspaceRetainedBundle {
+  const retention = Object.freeze({
+    policy: 'evictable' as const,
+    reachability: 'anchored' as const,
+    protection: 'workspace' as const,
+  });
+  return Object.freeze({
+    version: staged.version,
+    state: 'retained',
+    handle: staged.handle,
+    bundle: staged.bundle,
+    limits: staged.limits,
+    retention,
+    witness,
+    observedAt: staged.observedAt,
+    toJSON: () => Object.freeze({
+      ...staged.toJSON(),
+      state: 'retained' as const,
+      retention,
+      witness: witness.toJSON(),
+    }),
+  });
 }
 
 async function encryptAsset(bytes: Uint8Array, keyBytes: Uint8Array): Promise<Uint8Array> {

--- a/test/helpers/InMemoryMaterializationStore.ts
+++ b/test/helpers/InMemoryMaterializationStore.ts
@@ -18,6 +18,7 @@ export class InMemoryMaterializationWorkspace extends MaterializationWorkspacePo
   readonly #promoteMaterialization: (
     request: PromoteMaterializationRequest,
   ) => Promise<MaterializationHandle>;
+  #nextArtifact = 1;
   released = false;
 
   constructor(
@@ -33,6 +34,18 @@ export class InMemoryMaterializationWorkspace extends MaterializationWorkspacePo
     this.checkpoints.push(roots);
     const bundle = new BundleHandle(`test:workspace:${String(this.checkpoints.length)}`);
     return Promise.resolve(workspaceRetentionWitness(bundle));
+  }
+
+  override stagePage(): Promise<string> {
+    const handle = `test:workspace-page:${String(this.#nextArtifact)}`;
+    this.#nextArtifact += 1;
+    return Promise.resolve(handle);
+  }
+
+  override stageOrderedBundle(): Promise<BundleHandle> {
+    const handle = new BundleHandle(`test:workspace-bundle:${String(this.#nextArtifact)}`);
+    this.#nextArtifact += 1;
+    return Promise.resolve(handle);
   }
 
   override release(): Promise<void> {
@@ -144,13 +157,13 @@ export function workspaceRetentionWitness(
     readonly generation?: string;
   } = {},
 ): StorageRetentionWitness {
-  const namespace = options.namespace ?? 'test/materialization-workspaces';
+  const namespace = options.namespace ?? 'test/materializations';
   return new StorageRetentionWitness({
     handle,
-    policy: 'pinned',
+    policy: 'evictable',
     reachability: 'anchored',
     root: new StorageRetentionRoot({
-      kind: 'cache-set',
+      kind: 'root-set',
       namespace,
       locator: namespace,
       generation: options.generation ?? 'test-workspace-generation',

--- a/test/helpers/InMemoryMaterializationStore.ts
+++ b/test/helpers/InMemoryMaterializationStore.ts
@@ -31,18 +31,21 @@ export class InMemoryMaterializationWorkspace extends MaterializationWorkspacePo
   }
 
   override checkpoint(roots: MaterializationWorkspaceRoots): Promise<StorageRetentionWitness> {
+    this.#assertMutable();
     this.checkpoints.push(roots);
     const bundle = new BundleHandle(`test:workspace:${String(this.checkpoints.length)}`);
     return Promise.resolve(workspaceRetentionWitness(bundle));
   }
 
   override stagePage(): Promise<string> {
+    this.#assertMutable();
     const handle = `test:workspace-page:${String(this.#nextArtifact)}`;
     this.#nextArtifact += 1;
     return Promise.resolve(handle);
   }
 
   override stageOrderedBundle(): Promise<BundleHandle> {
+    this.#assertMutable();
     const handle = new BundleHandle(`test:workspace-bundle:${String(this.#nextArtifact)}`);
     this.#nextArtifact += 1;
     return Promise.resolve(handle);
@@ -54,7 +57,14 @@ export class InMemoryMaterializationWorkspace extends MaterializationWorkspacePo
   }
 
   override promote(request: PromoteMaterializationRequest): Promise<MaterializationHandle> {
+    this.#assertMutable();
     return this.#promoteMaterialization(request);
+  }
+
+  #assertMutable(): void {
+    if (this.released) {
+      throw new Error('In-memory materialization workspace is released');
+    }
   }
 }
 

--- a/test/helpers/MockIndexStorage.ts
+++ b/test/helpers/MockIndexStorage.ts
@@ -49,7 +49,10 @@ export default class MockIndexStorage extends IndexStorePort {
     indexHandle: BundleHandle,
     path: string,
   ): Promise<AssetHandle | null> {
-    return (this.#indexes.get(indexHandle.toString()) ?? {})[path] ?? null;
+    const shards = this.#indexes.get(indexHandle.toString());
+    return shards !== undefined && Object.hasOwn(shards, path)
+      ? shards[path] ?? null
+      : null;
   }
 
   override async *openShard(handle: AssetHandle): AsyncIterable<Uint8Array> {

--- a/test/helpers/MockIndexStorage.ts
+++ b/test/helpers/MockIndexStorage.ts
@@ -44,6 +44,13 @@ export default class MockIndexStorage extends IndexStorePort {
     return this.#indexes.get(indexHandle.toString()) ?? Object.freeze({});
   }
 
+  override async readShardHandle(
+    indexHandle: BundleHandle,
+    path: string,
+  ): Promise<AssetHandle | null> {
+    return (this.#indexes.get(indexHandle.toString()) ?? {})[path] ?? null;
+  }
+
   override async *openShard(handle: AssetHandle): AsyncIterable<Uint8Array> {
     this.openedShardHandles.push(handle.toString());
     const bytes = this.#blobs.get(handle.toString());

--- a/test/helpers/MockIndexStorage.ts
+++ b/test/helpers/MockIndexStorage.ts
@@ -16,6 +16,7 @@ export default class MockIndexStorage extends IndexStorePort {
   #counter = 0;
   readonly openedShardHandles: string[] = [];
   readonly decodedShardHandles: string[] = [];
+  readonly decodedShardPaths: string[] = [];
 
   readonly writeBlob = vi.fn(async (content: Uint8Array | string): Promise<AssetHandle> => {
     const handle = new AssetHandle(`test-index-shard:${String(this.#counter++).padStart(8, '0')}`);
@@ -75,5 +76,17 @@ export default class MockIndexStorage extends IndexStorePort {
       });
     }
     return defaultCodec.decode<TDecoded>(bytes);
+  }
+
+  override async decodeShardAt<TDecoded extends CodecValue = CodecValue>(
+    indexHandle: BundleHandle,
+    path: string,
+  ): Promise<TDecoded | null> {
+    this.decodedShardPaths.push(path);
+    const handle = await this.readShardHandle(indexHandle, path);
+    if (handle === null) {
+      return null;
+    }
+    return await this.decodeShard<TDecoded>(handle);
   }
 }

--- a/test/integration/api/materialization.retainedResume.test.ts
+++ b/test/integration/api/materialization.retainedResume.test.ts
@@ -50,6 +50,7 @@ describe('API: retained materialization resume', () => {
     const coldHandle = firstStore.retainedHandles[0];
     expect(coldHandle?.roots.nodeAlive.status).toBe('retained');
     expect(coldHandle?.roots.edgeAlive.status).toBe('empty');
+    expect(coldHandle?.roots.properties.status).toBe('empty');
 
     const sameRuntimeReplay = vi.spyOn(firstRuntime, '_loadPatchChainFromSha');
     const warm = await firstRuntime.materialize();
@@ -100,6 +101,54 @@ describe('API: retained materialization resume', () => {
     const publishWholeState = vi.spyOn(reopenedRuntime, '_onMaterialized');
 
     await expect(reopenedRuntime.hasNode('node:retained')).resolves.toBe(true);
+
+    const reopenedStore = requireMaterializations(reopenedProvider);
+    expect(replay).not.toHaveBeenCalled();
+    expect(publishWholeState).not.toHaveBeenCalled();
+    expect(reopenedRuntime._cachedState).toBeNull();
+    expect(reopenedStore.exactLookups).toHaveLength(1);
+    expect(reopenedStore.exactHits).toHaveLength(1);
+    expect(reopenedStore.exactReleaseCount).toBe(1);
+  });
+
+  it('answers exact node properties from one retained shard after aggressive pruning', async () => {
+    if (repo === null) {
+      throw new Error('Test repository is not initialized');
+    }
+    const firstProvider = recordingProvider(repo);
+    const firstRuntime = await openRuntime(repo, firstProvider);
+    await firstRuntime.patch((patch) => {
+      patch
+        .addNode('node:retained')
+        .setProperty('node:retained', 'status', 'ready')
+        .setProperty('node:retained', 'attempts', 2)
+        .setProperty('node:retained', '__proto__', 'retained-data');
+    });
+    await firstRuntime.materialize();
+
+    const coldHandle = requireMaterializations(firstProvider).retainedHandles[0];
+    expect(coldHandle?.roots.properties.status).toBe('retained');
+
+    await execFileAsync('git', [
+      '-C',
+      repo.tempDir,
+      'reflog',
+      'expire',
+      '--expire=now',
+      '--all',
+    ]);
+    await execFileAsync('git', ['-C', repo.tempDir, 'prune', '--expire=now']);
+
+    const reopenedProvider = recordingProvider(repo);
+    const reopenedRuntime = await openRuntime(repo, reopenedProvider);
+    const replay = vi.spyOn(reopenedRuntime, '_loadPatchChainFromSha');
+    const publishWholeState = vi.spyOn(reopenedRuntime, '_onMaterialized');
+
+    await expect(reopenedRuntime.getNodeProps('node:retained')).resolves.toEqual({
+      status: 'ready',
+      attempts: 2,
+      ['__proto__']: 'retained-data',
+    });
 
     const reopenedStore = requireMaterializations(reopenedProvider);
     expect(replay).not.toHaveBeenCalled();

--- a/test/integration/api/materialization.retainedResume.test.ts
+++ b/test/integration/api/materialization.retainedResume.test.ts
@@ -233,6 +233,18 @@ class RecordingMaterializationWorkspace extends MaterializationWorkspacePort {
     return this.#delegate.checkpoint(roots);
   }
 
+  override stagePage(
+    ...args: Parameters<MaterializationWorkspacePort['stagePage']>
+  ): ReturnType<MaterializationWorkspacePort['stagePage']> {
+    return this.#delegate.stagePage(...args);
+  }
+
+  override stageOrderedBundle(
+    ...args: Parameters<MaterializationWorkspacePort['stageOrderedBundle']>
+  ): ReturnType<MaterializationWorkspacePort['stageOrderedBundle']> {
+    return this.#delegate.stageOrderedBundle(...args);
+  }
+
   override promote(request: PromoteMaterializationRequest): Promise<MaterializationHandle> {
     return this.#promote(request);
   }

--- a/test/integration/infrastructure/adapters/GitCasMaterializationStoreAdapter.integration.test.ts
+++ b/test/integration/infrastructure/adapters/GitCasMaterializationStoreAdapter.integration.test.ts
@@ -13,11 +13,6 @@ import MaterializationRoot from '../../../../src/domain/materialization/Material
 import MaterializationRoots from '../../../../src/domain/materialization/MaterializationRoots.ts';
 import BundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
 import GitCasRepositoryAdapter from '../../../../src/infrastructure/adapters/GitCasRepositoryAdapter.ts';
-import GitCasMaterializationWorkspace from '../../../../src/infrastructure/adapters/GitCasMaterializationWorkspace.ts';
-import type {
-  MaterializationWorkspaceLease,
-  MaterializationWorkspaceLeaseScheduler,
-} from '../../../../src/infrastructure/adapters/GitCasMaterializationWorkspace.ts';
 import GitCasTrieStoreAdapter from '../../../../src/infrastructure/adapters/GitCasTrieStoreAdapter.ts';
 import GitTimelineHistoryAdapter from '../../../../src/infrastructure/adapters/GitTimelineHistoryAdapter.ts';
 import NodeCryptoAdapter from '../../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
@@ -133,67 +128,62 @@ describe('GitCasMaterializationStoreAdapter integration', () => {
   });
 
   it('keeps workspace roots readable across aggressive Git pruning', async () => {
-    const trieFixture = await createTrieRoot(harness.cas);
     const workspace = await harness.materializations.openWorkspace(workspaceCoordinate());
+    const trie = new GitCasTrieStoreAdapter({ cas: harness.cas });
+    const bytes = new Uint8Array([7, 8, 9]);
+    const leafRoot = await trie.writeLeaf(bytes, workspace);
+    await execFileAsync('git', ['-C', harness.path, 'prune', '--expire=now']);
+    const branchRoot = await trie.writeBranch(new Map([[0, leafRoot]]), workspace);
+    await execFileAsync('git', ['-C', harness.path, 'prune', '--expire=now']);
 
     const witness = await workspace.checkpoint({
-      nodeAliveRoot: trieFixture.root.toString(),
+      nodeAliveRoot: branchRoot,
       edgeAliveRoot: null,
     });
     if (witness === null) {
       throw new Error('Workspace did not witness its non-empty trie root');
     }
     expect(witness).toMatchObject({
-      policy: 'pinned',
+      policy: 'evictable',
       reachability: 'anchored',
+      root: { kind: 'root-set' },
     });
     expect(await prunableOids(harness.path)).not.toContain(
-      GitCasBundleHandle.parse(trieFixture.root.toString()).oid,
+      GitCasBundleHandle.parse(branchRoot).oid,
     );
 
     await execFileAsync('git', ['-C', harness.path, 'prune', '--expire=now']);
-    const trie = new GitCasTrieStoreAdapter({ cas: harness.cas });
-    const children = await trie.readBranch(trieFixture.root.toString());
+    const children = await trie.readBranch(branchRoot);
     expect(children.size).toBe(1);
+    expect(await trie.readLeaf(leafRoot)).toEqual(bytes);
 
     await workspace.release();
   });
 
-  it('renews an active workspace across expiry, sweep, and aggressive pruning', async () => {
+  it('renews an active workspace on checkpoint without a git-warp lease timer', async () => {
     const clock = new MutableClock('2026-07-16T00:00:00.000Z');
     const leaseHarness = await createHarness(clock);
     try {
-      const trieFixture = await createTrieRoot(leaseHarness.cas);
-      const cache = await leaseHarness.cas.caches.open({
-        namespace: 'git-warp/materialization-workspaces',
-      });
-      const scheduler = new ManualLeaseScheduler();
-      const workspace = new GitCasMaterializationWorkspace({
-        bundles: leaseHarness.cas.bundles,
-        cache,
-        key: 'active-lease',
-        clock,
-        leaseTtlMs: 1_000,
-        leaseRenewalMs: 500,
-        leaseScheduler: scheduler,
-        promote: rejectPromotion,
-      });
+      const workspace = await leaseHarness.materializations.openWorkspace(workspaceCoordinate());
+      const trie = new GitCasTrieStoreAdapter({ cas: leaseHarness.cas });
+      const leafRoot = await trie.writeLeaf(new Uint8Array([1, 2, 3]), workspace);
+      const branchRoot = await trie.writeBranch(new Map([[0, leafRoot]]), workspace);
 
+      clock.advance(90 * 60 * 1_000);
       await workspace.checkpoint({
-        nodeAliveRoot: trieFixture.root.toString(),
+        nodeAliveRoot: branchRoot,
         edgeAliveRoot: null,
       });
-      clock.advance(600);
-      await scheduler.runNext();
-      clock.advance(500);
+      clock.advance(90 * 60 * 1_000);
 
-      const sweep = await cache.sweep();
-      expect(sweep.removed).toBe(0);
-      expect(await cache.get('active-lease')).not.toBeNull();
+      const sweep = await leaseHarness.cas.workspaces.sweep({
+        namespace: 'git-warp/materializations',
+        limit: 10,
+      });
+      expect(sweep.changed).toBe(0);
       await execFileAsync('git', ['-C', leaseHarness.path, 'prune', '--expire=now']);
 
-      const trie = new GitCasTrieStoreAdapter({ cas: leaseHarness.cas });
-      expect((await trie.readBranch(trieFixture.root.toString())).size).toBe(1);
+      expect((await trie.readBranch(branchRoot)).size).toBe(1);
       await workspace.release();
     } finally {
       await rm(leaseHarness.path, { recursive: true, force: true });
@@ -353,10 +343,6 @@ function workspaceCoordinate(): MaterializationCoordinate {
   });
 }
 
-function rejectPromotion(): Promise<never> {
-  return Promise.reject(new Error('Promotion is not used by the lease integration test'));
-}
-
 class MutableClock {
   #current: number;
 
@@ -370,30 +356,6 @@ class MutableClock {
 
   advance(milliseconds: number): void {
     this.#current += milliseconds;
-  }
-}
-
-class ManualLeaseScheduler implements MaterializationWorkspaceLeaseScheduler {
-  #task: (() => Promise<void>) | null = null;
-
-  schedule(task: () => Promise<void>, _delayMs: number): MaterializationWorkspaceLease {
-    this.#task = task;
-    return Object.freeze({
-      cancel: () => {
-        if (this.#task === task) {
-          this.#task = null;
-        }
-      },
-    });
-  }
-
-  async runNext(): Promise<void> {
-    const task = this.#task;
-    if (task === null) {
-      throw new Error('Expected a scheduled lease renewal');
-    }
-    this.#task = null;
-    await task();
   }
 }
 

--- a/test/integration/infrastructure/adapters/GitCasMaterializationStoreAdapter.integration.test.ts
+++ b/test/integration/infrastructure/adapters/GitCasMaterializationStoreAdapter.integration.test.ts
@@ -82,7 +82,7 @@ describe('GitCasMaterializationStoreAdapter integration', () => {
     await acquisition.release();
   });
 
-  it('keeps an acquired generation reachable across replacement until release', async () => {
+  it('keeps a replaced generation reachable until its runtime lease closes', async () => {
     const coordinate = workspaceCoordinate();
     const firstTrie = await createTrieRoot(harness.cas, 7);
     const firstRoots = await createRoots(harness.cas, firstTrie, 0);
@@ -121,6 +121,12 @@ describe('GitCasMaterializationStoreAdapter integration', () => {
     );
 
     await acquisition.release();
+    await expireAllReflogs(harness.path);
+    expect(await prunableOids(harness.path)).not.toContain(
+      GitCasBundleHandle.parse(first.bundle.toString()).oid,
+    );
+
+    await harness.materializations.close();
     await expireAllReflogs(harness.path);
     const prunable = await prunableOids(harness.path);
     expect(prunable).toContain(GitCasBundleHandle.parse(first.bundle.toString()).oid);

--- a/test/unit/domain/materialization/MaterializationIdentity.test.ts
+++ b/test/unit/domain/materialization/MaterializationIdentity.test.ts
@@ -116,6 +116,17 @@ describe('MaterializationRoots', () => {
     expect(Object.isFrozen(roots.entries()[0])).toBe(true);
   });
 
+  it('compares every root posture and retained handle', () => {
+    const roots = materializationRoots();
+    const changedOptions = {
+      ...rootsOptions(),
+      properties: retainedRoot('other-properties'),
+    };
+
+    expect(roots.equals(materializationRoots())).toBe(true);
+    expect(roots.equals(new MaterializationRoots(changedOptions))).toBe(false);
+  });
+
   it.each([
     'adjacency',
     'edgeAlive',
@@ -159,6 +170,13 @@ describe('MaterializationRoot', () => {
       MaterializationRoot,
       [new StorageHandle('not-a-bundle')],
     )).toThrowError(/Materialization root/u);
+  });
+
+  it('compares posture and retained handle identity', () => {
+    expect(retainedRoot('same').equals(retainedRoot('same'))).toBe(true);
+    expect(retainedRoot('same').equals(retainedRoot('different'))).toBe(false);
+    expect(MaterializationRoot.empty().equals(MaterializationRoot.empty())).toBe(true);
+    expect(MaterializationRoot.empty().equals(MaterializationRoot.unavailable())).toBe(false);
   });
 });
 

--- a/test/unit/domain/materialization/TrieMaterializationReader.test.ts
+++ b/test/unit/domain/materialization/TrieMaterializationReader.test.ts
@@ -5,7 +5,7 @@ import WarpError from '../../../../src/domain/errors/WarpError.ts';
 import TrieMaterializationReader from '../../../../src/domain/materialization/TrieMaterializationReader.ts';
 import {
   materializationPropertyShardKey,
-  MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS,
+  MATERIALIZATION_PROPERTY_SHARD_LIMITS,
 } from '../../../../src/domain/materialization/MaterializationPropertyProfile.ts';
 import StateSession from '../../../../src/domain/orset/session/StateSession.ts';
 import PageCache from '../../../../src/domain/orset/trie/PageCache.ts';
@@ -86,7 +86,7 @@ describe('TrieMaterializationReader', () => {
     expect(decodeShardAt).toHaveBeenCalledWith(
       root,
       expect.stringContaining('props_'),
-      MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS,
+      MATERIALIZATION_PROPERTY_SHARD_LIMITS,
     );
     await expect(reader.getNodeProperties(root, 'node:missing')).resolves.toBeNull();
   });

--- a/test/unit/domain/materialization/TrieMaterializationReader.test.ts
+++ b/test/unit/domain/materialization/TrieMaterializationReader.test.ts
@@ -1,13 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Dot } from '../../../../src/domain/crdt/Dot.ts';
 import WarpError from '../../../../src/domain/errors/WarpError.ts';
 import TrieMaterializationReader from '../../../../src/domain/materialization/TrieMaterializationReader.ts';
+import {
+  materializationPropertyShardKey,
+  MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS,
+} from '../../../../src/domain/materialization/MaterializationPropertyProfile.ts';
 import StateSession from '../../../../src/domain/orset/session/StateSession.ts';
 import PageCache from '../../../../src/domain/orset/trie/PageCache.ts';
 import TrieGeometry from '../../../../src/domain/orset/trie/TrieGeometry.ts';
 import BundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
+import { PropertyShard } from '../../../../src/domain/artifacts/PropertyShard.ts';
+import WarpStream from '../../../../src/domain/stream/WarpStream.ts';
 import cborCodec from '../../../../src/infrastructure/codecs/CborCodec.ts';
+import MockIndexStorage from '../../../helpers/MockIndexStorage.ts';
 import { InMemoryTrieStore } from '../../../helpers/trieHelpers.ts';
 
 describe('TrieMaterializationReader', () => {
@@ -40,11 +47,97 @@ describe('TrieMaterializationReader', () => {
     expect(reads.leaf + reads.branch).toBeLessThanOrEqual(4);
   });
 
+  it('decodes only the exact retained property shard without a reader-owned cache', async () => {
+    const store = new InMemoryTrieStore();
+    const indexStore = new MockIndexStorage();
+    const decodeShard = vi.spyOn(indexStore, 'decodeShard');
+    const nodeId = 'node:present';
+    const properties = Object.create(null) as Record<string, unknown>;
+    properties['status'] = 'ready';
+    properties['attempts'] = 2;
+    properties['__proto__'] = 'retained-data';
+    const root = await indexStore.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey: materializationPropertyShardKey(nodeId),
+        schemaVersion: 2,
+        entries: [[nodeId, properties]],
+      }),
+    ]));
+    const reader = new TrieMaterializationReader({
+      store,
+      codec: cborCodec,
+      indexStore,
+    });
+
+    await expect(reader.getNodeProperties(root, nodeId)).resolves.toEqual({
+      status: 'ready',
+      attempts: 2,
+      ['__proto__']: 'retained-data',
+    });
+    await expect(reader.getNodeProperties(root, nodeId)).resolves.toEqual({
+      status: 'ready',
+      attempts: 2,
+      ['__proto__']: 'retained-data',
+    });
+
+    expect(indexStore.openedShardHandles).toEqual([]);
+    expect(indexStore.decodedShardHandles).toHaveLength(2);
+    expect(decodeShard).toHaveBeenCalledWith(
+      expect.anything(),
+      MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS,
+    );
+    await expect(reader.getNodeProperties(root, 'node:missing')).resolves.toBeNull();
+  });
+
+  it('rejects legacy property-shard encoding in the current retained profile', async () => {
+    const indexStore = new MockIndexStorage();
+    const nodeId = 'node:legacy';
+    const root = await indexStore.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey: materializationPropertyShardKey(nodeId),
+        schemaVersion: 1,
+        entries: [[nodeId, { status: 'legacy' }]],
+      }),
+    ]));
+    const reader = new TrieMaterializationReader({
+      store: new InMemoryTrieStore(),
+      codec: cborCodec,
+      indexStore,
+    });
+
+    await expect(reader.getNodeProperties(root, nodeId))
+      .rejects.toMatchObject({ code: 'E_INDEX_SHARD_MALFORMED' });
+  });
+
+  it('rejects non-bundle retained roots at the reader boundary', async () => {
+    const reader = new TrieMaterializationReader({
+      store: new InMemoryTrieStore(),
+      codec: cborCodec,
+      indexStore: new MockIndexStorage(),
+    });
+
+    await expect(Reflect.apply(reader.hasNode, reader, [null, 'node:present']))
+      .rejects.toMatchObject({ code: 'E_MATERIALIZATION_RESUME' });
+    await expect(Reflect.apply(reader.getNodeProperties, reader, [null, 'node:present']))
+      .rejects.toMatchObject({ code: 'E_MATERIALIZATION_RESUME' });
+  });
+
+  it('reports property reads as unsupported for a node-liveness-only reader', async () => {
+    const reader = new TrieMaterializationReader({
+      store: new InMemoryTrieStore(),
+      codec: cborCodec,
+    });
+
+    await expect(reader.getNodeProperties(new BundleHandle('bundle:properties'), 'node:present'))
+      .resolves.toBeUndefined();
+  });
+
   it.each([
     ['options', null],
     ['store', { store: {}, codec: cborCodec }],
     ['codec', { store: new InMemoryTrieStore(), codec: {} }],
     ['geometry', { store: new InMemoryTrieStore(), codec: cborCodec, geometry: {} }],
+    ['indexStore', { store: new InMemoryTrieStore(), codec: cborCodec, indexStore: {} }],
   ])('rejects malformed %s with a domain error', (_field, options) => {
     expect(() => Reflect.construct(TrieMaterializationReader, [options])).toThrowError(
       expect.objectContaining<Pick<WarpError, 'code'>>({ code: 'E_MATERIALIZATION_RESUME' })

--- a/test/unit/domain/materialization/TrieMaterializationReader.test.ts
+++ b/test/unit/domain/materialization/TrieMaterializationReader.test.ts
@@ -50,7 +50,7 @@ describe('TrieMaterializationReader', () => {
   it('decodes only the exact retained property shard without a reader-owned cache', async () => {
     const store = new InMemoryTrieStore();
     const indexStore = new MockIndexStorage();
-    const decodeShard = vi.spyOn(indexStore, 'decodeShard');
+    const decodeShardAt = vi.spyOn(indexStore, 'decodeShardAt');
     const nodeId = 'node:present';
     const properties = Object.create(null) as Record<string, unknown>;
     properties['status'] = 'ready';
@@ -82,8 +82,10 @@ describe('TrieMaterializationReader', () => {
 
     expect(indexStore.openedShardHandles).toEqual([]);
     expect(indexStore.decodedShardHandles).toHaveLength(2);
-    expect(decodeShard).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(indexStore.decodedShardPaths).toHaveLength(2);
+    expect(decodeShardAt).toHaveBeenCalledWith(
+      root,
+      expect.stringContaining('props_'),
       MATERIALIZATION_PROPERTY_SHARD_READ_LIMITS,
     );
     await expect(reader.getNodeProperties(root, 'node:missing')).resolves.toBeNull();

--- a/test/unit/domain/orset/session/StateSession.test.ts
+++ b/test/unit/domain/orset/session/StateSession.test.ts
@@ -463,6 +463,14 @@ class RecordingWorkspace extends MaterializationWorkspacePort {
     }));
   }
 
+  override stagePage(): Promise<never> {
+    return Promise.reject(new Error("StateSession fake store does not stage through the workspace"));
+  }
+
+  override stageOrderedBundle(): Promise<never> {
+    return Promise.reject(new Error("StateSession fake store does not stage through the workspace"));
+  }
+
   override release(): Promise<void> {
     return Promise.resolve();
   }
@@ -473,6 +481,14 @@ class RecordingWorkspace extends MaterializationWorkspacePort {
 }
 
 class NullWitnessWorkspace extends MaterializationWorkspacePort {
+  override stagePage(): Promise<never> {
+    return Promise.reject(new Error("StateSession fake store does not stage through the workspace"));
+  }
+
+  override stageOrderedBundle(): Promise<never> {
+    return Promise.reject(new Error("StateSession fake store does not stage through the workspace"));
+  }
+
   override checkpoint(): Promise<null> {
     return Promise.resolve(null);
   }

--- a/test/unit/domain/services/PropertyIndex.test.ts
+++ b/test/unit/domain/services/PropertyIndex.test.ts
@@ -164,6 +164,21 @@ describe('PropertyIndex handle-backed reads', () => {
     expect(computeShardKey('node:1')).not.toBe('custom');
   });
 
+  it('accepts only property shard schemas implemented by the encoder', () => {
+    const builder = new PropertyIndexBuilder({ schemaVersion: 2, shardKey: () => 'current' });
+    builder.addProperty('node:1', 'status', 'ready');
+
+    expect([...builder.yieldShards()][0]?.schemaVersion).toBe(2);
+    expect(() => new PropertyIndexBuilder({
+      // @ts-expect-error Runtime guard for JavaScript callers.
+      schemaVersion: 3,
+    })).toThrowError(expect.objectContaining({ code: 'E_INDEX_SHARD_SCHEMA' }));
+    expect(() => new PropertyIndexBuilder({
+      // @ts-expect-error Runtime guard for JavaScript callers.
+      schemaVersion: null,
+    })).toThrowError(expect.objectContaining({ code: 'E_INDEX_SHARD_SCHEMA' }));
+  });
+
   it('rejects an over-limit flat property root before persistence', () => {
     expect(() => requireMaterializationPropertyShardCount(
       MAX_MATERIALIZATION_PROPERTY_SHARDS + 1,

--- a/test/unit/domain/services/PropertyIndex.test.ts
+++ b/test/unit/domain/services/PropertyIndex.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { PropertyShard } from '../../../../src/domain/artifacts/PropertyShard.ts';
 import PropertyIndexBuilder from '../../../../src/domain/services/index/PropertyIndexBuilder.ts';
 import PropertyIndexReader from '../../../../src/domain/services/index/PropertyIndexReader.ts';
+import { decodePropertyShard } from '../../../../src/domain/services/index/PropertyIndexReader.ts';
+import {
+  MAX_MATERIALIZATION_PROPERTY_SHARDS,
+  requireMaterializationPropertyShardCount,
+} from '../../../../src/domain/materialization/MaterializationPropertyProfile.ts';
 import computeShardKey from '../../../../src/domain/utils/shardKey.ts';
 import defaultCodec from '../../../../src/infrastructure/codecs/CborCodec.ts';
 import { F10_PROTO_POLLUTION } from '../../../helpers/fixtureDsl.ts';
@@ -30,7 +35,10 @@ describe('PropertyIndex handle-backed reads', () => {
 
     await expect(reader.getNodeProps('user:alice')).resolves.toEqual({ name: 'Alice', age: 30 });
     await expect(reader.getProperty('user:bob', 'name')).resolves.toBe('Bob');
+    await expect(reader.getProperty('user:alice', 'constructor')).resolves.toBeUndefined();
+    await expect(reader.getProperty('user:alice', 'toString')).resolves.toBeUndefined();
     await expect(reader.getNodeProps('missing')).resolves.toBeNull();
+    await expect(reader.getProperty('missing', 'name')).resolves.toBeUndefined();
   });
 
   it('reads freshly materialized in-memory shards without a storage adapter', async () => {
@@ -81,6 +89,85 @@ describe('PropertyIndex handle-backed reads', () => {
     await expect(reader.getNodeProps('node:1')).rejects.toMatchObject({
       code: 'E_INDEX_SHARD_MALFORMED',
     });
+  });
+
+  it('rejects duplicate and wrong-bucket node entries', () => {
+    const nodeId = 'node:1';
+    const path = `props_${computeShardKey(nodeId)}.cbor`;
+
+    expect(() => decodePropertyShard([
+      [nodeId, { status: 'first' }],
+      [nodeId, { status: 'second' }],
+    ], path)).toThrowError(expect.objectContaining({ code: 'E_INDEX_SHARD_MALFORMED' }));
+    expect(() => decodePropertyShard(
+      [[nodeId, { status: 'misbucketed' }]],
+      'props_00.cbor',
+    )).toThrowError(expect.objectContaining({ code: 'E_INDEX_SHARD_MALFORMED' }));
+  });
+
+  it('decodes schema-v1 object bags and schema-v2 entry bags explicitly', () => {
+    const nodeId = 'node:1';
+    const path = `props_${computeShardKey(nodeId)}.cbor`;
+    const legacy = decodePropertyShard([[nodeId, { status: 'legacy' }]], path);
+    const current = decodePropertyShard({
+      schemaVersion: 2,
+      entries: [[nodeId, [[
+        '__proto__',
+        'retained-data',
+      ], [
+        'status',
+        'current',
+      ]]]],
+    }, path);
+    const currentBag = current.get(nodeId);
+
+    expect(legacy.get(nodeId)).toEqual({ status: 'legacy' });
+    expect(currentBag?.['status']).toBe('current');
+    expect(Object.hasOwn(currentBag ?? {}, '__proto__')).toBe(true);
+    expect(currentBag?.['__proto__']).toBe('retained-data');
+    expect(Object.getPrototypeOf(currentBag)).toBeNull();
+    expect(Object.isFrozen(currentBag)).toBe(true);
+    expect(({} as Record<string, unknown>)['retained-data']).toBeUndefined();
+  });
+
+  it('rejects ambiguous, duplicate, and invalid schema-v2 property entries', () => {
+    const nodeId = 'node:1';
+    const path = `props_${computeShardKey(nodeId)}.cbor`;
+
+    for (const payload of [
+      null,
+      { schemaVersion: 2, entries: [[nodeId, [['status', 'first'], ['status', 'second']]]] },
+      { schemaVersion: 2, entries: [[nodeId, [['', 'empty-key']]]] },
+      { schemaVersion: 2, entries: [[nodeId, [['bad\0key', 'nul-key']]]] },
+      { schemaVersion: 2, entries: [[nodeId, { status: 'object-bag' }]] },
+      { schemaVersion: 2, entries: 'not-an-array' },
+      { schemaVersion: 2, entries: [['', []]] },
+      { schemaVersion: 3, entries: [] },
+      { schemaVersion: 2, entries: [], extra: true },
+    ]) {
+      expect(() => decodePropertyShard(payload, path)).toThrowError(
+        expect.objectContaining({ code: 'E_INDEX_SHARD_MALFORMED' }),
+      );
+    }
+
+    expect(() => decodePropertyShard(
+      [[nodeId, [['status', 'ambiguous-v1-array-bag']]]],
+      path,
+    )).toThrowError(expect.objectContaining({ code: 'E_INDEX_SHARD_MALFORMED' }));
+  });
+
+  it('uses an injected shard routing profile without changing the default profile', () => {
+    const builder = new PropertyIndexBuilder({ shardKey: () => 'custom' });
+    builder.addProperty('node:1', 'status', 'ready');
+
+    expect([...builder.yieldShards()].map((shard) => shard.shardKey)).toEqual(['custom']);
+    expect(computeShardKey('node:1')).not.toBe('custom');
+  });
+
+  it('rejects an over-limit flat property root before persistence', () => {
+    expect(() => requireMaterializationPropertyShardCount(
+      MAX_MATERIALIZATION_PROPERTY_SHARDS + 1,
+    )).toThrowError(expect.objectContaining({ code: 'E_INDEX_SHARD_COUNT_LIMIT' }));
   });
 
   it('does not permit __proto__ property data to mutate Object.prototype', async () => {

--- a/test/unit/domain/services/controllers/MaterializationWorkspaceCleanup.test.ts
+++ b/test/unit/domain/services/controllers/MaterializationWorkspaceCleanup.test.ts
@@ -63,6 +63,14 @@ class RejectingWorkspace extends MaterializationWorkspacePort {
     return Promise.resolve(null);
   }
 
+  override stagePage(): Promise<never> {
+    return Promise.reject(new Error('staging is not used by this test'));
+  }
+
+  override stageOrderedBundle(): Promise<never> {
+    return Promise.reject(new Error('staging is not used by this test'));
+  }
+
   override promote(): Promise<never> {
     return Promise.reject(new Error('promotion is not used by this test'));
   }

--- a/test/unit/domain/services/controllers/MaterializeController.liveNodeRead.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.liveNodeRead.test.ts
@@ -152,6 +152,86 @@ describe('MaterializeController live node reads', () => {
     expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
     expect(fixture.materializations.acquisitions[0]?.released).toBe(true);
   });
+
+  it('reads retained node properties without projecting whole state', async () => {
+    const fixture = await createFixture({
+      propertyRootStatus: 'retained',
+      properties: { status: 'ready' },
+    });
+
+    await expect(fixture.controller.readLiveNodeProperties('node:retained'))
+      .resolves.toEqual({ status: 'ready' });
+
+    expect(fixture.materializationRead.hasNode).toHaveBeenCalledWith(
+      fixture.nodeRoot,
+      'node:retained',
+    );
+    expect(fixture.materializationRead.getNodeProperties).toHaveBeenCalledWith(
+      fixture.propertyRoot,
+      'node:retained',
+    );
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+    expect(fixture.deps.crypto.hash).not.toHaveBeenCalled();
+  });
+
+  it('returns null properties for a missing retained node', async () => {
+    const fixture = await createFixture({
+      presence: false,
+      propertyRootStatus: 'retained',
+    });
+
+    await expect(fixture.controller.readLiveNodeProperties('node:missing'))
+      .resolves.toBeNull();
+
+    expect(fixture.materializationRead.getNodeProperties).not.toHaveBeenCalled();
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+  });
+
+  it('returns an empty bag from an empty retained properties root', async () => {
+    const fixture = await createFixture({ propertyRootStatus: 'empty' });
+
+    await expect(fixture.controller.readLiveNodeProperties('node:retained'))
+      .resolves.toEqual({});
+
+    expect(fixture.materializationRead.getNodeProperties).not.toHaveBeenCalled();
+  });
+
+  it('falls back after releasing an unavailable retained properties root', async () => {
+    const fixture = await createFixture({ propertyRootStatus: 'unavailable' });
+
+    await expect(fixture.controller.readLiveNodeProperties('node:retained'))
+      .resolves.toBeUndefined();
+
+    expect(fixture.materializationRead.getNodeProperties).not.toHaveBeenCalled();
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+  });
+
+  it('falls back when the configured reader does not support property roots', async () => {
+    const fixture = await createFixture({
+      propertyRootStatus: 'retained',
+      propertyReadUnsupported: true,
+    });
+
+    await expect(fixture.controller.readLiveNodeProperties('node:retained'))
+      .resolves.toBeUndefined();
+
+    expect(fixture.materializationRead.getNodeProperties).toHaveBeenCalledOnce();
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+  });
+
+  it('releases retained roots when the bounded property read fails', async () => {
+    const propertyReadFailure = new Error('property read failed');
+    const fixture = await createFixture({
+      propertyRootStatus: 'retained',
+      propertyReadFailure,
+    });
+
+    await expect(fixture.controller.readLiveNodeProperties('node:retained'))
+      .rejects.toBe(propertyReadFailure);
+
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+    expect(fixture.materializations.acquisitions[0]?.released).toBe(true);
+  });
 });
 
 async function createFixture(
@@ -159,6 +239,10 @@ async function createFixture(
     readonly frontier?: Map<string, string>;
     readonly materializationRead?: boolean;
     readonly presence?: boolean;
+    readonly properties?: Readonly<Record<string, string>>;
+    readonly propertyReadFailure?: Error;
+    readonly propertyReadUnsupported?: boolean;
+    readonly propertyRootStatus?: MaterializationRootStatus;
     readonly readFailure?: Error;
     readonly retain?: boolean;
     readonly rootStatus?: MaterializationRootStatus;
@@ -168,10 +252,16 @@ async function createFixture(
   patches.frontier = new Map(options.frontier ?? FRONTIER);
   const materializations = new InMemoryMaterializationStore();
   const nodeRoot = new BundleHandle('test:node-root');
+  const propertyRoot = new BundleHandle('test:property-root');
   if (options.retain !== false && patches.frontier.size > 0) {
     await materializations.retain({
       coordinate: new MaterializationCoordinate({ frontier: patches.frontier, ceiling: null }),
-      roots: rootsWithNodeStatus(options.rootStatus ?? 'retained', nodeRoot),
+      roots: rootsWithStatus({
+        nodeStatus: options.rootStatus ?? 'retained',
+        nodeRoot,
+        propertyStatus: options.propertyRootStatus ?? 'unavailable',
+        propertyRoot,
+      }),
       stateHash: 'state-hash',
     });
   }
@@ -181,13 +271,31 @@ async function createFixture(
   } else {
     hasNode.mockRejectedValue(options.readFailure);
   }
-  const materializationRead = { hasNode };
+  const getNodeProperties = vi.fn();
+  if (options.propertyReadUnsupported === true) {
+    getNodeProperties.mockResolvedValue(undefined);
+  } else if (options.propertyReadFailure === undefined) {
+    getNodeProperties.mockResolvedValue(options.properties ?? null);
+  } else {
+    getNodeProperties.mockRejectedValue(options.propertyReadFailure);
+  }
+  const materializationRead = {
+    hasNode,
+    getNodeProperties,
+  };
   const deps = createDeps({ materializations, patches, materializationRead });
   const controller =
     options.materializationRead === false
       ? new MaterializeController(withoutMaterializationRead(deps))
       : new MaterializeController(deps);
-  return { controller, deps, materializationRead, materializations, nodeRoot };
+  return {
+    controller,
+    deps,
+    materializationRead,
+    materializations,
+    nodeRoot,
+    propertyRoot,
+  };
 }
 
 function createDeps(options: {
@@ -195,6 +303,10 @@ function createDeps(options: {
   readonly patches: PatchCollector;
   readonly materializationRead: {
     hasNode(nodeAliveRoot: BundleHandle, nodeId: string): Promise<boolean>;
+    getNodeProperties(
+      propertiesRoot: BundleHandle,
+      nodeId: string,
+    ): Promise<Readonly<Record<string, string>> | null | undefined>;
   };
 }): MaterializeDeps {
   return {
@@ -226,10 +338,12 @@ function withoutMaterializationRead(deps: MaterializeDeps): MaterializeDeps {
   return withoutReader;
 }
 
-function rootsWithNodeStatus(
-  status: MaterializationRootStatus,
-  nodeRoot: BundleHandle
-): MaterializationRoots {
+function rootsWithStatus(options: {
+  nodeStatus: MaterializationRootStatus;
+  nodeRoot: BundleHandle;
+  propertyStatus: MaterializationRootStatus;
+  propertyRoot: BundleHandle;
+}): MaterializationRoots {
   const unavailable = MaterializationRoot.unavailable();
   return new MaterializationRoots({
     adjacency: unavailable,
@@ -237,12 +351,17 @@ function rootsWithNodeStatus(
     edgeBirths: unavailable,
     frontier: unavailable,
     nodeAlive:
-      status === 'retained'
-        ? MaterializationRoot.retained(nodeRoot)
-        : status === 'empty'
+      options.nodeStatus === 'retained'
+        ? MaterializationRoot.retained(options.nodeRoot)
+        : options.nodeStatus === 'empty'
           ? MaterializationRoot.empty()
           : unavailable,
-    properties: unavailable,
+    properties:
+      options.propertyStatus === 'retained'
+        ? MaterializationRoot.retained(options.propertyRoot)
+        : options.propertyStatus === 'empty'
+          ? MaterializationRoot.empty()
+          : unavailable,
     provenanceSupport: unavailable,
     roaringIndexes: unavailable,
   });

--- a/test/unit/domain/services/controllers/MaterializeController.propertyRootRetention.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.propertyRootRetention.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from "vitest";
+
+import PatchCollector, {
+  type CheckpointData,
+  type PatchWithSha,
+} from "../../../../../src/domain/capabilities/PatchCollector.ts";
+import PatchEntry from "../../../../../src/domain/artifacts/PatchEntry.ts";
+import { Dot } from "../../../../../src/domain/crdt/Dot.ts";
+import MaterializationCoordinate from "../../../../../src/domain/materialization/MaterializationCoordinate.ts";
+import MaterializationRoot from "../../../../../src/domain/materialization/MaterializationRoot.ts";
+import StateSession from "../../../../../src/domain/orset/session/StateSession.ts";
+import PageCache from "../../../../../src/domain/orset/trie/PageCache.ts";
+import TrieGeometry from "../../../../../src/domain/orset/trie/TrieGeometry.ts";
+import MaterializeController from "../../../../../src/domain/services/controllers/MaterializeController.ts";
+import { reduceSessionBackedState } from "../../../../../src/domain/services/controllers/MaterializeSessionBridge.ts";
+import BundleHandle from "../../../../../src/domain/storage/BundleHandle.ts";
+import Patch from "../../../../../src/domain/types/Patch.ts";
+import NodeAdd from "../../../../../src/domain/types/ops/NodeAdd.ts";
+import NodePropSet from "../../../../../src/domain/types/ops/NodePropSet.ts";
+import cborCodec from "../../../../../src/infrastructure/codecs/CborCodec.ts";
+import type MaterializationWorkspacePort from "../../../../../src/ports/MaterializationWorkspacePort.ts";
+import InMemoryCheckpointStore from "../../../../helpers/InMemoryCheckpointStore.ts";
+import InMemoryMaterializationStore, {
+  InMemoryMaterializationWorkspace,
+} from "../../../../helpers/InMemoryMaterializationStore.ts";
+import MockIndexStorage from "../../../../helpers/MockIndexStorage.ts";
+import { InMemoryTrieStore } from "../../../../helpers/trieHelpers.ts";
+
+const GEOMETRY = TrieGeometry.default16way();
+const PATCH_SHA = "a1b2";
+
+class PropertyPatchCollector extends PatchCollector {
+  readonly #entry: PatchWithSha;
+
+  constructor() {
+    super();
+    this.#entry = propertyPatch();
+  }
+
+  override discoverWriters(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadWriterPatches(_writerId: string): Promise<PatchWithSha[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadCheckpoint(): Promise<CheckpointData | null> {
+    return Promise.resolve(null);
+  }
+
+  override loadPatchesSince(_checkpoint: CheckpointData): Promise<PatchWithSha[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadPatchChain(_toSha: string, _fromSha?: string | null): Promise<PatchWithSha[]> {
+    return Promise.resolve([this.#entry]);
+  }
+
+  override getFrontier(): Promise<Map<string, string>> {
+    return Promise.resolve(new Map([["writer-1", PATCH_SHA]]));
+  }
+}
+
+describe("MaterializeController property-root retention", () => {
+  it("releases the workspace without promotion when the property-root checkpoint fails", async () => {
+    const materializations = new InMemoryMaterializationStore();
+    const controller = new MaterializeController({
+      logger: testLogger(),
+      codec: cborCodec,
+      crypto: testCrypto(),
+      persistence: testPersistence(),
+      checkpointStore: new InMemoryCheckpointStore(),
+      materializations,
+      getStateCache: () => null,
+      patches: new PropertyPatchCollector(),
+      graphCloner: { openReadOnly: vi.fn() },
+      graphName: "test-graph",
+      openStateSession: createStateSessionOpener(),
+      propertyStore: new MockIndexStorage(),
+    });
+    const failure = new Error("property-root checkpoint failed");
+    const originalCheckpoint = InMemoryMaterializationWorkspace.prototype.checkpoint;
+    const checkpoint = vi.spyOn(InMemoryMaterializationWorkspace.prototype, "checkpoint")
+      .mockImplementation(function (
+        this: InMemoryMaterializationWorkspace,
+        roots,
+      ) {
+        if (roots.propertiesRoot !== undefined) {
+          return Promise.reject(failure);
+        }
+        return originalCheckpoint.call(this, roots);
+      });
+    const promote = vi.spyOn(InMemoryMaterializationWorkspace.prototype, "promote");
+
+    try {
+      await expect(controller.materialize()).rejects.toBe(failure);
+
+      expect(checkpoint).toHaveBeenCalledWith(expect.objectContaining({
+        propertiesRoot: expect.any(String),
+      }));
+      expect(promote).not.toHaveBeenCalled();
+      expect(materializations.retainedRequests).toHaveLength(0);
+      expect(materializations.workspaces[0]?.released).toBe(true);
+    } finally {
+      promote.mockRestore();
+      checkpoint.mockRestore();
+    }
+  });
+
+  it("rebuilds a supplied property root when the reduction observes a patch", async () => {
+    const materializations = new InMemoryMaterializationStore();
+    const propertyStore = new MockIndexStorage();
+    const stale = MaterializationRoot.retained(new BundleHandle("test:stale-properties"));
+
+    const reduced = await reduceSessionBackedState({
+      openStateSession: createStateSessionOpener(),
+      materializations,
+      propertyStore,
+      propertyRoot: stale,
+      coordinate: new MaterializationCoordinate({
+        frontier: new Map([["writer-1", PATCH_SHA]]),
+        ceiling: null,
+      }),
+      patches: [new PatchEntry(propertyPatch())],
+      receipts: false,
+      wantDiff: false,
+    });
+
+    expect(reduced.roots.properties.status).toBe("retained");
+    expect(reduced.roots.properties.equals(stale)).toBe(false);
+    expect(propertyStore.writeBlob).toHaveBeenCalledOnce();
+    await reduced.workspace.release();
+  });
+});
+
+function propertyPatch(): PatchWithSha {
+  return {
+    patch: new Patch({
+      writer: "writer-1",
+      lamport: 1,
+      context: {},
+      ops: [
+        new NodeAdd("node:retained", Dot.create("writer-1", 1)),
+        new NodePropSet("node:retained", "status", "ready"),
+      ],
+      reads: [],
+      writes: ["node:retained"],
+    }),
+    sha: PATCH_SHA,
+  };
+}
+
+function createStateSessionOpener() {
+  const store = new InMemoryTrieStore();
+  const pageCache = new PageCache({ maxResident: 32 });
+  return async (
+    roots: {
+      readonly nodeAliveRootOid: string | null;
+      readonly edgeAliveRootOid: string | null;
+    },
+    options: { readonly workspace: MaterializationWorkspacePort },
+  ): Promise<StateSession> => await StateSession.open({
+    nodeAliveRootOid: roots.nodeAliveRootOid,
+    edgeAliveRootOid: roots.edgeAliveRootOid,
+    store,
+    codec: cborCodec,
+    geometry: GEOMETRY,
+    pageCache,
+    maxDirtyPages: 1,
+    workspace: options.workspace,
+  });
+}
+
+function testLogger() {
+  return {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+}
+
+function testCrypto() {
+  return {
+    hash: vi.fn().mockResolvedValue("state-hash-1"),
+    hmac: vi.fn().mockResolvedValue(new Uint8Array([1])),
+    timingSafeEqual: vi.fn().mockReturnValue(false),
+  };
+}
+
+function testPersistence() {
+  return {
+    readRef: vi.fn().mockResolvedValue(null),
+    readTreeOids: vi.fn().mockResolvedValue({}),
+    showNode: vi.fn().mockResolvedValue(""),
+    readBlob: vi.fn().mockResolvedValue(new Uint8Array([1])),
+  };
+}

--- a/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
@@ -5,6 +5,7 @@ import PatchEntry from "../../../../../src/domain/artifacts/PatchEntry.ts";
 import MaterializeController from "../../../../../src/domain/services/controllers/MaterializeController.ts";
 import { reduceSessionBackedState } from "../../../../../src/domain/services/controllers/MaterializeSessionBridge.ts";
 import NodeAdd from "../../../../../src/domain/types/ops/NodeAdd.ts";
+import NodePropSet from "../../../../../src/domain/types/ops/NodePropSet.ts";
 import EdgeAdd from "../../../../../src/domain/types/ops/EdgeAdd.ts";
 import StateSession from "../../../../../src/domain/orset/session/StateSession.ts";
 import PageCache from "../../../../../src/domain/orset/trie/PageCache.ts";
@@ -25,6 +26,7 @@ import type MaterializationWorkspacePort from "../../../../../src/ports/Material
 import MaterializationCoordinate from "../../../../../src/domain/materialization/MaterializationCoordinate.ts";
 import MaterializationHandle from "../../../../../src/domain/materialization/MaterializationHandle.ts";
 import type { RetainMaterializationRequest } from "../../../../../src/ports/MaterializationStorePort.ts";
+import MockIndexStorage from "../../../../helpers/MockIndexStorage.ts";
 
 const GEOMETRY = TrieGeometry.default16way();
 
@@ -47,6 +49,30 @@ function nodeAddPatchRecord(args: {
       lamport: args.lamport,
       context: {},
       ops: [new NodeAdd(args.node, Dot.create(args.writer, args.lamport))],
+      reads: [],
+      writes: [args.node],
+    }),
+    sha: args.sha,
+  };
+}
+
+function nodePropertyPatchRecord(args: {
+  readonly writer: string;
+  readonly lamport: number;
+  readonly sha: string;
+  readonly node: string;
+  readonly key: string;
+  readonly value: string;
+}): PatchRecord {
+  return {
+    patch: new Patch({
+      writer: args.writer,
+      lamport: args.lamport,
+      context: {},
+      ops: [
+        new NodeAdd(args.node, Dot.create(args.writer, args.lamport)),
+        new NodePropSet(args.node, args.key, args.value),
+      ],
       reads: [],
       writes: [args.node],
     }),
@@ -503,6 +529,43 @@ describe("MaterializeController — state session integration", () => {
     expect(reopened.state.nodeAlive.contains("node:retained")).toBe(true);
     expect(warm.materialization?.bundle.equals(cold.materialization?.bundle)).toBe(true);
     expect(reopened.materialization?.bundle.equals(cold.materialization?.bundle)).toBe(true);
+  });
+
+  it("promotes a newly available property root instead of reusing an incomplete handle", async () => {
+    const fixtures = createControllerFixtures();
+    fixtures.patches.collectForFrontier.mockResolvedValue([
+      nodePropertyPatchRecord({
+        writer: "writer-1",
+        lamport: 1,
+        sha: "a1b2",
+        node: "node:retained",
+        key: "status",
+        value: "ready",
+      }),
+    ]);
+    const cold = await fixtures.controller.materialize();
+    const published = fixtures.stateCache.put.mock.calls[0]?.[0];
+    if (cold.materialization === undefined || published === undefined) {
+      throw new Error("Cold materialization did not publish retained state");
+    }
+    expect(cold.materialization.roots.properties.status).toBe("unavailable");
+
+    fixtures.stateCache.getExact.mockResolvedValue(published);
+    const propertyStore = new MockIndexStorage();
+    const upgradedController = new MaterializeController({
+      ...fixtures.deps,
+      propertyStore,
+    });
+    const upgraded = await upgradedController.materialize();
+    const reused = await upgradedController.materialize();
+
+    expect(fixtures.materializations.retainedRequests).toHaveLength(2);
+    expect(upgraded.materialization?.roots.properties.status).toBe("retained");
+    expect(upgraded.materialization?.bundle.equals(cold.materialization.bundle)).toBe(false);
+    expect(reused.materialization?.bundle.equals(upgraded.materialization?.bundle)).toBe(true);
+    expect(propertyStore.writeBlob).toHaveBeenCalledOnce();
+    expect(fixtures.materializations.workspaces[1]?.checkpoints.at(-1)?.propertiesRoot)
+      .toBe(upgraded.materialization?.roots.properties.handle?.toString());
   });
 
   it("does not retry an exact acquisition release failure", async () => {

--- a/test/unit/domain/services/controllers/QueryController.test.ts
+++ b/test/unit/domain/services/controllers/QueryController.test.ts
@@ -119,6 +119,7 @@ function createHost(state, overrides = {}) {
     getFrontier: vi.fn().mockResolvedValue(new Map(frontier)),
     _ensureFreshState: vi.fn().mockResolvedValue(undefined),
     _readLiveNodePresence: vi.fn().mockResolvedValue(null),
+    _readLiveNodeProperties: vi.fn().mockResolvedValue(undefined),
     _assetStorage: {
       open: vi.fn(() => chunks(new Uint8Array([1, 2, 3]))),
     },
@@ -227,6 +228,39 @@ describe('QueryController', () => {
     it('returns empty object for a node with no properties', async () => {
       const props = await ctrl.getNodeProps('carol');
       expect(props).toEqual({});
+    });
+
+    it('returns retained properties without requiring whole state', async () => {
+      host._cachedState = null;
+      host._readLiveNodeProperties.mockResolvedValue({ age: 30, name: 'Alice' });
+
+      await expect(ctrl.getNodeProps('alice')).resolves.toEqual({
+        age: 30,
+        name: 'Alice',
+      });
+
+      expect(host._readLiveNodeProperties).toHaveBeenCalledWith('alice');
+      expect(host._ensureFreshState).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid public node target before retained lookup', async () => {
+      host._cachedState = null;
+
+      await expect(ctrl.getNodeProps('')).resolves.toBeNull();
+
+      expect(host._readLiveNodeProperties).not.toHaveBeenCalled();
+      expect(host._ensureFreshState).not.toHaveBeenCalled();
+    });
+
+    it('falls back to whole state only when retained properties are unavailable', async () => {
+      host._readLiveNodeProperties.mockResolvedValue(undefined);
+
+      await expect(ctrl.getNodeProps('alice')).resolves.toEqual({
+        age: 30,
+        name: 'Alice',
+      });
+
+      expect(host._ensureFreshState).toHaveBeenCalledOnce();
     });
 
     it('uses indexed fast path when propertyReader is available', async () => {

--- a/test/unit/helpers/StorageTestDoubles.test.ts
+++ b/test/unit/helpers/StorageTestDoubles.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import WarpStream from '../../../src/domain/stream/WarpStream.ts';
+import { InMemoryMaterializationWorkspace } from '../../helpers/InMemoryMaterializationStore.ts';
+import MockIndexStorage from '../../helpers/MockIndexStorage.ts';
+
+describe('storage test doubles', () => {
+  it('rejects materialization workspace writes after release', async () => {
+    const workspace = new InMemoryMaterializationWorkspace(async () => {
+      throw new Error('promotion must not run');
+    });
+
+    await workspace.release();
+
+    expect(() => workspace.stagePage()).toThrow(/workspace is released/);
+    expect(() => workspace.stageOrderedBundle()).toThrow(/workspace is released/);
+    expect(() => workspace.checkpoint({ nodeAliveRoot: null, edgeAliveRoot: null })).toThrow(
+      /workspace is released/,
+    );
+  });
+
+  it('does not resolve inherited object properties as shard paths', async () => {
+    const storage = new MockIndexStorage();
+    const index = await storage.writeShards(WarpStream.of());
+
+    await expect(storage.readShardHandle(index, 'constructor')).resolves.toBeNull();
+    await expect(storage.decodeShardAt(index, 'toString')).resolves.toBeNull();
+  });
+});

--- a/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
+++ b/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
@@ -196,9 +196,9 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     const directIndexes = indexAdapter(assets, {
       pages: cas.pages,
       bundles: {
-        getMember: cas.bundles.getMember,
+        getMemberReference: cas.bundles.getMemberReference,
         putOrdered: cas.bundles.putOrdered,
-        iterateMembers: () => {
+        iterateMemberReferences: () => {
           throw new Error('readShardHandle must not enumerate bundle members');
         },
       },
@@ -539,11 +539,11 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     const duplicateCas: GitCasIndexFacade = {
       pages: cas.pages,
       bundles: {
-        getMember: cas.bundles.getMember,
+        getMemberReference: cas.bundles.getMemberReference,
         putOrdered: cas.bundles.putOrdered,
-        iterateMembers: async function* (request) {
+        iterateMemberReferences: async function* (request) {
           let duplicated = false;
-          for await (const member of cas.bundles.iterateMembers(request)) {
+          for await (const member of cas.bundles.iterateMemberReferences(request)) {
             yield member;
             if (!duplicated) {
               yield member;
@@ -566,10 +566,10 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     const nonAssetCas: GitCasIndexFacade = {
       pages: cas.pages,
       bundles: {
-        getMember: cas.bundles.getMember,
+        getMemberReference: cas.bundles.getMemberReference,
         putOrdered: cas.bundles.putOrdered,
-        iterateMembers: async function* (request) {
-          for await (const member of cas.bundles.iterateMembers(request)) {
+        iterateMemberReferences: async function* (request) {
+          for await (const member of cas.bundles.iterateMemberReferences(request)) {
             yield Object.freeze({
               ...member,
               path: 'unknown.cbor',

--- a/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
+++ b/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
@@ -4,6 +4,7 @@ import {
   PageHandle as GitCasPageHandle,
 } from '@git-stunts/git-cas';
 import { EdgeShard } from '../../../src/domain/artifacts/EdgeShard.ts';
+import { IndexShard } from '../../../src/domain/artifacts/IndexShard.ts';
 import { LabelShard } from '../../../src/domain/artifacts/LabelShard.ts';
 import { MetaShard } from '../../../src/domain/artifacts/MetaShard.ts';
 import { PropertyShard } from '../../../src/domain/artifacts/PropertyShard.ts';
@@ -23,6 +24,7 @@ import {
   type CborStructureLimits,
 } from '../../../src/infrastructure/adapters/BoundedCborValidation.ts';
 import GitCasAssetStorageAdapter from '../../../src/infrastructure/adapters/GitCasAssetStorageAdapter.ts';
+import { IndexShardEncodeTransform } from '../../../src/infrastructure/adapters/IndexShardEncodeTransform.ts';
 import defaultCodec from '../../../src/infrastructure/codecs/CborCodec.ts';
 import IndexStorePort from '../../../src/ports/IndexStorePort.ts';
 import InMemoryGraphAdapter from '../../helpers/InMemoryGraphAdapter.ts';
@@ -101,6 +103,18 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       // @ts-expect-error Runtime dependency guard for JavaScript callers.
       cas: null,
     })).toThrow(/cas/);
+  });
+
+  it('rejects an invalid encoder dependency and unsupported shard class', async () => {
+    expect(() => new IndexShardEncodeTransform(
+      // @ts-expect-error Runtime dependency guard for JavaScript callers.
+      null,
+    )).toThrowError(expect.objectContaining({ code: 'E_INVALID_DEPENDENCY' }));
+
+    const encoded = WarpStream.from<IndexShard>([
+      new IndexShard({ shardKey: 'unsupported', schemaVersion: 1 }),
+    ]).pipe(new IndexShardEncodeTransform(defaultCodec));
+    await expect(encoded.collect()).rejects.toMatchObject({ code: 'E_UNKNOWN_SHARD' });
   });
 
   it('writes and scans every supported shard class through one index handle', async () => {
@@ -231,6 +245,9 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       memberStorage: 'page',
       maxShardCount: 1,
       maxShardBytes: 1024,
+      maxContainerEntries: 16,
+      maxDepth: 8,
+      maxItems: 64,
     });
     const token = cas.readBundleMembers(indexHandle.toString())[0]?.[1];
     if (token === undefined) {
@@ -283,6 +300,31 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     );
   });
 
+  it('rejects structurally over-limit shards before staging them', async () => {
+    const stagePage = vi.fn(async () => 'test:must-not-stage-page');
+    const stageOrderedBundle = vi.fn(async () => new BundleHandle('test:must-not-stage-bundle'));
+
+    await expect(indexes.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey: materializationPropertyShardKey('node:deep'),
+        schemaVersion: 2,
+        entries: [['node:deep', { value: [[[[['too-deep']]]]] }]],
+      }),
+    ]), {
+      expectedShardCount: 1,
+      memberStorage: 'page',
+      maxShardCount: 1,
+      maxShardBytes: 1024,
+      maxContainerEntries: 16,
+      maxDepth: 4,
+      maxItems: 64,
+      staging: { stagePage, stageOrderedBundle },
+    })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_MALFORMED' });
+
+    expect(stagePage).not.toHaveBeenCalled();
+    expect(stageOrderedBundle).not.toHaveBeenCalled();
+  });
+
   it('opens and decodes exactly one selected shard handle', async () => {
     const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
     const handles = await indexes.readShardHandles(indexHandle);
@@ -299,6 +341,48 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       shardCount: 5,
     });
     await expect(indexes.decodeShard(receiptHandle)).resolves.toEqual(defaultCodec.decode(bytes));
+  });
+
+  it('decodes a fragmented asset member by exact bundle path', async () => {
+    const path = 'props_fragmented.cbor';
+    const value = { status: 'fragmented' };
+    const bytes = defaultCodec.encode(value);
+    const staged = await assets.stage(WarpStream.from([bytes]), {
+      slug: 'fragmented-exact-index-shard',
+      filename: path,
+    });
+    const bundle = await cas.bundles.putOrdered({
+      members: [[path, staged.handle.toString()]],
+    });
+    const split = Math.floor(bytes.byteLength / 2);
+    vi.spyOn(assets, 'open').mockImplementation(async function* () {
+      yield new Uint8Array();
+      yield bytes.subarray(0, split);
+      yield bytes.subarray(split);
+    });
+
+    await expect(indexes.decodeShardAt(
+      new BundleHandle(bundle.handle.toString()),
+      path,
+      {
+        maxBytes: 1024,
+        maxContainerEntries: 16,
+        maxDepth: 8,
+        maxItems: 64,
+      },
+    )).resolves.toEqual(value);
+  });
+
+  it('rejects a non-page, non-asset exact bundle member', async () => {
+    const nested = await cas.bundles.putOrdered({ members: [] });
+    const bundle = await cas.bundles.putOrdered({
+      members: [['nested.cbor', nested.handle.toString()]],
+    });
+
+    await expect(indexes.decodeShardAt(
+      new BundleHandle(bundle.handle.toString()),
+      'nested.cbor',
+    )).rejects.toMatchObject({ code: 'E_INDEX_INVALID_BUNDLE_MEMBER' });
   });
 
   it('rejects oversized shards on write and exact read', async () => {
@@ -360,6 +444,25 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     await expect(indexes.writeShards(WarpStream.of(), {
       memberStorage: 'page',
     })).rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
+  });
+
+  it('rejects invalid write storage policies before consuming shards', async () => {
+    await expect(indexes.writeShards(WarpStream.of(), {
+      // @ts-expect-error Runtime guard for JavaScript callers.
+      memberStorage: 'blob',
+    })).rejects.toMatchObject({ code: 'E_INDEX_INVALID_STORAGE' });
+    await expect(indexes.writeShards(WarpStream.of(), {
+      // @ts-expect-error Runtime guard for JavaScript callers.
+      staging: { stagePage: null, stageOrderedBundle: null },
+    })).rejects.toMatchObject({ code: 'E_INDEX_INVALID_STORAGE' });
+  });
+
+  it('enforces the encoded byte ceiling for non-property shards', async () => {
+    await expect(indexes.writeShards(WarpStream.from([
+      new ReceiptShard({ version: 1, nodeCount: 1, labelCount: 1, shardCount: 1 }),
+    ]), { maxShardBytes: 1 })).rejects.toMatchObject({
+      code: 'E_INDEX_SHARD_TOO_LARGE',
+    });
   });
 
   it('rejects dangerous CBOR containers before general decoding', async () => {
@@ -485,6 +588,18 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       { maxContainerEntries: 10, maxDepth: 10, maxItems: 0 },
     ]) {
       await expect(indexes.decodeShard(staged.handle, options))
+        .rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
+    }
+  });
+
+  it('rejects partial and invalid write-side structure limits', async () => {
+    for (const options of [
+      { maxContainerEntries: 10 },
+      { maxContainerEntries: 0, maxDepth: 10, maxItems: 100 },
+      { maxContainerEntries: 10, maxDepth: -1, maxItems: 100 },
+      { maxContainerEntries: 10, maxDepth: 10, maxItems: 0 },
+    ]) {
+      await expect(indexes.writeShards(WarpStream.of(), options))
         .rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
     }
   });

--- a/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
+++ b/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
@@ -245,9 +245,11 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       memberStorage: 'page',
       maxShardCount: 1,
       maxShardBytes: 1024,
-      maxContainerEntries: 16,
-      maxDepth: 8,
-      maxItems: 64,
+      structureLimits: {
+        maxContainerEntries: 16,
+        maxDepth: 8,
+        maxItems: 64,
+      },
     });
     const token = cas.readBundleMembers(indexHandle.toString())[0]?.[1];
     if (token === undefined) {
@@ -258,9 +260,11 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     expect(stage).not.toHaveBeenCalled();
     await expect(indexes.decodeShardAt(indexHandle, path, {
       maxBytes: 1024,
-      maxContainerEntries: 16,
-      maxDepth: 8,
-      maxItems: 64,
+      structureLimits: {
+        maxContainerEntries: 16,
+        maxDepth: 8,
+        maxItems: 64,
+      },
     })).resolves.toEqual({
       schemaVersion: 2,
       entries: [[nodeId, [['status', 'ready']]]],
@@ -315,9 +319,11 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       memberStorage: 'page',
       maxShardCount: 1,
       maxShardBytes: 1024,
-      maxContainerEntries: 16,
-      maxDepth: 4,
-      maxItems: 64,
+      structureLimits: {
+        maxContainerEntries: 16,
+        maxDepth: 4,
+        maxItems: 64,
+      },
       staging: { stagePage, stageOrderedBundle },
     })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_MALFORMED' });
 
@@ -366,9 +372,11 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       path,
       {
         maxBytes: 1024,
-        maxContainerEntries: 16,
-        maxDepth: 8,
-        maxItems: 64,
+        structureLimits: {
+          maxContainerEntries: 16,
+          maxDepth: 8,
+          maxItems: 64,
+        },
       },
     )).resolves.toEqual(value);
   });
@@ -401,9 +409,11 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     });
     await expect(indexes.decodeShard(staged.handle, {
       maxBytes: 8,
-      maxContainerEntries: 10,
-      maxDepth: 10,
-      maxItems: 100,
+      structureLimits: {
+        maxContainerEntries: 10,
+        maxDepth: 10,
+        maxItems: 100,
+      },
     })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_TOO_LARGE' });
   });
 
@@ -419,6 +429,21 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     });
 
     await expect(indexes.decodeShard(staged.handle, { maxBytes: 5000 }))
+      .rejects.toMatchObject({ code: 'E_INDEX_SHARD_CHUNK_LIMIT' });
+  });
+
+  it('bounds empty chunks in one exact-read stream', async () => {
+    const staged = await assets.stage(WarpStream.from([defaultCodec.encode(['value'])]), {
+      slug: 'empty-fragmented-index-shard',
+      filename: 'props_00.cbor',
+    });
+    vi.spyOn(assets, 'open').mockImplementation(async function* () {
+      for (let index = 0; index < 4097; index += 1) {
+        yield new Uint8Array();
+      }
+    });
+
+    await expect(indexes.decodeShard(staged.handle, { maxBytes: 1 }))
       .rejects.toMatchObject({ code: 'E_INDEX_SHARD_CHUNK_LIMIT' });
   });
 
@@ -441,9 +466,13 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
   });
 
   it('requires an explicit byte limit for page-backed shards', async () => {
-    await expect(indexes.writeShards(WarpStream.of(), {
+    const options = {
       memberStorage: 'page',
-    })).rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
+    } as const;
+
+    // @ts-expect-error Runtime guard for JavaScript callers without a page byte limit.
+    await expect(indexes.writeShards(WarpStream.of(), options))
+      .rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
   });
 
   it('rejects invalid write storage policies before consuming shards', async () => {
@@ -454,6 +483,14 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     await expect(indexes.writeShards(WarpStream.of(), {
       // @ts-expect-error Runtime guard for JavaScript callers.
       staging: { stagePage: null, stageOrderedBundle: null },
+    })).rejects.toMatchObject({ code: 'E_INDEX_INVALID_STORAGE' });
+    await expect(indexes.writeShards(WarpStream.of(), {
+      // @ts-expect-error Runtime guard for JavaScript callers.
+      staging: null,
+    })).rejects.toMatchObject({ code: 'E_INDEX_INVALID_STORAGE' });
+    await expect(indexes.writeShards(WarpStream.of(), {
+      // @ts-expect-error Runtime guard for JavaScript callers.
+      staging: 'workspace',
     })).rejects.toMatchObject({ code: 'E_INDEX_INVALID_STORAGE' });
   });
 
@@ -474,9 +511,11 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     });
     await expect(indexes.decodeShard(declaredArray.handle, {
       maxBytes: 64,
-      maxContainerEntries: 100,
-      maxDepth: 10,
-      maxItems: 1_000,
+      structureLimits: {
+        maxContainerEntries: 100,
+        maxDepth: 10,
+        maxItems: 1_000,
+      },
     })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_MALFORMED' });
 
     const nested = await assets.stage(WarpStream.from([
@@ -487,9 +526,11 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     });
     await expect(indexes.decodeShard(nested.handle, {
       maxBytes: 64,
-      maxContainerEntries: 100,
-      maxDepth: 2,
-      maxItems: 1_000,
+      structureLimits: {
+        maxContainerEntries: 100,
+        maxDepth: 2,
+        maxItems: 1_000,
+      },
     })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_MALFORMED' });
   });
 
@@ -580,12 +621,16 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       filename: 'props_a0.cbor',
     });
 
+    const partial = { structureLimits: { maxContainerEntries: 10 } };
+    // @ts-expect-error Runtime guard for JavaScript callers with partial structure limits.
+    await expect(indexes.decodeShard(staged.handle, partial))
+      .rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
+
     for (const options of [
-      { maxContainerEntries: 10 },
       { maxBytes: 0 },
-      { maxContainerEntries: 0, maxDepth: 10, maxItems: 100 },
-      { maxContainerEntries: 10, maxDepth: -1, maxItems: 100 },
-      { maxContainerEntries: 10, maxDepth: 10, maxItems: 0 },
+      { structureLimits: { maxContainerEntries: 0, maxDepth: 10, maxItems: 100 } },
+      { structureLimits: { maxContainerEntries: 10, maxDepth: -1, maxItems: 100 } },
+      { structureLimits: { maxContainerEntries: 10, maxDepth: 10, maxItems: 0 } },
     ]) {
       await expect(indexes.decodeShard(staged.handle, options))
         .rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
@@ -593,11 +638,15 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
   });
 
   it('rejects partial and invalid write-side structure limits', async () => {
+    const partial = { structureLimits: { maxContainerEntries: 10 } };
+    // @ts-expect-error Runtime guard for JavaScript callers with partial structure limits.
+    await expect(indexes.writeShards(WarpStream.of(), partial))
+      .rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
+
     for (const options of [
-      { maxContainerEntries: 10 },
-      { maxContainerEntries: 0, maxDepth: 10, maxItems: 100 },
-      { maxContainerEntries: 10, maxDepth: -1, maxItems: 100 },
-      { maxContainerEntries: 10, maxDepth: 10, maxItems: 0 },
+      { structureLimits: { maxContainerEntries: 0, maxDepth: 10, maxItems: 100 } },
+      { structureLimits: { maxContainerEntries: 10, maxDepth: -1, maxItems: 100 } },
+      { structureLimits: { maxContainerEntries: 10, maxDepth: 10, maxItems: 0 } },
     ]) {
       await expect(indexes.writeShards(WarpStream.of(), options))
         .rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });

--- a/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
+++ b/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
@@ -9,16 +9,28 @@ import AssetHandle from '../../../src/domain/storage/AssetHandle.ts';
 import BundleHandle from '../../../src/domain/storage/BundleHandle.ts';
 import WarpStream from '../../../src/domain/stream/WarpStream.ts';
 import { collectAsyncIterable } from '../../../src/domain/utils/streamUtils.ts';
+import computeShardKey from '../../../src/domain/utils/shardKey.ts';
+import { materializationPropertyShardKey } from '../../../src/domain/materialization/MaterializationPropertyProfile.ts';
 import {
   CborIndexStoreAdapter,
   type GitCasIndexFacade,
 } from '../../../src/infrastructure/adapters/CborIndexStoreAdapter.ts';
+import {
+  validateBoundedCbor,
+  type CborStructureLimits,
+} from '../../../src/infrastructure/adapters/BoundedCborValidation.ts';
 import GitCasAssetStorageAdapter from '../../../src/infrastructure/adapters/GitCasAssetStorageAdapter.ts';
 import defaultCodec from '../../../src/infrastructure/codecs/CborCodec.ts';
 import IndexStorePort from '../../../src/ports/IndexStorePort.ts';
 import InMemoryGraphAdapter from '../../helpers/InMemoryGraphAdapter.ts';
 import InMemoryBlobStorageAdapter from '../../helpers/InMemoryBlobStorageAdapter.ts';
 import InMemoryGitCasFacade from '../../helpers/InMemoryGitCasFacade.ts';
+
+const CBOR_STRUCTURE_LIMITS: CborStructureLimits = Object.freeze({
+  maxContainerEntries: 100,
+  maxDepth: 10,
+  maxItems: 100,
+});
 
 function shards() {
   return [
@@ -39,7 +51,10 @@ function shards() {
       buckets: { all: { '1': new Uint8Array([0x02]) } },
     }),
     new LabelShard({ labels: [['manages', 0], ['owns', 1]] }),
-    new PropertyShard({ shardKey: 'a0', entries: [['node:1', { name: 'Alice' }]] }),
+    new PropertyShard({
+      shardKey: computeShardKey('node:1'),
+      entries: [['node:1', { name: 'Alice' }]],
+    }),
     new ReceiptShard({ version: 1, nodeCount: 2, labelCount: 2, shardCount: 5 }),
   ];
 }
@@ -99,6 +114,62 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     expect(recovered.some((shard) => shard instanceof ReceiptShard)).toBe(true);
   });
 
+  it('round-trips schema-v2 property entry bags without interpreting property names', async () => {
+    const shardKey = materializationPropertyShardKey('node:1');
+    const properties = Object.create(null) as Record<string, unknown>;
+    properties['a'] = 'lowercase';
+    properties['Z'] = 'uppercase';
+    properties['status'] = 'ready';
+    properties['__proto__'] = 'retained-data';
+    const indexHandle = await indexes.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey,
+        schemaVersion: 2,
+        entries: [['node:1', properties]],
+      }),
+    ]));
+
+    const handles = await indexes.readShardHandles(indexHandle);
+    const propertyHandle = handles[`props_${shardKey}.cbor`];
+    if (propertyHandle === undefined) {
+      throw new Error('expected a property shard handle');
+    }
+    await expect(indexes.decodeShard(propertyHandle)).resolves.toEqual({
+      schemaVersion: 2,
+      entries: [['node:1', [
+        ['Z', 'uppercase'],
+        ['__proto__', 'retained-data'],
+        ['a', 'lowercase'],
+        ['status', 'ready'],
+      ]]],
+    });
+
+    const recovered = await indexes.scanShards(indexHandle).collect();
+    const shard = recovered[0];
+    expect(shard).toBeInstanceOf(PropertyShard);
+    if (!(shard instanceof PropertyShard)) {
+      throw new Error('expected a property shard');
+    }
+    const bag = shard.entries[0]?.[1];
+    expect(shard.schemaVersion).toBe(2);
+    expect(bag).toBeDefined();
+    expect(Object.hasOwn(bag ?? {}, '__proto__')).toBe(true);
+    expect(bag?.['__proto__']).toBe('retained-data');
+    expect(Object.getPrototypeOf(bag)).toBeNull();
+    expect(Object.isFrozen(bag)).toBe(true);
+    expect(({} as Record<string, unknown>)['retained-data']).toBeUndefined();
+  });
+
+  it('rejects unsupported property shard schema versions during encoding', async () => {
+    await expect(indexes.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey: 'a0',
+        schemaVersion: 3,
+        entries: [['node:1', { status: 'future' }]],
+      }),
+    ]))).rejects.toMatchObject({ code: 'E_INDEX_SHARD_SCHEMA' });
+  });
+
   it('lists shard handles without opening shard payloads', async () => {
     const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
     const open = vi.spyOn(assets, 'open');
@@ -108,11 +179,35 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       'fwd_a0.cbor',
       'labels.cbor',
       'meta_a0.cbor',
-      'props_a0.cbor',
+      `props_${computeShardKey('node:1')}.cbor`,
       'receipt.cbor',
       'rev_a0.cbor',
     ]);
     expect(Object.values(handles).every((handle) => handle instanceof AssetHandle)).toBe(true);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('resolves one shard handle without enumerating or opening siblings', async () => {
+    const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
+    const open = vi.spyOn(assets, 'open');
+    const directIndexes = indexAdapter(assets, {
+      bundles: {
+        getMember: cas.bundles.getMember,
+        putOrdered: cas.bundles.putOrdered,
+        iterateMembers: () => {
+          throw new Error('readShardHandle must not enumerate bundle members');
+        },
+      },
+    });
+
+    await expect(directIndexes.readShardHandle(
+      indexHandle,
+      `props_${computeShardKey('node:1')}.cbor`,
+    ))
+      .resolves.toBeInstanceOf(AssetHandle);
+    await expect(directIndexes.readShardHandle(indexHandle, 'missing.cbor'))
+      .resolves.toBeNull();
+
     expect(open).not.toHaveBeenCalled();
   });
 
@@ -134,6 +229,188 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     await expect(indexes.decodeShard(receiptHandle)).resolves.toEqual(defaultCodec.decode(bytes));
   });
 
+  it('rejects oversized shards on write and exact read', async () => {
+    const encode = vi.spyOn(defaultCodec, 'encode');
+    await expect(indexes.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey: 'a0',
+        entries: [['node:1', { value: 'larger than this limit' }]],
+      }),
+    ]), { maxShardBytes: 8 })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_TOO_LARGE' });
+    expect(encode).not.toHaveBeenCalled();
+
+    const staged = await assets.stage(WarpStream.from([new Uint8Array(9)]), {
+      slug: 'oversized-index-shard',
+      filename: 'props_a0.cbor',
+    });
+    await expect(indexes.decodeShard(staged.handle, {
+      maxBytes: 8,
+      maxContainerEntries: 10,
+      maxDepth: 10,
+      maxItems: 100,
+    })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_TOO_LARGE' });
+  });
+
+  it('bounds the number of non-empty chunks collected for one exact read', async () => {
+    const staged = await assets.stage(WarpStream.from([defaultCodec.encode(['value'])]), {
+      slug: 'fragmented-index-shard',
+      filename: 'props_00.cbor',
+    });
+    vi.spyOn(assets, 'open').mockImplementation(async function* () {
+      for (let index = 0; index < 4097; index += 1) {
+        yield new Uint8Array([0]);
+      }
+    });
+
+    await expect(indexes.decodeShard(staged.handle, { maxBytes: 5000 }))
+      .rejects.toMatchObject({ code: 'E_INDEX_SHARD_CHUNK_LIMIT' });
+  });
+
+  it('rejects an over-limit declared shard count before staging any assets', async () => {
+    const stage = vi.spyOn(assets, 'stage');
+
+    await expect(indexes.writeShards(WarpStream.of(), {
+      expectedShardCount: 100_001,
+      maxShardCount: 100_000,
+    })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_COUNT_LIMIT' });
+
+    expect(stage).not.toHaveBeenCalled();
+  });
+
+  it('rejects a shard stream that violates its declared count', async () => {
+    await expect(indexes.writeShards(WarpStream.of(), {
+      expectedShardCount: 1,
+      maxShardCount: 1,
+    })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_COUNT_LIMIT' });
+  });
+
+  it('rejects dangerous CBOR containers before general decoding', async () => {
+    const declaredArray = await assets.stage(WarpStream.from([
+      new Uint8Array([0x99, 0x03, 0xe9]),
+    ]), {
+      slug: 'declared-array-index-shard',
+      filename: 'props_a0.cbor',
+    });
+    await expect(indexes.decodeShard(declaredArray.handle, {
+      maxBytes: 64,
+      maxContainerEntries: 100,
+      maxDepth: 10,
+      maxItems: 1_000,
+    })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_MALFORMED' });
+
+    const nested = await assets.stage(WarpStream.from([
+      defaultCodec.encode([[[['value']]]]),
+    ]), {
+      slug: 'nested-index-shard',
+      filename: 'props_a0.cbor',
+    });
+    await expect(indexes.decodeShard(nested.handle, {
+      maxBytes: 64,
+      maxContainerEntries: 100,
+      maxDepth: 2,
+      maxItems: 1_000,
+    })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_MALFORMED' });
+  });
+
+  it.each([
+    ['unsigned integer', new Uint8Array([0x00])],
+    ['negative integer', new Uint8Array([0x20])],
+    ['byte string', new Uint8Array([0x41, 0x00])],
+    ['text string', new Uint8Array([0x61, 0x61])],
+    ['array', new Uint8Array([0x81, 0x00])],
+    ['map', new Uint8Array([0xa1, 0x61, 0x61, 0x00])],
+    ['tagged value', new Uint8Array([0xc0, 0x00])],
+    ['simple value', new Uint8Array([0xf4])],
+    ['wide simple value', new Uint8Array([0xf9, 0x00, 0x00])],
+  ])('preflights a bounded %s CBOR value', (_name, bytes) => {
+    expect(() => validateBoundedCbor(bytes, CBOR_STRUCTURE_LIMITS)).not.toThrow();
+  });
+
+  it.each([
+    [
+      'trailing value',
+      new Uint8Array([0x00, 0x00]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'exhausted item budget',
+      new Uint8Array([0x81, 0x00]),
+      { ...CBOR_STRUCTURE_LIMITS, maxItems: 1 },
+    ],
+    [
+      'reserved simple value',
+      new Uint8Array([0xfc]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'indefinite value',
+      new Uint8Array([0x5f, 0xff]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'reserved additional information',
+      new Uint8Array([0x1c]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'duplicate map key',
+      new Uint8Array([0xa2, 0x61, 0x61, 0x01, 0x61, 0x61, 0x02]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'non-preferred duplicate map key',
+      new Uint8Array([0xa2, 0x61, 0x61, 0x01, 0x78, 0x01, 0x61, 0x02]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'invalid UTF-8 map key',
+      new Uint8Array([0xa1, 0x61, 0xff, 0x01]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'non-text map key',
+      new Uint8Array([0xa1, 0x00, 0x00]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'unsafe declared length',
+      new Uint8Array([0x5b, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'missing initial byte',
+      new Uint8Array(),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+    [
+      'truncated byte string',
+      new Uint8Array([0x42, 0x00]),
+      CBOR_STRUCTURE_LIMITS,
+    ],
+  ])('rejects a malformed CBOR %s before decoding', (_name, bytes, limits) => {
+    expect(() => validateBoundedCbor(bytes, limits)).toThrowError(
+      expect.objectContaining({ code: 'E_INDEX_SHARD_MALFORMED' }),
+    );
+  });
+
+  it('rejects partial and invalid exact-read limits', async () => {
+    const staged = await assets.stage(WarpStream.from([defaultCodec.encode(['bounded'])]), {
+      slug: 'invalid-limit-index-shard',
+      filename: 'props_a0.cbor',
+    });
+
+    for (const options of [
+      { maxContainerEntries: 10 },
+      { maxBytes: 0 },
+      { maxContainerEntries: 0, maxDepth: 10, maxItems: 100 },
+      { maxContainerEntries: 10, maxDepth: -1, maxItems: 100 },
+      { maxContainerEntries: 10, maxDepth: 10, maxItems: 0 },
+    ]) {
+      await expect(indexes.decodeShard(staged.handle, options))
+        .rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
+    }
+  });
+
   it('ignores unknown physical paths while scanning compatibility indexes', async () => {
     const staged = await assets.stage(WarpStream.from([defaultCodec.encode({ ignored: true })]), {
       slug: 'unknown-index-member',
@@ -147,10 +424,43 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       .resolves.toEqual([]);
   });
 
+  it('rejects property entries routed under the wrong compatibility shard path', async () => {
+    const nodeId = 'node:misrouted';
+    const expected = computeShardKey(nodeId);
+    const wrong = expected === '00' ? '01' : '00';
+    const staged = await assets.stage(WarpStream.from([
+      defaultCodec.encode([[nodeId, { status: 'misrouted' }]]),
+    ]), {
+      slug: 'misrouted-property-shard',
+      filename: `props_${wrong}.cbor`,
+    });
+    const bundle = await cas.bundles.putOrdered({
+      members: [[`props_${wrong}.cbor`, staged.handle.toString()]],
+    });
+
+    await expect(indexes.scanShards(new BundleHandle(bundle.handle.toString())).collect())
+      .rejects.toMatchObject({ code: 'E_INDEX_SHARD_MALFORMED' });
+  });
+
+  it('rejects schema-v2 property entries routed under the legacy shard profile', async () => {
+    const nodeId = 'node:retained-profile';
+    const indexHandle = await indexes.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey: computeShardKey(nodeId),
+        schemaVersion: 2,
+        entries: [[nodeId, { status: 'misrouted' }]],
+      }),
+    ]));
+
+    await expect(indexes.scanShards(indexHandle).collect())
+      .rejects.toMatchObject({ code: 'E_INDEX_SHARD_MALFORMED' });
+  });
+
   it('rejects duplicate member paths while listing or scanning an index bundle', async () => {
     const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
     const duplicateCas: GitCasIndexFacade = {
       bundles: {
+        getMember: cas.bundles.getMember,
         putOrdered: cas.bundles.putOrdered,
         iterateMembers: async function* (request) {
           let duplicated = false;
@@ -176,6 +486,7 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
     const nonAssetCas: GitCasIndexFacade = {
       bundles: {
+        getMember: cas.bundles.getMember,
         putOrdered: cas.bundles.putOrdered,
         iterateMembers: async function* (request) {
           for await (const member of cas.bundles.iterateMembers(request)) {

--- a/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
+++ b/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { BundleHandle as GitCasBundleHandle } from '@git-stunts/git-cas';
+import {
+  BundleHandle as GitCasBundleHandle,
+  PageHandle as GitCasPageHandle,
+} from '@git-stunts/git-cas';
 import { EdgeShard } from '../../../src/domain/artifacts/EdgeShard.ts';
 import { LabelShard } from '../../../src/domain/artifacts/LabelShard.ts';
 import { MetaShard } from '../../../src/domain/artifacts/MetaShard.ts';
@@ -191,6 +194,7 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
     const open = vi.spyOn(assets, 'open');
     const directIndexes = indexAdapter(assets, {
+      pages: cas.pages,
       bundles: {
         getMember: cas.bundles.getMember,
         putOrdered: cas.bundles.putOrdered,
@@ -209,6 +213,74 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       .resolves.toBeNull();
 
     expect(open).not.toHaveBeenCalled();
+  });
+
+  it('stores bounded exact-read shards as pages and decodes one bundle member', async () => {
+    const stage = vi.spyOn(assets, 'stage');
+    const nodeId = 'node:page-backed';
+    const shardKey = materializationPropertyShardKey(nodeId);
+    const path = `props_${shardKey}.cbor`;
+    const indexHandle = await indexes.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey,
+        schemaVersion: 2,
+        entries: [[nodeId, { status: 'ready' }]],
+      }),
+    ]), {
+      expectedShardCount: 1,
+      memberStorage: 'page',
+      maxShardCount: 1,
+      maxShardBytes: 1024,
+    });
+    const token = cas.readBundleMembers(indexHandle.toString())[0]?.[1];
+    if (token === undefined) {
+      throw new Error('expected one page-backed bundle member');
+    }
+
+    expect(GitCasPageHandle.from(token)).toBeInstanceOf(GitCasPageHandle);
+    expect(stage).not.toHaveBeenCalled();
+    await expect(indexes.decodeShardAt(indexHandle, path, {
+      maxBytes: 1024,
+      maxContainerEntries: 16,
+      maxDepth: 8,
+      maxItems: 64,
+    })).resolves.toEqual({
+      schemaVersion: 2,
+      entries: [[nodeId, [['status', 'ready']]]],
+    });
+    await expect(indexes.decodeShardAt(indexHandle, 'missing.cbor', {
+      maxBytes: 1024,
+    })).resolves.toBeNull();
+    await expect(indexes.readShardHandles(indexHandle))
+      .rejects.toMatchObject({ code: 'E_INDEX_INVALID_BUNDLE_MEMBER' });
+  });
+
+  it('routes page-backed shards and their bundle through the staging scope', async () => {
+    const bundle = new BundleHandle('test:staged-property-bundle');
+    const stagePage = vi.fn(async () => 'test:staged-property-page');
+    const stageOrderedBundle = vi.fn(async () => bundle);
+    const shardKey = materializationPropertyShardKey('node:staged');
+
+    await expect(indexes.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey,
+        schemaVersion: 2,
+        entries: [['node:staged', { status: 'ready' }]],
+      }),
+    ]), {
+      expectedShardCount: 1,
+      memberStorage: 'page',
+      maxShardCount: 1,
+      maxShardBytes: 1024,
+      staging: { stagePage, stageOrderedBundle },
+    })).resolves.toBe(bundle);
+
+    expect(stagePage).toHaveBeenCalledOnce();
+    expect(stagePage).toHaveBeenCalledWith(expect.any(Uint8Array), { maxBytes: 1024 });
+    expect(stageOrderedBundle).toHaveBeenCalledWith(
+      [[`props_${shardKey}.cbor`, 'test:staged-property-page']],
+      { maxMembers: 1 },
+    );
   });
 
   it('opens and decodes exactly one selected shard handle', async () => {
@@ -282,6 +354,12 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       expectedShardCount: 1,
       maxShardCount: 1,
     })).rejects.toMatchObject({ code: 'E_INDEX_SHARD_COUNT_LIMIT' });
+  });
+
+  it('requires an explicit byte limit for page-backed shards', async () => {
+    await expect(indexes.writeShards(WarpStream.of(), {
+      memberStorage: 'page',
+    })).rejects.toMatchObject({ code: 'E_INDEX_INVALID_LIMIT' });
   });
 
   it('rejects dangerous CBOR containers before general decoding', async () => {
@@ -459,6 +537,7 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
   it('rejects duplicate member paths while listing or scanning an index bundle', async () => {
     const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
     const duplicateCas: GitCasIndexFacade = {
+      pages: cas.pages,
       bundles: {
         getMember: cas.bundles.getMember,
         putOrdered: cas.bundles.putOrdered,
@@ -485,6 +564,7 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
   it('rejects non-asset members while listing or scanning an index bundle', async () => {
     const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
     const nonAssetCas: GitCasIndexFacade = {
+      pages: cas.pages,
       bundles: {
         getMember: cas.bundles.getMember,
         putOrdered: cas.bundles.putOrdered,

--- a/test/unit/infrastructure/adapters/CborCheckpointStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/CborCheckpointStoreAdapter.test.ts
@@ -255,8 +255,8 @@ describe('CborCheckpointStoreAdapter semantic lifecycle', () => {
     const cas: GitCasCheckpointFacade = {
       bundles: {
         putOrdered: fixture.cas.bundles.putOrdered,
-        iterateMembers: async function* (request) {
-          for await (const member of fixture.cas.bundles.iterateMembers(request)) {
+        iterateMemberReferences: async function* (request) {
+          for await (const member of fixture.cas.bundles.iterateMemberReferences(request)) {
             yield Object.freeze({
               ...member,
               handle: GitCasBundleHandle.parse(published.bundleHandle.toString()),
@@ -277,9 +277,9 @@ describe('CborCheckpointStoreAdapter semantic lifecycle', () => {
     const cas: GitCasCheckpointFacade = {
       bundles: {
         putOrdered: fixture.cas.bundles.putOrdered,
-        iterateMembers: async function* (request) {
+        iterateMemberReferences: async function* (request) {
           let duplicated = false;
-          for await (const member of fixture.cas.bundles.iterateMembers(request)) {
+          for await (const member of fixture.cas.bundles.iterateMemberReferences(request)) {
             yield member;
             if (!duplicated) {
               yield member;
@@ -301,9 +301,9 @@ describe('CborCheckpointStoreAdapter semantic lifecycle', () => {
     const cas: GitCasCheckpointFacade = {
       bundles: {
         putOrdered: fixture.cas.bundles.putOrdered,
-        iterateMembers: async function* (request) {
+        iterateMemberReferences: async function* (request) {
           let replaced = false;
-          for await (const member of fixture.cas.bundles.iterateMembers(request)) {
+          for await (const member of fixture.cas.bundles.iterateMemberReferences(request)) {
             yield replaced ? member : Object.freeze({ ...member, path: 'index/' });
             replaced = true;
           }

--- a/test/unit/infrastructure/adapters/GitCasMaterializationLease.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationLease.test.ts
@@ -1,0 +1,62 @@
+import type { CacheAcquisition } from '@git-stunts/git-cas';
+import { describe, expect, it, vi } from 'vitest';
+import MaterializationCoordinate from '../../../../src/domain/materialization/MaterializationCoordinate.ts';
+import type MaterializationHandle from '../../../../src/domain/materialization/MaterializationHandle.ts';
+import GitCasMaterializationLease from '../../../../src/infrastructure/adapters/GitCasMaterializationLease.ts';
+
+describe('GitCasMaterializationLease', () => {
+  it('does not block a retired borrower behind a concurrent borrower', async () => {
+    const release = vi.fn(async () => undefined);
+    const lease = createLease(release);
+    const first = lease.acquire();
+    const concurrent = lease.acquire();
+    const retirement = lease.retire();
+
+    await expect(Promise.race([
+      first.release().then(() => 'released'),
+      new Promise<string>((resolve) => setTimeout(() => resolve('blocked'), 0)),
+    ])).resolves.toBe('released');
+    expect(release).not.toHaveBeenCalled();
+
+    await concurrent.release();
+    await retirement;
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('releases a borrower-free lease and rejects acquisitions after retirement', async () => {
+    const release = vi.fn(async () => undefined);
+    const lease = createLease(release);
+    const retirement = lease.retire();
+
+    await retirement;
+    expect(release).toHaveBeenCalledOnce();
+    expect(lease.retire()).toBe(retirement);
+    expect(() => lease.acquire()).toThrowError(
+      expect.objectContaining({ code: 'E_MATERIALIZATION_STORAGE' }),
+    );
+  });
+
+  it('propagates an underlying release failure to the final borrower', async () => {
+    const failure = new Error('release failed');
+    const lease = createLease(vi.fn(async () => {
+      throw failure;
+    }));
+    const borrower = lease.acquire();
+    const retirement = lease.retire();
+
+    await expect(borrower.release()).rejects.toBe(failure);
+    await expect(retirement).rejects.toBe(failure);
+    await expect(borrower.release()).resolves.toBeUndefined();
+  });
+});
+
+function createLease(release: () => Promise<void>): GitCasMaterializationLease {
+  return new GitCasMaterializationLease({
+    acquisition: {
+      acquiredAt: '2026-07-18T00:00:00.000Z',
+      release,
+    } as unknown as CacheAcquisition,
+    coordinate: new MaterializationCoordinate({ frontier: new Map(), ceiling: null }),
+    materialization: {} as MaterializationHandle,
+  });
+}

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.lifecycle.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.lifecycle.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import MaterializationCoordinate from '../../../../src/domain/materialization/MaterializationCoordinate.ts';
+import MaterializationRoot from '../../../../src/domain/materialization/MaterializationRoot.ts';
+import MaterializationRoots from '../../../../src/domain/materialization/MaterializationRoots.ts';
+import BundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
+import GitCasMaterializationStoreAdapter, {
+  type GitCasMaterializationFacade,
+} from '../../../../src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts';
+import { materializationCoordinateData } from '../../../../src/infrastructure/adapters/GitCasMaterializationDescriptor.ts';
+import NodeCryptoAdapter from '../../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
+import defaultCodec from '../../../../src/infrastructure/codecs/CborCodec.ts';
+import InMemoryBlobStorageAdapter from '../../../helpers/InMemoryBlobStorageAdapter.ts';
+import InMemoryGitCasFacade from '../../../helpers/InMemoryGitCasFacade.ts';
+import InMemoryGraphAdapter from '../../../helpers/InMemoryGraphAdapter.ts';
+
+const CACHE_NAMESPACE = 'git-warp/materializations';
+const ROOT_COUNT = 8;
+
+describe('GitCasMaterializationStoreAdapter legacy lifecycle', () => {
+  it('keeps the matching v2 cache anchor until the v3 profile is retained', async () => {
+    const harness = await createHarness();
+    const coordinate = exactCoordinate();
+    const roots = await createRoots(harness.cas);
+    const retained = await harness.adapter.retain({ coordinate, roots, stateHash: 'state-hash' });
+    const cache = await harness.cas.caches.open({ namespace: CACHE_NAMESPACE });
+    const v3Key = requireSingleCacheKey(harness.cas);
+    const v2Key = await cacheKeyForSchema(coordinate, 2);
+    await cache.put(v2Key, retained.bundle.toString());
+    await cache.remove(v3Key);
+
+    await expect(harness.adapter.acquireExact(coordinate)).resolves.toBeNull();
+    expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toEqual([v2Key]);
+
+    await harness.adapter.retain({ coordinate, roots, stateHash: 'replacement-state-hash' });
+    expect(requireSingleCacheKey(harness.cas)).toMatch(/^v3:[0-9a-f]{64}$/u);
+  });
+
+  it('removes the matching v2 cache anchor after direct v3 retention', async () => {
+    const harness = await createHarness();
+    const coordinate = exactCoordinate();
+    const roots = await createRoots(harness.cas);
+    const retained = await harness.adapter.retain({ coordinate, roots, stateHash: 'state-hash' });
+    const cache = await harness.cas.caches.open({ namespace: CACHE_NAMESPACE });
+    const v3Key = requireSingleCacheKey(harness.cas);
+    const v2Key = await cacheKeyForSchema(coordinate, 2);
+    await cache.put(v2Key, retained.bundle.toString());
+    await cache.remove(v3Key);
+
+    const replacement = await harness.adapter.retain({
+      coordinate,
+      roots,
+      stateHash: 'replacement-state-hash',
+    });
+    const acquisition = await harness.adapter.acquireExact(coordinate);
+
+    expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toEqual([
+      expect.stringMatching(/^v3:[0-9a-f]{64}$/u),
+    ]);
+    expect(replacement.retention.root.generation)
+      .toBe(acquisition?.materialization.retention.root.generation);
+    await acquisition?.release();
+  });
+
+  it('keeps the v2 anchor when the exact v3 target cannot be acquired', async () => {
+    const harness = await createHarness();
+    const coordinate = exactCoordinate();
+    const roots = await createRoots(harness.cas);
+    const original = await harness.adapter.retain({ coordinate, roots, stateHash: 'state-hash' });
+    const cache = await harness.cas.caches.open({ namespace: CACHE_NAMESPACE });
+    const v3Key = requireSingleCacheKey(harness.cas);
+    const v2Key = await cacheKeyForSchema(coordinate, 2);
+    await cache.put(v2Key, original.bundle.toString());
+    await cache.remove(v3Key);
+
+    await expect(adapterFor(withoutCacheAcquisition(harness.cas)).retain({
+      coordinate,
+      roots,
+      stateHash: 'replacement-state-hash',
+    })).rejects.toMatchObject({
+      code: 'E_MATERIALIZATION_STORAGE',
+      message: expect.stringContaining('before legacy cleanup'),
+    });
+
+    expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toContain(v2Key);
+  });
+});
+
+async function createHarness(): Promise<Readonly<{
+  adapter: GitCasMaterializationStoreAdapter;
+  cas: InMemoryGitCasFacade;
+}>> {
+  const cas = new InMemoryGitCasFacade({
+    history: new InMemoryGraphAdapter(),
+    storage: new InMemoryBlobStorageAdapter(),
+  });
+  return Object.freeze({ cas, adapter: adapterFor(cas) });
+}
+
+function adapterFor(cas: GitCasMaterializationFacade): GitCasMaterializationStoreAdapter {
+  return new GitCasMaterializationStoreAdapter({
+    cas,
+    codec: defaultCodec,
+    crypto: new NodeCryptoAdapter(),
+    laneName: 'events',
+  });
+}
+
+function withoutCacheAcquisition(cas: InMemoryGitCasFacade): GitCasMaterializationFacade {
+  return {
+    bundles: cas.bundles,
+    pages: cas.pages,
+    caches: {
+      open: async (options) => {
+        const cache = await cas.caches.open(options);
+        return {
+          acquire: async () => null,
+          put: async (key, handle, entryOptions) => await cache.put(key, handle, entryOptions),
+          remove: async (key) => await cache.remove(key),
+        };
+      },
+    },
+  };
+}
+
+async function createRoots(cas: InMemoryGitCasFacade): Promise<MaterializationRoots> {
+  const handles: BundleHandle[] = [];
+  for (let index = 0; index < ROOT_COUNT; index += 1) {
+    const page = await cas.pages.put({ source: new Uint8Array([index]) });
+    const bundle = await cas.bundles.putOrdered({ members: [['root', page.handle]] });
+    handles.push(new BundleHandle(bundle.handle.toString()));
+  }
+  return rootsFromHandles(handles);
+}
+
+function rootsFromHandles(handles: readonly BundleHandle[]): MaterializationRoots {
+  const root = (index: number): MaterializationRoot => {
+    const handle = handles[index];
+    if (handle === undefined) {
+      throw new Error('Root fixture did not create every materialization root');
+    }
+    return MaterializationRoot.retained(handle);
+  };
+  return new MaterializationRoots({
+    adjacency: root(0),
+    edgeAlive: root(1),
+    edgeBirths: root(2),
+    frontier: root(3),
+    nodeAlive: root(4),
+    properties: root(5),
+    provenanceSupport: root(6),
+    roaringIndexes: root(7),
+  });
+}
+
+function exactCoordinate(): MaterializationCoordinate {
+  return new MaterializationCoordinate({
+    frontier: new Map([
+      ['writer-a', 'patch-a'],
+      ['writer-b', 'patch-b'],
+    ]),
+    ceiling: 12,
+  });
+}
+
+async function cacheKeyForSchema(
+  coordinate: MaterializationCoordinate,
+  schemaVersion: number,
+): Promise<string> {
+  const encoded = defaultCodec.encode({
+    schemaVersion,
+    laneName: 'events',
+    coordinate: materializationCoordinateData(coordinate),
+  });
+  return `v${String(schemaVersion)}:${await new NodeCryptoAdapter().hash('sha256', encoded)}`;
+}
+
+function requireSingleCacheKey(cas: InMemoryGitCasFacade): string {
+  const keys = cas.readCacheKeys(CACHE_NAMESPACE);
+  const key = keys[0];
+  if (keys.length !== 1 || key === undefined) {
+    throw new Error('Expected exactly one materialization cache key');
+  }
+  return key;
+}

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.lifecycle.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.lifecycle.test.ts
@@ -113,12 +113,14 @@ function withoutCacheAcquisition(cas: InMemoryGitCasFacade): GitCasMaterializati
       open: async (options) => {
         const cache = await cas.caches.open(options);
         return {
+          ref: cache.ref,
           acquire: async () => null,
           put: async (key, handle, entryOptions) => await cache.put(key, handle, entryOptions),
           remove: async (key) => await cache.remove(key),
         };
       },
     },
+    workspaces: cas.workspaces,
   };
 }
 

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.test.ts
@@ -15,7 +15,6 @@ import InMemoryGitCasFacade from '../../../helpers/InMemoryGitCasFacade.ts';
 import InMemoryGraphAdapter from '../../../helpers/InMemoryGraphAdapter.ts';
 
 const CACHE_NAMESPACE = 'git-warp/materializations';
-const WORKSPACE_CACHE_NAMESPACE = 'git-warp/materialization-workspaces';
 const ROOT_PATHS = Object.freeze([
   'roots/adjacency',
   'roots/edge-alive',
@@ -84,13 +83,13 @@ describe('GitCasMaterializationStoreAdapter', () => {
     expect(await harness.adapter.acquireExact(exactCoordinate())).toBeNull();
   });
 
-  it('promotes terminal roots without installing an unnecessary workspace entry', async () => {
+  it('promotes terminal roots and releases the git-cas workspace', async () => {
     const harness = await createHarness();
     const coordinate = exactCoordinate();
     const roots = await createRoots(harness.cas);
     const workspace = await harness.adapter.openWorkspace(coordinate);
 
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
+    expect(harness.cas.readActiveWorkspaceCount()).toBe(0);
 
     const promoted = await workspace.promote({
       coordinate,
@@ -99,7 +98,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
     });
     await workspace.release();
 
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
+    expect(harness.cas.readActiveWorkspaceCount()).toBe(0);
     expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toHaveLength(1);
     expect((await acquireAndRelease(harness.adapter, coordinate))?.bundle.equals(promoted.bundle))
       .toBe(true);
@@ -113,7 +112,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
       nodeAliveRoot: roots.nodeAlive.handle?.toString() ?? null,
       edgeAliveRoot: null,
     });
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toHaveLength(1);
+    expect(harness.cas.readActiveWorkspaceCount()).toBe(1);
 
     await expect(workspace.promote({
       coordinate: new MaterializationCoordinate({
@@ -128,7 +127,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
     });
     await workspace.release();
 
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
+    expect(harness.cas.readActiveWorkspaceCount()).toBe(0);
     expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toEqual([]);
   });
 
@@ -556,6 +555,7 @@ function withCacheResult(
       open: async (options) => {
         const cache = await cas.caches.open(options);
         return {
+          ref: cache.ref,
           acquire: async (key) => await cache.acquire(key),
           put: async (key, handle, entryOptions) => rewrite(
             await cache.put(key, handle, entryOptions),
@@ -564,6 +564,7 @@ function withCacheResult(
         };
       },
     },
+    workspaces: cas.workspaces,
   };
 }
 

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.test.ts
@@ -27,7 +27,7 @@ const ROOT_PATHS = Object.freeze([
 ]);
 
 describe('GitCasMaterializationStoreAdapter', () => {
-  it('retains deterministic independent roots and resolves the exact coordinate', async () => {
+  it('retains deterministic roots and reuses the exact-coordinate lease', async () => {
     const harness = await createHarness();
     const coordinate = exactCoordinate();
     const roots = await createRoots(harness.cas);
@@ -75,6 +75,39 @@ describe('GitCasMaterializationStoreAdapter', () => {
     expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(1);
     await acquisition?.release();
     await acquisition?.release();
+    expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(1);
+    const repeated = await harness.adapter.acquireExact(coordinate);
+    expect(repeated?.materialization.bundle.equals(retained.bundle)).toBe(true);
+    expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(1);
+    await repeated?.release();
+    await harness.adapter.close();
+    await harness.adapter.close();
+    expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(0);
+  });
+
+  it('retires a replaced coordinate after its in-flight reader releases', async () => {
+    const harness = await createHarness();
+    const firstCoordinate = exactCoordinate();
+    const secondCoordinate = new MaterializationCoordinate({
+      frontier: new Map([
+        ['writer-a', 'patch-next'],
+        ['writer-b', 'patch-b'],
+      ]),
+      ceiling: 13,
+    });
+    const roots = await createRoots(harness.cas);
+    await harness.adapter.retain({ coordinate: firstCoordinate, roots, stateHash: 'first' });
+    await harness.adapter.retain({ coordinate: secondCoordinate, roots, stateHash: 'second' });
+
+    const first = await harness.adapter.acquireExact(firstCoordinate);
+    const second = await harness.adapter.acquireExact(secondCoordinate);
+    expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(2);
+
+    await first?.release();
+    expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(1);
+    await second?.release();
+    expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(1);
+    await harness.adapter.close();
     expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(0);
   });
 
@@ -100,7 +133,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
 
     expect(harness.cas.readActiveWorkspaceCount()).toBe(0);
     expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toHaveLength(1);
-    expect((await acquireAndRelease(harness.adapter, coordinate))?.bundle.equals(promoted.bundle))
+    expect((await acquireReleaseAndClose(harness.adapter, coordinate))?.bundle.equals(promoted.bundle))
       .toBe(true);
   });
 
@@ -144,7 +177,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
       roots,
       stateHash: 'partial-state-hash',
     });
-    const resolved = await acquireAndRelease(harness.adapter, exactCoordinate());
+    const resolved = await acquireReleaseAndClose(harness.adapter, exactCoordinate());
 
     expect(harness.cas.readBundleMembers(retained.bundle.toString()).map(([path]) => path))
       .toEqual(['meta/descriptor', 'roots/node-alive']);
@@ -162,7 +195,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
       roots: await createRoots(harness.cas),
       stateHash: 'empty-state-hash',
     });
-    expect((await acquireAndRelease(harness.adapter, coordinate))?.coordinate.ceiling).toBeNull();
+    expect((await acquireReleaseAndClose(harness.adapter, coordinate))?.coordinate.ceiling).toBeNull();
   });
 
   it('fails closed when git-cas declines materialization retention', async () => {
@@ -491,18 +524,20 @@ type RetainedHarness = Harness & Readonly<{
   retainedBundle: BundleHandle;
 }>;
 
-async function acquireAndRelease(
+async function acquireReleaseAndClose(
   adapter: GitCasMaterializationStoreAdapter,
   coordinate: MaterializationCoordinate,
 ): Promise<MaterializationHandle | null> {
   const acquisition = await adapter.acquireExact(coordinate);
   if (acquisition === null) {
+    await adapter.close();
     return null;
   }
   try {
     return acquisition.materialization;
   } finally {
     await acquisition.release();
+    await adapter.close();
   }
 }
 

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.test.ts
@@ -71,7 +71,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
     expect(members.map(([path]) => path)).toEqual(['meta/descriptor', ...ROOT_PATHS]);
     const cacheKeys = harness.cas.readCacheKeys(CACHE_NAMESPACE);
     expect(cacheKeys).toHaveLength(1);
-    expect(cacheKeys[0]).toMatch(/^v2:[0-9a-f]{64}$/u);
+    expect(cacheKeys[0]).toMatch(/^v3:[0-9a-f]{64}$/u);
     expect(cacheKeys[0]?.length).toBeLessThan(1024);
     expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(1);
     await acquisition?.release();
@@ -152,7 +152,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
     expect(resolved?.roots.nodeAlive.status).toBe('retained');
     expect(resolved?.roots.nodeAlive.handle?.toString()).toBe(nodeBundle.handle.toString());
     expect(resolved?.roots.edgeAlive.status).toBe('empty');
-    expect(resolved?.roots.properties.status).toBe('unavailable');
+    expect(resolved?.roots.properties.status).toBe('empty');
   });
 
   it('round-trips an unbounded live coordinate with a null ceiling', async () => {
@@ -291,7 +291,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
 
   it.each([
     ['non-object descriptor', null, 'descriptor must be an object'],
-    ['schema', { schemaVersion: 3 }, 'schema is unsupported'],
+    ['schema', { schemaVersion: 2 }, 'schema is unsupported'],
     [
       'coordinate object',
       descriptor({ coordinate: null }),
@@ -357,6 +357,11 @@ describe('GitCasMaterializationStoreAdapter', () => {
       'missing root status',
       descriptor({ roots: rootStatusFixture().filter(([name]) => name !== 'adjacency') }),
       'no adjacency root status',
+    ],
+    [
+      'unavailable current property root',
+      descriptor({ roots: replaceRootStatus(rootStatusFixture(), 'properties', 'unavailable') }),
+      'requires a property root',
     ],
     ['lane', descriptor({ laneName: '' }), 'laneName must be a non-empty string'],
     ['state hash', descriptor({ stateHash: '' }), 'stateHash must be a non-empty string'],
@@ -446,6 +451,18 @@ describe('GitCasMaterializationStoreAdapter', () => {
       roots,
       stateHash: '',
     })).rejects.toMatchObject({ code: 'E_MATERIALIZATION_STORAGE' });
+    const nodeAlive = roots.nodeAlive.handle;
+    if (nodeAlive === null) {
+      throw new Error('Expected retained node-alive test root');
+    }
+    await expect(harness.adapter.retain({
+      coordinate: exactCoordinate(),
+      roots: unavailablePropertyRoots(nodeAlive),
+      stateHash: 'state-hash',
+    })).rejects.toMatchObject({
+      code: 'E_MATERIALIZATION_STORAGE',
+      message: expect.stringContaining('requires a property root'),
+    });
     await expect(Reflect.apply(harness.adapter.acquireExact, harness.adapter, [{
       frontier: new Map(),
       ceiling: null,
@@ -617,9 +634,23 @@ function partialRoots(nodeAlive: BundleHandle): MaterializationRoots {
     edgeBirths: MaterializationRoot.unavailable(),
     frontier: MaterializationRoot.unavailable(),
     nodeAlive: MaterializationRoot.retained(nodeAlive),
-    properties: MaterializationRoot.unavailable(),
+    properties: MaterializationRoot.empty(),
     provenanceSupport: MaterializationRoot.unavailable(),
     roaringIndexes: MaterializationRoot.unavailable(),
+  });
+}
+
+function unavailablePropertyRoots(nodeAlive: BundleHandle): MaterializationRoots {
+  const roots = partialRoots(nodeAlive);
+  return new MaterializationRoots({
+    adjacency: roots.adjacency,
+    edgeAlive: roots.edgeAlive,
+    edgeBirths: roots.edgeBirths,
+    frontier: roots.frontier,
+    nodeAlive: roots.nodeAlive,
+    properties: MaterializationRoot.unavailable(),
+    provenanceSupport: roots.provenanceSupport,
+    roaringIndexes: roots.roaringIndexes,
   });
 }
 
@@ -635,7 +666,7 @@ function exactCoordinate(): MaterializationCoordinate {
 
 function descriptor(overrides: Record<string, object | string | number | null> = {}): object {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     laneName: 'events',
     stateHash: 'state-hash',
     roots: rootStatusFixture(),

--- a/test/unit/infrastructure/adapters/GitCasMaterializationWorkspace.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationWorkspace.test.ts
@@ -1,25 +1,33 @@
-import { describe, expect, it, vi } from 'vitest';
-import type { CacheStoreResult } from '@git-stunts/git-cas';
+import { describe, expect, it } from 'vitest';
 import MaterializationCoordinate from '../../../../src/domain/materialization/MaterializationCoordinate.ts';
+import type MaterializationHandle from '../../../../src/domain/materialization/MaterializationHandle.ts';
 import GitCasMaterializationStoreAdapter, {
   type GitCasMaterializationFacade,
 } from '../../../../src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts';
 import GitCasMaterializationWorkspace from '../../../../src/infrastructure/adapters/GitCasMaterializationWorkspace.ts';
-import type {
-  MaterializationWorkspaceLease,
-  MaterializationWorkspaceLeaseScheduler,
-} from '../../../../src/infrastructure/adapters/GitCasMaterializationWorkspace.ts';
-import type { PromoteMaterializationRequest } from '../../../../src/ports/MaterializationWorkspacePort.ts';
 import NodeCryptoAdapter from '../../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
 import defaultCodec from '../../../../src/infrastructure/codecs/CborCodec.ts';
 import InMemoryBlobStorageAdapter from '../../../helpers/InMemoryBlobStorageAdapter.ts';
 import InMemoryGitCasFacade from '../../../helpers/InMemoryGitCasFacade.ts';
 import InMemoryGraphAdapter from '../../../helpers/InMemoryGraphAdapter.ts';
 
-const WORKSPACE_CACHE_NAMESPACE = 'git-warp/materialization-workspaces';
-
 describe('GitCasMaterializationWorkspace', () => {
-  it('retains the latest in-progress roots in a separate expiring workspace', async () => {
+  it('stages pages and bundles under one git-cas workspace root', async () => {
+    const harness = await createHarness();
+    const workspace = await harness.adapter.openWorkspace(workspaceCoordinate());
+
+    const page = await workspace.stagePage(new Uint8Array([1, 2, 3]), { maxBytes: 3 });
+    const bundle = await workspace.stageOrderedBundle([['value', page]], { maxMembers: 1 });
+
+    expect(harness.cas.readActiveWorkspaceCount()).toBe(1);
+    expect(harness.cas.readWorkspaceRoots()).toEqual([[page, bundle.toString()]]);
+    expect(harness.cas.readBundleMembers(bundle.toString())).toEqual([['value', page]]);
+
+    await workspace.release();
+    expect(harness.cas.readActiveWorkspaceCount()).toBe(0);
+  });
+
+  it('checkpoints a transitive aggregate and returns RootSet evidence', async () => {
     const harness = await createHarness();
     const roots = await createRoots(harness.cas);
     const workspace = await harness.adapter.openWorkspace(workspaceCoordinate());
@@ -27,370 +35,70 @@ describe('GitCasMaterializationWorkspace', () => {
     const witness = await workspace.checkpoint(roots);
 
     expect(witness).toMatchObject({
-      policy: 'pinned',
+      policy: 'evictable',
       reachability: 'anchored',
       root: {
-        kind: 'cache-set',
-        namespace: WORKSPACE_CACHE_NAMESPACE,
+        kind: 'root-set',
+        namespace: 'git-warp/materializations',
       },
     });
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toHaveLength(1);
-    expect(harness.cas.readCacheHits(WORKSPACE_CACHE_NAMESPACE)[0]?.expiresAt).not.toBeNull();
-    const retainedWorkspace = harness.cas.readCacheHits(WORKSPACE_CACHE_NAMESPACE)[0];
-    if (retainedWorkspace === undefined) {
-      throw new Error('Expected a retained workspace');
+    const retainedRoots = harness.cas.readWorkspaceRoots();
+    expect(retainedRoots).toHaveLength(1);
+    expect(retainedRoots[0]).toHaveLength(1);
+    const aggregate = retainedRoots[0]?.[0];
+    if (aggregate === undefined) {
+      throw new Error('Expected one retained checkpoint aggregate');
     }
-    expect(harness.cas.readBundleMembers(retainedWorkspace.handle.toString()))
-      .toEqual([
-        ['roots/edge-alive', expect.any(String)],
-        ['roots/node-alive', expect.any(String)],
-        ['roots/properties', expect.any(String)],
-      ]);
-
-    await workspace.release();
-    await workspace.release();
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
-  });
-
-  it('keeps empty and released workspaces side-effect free', async () => {
-    const harness = await createHarness();
-    const workspace = await harness.adapter.openWorkspace(workspaceCoordinate());
-
-    expect(await workspace.checkpoint({
-      nodeAliveRoot: null,
-      edgeAliveRoot: null,
-    })).toBeNull();
-    await workspace.release();
-    await workspace.release();
-
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
-    await expect(workspace.checkpoint({
-      nodeAliveRoot: null,
-      edgeAliveRoot: null,
-    })).rejects.toMatchObject({ code: 'E_MATERIALIZATION_STORAGE' });
-  });
-
-  it('fails closed when git-cas declines workspace retention', async () => {
-    const harness = await createHarness();
-    const roots = await createRoots(harness.cas);
-    const facade = withCacheResult(harness.cas, (stored) => Object.freeze({
-      ...stored,
-      accepted: false,
-      hit: null,
-      witness: null,
-    }));
-    const workspace = await adapterFor(facade).openWorkspace(workspaceCoordinate());
-
-    await expect(workspace.checkpoint(roots)).rejects.toMatchObject({
-      code: 'E_MATERIALIZATION_STORAGE',
-      message: expect.stringContaining('did not retain'),
-    });
-    await workspace.release();
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
-  });
-
-  it('cleans up when git-cas reports an unexpected workspace target', async () => {
-    const harness = await createHarness();
-    const roots = await createRoots(harness.cas);
-    const page = await harness.cas.pages.put({ source: new Uint8Array([9]) });
-    const cache = await harness.cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
-    const unexpected = await cache.put('unexpected-workspace-target', page.handle);
-    if (unexpected.hit === null) {
-      throw new Error('Expected an unexpected workspace cache hit');
-    }
-    const facade = withCacheResult(harness.cas, (stored) => Object.freeze({
-      ...stored,
-      hit: unexpected.hit,
-    }));
-    const workspace = await adapterFor(facade).openWorkspace(workspaceCoordinate());
-
-    await expect(workspace.checkpoint(roots)).rejects.toMatchObject({
-      code: 'E_MATERIALIZATION_STORAGE',
-      message: expect.stringContaining('unexpected workspace handle'),
-    });
-    await workspace.release();
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([
-      'unexpected-workspace-target',
+    expect(harness.cas.readBundleMembers(aggregate)).toEqual([
+      ['roots/edge-alive', roots.edgeAliveRoot],
+      ['roots/node-alive', roots.nodeAliveRoot],
+      ['roots/properties', roots.propertiesRoot],
     ]);
   });
 
-  it('serializes release behind an in-flight workspace checkpoint', async () => {
+  it('keeps empty checkpoints side-effect free and release idempotent', async () => {
     const harness = await createHarness();
-    const roots = await createRoots(harness.cas);
-    const cache = await harness.cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
-    let admitPut: () => void = () => undefined;
-    const putGate = new Promise<void>((resolve) => {
-      admitPut = resolve;
-    });
-    const workspace = new GitCasMaterializationWorkspace({
-      bundles: harness.cas.bundles,
-      cache: {
-        put: async (...args) => {
-          await putGate;
-          return await cache.put(...args);
-        },
-        remove: async (key) => await cache.remove(key),
-      },
-      key: 'concurrent-release',
-      promote: rejectPromotion,
-    });
+    const workspace = await harness.adapter.openWorkspace(workspaceCoordinate());
 
-    const checkpoint = workspace.checkpoint(roots);
-    const release = workspace.release();
-    admitPut();
-
-    await checkpoint;
-    await release;
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
     await expect(workspace.checkpoint({
       nodeAliveRoot: null,
       edgeAliveRoot: null,
-    })).rejects.toMatchObject({ code: 'E_MATERIALIZATION_STORAGE' });
-  });
-
-  it('renews an active lease without waiting for another root checkpoint', async () => {
-    const harness = await createHarness();
-    const roots = await createRoots(harness.cas);
-    const cache = await harness.cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
-    const scheduler = new ManualLeaseScheduler();
-    let now = Date.parse('2026-07-16T00:00:00.000Z');
-    const workspace = new GitCasMaterializationWorkspace({
-      bundles: harness.cas.bundles,
-      cache,
-      key: 'renewing-workspace',
-      clock: { now: () => new Date(now) },
-      leaseTtlMs: 100,
-      leaseRenewalMs: 40,
-      leaseScheduler: scheduler,
-      promote: rejectPromotion,
-    });
-
-    await workspace.checkpoint(roots);
-    const firstExpiry = requireWorkspaceExpiry(harness.cas);
-    now += 40;
-    await scheduler.runNext();
-    const renewedExpiry = requireWorkspaceExpiry(harness.cas);
-
-    expect(renewedExpiry).toBeGreaterThan(firstExpiry);
-    expect(scheduler.pending).toBe(true);
+    })).resolves.toBeNull();
     await workspace.release();
-    expect(scheduler.pending).toBe(false);
-  });
-
-  it('runs lease renewal through the production scheduler callback', async () => {
-    vi.useFakeTimers();
-    try {
-      const harness = await createHarness();
-      const roots = await createRoots(harness.cas);
-      const cache = await harness.cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
-      const workspace = new GitCasMaterializationWorkspace({
-        bundles: harness.cas.bundles,
-        cache,
-        key: 'system-scheduler',
-        leaseTtlMs: 100,
-        leaseRenewalMs: 40,
-        promote: rejectPromotion,
-      });
-
-      await workspace.checkpoint(roots);
-      const firstExpiry = requireWorkspaceExpiry(harness.cas);
-      await vi.advanceTimersByTimeAsync(40);
-
-      expect(requireWorkspaceExpiry(harness.cas)).toBeGreaterThan(firstExpiry);
-      await workspace.release();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('ignores lease timers that fire after release or target replacement', async () => {
-    const harness = await createHarness();
-    const roots = await createRoots(harness.cas);
-    const cache = await harness.cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
-    const scheduler = new ManualLeaseScheduler();
-    const workspace = new GitCasMaterializationWorkspace({
-      bundles: harness.cas.bundles,
-      cache,
-      key: 'stale-renewal',
-      leaseTtlMs: 100,
-      leaseRenewalMs: 40,
-      leaseScheduler: scheduler,
-      promote: rejectPromotion,
-    });
-
-    await workspace.checkpoint(roots);
-    const replacedTargetTimer = scheduler.takeNext();
-    const replacement = await createRoots(harness.cas);
-    await workspace.checkpoint(replacement);
-    await replacedTargetTimer();
-    const releasedTargetTimer = scheduler.takeNext();
     await workspace.release();
-    await releasedTargetTimer();
 
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
+    expect(harness.cas.readActiveWorkspaceCount()).toBe(0);
+    expect(() => workspace.stagePage(new Uint8Array([1]), { maxBytes: 1 }))
+      .toThrowError(/closed workspace/u);
   });
 
-  it('fails closed after a lease renewal error and releases without masking cleanup', async () => {
+  it('fails closed when checkpoint evidence omits the aggregate handle', async () => {
     const harness = await createHarness();
-    const roots = await createRoots(harness.cas);
-    const cache = await harness.cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
-    const scheduler = new ManualLeaseScheduler();
-    const promote = vi.fn(rejectPromotion);
-    let puts = 0;
+    const raw = await harness.cas.workspaces.open({ namespace: 'malformed-workspace' });
     const workspace = new GitCasMaterializationWorkspace({
-      bundles: harness.cas.bundles,
-      cache: {
-        put: async (...args) => {
-          puts += 1;
-          if (puts === 2) {
-            throw new Error('renewal unavailable');
-          }
-          return await cache.put(...args);
+      workspace: {
+        ...raw,
+        checkpoint: async (options) => {
+          const checkpoint = await raw.checkpoint(options);
+          return Object.freeze({ ...checkpoint, handles: Object.freeze([]) });
         },
-        remove: async (key) => await cache.remove(key),
       },
-      key: 'failing-renewal',
-      leaseTtlMs: 100,
-      leaseRenewalMs: 40,
-      leaseScheduler: scheduler,
-      promote,
+      promote: rejectPromotion,
     });
-
-    await workspace.checkpoint(roots);
-    await scheduler.runNext();
+    const roots = await createRoots(harness.cas);
 
     await expect(workspace.checkpoint(roots)).rejects.toMatchObject({
       code: 'E_MATERIALIZATION_STORAGE',
-      message: expect.stringContaining('lease renewal failed'),
+      message: expect.stringContaining('exact workspace root'),
     });
-    await expect(workspace.promote({} as PromoteMaterializationRequest)).rejects.toMatchObject({
-      code: 'E_MATERIALIZATION_STORAGE',
-      message: expect.stringContaining('lease renewal failed'),
-    });
-    expect(promote).not.toHaveBeenCalled();
-    await expect(workspace.release()).resolves.toBeUndefined();
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
+    await workspace.release();
   });
 
-  it('continues renewing while final materialization promotion is in flight', async () => {
-    const harness = await createHarness();
-    const roots = await createRoots(harness.cas);
-    const cache = await harness.cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
-    const scheduler = new ManualLeaseScheduler();
-    let now = Date.parse('2026-07-16T00:00:00.000Z');
-    let rejectPromotionGate: (reason: Error) => void = () => undefined;
-    const promotionFailure = new Error('final retention unavailable');
-    const promotionGate = new Promise<never>((_resolve, reject) => {
-      rejectPromotionGate = reject;
-    });
-    let signalPromotionStarted: () => void = () => undefined;
-    const promotionStarted = new Promise<void>((resolve) => {
-      signalPromotionStarted = resolve;
-    });
-    const workspace = new GitCasMaterializationWorkspace({
-      bundles: harness.cas.bundles,
-      cache,
-      key: 'long-promotion',
-      clock: { now: () => new Date(now) },
-      leaseTtlMs: 100,
-      leaseRenewalMs: 40,
-      leaseScheduler: scheduler,
-      promote: async (_request) => {
-        signalPromotionStarted();
-        return await promotionGate;
-      },
-    });
-
-    await workspace.checkpoint(roots);
-    const firstExpiry = requireWorkspaceExpiry(harness.cas);
-    const promotion = workspace.promote({} as PromoteMaterializationRequest);
-    const promotionAssertion = expect(promotion).rejects.toBe(promotionFailure);
-    await promotionStarted;
-    const release = workspace.release();
-    await expect(workspace.promote({} as PromoteMaterializationRequest)).rejects.toMatchObject({
-      code: 'E_MATERIALIZATION_STORAGE',
-      message: expect.stringContaining('cannot promote'),
-    });
-    now += 40;
-    await scheduler.runNext();
-
-    expect(requireWorkspaceExpiry(harness.cas)).toBeGreaterThan(firstExpiry);
-    rejectPromotionGate(promotionFailure);
-    await promotionAssertion;
-    await release;
-    expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toEqual([]);
-  });
-
-  it('rejects malformed roots and invalid clocks before retention', async () => {
-    const harness = await createHarness();
-    const cache = await harness.cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
-    const workspace = new GitCasMaterializationWorkspace({
-      bundles: harness.cas.bundles,
-      cache,
-      key: 'invalid-clock',
-      clock: { now: () => new Date(Number.NaN) },
-      promote: rejectPromotion,
-    });
-
-    await expect(workspace.checkpoint({
-      nodeAliveRoot: 'not-a-bundle',
-      edgeAliveRoot: null,
-    })).rejects.toMatchObject({
-      code: 'E_MATERIALIZATION_STORAGE',
-      message: expect.stringContaining('not a bundle handle'),
-    });
-    await expect(Reflect.apply(workspace.checkpoint, workspace, [null]))
-      .rejects.toMatchObject({
-        code: 'E_MATERIALIZATION_STORAGE',
-        message: expect.stringContaining('roots must be an object'),
-      });
-
-    const roots = await createRoots(harness.cas);
-    await expect(workspace.checkpoint(roots)).rejects.toMatchObject({
-      code: 'E_MATERIALIZATION_STORAGE',
-      message: expect.stringContaining('invalid Date'),
-    });
-  });
-
-  it('validates workspace dependencies and options', async () => {
-    const harness = await createHarness();
-    const cache = await harness.cas.caches.open({ namespace: WORKSPACE_CACHE_NAMESPACE });
-    const valid = {
-      bundles: harness.cas.bundles,
-      cache,
-      key: 'workspace-options',
-      promote: rejectPromotion,
-    };
-
-    expect(() => Reflect.construct(GitCasMaterializationWorkspace, [null]))
-      .toThrowError(/options/u);
-    for (const field of ['bundles', 'cache', 'promote']) {
-      const options = { ...valid };
-      Reflect.set(options, field, null);
-      expect(() => Reflect.construct(GitCasMaterializationWorkspace, [options]))
-        .toThrowError(new RegExp(`${field} dependency`, 'u'));
-    }
-    expect(() => new GitCasMaterializationWorkspace({
-      ...valid,
-      key: '',
-    })).toThrowError(/key/u);
+  it('validates the git-cas workspace dependency at construction', () => {
     expect(() => Reflect.construct(GitCasMaterializationWorkspace, [{
-      ...valid,
-      clock: {},
-    }])).toThrowError(/clock/u);
-    expect(() => new GitCasMaterializationWorkspace({
-      ...valid,
-      leaseTtlMs: 40,
-      leaseRenewalMs: 40,
-    })).toThrowError(/leaseRenewalMs/u);
-    expect(() => new GitCasMaterializationWorkspace({
-      ...valid,
-      leaseTtlMs: 0,
-    })).toThrowError(/leaseTtlMs/u);
-    expect(() => Reflect.construct(GitCasMaterializationWorkspace, [{
-      ...valid,
-      leaseScheduler: {},
-    }])).toThrowError(/leaseScheduler/u);
+      workspace: {},
+      promote: rejectPromotion,
+    }])).toThrowError(/workspace dependency/u);
   });
 });
 
@@ -410,10 +118,7 @@ async function createHarness(): Promise<Harness> {
     history: new InMemoryGraphAdapter(),
     storage: new InMemoryBlobStorageAdapter(),
   });
-  return Object.freeze({
-    cas,
-    adapter: adapterFor(cas),
-  });
+  return Object.freeze({ cas, adapter: adapterFor(cas) });
 }
 
 async function createRoots(cas: InMemoryGitCasFacade): Promise<WorkspaceRoots> {
@@ -441,37 +146,6 @@ function adapterFor(cas: GitCasMaterializationFacade): GitCasMaterializationStor
   });
 }
 
-function withCacheResult(
-  cas: InMemoryGitCasFacade,
-  rewrite: (stored: CacheStoreResult) => CacheStoreResult,
-): GitCasMaterializationFacade {
-  return {
-    bundles: cas.bundles,
-    pages: cas.pages,
-    caches: {
-      open: async (options) => {
-        const cache = await cas.caches.open(options);
-        return {
-          acquire: async (key) => await cache.acquire(key),
-          get: async (key) => await cache.get(key),
-          put: async (key, handle, entryOptions) => rewrite(
-            await cache.put(key, handle, entryOptions),
-          ),
-          remove: async (key) => await cache.remove(key),
-        };
-      },
-    },
-  };
-}
-
-function requireWorkspaceExpiry(cas: InMemoryGitCasFacade): number {
-  const expiresAt = cas.readCacheHits(WORKSPACE_CACHE_NAMESPACE)[0]?.expiresAt;
-  if (expiresAt === undefined || expiresAt === null) {
-    throw new Error('Expected the workspace to have an expiry');
-  }
-  return Date.parse(expiresAt);
-}
-
 function workspaceCoordinate(): MaterializationCoordinate {
   return new MaterializationCoordinate({
     frontier: new Map([['writer-a', 'patch-a']]),
@@ -479,38 +153,9 @@ function workspaceCoordinate(): MaterializationCoordinate {
   });
 }
 
-function rejectPromotion(): Promise<never> {
-  return Promise.reject(new Error('Promotion is not used by this workspace lifecycle test'));
-}
-
-class ManualLeaseScheduler implements MaterializationWorkspaceLeaseScheduler {
-  #task: (() => Promise<void>) | null = null;
-
-  get pending(): boolean {
-    return this.#task !== null;
-  }
-
-  schedule(task: () => Promise<void>, _delayMs: number): MaterializationWorkspaceLease {
-    this.#task = task;
-    return Object.freeze({
-      cancel: () => {
-        if (this.#task === task) {
-          this.#task = null;
-        }
-      },
-    });
-  }
-
-  async runNext(): Promise<void> {
-    await this.takeNext()();
-  }
-
-  takeNext(): () => Promise<void> {
-    const task = this.#task;
-    if (task === null) {
-      throw new Error('Expected a scheduled lease renewal');
-    }
-    this.#task = null;
-    return task;
-  }
+function rejectPromotion(
+  _workspace: unknown,
+  _request: unknown,
+): Promise<MaterializationHandle> {
+  return Promise.reject(new Error('Promotion is not used by this lifecycle test'));
 }

--- a/test/unit/infrastructure/adapters/GitCasMaterializationWorkspace.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationWorkspace.test.ts
@@ -36,6 +36,16 @@ describe('GitCasMaterializationWorkspace', () => {
     });
     expect(harness.cas.readCacheKeys(WORKSPACE_CACHE_NAMESPACE)).toHaveLength(1);
     expect(harness.cas.readCacheHits(WORKSPACE_CACHE_NAMESPACE)[0]?.expiresAt).not.toBeNull();
+    const retainedWorkspace = harness.cas.readCacheHits(WORKSPACE_CACHE_NAMESPACE)[0];
+    if (retainedWorkspace === undefined) {
+      throw new Error('Expected a retained workspace');
+    }
+    expect(harness.cas.readBundleMembers(retainedWorkspace.handle.toString()))
+      .toEqual([
+        ['roots/edge-alive', expect.any(String)],
+        ['roots/node-alive', expect.any(String)],
+        ['roots/properties', expect.any(String)],
+      ]);
 
     await workspace.release();
     await workspace.release();
@@ -387,6 +397,7 @@ describe('GitCasMaterializationWorkspace', () => {
 type WorkspaceRoots = Readonly<{
   nodeAliveRoot: string;
   edgeAliveRoot: string;
+  propertiesRoot: string;
 }>;
 
 type Harness = Readonly<{
@@ -408,11 +419,16 @@ async function createHarness(): Promise<Harness> {
 async function createRoots(cas: InMemoryGitCasFacade): Promise<WorkspaceRoots> {
   const nodePage = await cas.pages.put({ source: new Uint8Array([1]) });
   const edgePage = await cas.pages.put({ source: new Uint8Array([2]) });
+  const propertiesPage = await cas.pages.put({ source: new Uint8Array([3]) });
   const nodeBundle = await cas.bundles.putOrdered({ members: [['root', nodePage.handle]] });
   const edgeBundle = await cas.bundles.putOrdered({ members: [['root', edgePage.handle]] });
+  const propertiesBundle = await cas.bundles.putOrdered({
+    members: [['root', propertiesPage.handle]],
+  });
   return Object.freeze({
     nodeAliveRoot: nodeBundle.handle.toString(),
     edgeAliveRoot: edgeBundle.handle.toString(),
+    propertiesRoot: propertiesBundle.handle.toString(),
   });
 }
 
@@ -437,6 +453,7 @@ function withCacheResult(
         const cache = await cas.caches.open(options);
         return {
           acquire: async (key) => await cache.acquire(key),
+          get: async (key) => await cache.get(key),
           put: async (key, handle, entryOptions) => rewrite(
             await cache.put(key, handle, entryOptions),
           ),

--- a/test/unit/infrastructure/adapters/GitCasRepositoryAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasRepositoryAdapter.test.ts
@@ -130,6 +130,7 @@ describe('GitCasRepositoryAdapter', () => {
       bundles: highLevelCas.bundles,
       caches: highLevelCas.caches,
       pages: highLevelCas.pages,
+      workspaces: highLevelCas.workspaces,
       publications: highLevelCas.publications,
       rootSets: { open: vi.fn(async () => rootSet) },
       readManifest: vi.fn(),

--- a/test/unit/infrastructure/adapters/GitCasTrieStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasTrieStoreAdapter.test.ts
@@ -220,8 +220,8 @@ function failingPages(
 function failingBundleWrites(cas: InMemoryGitCasFacade): GitCasTrieFacade {
   return {
     bundles: {
-      getMember: cas.bundles.getMember,
-      iterateMembers: cas.bundles.iterateMembers,
+      getMemberReference: cas.bundles.getMemberReference,
+      iterateMemberReferences: cas.bundles.iterateMemberReferences,
       putOrdered: async () => { throw new Error('bundle write unavailable'); },
     },
     pages: cas.pages,

--- a/test/unit/infrastructure/adapters/GitCasTrieStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasTrieStoreAdapter.test.ts
@@ -1,8 +1,9 @@
 import { BundleHandle } from '@git-stunts/git-cas';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import GitCasTrieStoreAdapter, {
   type GitCasTrieFacade,
 } from '../../../../src/infrastructure/adapters/GitCasTrieStoreAdapter.ts';
+import DomainBundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
 import InMemoryBlobStorageAdapter from '../../../helpers/InMemoryBlobStorageAdapter.ts';
 import InMemoryGitCasFacade from '../../../helpers/InMemoryGitCasFacade.ts';
 import InMemoryGraphAdapter from '../../../helpers/InMemoryGraphAdapter.ts';
@@ -54,6 +55,28 @@ describe('GitCasTrieStoreAdapter', () => {
     await expect(adapter.readLeaf(root)).rejects.toMatchObject({
       code: 'E_TRIE_STORE_MISSING',
     });
+  });
+
+  it('routes every trie page and bundle write through the staging scope', async () => {
+    const stagePage = vi.fn(async (source: Uint8Array) => (
+      await cas.pages.put({ source, maxBytes: 16 * 1024 * 1024 })
+    ).handle.toString());
+    const stageOrderedBundle = vi.fn(async (members: Iterable<[string, string]>) => {
+      const staged = await cas.bundles.putOrdered({ members });
+      return new DomainBundleHandle(staged.handle.toString());
+    });
+    const staging = { stagePage, stageOrderedBundle };
+
+    const leaf = await adapter.writeLeaf(new Uint8Array([1, 2, 3]), staging);
+    const branch = await adapter.writeBranch(new Map([[0, leaf]]), staging);
+
+    expect(stagePage).toHaveBeenCalledOnce();
+    expect(stageOrderedBundle).toHaveBeenCalledTimes(2);
+    expect(cas.readBundleMembers(leaf)[0]).toEqual([
+      'leaf/data',
+      expect.stringMatching(/^git-cas:1:page:/u),
+    ]);
+    expect(cas.readBundleMembers(branch)).toEqual([['children/0', leaf]]);
   });
 
   it('maps an absent bundle to a typed missing-root error', async () => {

--- a/test/unit/ports/IndexStorePort.test.ts
+++ b/test/unit/ports/IndexStorePort.test.ts
@@ -11,6 +11,7 @@ describe('IndexStorePort', () => {
     expect(IndexStorePort.prototype.writeShards).toBeUndefined();
     expect(IndexStorePort.prototype.scanShards).toBeUndefined();
     expect(IndexStorePort.prototype.readShardHandles).toBeUndefined();
+    expect(IndexStorePort.prototype.readShardHandle).toBeUndefined();
     expect(IndexStorePort.prototype.openShard).toBeUndefined();
     expect(IndexStorePort.prototype.decodeShard).toBeUndefined();
   });
@@ -23,6 +24,9 @@ describe('IndexStorePort', () => {
       scanShards(_handle: BundleHandle) { return WarpStream.of<IndexShard>(); }
       async readShardHandles(_handle: BundleHandle) {
         return { 'shard.cbor': this.shardHandle };
+      }
+      async readShardHandle(_handle: BundleHandle, path: string) {
+        return path === 'shard.cbor' ? this.shardHandle : null;
       }
       async *openShard(_handle: AssetHandle) { yield new Uint8Array([1]); }
       async decodeShard<TDecoded extends CodecValue = CodecValue>(
@@ -37,5 +41,7 @@ describe('IndexStorePort', () => {
     await expect(store.readShardHandles(store.bundleHandle)).resolves.toEqual({
       'shard.cbor': store.shardHandle,
     });
+    await expect(store.readShardHandle(store.bundleHandle, 'shard.cbor'))
+      .resolves.toBe(store.shardHandle);
   });
 });

--- a/test/unit/ports/IndexStorePort.test.ts
+++ b/test/unit/ports/IndexStorePort.test.ts
@@ -4,7 +4,10 @@ import AssetHandle from '../../../src/domain/storage/AssetHandle.ts';
 import BundleHandle from '../../../src/domain/storage/BundleHandle.ts';
 import WarpStream from '../../../src/domain/stream/WarpStream.ts';
 import type CodecValue from '../../../src/domain/types/codec/CodecValue.ts';
-import IndexStorePort from '../../../src/ports/IndexStorePort.ts';
+import IndexStorePort, {
+  type IndexShardDecodeOptions,
+  type IndexShardWriteOptions,
+} from '../../../src/ports/IndexStorePort.ts';
 
 describe('IndexStorePort', () => {
   it('declares opaque-handle streaming methods', () => {
@@ -15,6 +18,31 @@ describe('IndexStorePort', () => {
     expect(IndexStorePort.prototype.openShard).toBeUndefined();
     expect(IndexStorePort.prototype.decodeShard).toBeUndefined();
     expect(IndexStorePort.prototype.decodeShardAt).toBeUndefined();
+  });
+
+  it('models page storage and structural limits as complete option states', () => {
+    const pageOptions = {
+      memberStorage: 'page',
+      maxShardBytes: 1024,
+    } satisfies IndexShardWriteOptions;
+    const decodeOptions = {
+      structureLimits: {
+        maxContainerEntries: 16,
+        maxDepth: 8,
+        maxItems: 64,
+      },
+    } satisfies IndexShardDecodeOptions;
+    // @ts-expect-error Page-backed shards require an explicit byte limit.
+    const missingPageLimit: IndexShardWriteOptions = { memberStorage: 'page' };
+    const partialStructureLimits: IndexShardDecodeOptions = {
+      // @ts-expect-error Structural limits are all-or-nothing.
+      structureLimits: { maxDepth: 8 },
+    };
+
+    expect(pageOptions.maxShardBytes).toBe(1024);
+    expect(decodeOptions.structureLimits.maxDepth).toBe(8);
+    expect(missingPageLimit.memberStorage).toBe('page');
+    expect(partialStructureLimits.structureLimits?.maxDepth).toBe(8);
   });
 
   it('can be implemented without object IDs', async () => {

--- a/test/unit/ports/IndexStorePort.test.ts
+++ b/test/unit/ports/IndexStorePort.test.ts
@@ -14,6 +14,7 @@ describe('IndexStorePort', () => {
     expect(IndexStorePort.prototype.readShardHandle).toBeUndefined();
     expect(IndexStorePort.prototype.openShard).toBeUndefined();
     expect(IndexStorePort.prototype.decodeShard).toBeUndefined();
+    expect(IndexStorePort.prototype.decodeShardAt).toBeUndefined();
   });
 
   it('can be implemented without object IDs', async () => {
@@ -34,6 +35,12 @@ describe('IndexStorePort', () => {
       ): Promise<TDecoded> {
         return Object.freeze({}) as TDecoded;
       }
+      async decodeShardAt<TDecoded extends CodecValue = CodecValue>(
+        _handle: BundleHandle,
+        path: string,
+      ): Promise<TDecoded | null> {
+        return path === 'shard.cbor' ? Object.freeze({}) as TDecoded : null;
+      }
     }
 
     const store = new TestStore();
@@ -43,5 +50,7 @@ describe('IndexStorePort', () => {
     });
     await expect(store.readShardHandle(store.bundleHandle, 'shard.cbor'))
       .resolves.toBe(store.shardHandle);
+    await expect(store.decodeShardAt(store.bundleHandle, 'shard.cbor'))
+      .resolves.toEqual({});
   });
 });

--- a/test/unit/scripts/v18-v17-fixture-wet-run-harness.test.ts
+++ b/test/unit/scripts/v18-v17-fixture-wet-run-harness.test.ts
@@ -92,17 +92,23 @@ describe('v18 v17 fixture wet-run harness', () => {
   });
 
   it('formats deterministic wet-run operator evidence without temp paths', async () => {
-    const targetDirectory = await temporaryDirectories.create('git-warp-v17-wet-run-report-');
+    const firstTargetDirectory = await temporaryDirectories.create('git-warp-v17-wet-run-report-a-');
+    const secondTargetDirectory = await temporaryDirectories.create('git-warp-v17-wet-run-report-b-');
 
-    const result = await runV17GoldenGraphFixtureWetRun({
+    const firstResult = await runV17GoldenGraphFixtureWetRun({
       manifestPath: FIXTURE_MANIFEST_PATH,
-      targetDirectory,
+      targetDirectory: firstTargetDirectory,
     });
-    const first = formatV17GoldenGraphFixtureWetRunReport(result);
-    const second = formatV17GoldenGraphFixtureWetRunReport(result);
+    const secondResult = await runV17GoldenGraphFixtureWetRun({
+      manifestPath: FIXTURE_MANIFEST_PATH,
+      targetDirectory: secondTargetDirectory,
+    });
+    const first = formatV17GoldenGraphFixtureWetRunReport(firstResult);
+    const second = formatV17GoldenGraphFixtureWetRunReport(secondResult);
 
     expect(first).toBe(second);
-    expect(first).not.toContain(targetDirectory);
+    expect(first).not.toContain(firstTargetDirectory);
+    expect(second).not.toContain(secondTargetDirectory);
     expect(first).toContain('git-warp v18 v17 fixture wet-run report');
     expect(first).toContain('fixtureId: v17-golden-graph-model-001');
     expect(first).toContain('command.equivalence: passed');

--- a/test/unit/scripts/v18-v17-fixture-wet-run-harness.test.ts
+++ b/test/unit/scripts/v18-v17-fixture-wet-run-harness.test.ts
@@ -92,20 +92,17 @@ describe('v18 v17 fixture wet-run harness', () => {
   });
 
   it('formats deterministic wet-run operator evidence without temp paths', async () => {
-    const firstTarget = await temporaryDirectories.create('git-warp-v17-wet-run-report-a-');
-    const secondTarget = await temporaryDirectories.create('git-warp-v17-wet-run-report-b-');
+    const targetDirectory = await temporaryDirectories.create('git-warp-v17-wet-run-report-');
 
-    const first = formatV17GoldenGraphFixtureWetRunReport(await runV17GoldenGraphFixtureWetRun({
+    const result = await runV17GoldenGraphFixtureWetRun({
       manifestPath: FIXTURE_MANIFEST_PATH,
-      targetDirectory: firstTarget,
-    }));
-    const second = formatV17GoldenGraphFixtureWetRunReport(await runV17GoldenGraphFixtureWetRun({
-      manifestPath: FIXTURE_MANIFEST_PATH,
-      targetDirectory: secondTarget,
-    }));
+      targetDirectory,
+    });
+    const first = formatV17GoldenGraphFixtureWetRunReport(result);
+    const second = formatV17GoldenGraphFixtureWetRunReport(result);
 
     expect(first).toBe(second);
-    expect(first).not.toContain(firstTarget);
+    expect(first).not.toContain(targetDirectory);
     expect(first).toContain('git-warp v18 v17 fixture wet-run report');
     expect(first).toContain('fixtureId: v17-golden-graph-model-001');
     expect(first).toContain('command.equivalence: passed');

--- a/test/unit/scripts/v18-v17-public-read-legacy-reading-builder.test.ts
+++ b/test/unit/scripts/v18-v17-public-read-legacy-reading-builder.test.ts
@@ -49,7 +49,7 @@ describe('v18 v17 public-read legacy reading builder', () => {
     // git-cas package versions are stamped into asset manifests, so dependency bumps
     // intentionally advance this migration-reading golden handle.
     expect(reading.facts.find((fact) => fact.factKey === 'node:alpha:_content')?.value)
-      .toBe('git-cas:1:asset:manifest-tree:cbor:sha1:5453687e3d0e74b5fbf43f347a4403824a52a697');
+      .toBe('git-cas:1:asset:manifest-tree:cbor:sha1:8851a151d100f2faad3a93892dfb83fa6f1345f7');
   });
 
   it('fails closed when a restored v17 writer ref drifts after restore', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/ports/**/*.ts', 'src/**/*.d.ts'],
       thresholds: {
-        lines: 92.78,
+        lines: 92.89,
         autoUpdate: shouldAutoUpdateCoverageRatchet(),
       },
     },


### PR DESCRIPTION
## Summary

- retain independent node/property materialization roots through scoped git-cas workspaces
- read bundle member references lazily through git-cas 6.5 without recursively hydrating bundle payloads
- reuse one runtime-owned git-cas cache acquisition for the current coordinate and retire it after in-flight readers finish
- release local retention resources through idempotent `RuntimeHost.close()`
- preserve bounded CBOR, shard-schema, storage-policy, and lifecycle validation on retained reads

## Issue

Refs #738.
Refs #739.
Refs #742.

This slice does not close those issues: incremental materialization still needs compatible-predecessor resume, and whole-state compatibility paths still exist.

## Test plan

- `npm run typecheck`
- `npm run lint`
- `npm run lint:md`
- `npm run typecheck:surface`
- `npm run test:coverage:ci`: 586 files passed, 1 skipped; 7,222 tests passed, 2 skipped; 92.90% line coverage
- focused retained-materialization, storage-contract, and lazy-reference tests: 68 passed
- independent wet-run determinism executions: 9 tests passed
- pre-push static and test firewall before merge

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] Persisted op formats are unchanged; no ADR 3 readiness issue is required
- [x] Wire compatibility is unchanged; canonical-only wire behavior is unaffected
- [x] Patch and checkpoint schema namespaces are unchanged