### PR TITLE
Define witnessed admission and settlement contracts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,7 +157,7 @@ dependency bag and owns the orchestration for its domain:
 | Controller | Capability | Key responsibility |
 |-----------|------------|-------------------|
 | QueryController | query | Node/edge reads, observers, worldlines |
-| PatchController | patches | Patch creation, commit, CRDT join |
+| PatchController | patches | Patch creation, commit, deterministic fold |
 | MaterializeController | materialize | Full and incremental materialization |
 | SyncController | sync | Frontier, sync, serve |
 | StrandController | strands | Strand lifecycle, braid, collapse |
@@ -190,7 +190,7 @@ owns folded state persistence rather than live query semantics.
 
 Stateless services that implement domain logic:
 
-- **JoinReducer** — CRDT state merge (the gravitational center)
+- **JoinReducer** — deterministic CRDT fold for laws that admit a semilattice join
 - **OpStrategy** — per-op-type mutation/outcome/snapshot logic
 - **StrandCoordinator** — strand lifecycle orchestration
 - **ConflictAnalyzer** — conflict detection and trace assembly
@@ -247,6 +247,19 @@ refs/warp/events/coverage      → coverage-sha
 ```
 
 Reads open a bounded timeline basis over those refs. Diagnostic materialization
-walks visible writer chains, applies patches through `JoinReducer` (CRDT merge),
+walks visible writer chains, applies admitted patches through `JoinReducer`,
 and produces a frozen `WarpState`; application code should prefer readings and
 receipts before whole-graph replay.
+
+`JoinReducer` is not the admission authority and does not imply that every pair
+of concurrent histories has a least upper bound. Admission first classifies a
+well-formed proposal as `derived`, `plural`, `conflict`, or `obstruction`, with
+a required variant-specific witness. A CRDT join is one possible settlement
+law for a domain that can prove the semilattice obligations. Other domains may
+retain plurality, require explicit conflict resolution, or obstruct admission.
+
+Settlement is a later cross-lane operation. A preview is non-authoritative and
+produces an immutable `SettlementPlan` bound to the exact source and target
+frontiers, proposal, law, and policy. Execution must revalidate those bindings;
+any bound-input change invalidates the plan rather than silently applying it to
+a different history.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If that sounds abstract, the short version is:
 
 - You can work **offline**.
 - Multiple writers can contribute **without central coordination**.
-- Conflicts resolve **deterministically**.
+- Concurrent histories are **classified deterministically** before settlement.
 - Every value keeps **provenance**.
 - Reads are designed to stay **bounded**, not accidentally materialize everything.
 
@@ -236,22 +236,32 @@ than maintained as long-form prose; see the generated
 
 ### Deterministic and offline-first
 
-Writers can make independent changes without a central coordinator. When history converges, the same patches produce the same visible result.
+Writers can make independent changes without a central coordinator. Admission
+first classifies how their histories meet: direct extension, lawful plurality,
+exclusive conflict, or obstruction. For the same admitted patch set and law,
+deterministic reducers produce the same visible result.
 
 <details>
-<summary><h4>For the Nerds™ — Convergence is a join-semilattice</h4></summary>
+<summary><h4>For the Nerds™ — CRDT join is a domain law</h4></summary>
 
-> Deterministic multi-writer merge is the statement that materialized state forms a **join-semilattice** $(L, \sqcup)$: a partial order with a least upper bound for any pair. Each writer's patches push state _up_ the order, and merge is the **join** $\sqcup$ — idempotent, commutative, and associative:
+> When a domain defines a **join-semilattice** $(L, \sqcup)$, its lawful
+> settlement reducer has a least upper bound for each pair in that domain. The
+> join remains idempotent, commutative, and associative:
 >
 > $$x \sqcup x = x \qquad x \sqcup y = y \sqcup x \qquad (x \sqcup y) \sqcup z = x \sqcup (y \sqcup z)$$
 >
-> Those three laws are exactly what "no central coordinator" buys you:
+> Those laws allow that domain to reconcile independently delivered updates:
 >
 > - **commutativity** ⇒ writers can apply each other's patches in any order,
 > - **associativity** ⇒ they can batch them however the network delivers them,
 > - **idempotence** ⇒ re-delivering the same patch is harmless.
 >
-> So convergence isn't luck; it's the **least upper bound** $\bigsqcup_i h_i$ of everyone's observed history $h_i$. This is the CRDT (state-based / CvRDT) guarantee: monotone updates into a semilattice always reconcile to the same join, independent of message order or duplication.
+> Git-warp does not require every pair of concurrent histories to have such a
+> join. It first classifies admission as **derived**, **plural**, **conflict**,
+> or **obstruction**. A settlement law may use a CRDT join for lawful plural
+> histories; another law may preserve plurality or require explicit conflict
+> resolution. Automatic merge is a policy with algebraic obligations, not a
+> universal property of all causal history.
 
 </details>
 
@@ -324,7 +334,7 @@ Each writer appends patch commits under `refs/warp/<graph>/writers/<writerId>`. 
 
 > Git's object store is a **Merkle DAG**: every object is named by the hash of its content, so a commit's id transitively fixes its entire history. That gives **structural sharing** (equal subhistories are stored once — hash-consing) and **tamper-evidence** for free: change one byte upstream and every downstream id changes.
 >
-> `git-warp` leans on two consequences. First, each writer's chain at `refs/warp/<graph>/writers/<writerId>` is the **free monoid** $(W^{*},\, \cdot,\, \varepsilon)$ on that writer's claims $W$ — append-only concatenation $\cdot$, empty history $\varepsilon$ as identity, no rewriting. Second, the commits live on WARP refs rather than source-tree refs, so graph history rides Git's transport and dedup without touching your working tree. Merge law lives one layer above this (see the semilattice note); Git supplies the verifiable spine.
+> `git-warp` leans on two consequences. First, each writer's chain at `refs/warp/<graph>/writers/<writerId>` is the **free monoid** $(W^{*},\, \cdot,\, \varepsilon)$ on that writer's claims $W$ — append-only concatenation $\cdot$, empty history $\varepsilon$ as identity, no rewriting. Second, the commits live on WARP refs rather than source-tree refs, so graph history rides Git's transport and dedup without touching your working tree. Admission and settlement law live one layer above this; Git supplies the verifiable spine.
 
 </details>
 
@@ -347,16 +357,16 @@ In the stack, **git-warp and Echo own runtime truth**, while Continuum owns the 
 
 ## When to use it
 
-| Use case                                    | Fit                             |
-| ------------------------------------------- | ------------------------------- |
-| Offline-first multi-writer convergence      | Strong                          |
-| Agent/tool substrate with causal history    | Strong                          |
-| Graph semantics without inventing merge law | Strong                          |
-| Speculative lanes for what-if exploration   | Strong                          |
-| High-throughput real-time execution         | Use Echo instead                |
-| General-purpose OLTP                        | Use Postgres                    |
-| Full-text search / analytics                | Use purpose-built engines       |
-| Time-travel debugging UI                    | Use warp-ttd on top of git-warp |
+| Use case                                  | Fit                             |
+| ----------------------------------------- | ------------------------------- |
+| Offline-first multi-writer causal history | Strong                          |
+| Agent/tool substrate with causal history  | Strong                          |
+| Graph-shaped views under explicit law     | Strong                          |
+| Speculative lanes for what-if exploration | Strong                          |
+| High-throughput real-time execution       | Use Echo instead                |
+| General-purpose OLTP                      | Use Postgres                    |
+| Full-text search / analytics              | Use purpose-built engines       |
+| Time-travel debugging UI                  | Use warp-ttd on top of git-warp |
 
 ## Runtime posture
 
@@ -392,9 +402,13 @@ It is deliberately "weird": optimized for offline-first, multi-writer, provenanc
 
 ### How does it differ from a normal CRDT or graph database?
 
-It is a **state-based CvRDT substrate** with strong emphasis on bounded reads, perfect provenance, and Git as the transport layer.
+It is a causal-history runtime that can host CRDT reducers where the domain law
+admits an automatic join. It adds bounded reads, explicit admission,
+provenance, plurality, conflict, and obstruction rather than assuming every
+concurrent pair must merge.
 
-This gives you deterministic convergence without a central server, but reads are intentionally scoped (via optics and coordinates) instead of materializing the entire graph.
+Git supplies durable transport and content addressing. Optics and coordinates
+keep reads scoped instead of materializing the entire graph.
 
 ### What does the data model look like?
 
@@ -402,7 +416,10 @@ This gives you deterministic convergence without a central server, but reads are
 
 ### Can multiple people/agents write at the same time?
 
-Yes — independently, even fully offline. Histories converge deterministically via the join-semilattice model. No locking required.
+Yes — independently, even fully offline. Admission classifies concurrent
+histories deterministically. Non-interfering histories may remain plural or be
+settled by a domain law; exclusive conflicts require resolution, and
+obstructions do not enter history. No global lock is required.
 
 ### How do I install and set it up?
 

--- a/docs/topics/api/README.md
+++ b/docs/topics/api/README.md
@@ -316,9 +316,11 @@ is therefore an interpretation or subtype of Reading, not its replacement.
 `ObservationPage` is not a public causal noun. Paging and batching are
 transport framing.
 
-## Outcomes, Evidence, And Receipts
+## Admission Outcomes, Evidence, And Receipts
 
-The operational outcome algebra is exactly:
+Admission classifies how a well-formed proposed history relates to the
+destination history under an explicit basis and law. The admission outcome
+algebra is exactly:
 
 ```text
 derived
@@ -326,6 +328,53 @@ plural
 conflict
 obstruction
 ```
+
+These variants are disjoint causal relations, not success and failure labels:
+
+| Outcome       | Meaning                                                            | Residual posture               |
+| ------------- | ------------------------------------------------------------------ | ------------------------------ |
+| `derived`     | The proposal directly extends the destination basis                | Destination frontier advanced  |
+| `plural`      | Concurrent histories are non-interfering and both are admitted     | Plural coordinates retained    |
+| `conflict`    | Honest claims overlap an exclusive footprint                       | Conflict remains unsettled     |
+| `obstruction` | Law, authority, evidence, budget, or basis gates prevent admission | Destination frontier unchanged |
+
+`plural` is a lawful terminal posture. It is not a successful conflict or an
+error waiting to be linearized. A settlement policy may later promote a plural
+coordinate, but admission does not choose a winner merely because a
+conventional API expects one value.
+
+For every structurally well-formed proposal evaluated against a resolved
+destination basis and law family, a completed admission produces exactly one
+of these four outcomes. A failed derivation proof is an `obstruction` with the
+stable reason family `invalid-derivation`. An unparseable envelope never enters
+the admission mapping. Process crashes, I/O failures, corruption, and internal
+invariant violations are runtime failures outside this four-way union.
+
+Every outcome requires a distinct runtime-backed witness:
+
+```text
+derived      -> DerivationWitness
+plural       -> PluralityWitness
+conflict     -> ConflictWitness
+obstruction  -> ObstructionWitness
+```
+
+The witnesses bind the decision to source and destination identities, source
+and destination bases, proposal digest, law and profile digests, and the
+evaluation coordinate. Variant-specific evidence records direct extension,
+non-interference, overlap, or the exact obstruction reason. The outcome also
+carries a residual posture so callers do not reconstruct resulting topology
+from a label.
+
+Admission execution is a separate outer union:
+
+```text
+completed -> AdmissionOutcome
+failed    -> AdmissionRuntimeFailure
+```
+
+A runtime failure is not an obstruction. Obstruction is a completed causal
+classification; a runtime failure means classification did not complete.
 
 The operation axis remains separate:
 
@@ -337,9 +386,11 @@ fork
 sync
 ```
 
-Epistemic support remains separate from both. A derived operation does not by
-itself prove that an application claim is supported, and a supported claim does
-not change a conflict into a derived operation.
+Observation cardinality and epistemic support remain separate from both. A
+plural admission may produce one Reading, and a derived admission may produce
+many. A derived admission does not by itself prove that an application claim
+is supported, and a supported claim does not change a conflict into a derived
+admission.
 
 Introductory documentation defines Receipt simply:
 
@@ -355,7 +406,7 @@ Human rendering visually separates operational and epistemic fields:
 Receipt
 ------------------------------
 Operation    write
-Outcome      derived
+Admission    derived
 Lane         events
 Coordinate   @842
 
@@ -372,8 +423,29 @@ machine-readable envelopes.
 
 ## Settlement
 
+Admission and settlement are different phases. Admission classifies how
+histories meet. Settlement is the later, law-governed promotion of a plural or
+resolved coordinate into a canonical shared Lane. A `conflict` has not settled,
+an `obstruction` cannot settle, and a `plural` admission may lawfully remain
+plural forever.
+
+```text
+Proposed suffix
+      |
+      v
+Derivation verification
+      |
+      v
+Destination admission
+  /      |       |          \
+derived plural conflict obstruction
+   |       |       |           |
+advance  retain  resolve     repair/stop
+frontier plurality
+```
+
 Settlement is a cross-lane Runtime operation. Preview presentation and the
-admissible plan are distinct values:
+executable plan are distinct values:
 
 ```typescript
 const preview = await runtime.previewSettlement({
@@ -387,13 +459,33 @@ const receipt = await runtime.settle(preview.plan);
 ```
 
 `SettlementPreview` is inspectable presentation plus evidence. Its `plan` is an
-immutable, runtime-backed `SettlementPlan`. `Runtime.settle()` accepts only a
-validated SettlementPlan, never an arbitrary object that resembles preview
-output.
+immutable, runtime-backed `SettlementPlan` bound to source and target Lane IDs,
+their exact frontiers, proposal digest, law digest, settlement-policy digest,
+and its own plan digest. `Runtime.settle()` accepts only a validated
+SettlementPlan, never an arbitrary object that resembles preview output.
 
 Settlement revalidates the plan against the current source and target
-frontiers. A stale or newly obstructed plan returns the appropriate Receipt; a
-preview is not a promise that later settlement must derive.
+frontiers and law. A preview does not reserve, admit, publish, linearize, or
+mutate canonical history. A stale plan is reclassified as a `stale-basis`
+obstruction or replaced by a newly previewed classification; it never executes
+unchecked against a different basis. Any change to a bound frontier, proposal,
+law, or settlement policy invalidates the plan.
+
+```text
+plural or resolved coordinate
+            |
+            v
+     previewSettlement
+            |
+            v
+      SettlementPlan
+            |
+            v
+         settle()
+            |
+            v
+ canonical promotion receipt
+```
 
 Use `previewSettlement()`, not `settle({ dryRun: true })`. Do not use `merge()`
 as the first-use verb. Braid remains the formal implementation noun until the

--- a/src/domain/admission/AdmissionEvaluation.ts
+++ b/src/domain/admission/AdmissionEvaluation.ts
@@ -1,0 +1,49 @@
+import WarpError from '../errors/WarpError.ts';
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+
+export type AdmissionEvaluationFields = {
+  readonly sourceParticipantId: string;
+  readonly destinationRuntimeId: string;
+  readonly sourceBasisRef: string;
+  readonly destinationBasisRef: string;
+  readonly proposalDigest: string;
+  readonly lawDigest: string;
+  readonly profileDigest: string;
+  readonly evaluationCoordinateRef: string;
+};
+
+/** Immutable coordinates and policy identity for one admission decision. */
+export default class AdmissionEvaluation {
+  readonly sourceParticipantId: string;
+  readonly destinationRuntimeId: string;
+  readonly sourceBasisRef: string;
+  readonly destinationBasisRef: string;
+  readonly proposalDigest: string;
+  readonly lawDigest: string;
+  readonly profileDigest: string;
+  readonly evaluationCoordinateRef: string;
+
+  constructor(fields: AdmissionEvaluationFields) {
+    if (fields === null || fields === undefined) {
+      throw new WarpError('AdmissionEvaluation fields are required', 'E_VALIDATION');
+    }
+    requireNonEmptyString(fields.sourceParticipantId, 'sourceParticipantId');
+    requireNonEmptyString(fields.destinationRuntimeId, 'destinationRuntimeId');
+    requireNonEmptyString(fields.sourceBasisRef, 'sourceBasisRef');
+    requireNonEmptyString(fields.destinationBasisRef, 'destinationBasisRef');
+    requireNonEmptyString(fields.proposalDigest, 'proposalDigest');
+    requireNonEmptyString(fields.lawDigest, 'lawDigest');
+    requireNonEmptyString(fields.profileDigest, 'profileDigest');
+    requireNonEmptyString(fields.evaluationCoordinateRef, 'evaluationCoordinateRef');
+
+    this.sourceParticipantId = fields.sourceParticipantId;
+    this.destinationRuntimeId = fields.destinationRuntimeId;
+    this.sourceBasisRef = fields.sourceBasisRef;
+    this.destinationBasisRef = fields.destinationBasisRef;
+    this.proposalDigest = fields.proposalDigest;
+    this.lawDigest = fields.lawDigest;
+    this.profileDigest = fields.profileDigest;
+    this.evaluationCoordinateRef = fields.evaluationCoordinateRef;
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/AdmissionExecution.ts
+++ b/src/domain/admission/AdmissionExecution.ts
@@ -1,0 +1,4 @@
+import type CompletedAdmissionExecution from './CompletedAdmissionExecution.ts';
+import type FailedAdmissionExecution from './FailedAdmissionExecution.ts';
+
+export type AdmissionExecution = CompletedAdmissionExecution | FailedAdmissionExecution;

--- a/src/domain/admission/AdmissionObstructionReason.ts
+++ b/src/domain/admission/AdmissionObstructionReason.ts
@@ -54,6 +54,26 @@ export default class AdmissionObstructionReason {
   static staleBasis(code: string): AdmissionObstructionReason {
     return new AdmissionObstructionReason(STALE_BASIS, code);
   }
+
+  static capabilityDenied(code: string): AdmissionObstructionReason {
+    return new AdmissionObstructionReason(CAPABILITY_DENIED, code);
+  }
+
+  static unsupportedEvidence(code: string): AdmissionObstructionReason {
+    return new AdmissionObstructionReason(UNSUPPORTED_EVIDENCE, code);
+  }
+
+  static lawViolation(code: string): AdmissionObstructionReason {
+    return new AdmissionObstructionReason(LAW_VIOLATION, code);
+  }
+
+  static budgetExceeded(code: string): AdmissionObstructionReason {
+    return new AdmissionObstructionReason(BUDGET_EXCEEDED, code);
+  }
+
+  static unsupportedContract(code: string): AdmissionObstructionReason {
+    return new AdmissionObstructionReason(UNSUPPORTED_CONTRACT, code);
+  }
 }
 
 function requireQualifiedCode(code: string): void {

--- a/src/domain/admission/AdmissionObstructionReason.ts
+++ b/src/domain/admission/AdmissionObstructionReason.ts
@@ -1,0 +1,65 @@
+import WarpError from '../errors/WarpError.ts';
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+
+const CAPABILITY_DENIED = 'capability-denied';
+const UNSUPPORTED_EVIDENCE = 'unsupported-evidence';
+const LAW_VIOLATION = 'law-violation';
+const STALE_BASIS = 'stale-basis';
+const BUDGET_EXCEEDED = 'budget-exceeded';
+const INVALID_DERIVATION = 'invalid-derivation';
+const UNSUPPORTED_CONTRACT = 'unsupported-contract';
+
+export type AdmissionObstructionFamily =
+  | typeof CAPABILITY_DENIED
+  | typeof UNSUPPORTED_EVIDENCE
+  | typeof LAW_VIOLATION
+  | typeof STALE_BASIS
+  | typeof BUDGET_EXCEEDED
+  | typeof INVALID_DERIVATION
+  | typeof UNSUPPORTED_CONTRACT;
+
+const FAMILIES: readonly AdmissionObstructionFamily[] = Object.freeze([
+  CAPABILITY_DENIED,
+  UNSUPPORTED_EVIDENCE,
+  LAW_VIOLATION,
+  STALE_BASIS,
+  BUDGET_EXCEEDED,
+  INVALID_DERIVATION,
+  UNSUPPORTED_CONTRACT,
+]);
+
+/** Stable obstruction family plus a lawpack-qualified reason code. */
+export default class AdmissionObstructionReason {
+  readonly family: AdmissionObstructionFamily;
+  readonly code: string;
+
+  constructor(family: string, code: string) {
+    const supported = FAMILIES.find((candidate) => candidate === family);
+    if (supported === undefined) {
+      throw new WarpError(
+        `Admission obstruction family must be one of: ${FAMILIES.join(', ')}`,
+        'E_VALIDATION'
+      );
+    }
+    requireQualifiedCode(code);
+    this.family = supported;
+    this.code = code;
+    Object.freeze(this);
+  }
+
+  static invalidDerivation(code: string): AdmissionObstructionReason {
+    return new AdmissionObstructionReason(INVALID_DERIVATION, code);
+  }
+
+  static staleBasis(code: string): AdmissionObstructionReason {
+    return new AdmissionObstructionReason(STALE_BASIS, code);
+  }
+}
+
+function requireQualifiedCode(code: string): void {
+  requireNonEmptyString(code, 'code');
+  const separator = code.indexOf('.');
+  if (separator < 1 || separator === code.length - 1) {
+    throw new WarpError('Admission obstruction code must be namespace-qualified', 'E_VALIDATION');
+  }
+}

--- a/src/domain/admission/AdmissionOutcome.ts
+++ b/src/domain/admission/AdmissionOutcome.ts
@@ -1,0 +1,11 @@
+import type ConflictAdmission from './ConflictAdmission.ts';
+import type DerivedAdmission from './DerivedAdmission.ts';
+import type ObstructedAdmission from './ObstructedAdmission.ts';
+import type PluralAdmission from './PluralAdmission.ts';
+
+/** Exhaustive causal classification for a completed, well-formed admission. */
+export type AdmissionOutcome =
+  | DerivedAdmission
+  | PluralAdmission
+  | ConflictAdmission
+  | ObstructedAdmission;

--- a/src/domain/admission/AdmissionResidualPosture.ts
+++ b/src/domain/admission/AdmissionResidualPosture.ts
@@ -1,0 +1,10 @@
+import type AdvancedAdmissionPosture from './AdvancedAdmissionPosture.ts';
+import type PluralAdmissionPosture from './PluralAdmissionPosture.ts';
+import type UnchangedAdmissionPosture from './UnchangedAdmissionPosture.ts';
+import type UnsettledConflictAdmissionPosture from './UnsettledConflictAdmissionPosture.ts';
+
+export type AdmissionResidualPosture =
+  | AdvancedAdmissionPosture
+  | PluralAdmissionPosture
+  | UnsettledConflictAdmissionPosture
+  | UnchangedAdmissionPosture;

--- a/src/domain/admission/AdmissionRetryDisposition.ts
+++ b/src/domain/admission/AdmissionRetryDisposition.ts
@@ -3,7 +3,7 @@ import WarpError from '../errors/WarpError.ts';
 const AFTER_CHANGE = 'after-change';
 const WITH_EVIDENCE = 'with-evidence';
 const NEVER = 'never';
-const UNKNOWN = 'unknown';
+const UNKNOWN = 'unknown'; // nosemgrep: ts-no-unknown-outside-adapters -- semantic value
 
 export type AdmissionRetryDispositionValue =
   | typeof AFTER_CHANGE
@@ -46,7 +46,7 @@ export default class AdmissionRetryDisposition {
     return new AdmissionRetryDisposition(NEVER);
   }
 
-  static unknown(): AdmissionRetryDisposition {
+  static unknown(): AdmissionRetryDisposition { // nosemgrep: ts-no-unknown-outside-adapters -- semantic constructor
     return new AdmissionRetryDisposition(UNKNOWN);
   }
 }

--- a/src/domain/admission/AdmissionRetryDisposition.ts
+++ b/src/domain/admission/AdmissionRetryDisposition.ts
@@ -1,0 +1,52 @@
+import WarpError from '../errors/WarpError.ts';
+
+const AFTER_CHANGE = 'after-change';
+const WITH_EVIDENCE = 'with-evidence';
+const NEVER = 'never';
+const UNKNOWN = 'unknown';
+
+export type AdmissionRetryDispositionValue =
+  | typeof AFTER_CHANGE
+  | typeof WITH_EVIDENCE
+  | typeof NEVER
+  | typeof UNKNOWN;
+
+const VALUES: readonly AdmissionRetryDispositionValue[] = Object.freeze([
+  AFTER_CHANGE,
+  WITH_EVIDENCE,
+  NEVER,
+  UNKNOWN,
+]);
+
+/** States whether retry can become meaningful and what must change first. */
+export default class AdmissionRetryDisposition {
+  readonly value: AdmissionRetryDispositionValue;
+
+  constructor(value: string) {
+    const supported = VALUES.find((candidate) => candidate === value);
+    if (supported === undefined) {
+      throw new WarpError(
+        `Admission retry disposition must be one of: ${VALUES.join(', ')}`,
+        'E_VALIDATION'
+      );
+    }
+    this.value = supported;
+    Object.freeze(this);
+  }
+
+  static afterChange(): AdmissionRetryDisposition {
+    return new AdmissionRetryDisposition(AFTER_CHANGE);
+  }
+
+  static withEvidence(): AdmissionRetryDisposition {
+    return new AdmissionRetryDisposition(WITH_EVIDENCE);
+  }
+
+  static never(): AdmissionRetryDisposition {
+    return new AdmissionRetryDisposition(NEVER);
+  }
+
+  static unknown(): AdmissionRetryDisposition {
+    return new AdmissionRetryDisposition(UNKNOWN);
+  }
+}

--- a/src/domain/admission/AdmissionRuntimeFailure.ts
+++ b/src/domain/admission/AdmissionRuntimeFailure.ts
@@ -1,0 +1,15 @@
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+
+/** Operational failure outside the four-way causal admission algebra. */
+export default class AdmissionRuntimeFailure {
+  readonly code: string;
+  readonly message: string;
+
+  constructor(code: string, message: string) {
+    requireNonEmptyString(code, 'code');
+    requireNonEmptyString(message, 'message');
+    this.code = code;
+    this.message = message;
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/AdvancedAdmissionPosture.ts
+++ b/src/domain/admission/AdvancedAdmissionPosture.ts
@@ -1,0 +1,13 @@
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+
+/** Destination frontier after a direct extension is admitted. */
+export default class AdvancedAdmissionPosture {
+  readonly kind: 'advanced' = 'advanced';
+  readonly frontierRef: string;
+
+  constructor(frontierRef: string) {
+    requireNonEmptyString(frontierRef, 'frontierRef');
+    this.frontierRef = frontierRef;
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/CompletedAdmissionExecution.ts
+++ b/src/domain/admission/CompletedAdmissionExecution.ts
@@ -1,0 +1,25 @@
+import WarpError from '../errors/WarpError.ts';
+import type { AdmissionOutcome } from './AdmissionOutcome.ts';
+import ConflictAdmission from './ConflictAdmission.ts';
+import DerivedAdmission from './DerivedAdmission.ts';
+import ObstructedAdmission from './ObstructedAdmission.ts';
+import PluralAdmission from './PluralAdmission.ts';
+
+/** Successful execution of admission classification, regardless of outcome kind. */
+export default class CompletedAdmissionExecution {
+  readonly status: 'completed' = 'completed';
+  readonly outcome: AdmissionOutcome;
+
+  constructor(outcome: AdmissionOutcome) {
+    if (
+      !(outcome instanceof DerivedAdmission) &&
+      !(outcome instanceof PluralAdmission) &&
+      !(outcome instanceof ConflictAdmission) &&
+      !(outcome instanceof ObstructedAdmission)
+    ) {
+      throw new WarpError('outcome must be an AdmissionOutcome', 'E_VALIDATION');
+    }
+    this.outcome = outcome;
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/ConflictAdmission.ts
+++ b/src/domain/admission/ConflictAdmission.ts
@@ -1,0 +1,19 @@
+import WarpError from '../errors/WarpError.ts';
+import ConflictWitness from './ConflictWitness.ts';
+import UnsettledConflictAdmissionPosture from './UnsettledConflictAdmissionPosture.ts';
+
+/** Honest proposal retained outside admission because exclusive claims collide. */
+export default class ConflictAdmission {
+  readonly kind: 'conflict' = 'conflict';
+  readonly witness: ConflictWitness;
+  readonly residual: UnsettledConflictAdmissionPosture;
+
+  constructor(witness: ConflictWitness) {
+    if (!(witness instanceof ConflictWitness)) {
+      throw new WarpError('witness must be a ConflictWitness', 'E_VALIDATION');
+    }
+    this.witness = witness;
+    this.residual = new UnsettledConflictAdmissionPosture(witness.conflictRef);
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/ConflictWitness.ts
+++ b/src/domain/admission/ConflictWitness.ts
@@ -1,0 +1,56 @@
+import WarpError from '../errors/WarpError.ts';
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+import AdmissionEvaluation from './AdmissionEvaluation.ts';
+import { freezeAdmissionRefs } from './admissionValidation.ts';
+
+export type ConflictWitnessFields = {
+  readonly evaluation: AdmissionEvaluation;
+  readonly conflictRef: string;
+  readonly claimRefs: readonly string[];
+  readonly overlappingFootprintRefs: readonly string[];
+  readonly contestedDomain: string;
+  readonly derivationEvidenceRef: string;
+  readonly overlapEvidenceRef: string;
+  readonly resolutionProcedureRefs: readonly string[];
+};
+
+/** Evidence that honest claims collide over an exclusive causal footprint. */
+export default class ConflictWitness {
+  readonly evaluation: AdmissionEvaluation;
+  readonly conflictRef: string;
+  readonly claimRefs: readonly string[];
+  readonly overlappingFootprintRefs: readonly string[];
+  readonly contestedDomain: string;
+  readonly derivationEvidenceRef: string;
+  readonly overlapEvidenceRef: string;
+  readonly resolutionProcedureRefs: readonly string[];
+
+  constructor(fields: ConflictWitnessFields) {
+    if (fields === null || fields === undefined) {
+      throw new WarpError('ConflictWitness fields are required', 'E_VALIDATION');
+    }
+    if (!(fields.evaluation instanceof AdmissionEvaluation)) {
+      throw new WarpError('evaluation must be an AdmissionEvaluation', 'E_VALIDATION');
+    }
+    requireNonEmptyString(fields.conflictRef, 'conflictRef');
+    requireNonEmptyString(fields.contestedDomain, 'contestedDomain');
+    requireNonEmptyString(fields.derivationEvidenceRef, 'derivationEvidenceRef');
+    requireNonEmptyString(fields.overlapEvidenceRef, 'overlapEvidenceRef');
+    this.evaluation = fields.evaluation;
+    this.conflictRef = fields.conflictRef;
+    this.claimRefs = freezeAdmissionRefs(fields.claimRefs, 'claimRefs', 2);
+    this.overlappingFootprintRefs = freezeAdmissionRefs(
+      fields.overlappingFootprintRefs,
+      'overlappingFootprintRefs',
+      1
+    );
+    this.contestedDomain = fields.contestedDomain;
+    this.derivationEvidenceRef = fields.derivationEvidenceRef;
+    this.overlapEvidenceRef = fields.overlapEvidenceRef;
+    this.resolutionProcedureRefs = freezeAdmissionRefs(
+      fields.resolutionProcedureRefs,
+      'resolutionProcedureRefs'
+    );
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/DerivationWitness.ts
+++ b/src/domain/admission/DerivationWitness.ts
@@ -1,6 +1,6 @@
-import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
-import AdmissionEvaluation from './AdmissionEvaluation.ts';
+import type AdmissionEvaluation from './AdmissionEvaluation.ts';
+import { requireAdmissionEvaluation } from './admissionValidation.ts';
 
 export type DerivationWitnessFields = {
   readonly evaluation: AdmissionEvaluation;
@@ -19,21 +19,16 @@ export default class DerivationWitness {
   readonly directExtensionEvidenceRef: string;
 
   constructor(fields: DerivationWitnessFields) {
-    if (fields === null || fields === undefined) {
-      throw new WarpError('DerivationWitness fields are required', 'E_VALIDATION');
-    }
-    if (!(fields.evaluation instanceof AdmissionEvaluation)) {
-      throw new WarpError('evaluation must be an AdmissionEvaluation', 'E_VALIDATION');
-    }
-    requireNonEmptyString(fields.admittedSuffixRef, 'admittedSuffixRef');
-    requireNonEmptyString(fields.resultingFrontierRef, 'resultingFrontierRef');
-    requireNonEmptyString(fields.authorityEvidenceRef, 'authorityEvidenceRef');
-    requireNonEmptyString(fields.directExtensionEvidenceRef, 'directExtensionEvidenceRef');
-    this.evaluation = fields.evaluation;
-    this.admittedSuffixRef = fields.admittedSuffixRef;
-    this.resultingFrontierRef = fields.resultingFrontierRef;
-    this.authorityEvidenceRef = fields.authorityEvidenceRef;
-    this.directExtensionEvidenceRef = fields.directExtensionEvidenceRef;
+    const checked = requireAdmissionEvaluation(fields, 'DerivationWitness');
+    requireNonEmptyString(checked.admittedSuffixRef, 'admittedSuffixRef');
+    requireNonEmptyString(checked.resultingFrontierRef, 'resultingFrontierRef');
+    requireNonEmptyString(checked.authorityEvidenceRef, 'authorityEvidenceRef');
+    requireNonEmptyString(checked.directExtensionEvidenceRef, 'directExtensionEvidenceRef');
+    this.evaluation = checked.evaluation;
+    this.admittedSuffixRef = checked.admittedSuffixRef;
+    this.resultingFrontierRef = checked.resultingFrontierRef;
+    this.authorityEvidenceRef = checked.authorityEvidenceRef;
+    this.directExtensionEvidenceRef = checked.directExtensionEvidenceRef;
     Object.freeze(this);
   }
 }

--- a/src/domain/admission/DerivationWitness.ts
+++ b/src/domain/admission/DerivationWitness.ts
@@ -1,0 +1,39 @@
+import WarpError from '../errors/WarpError.ts';
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+import AdmissionEvaluation from './AdmissionEvaluation.ts';
+
+export type DerivationWitnessFields = {
+  readonly evaluation: AdmissionEvaluation;
+  readonly admittedSuffixRef: string;
+  readonly resultingFrontierRef: string;
+  readonly authorityEvidenceRef: string;
+  readonly directExtensionEvidenceRef: string;
+};
+
+/** Evidence that a suffix lawfully and directly extended the destination basis. */
+export default class DerivationWitness {
+  readonly evaluation: AdmissionEvaluation;
+  readonly admittedSuffixRef: string;
+  readonly resultingFrontierRef: string;
+  readonly authorityEvidenceRef: string;
+  readonly directExtensionEvidenceRef: string;
+
+  constructor(fields: DerivationWitnessFields) {
+    if (fields === null || fields === undefined) {
+      throw new WarpError('DerivationWitness fields are required', 'E_VALIDATION');
+    }
+    if (!(fields.evaluation instanceof AdmissionEvaluation)) {
+      throw new WarpError('evaluation must be an AdmissionEvaluation', 'E_VALIDATION');
+    }
+    requireNonEmptyString(fields.admittedSuffixRef, 'admittedSuffixRef');
+    requireNonEmptyString(fields.resultingFrontierRef, 'resultingFrontierRef');
+    requireNonEmptyString(fields.authorityEvidenceRef, 'authorityEvidenceRef');
+    requireNonEmptyString(fields.directExtensionEvidenceRef, 'directExtensionEvidenceRef');
+    this.evaluation = fields.evaluation;
+    this.admittedSuffixRef = fields.admittedSuffixRef;
+    this.resultingFrontierRef = fields.resultingFrontierRef;
+    this.authorityEvidenceRef = fields.authorityEvidenceRef;
+    this.directExtensionEvidenceRef = fields.directExtensionEvidenceRef;
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/DerivedAdmission.ts
+++ b/src/domain/admission/DerivedAdmission.ts
@@ -1,0 +1,19 @@
+import WarpError from '../errors/WarpError.ts';
+import AdvancedAdmissionPosture from './AdvancedAdmissionPosture.ts';
+import DerivationWitness from './DerivationWitness.ts';
+
+/** Direct frontier extension admitted by the destination runtime. */
+export default class DerivedAdmission {
+  readonly kind: 'derived' = 'derived';
+  readonly witness: DerivationWitness;
+  readonly residual: AdvancedAdmissionPosture;
+
+  constructor(witness: DerivationWitness) {
+    if (!(witness instanceof DerivationWitness)) {
+      throw new WarpError('witness must be a DerivationWitness', 'E_VALIDATION');
+    }
+    this.witness = witness;
+    this.residual = new AdvancedAdmissionPosture(witness.resultingFrontierRef);
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/FailedAdmissionExecution.ts
+++ b/src/domain/admission/FailedAdmissionExecution.ts
@@ -1,0 +1,16 @@
+import WarpError from '../errors/WarpError.ts';
+import AdmissionRuntimeFailure from './AdmissionRuntimeFailure.ts';
+
+/** Admission execution that failed before causal classification completed. */
+export default class FailedAdmissionExecution {
+  readonly status: 'failed' = 'failed';
+  readonly failure: AdmissionRuntimeFailure;
+
+  constructor(failure: AdmissionRuntimeFailure) {
+    if (!(failure instanceof AdmissionRuntimeFailure)) {
+      throw new WarpError('failure must be an AdmissionRuntimeFailure', 'E_VALIDATION');
+    }
+    this.failure = failure;
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/ObstructedAdmission.ts
+++ b/src/domain/admission/ObstructedAdmission.ts
@@ -1,0 +1,19 @@
+import WarpError from '../errors/WarpError.ts';
+import ObstructionWitness from './ObstructionWitness.ts';
+import UnchangedAdmissionPosture from './UnchangedAdmissionPosture.ts';
+
+/** Proposal blocked by destination law, authority, evidence, or basis gates. */
+export default class ObstructedAdmission {
+  readonly kind: 'obstruction' = 'obstruction';
+  readonly witness: ObstructionWitness;
+  readonly residual: UnchangedAdmissionPosture;
+
+  constructor(witness: ObstructionWitness) {
+    if (!(witness instanceof ObstructionWitness)) {
+      throw new WarpError('witness must be an ObstructionWitness', 'E_VALIDATION');
+    }
+    this.witness = witness;
+    this.residual = new UnchangedAdmissionPosture(witness.evaluation.destinationBasisRef);
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/ObstructionWitness.ts
+++ b/src/domain/admission/ObstructionWitness.ts
@@ -1,9 +1,9 @@
 import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
-import AdmissionEvaluation from './AdmissionEvaluation.ts';
+import type AdmissionEvaluation from './AdmissionEvaluation.ts';
 import AdmissionObstructionReason from './AdmissionObstructionReason.ts';
 import AdmissionRetryDisposition from './AdmissionRetryDisposition.ts';
-import { freezeAdmissionRefs } from './admissionValidation.ts';
+import { freezeAdmissionRefs, requireAdmissionEvaluation } from './admissionValidation.ts';
 
 export type ObstructionWitnessFields = {
   readonly evaluation: AdmissionEvaluation;
@@ -24,8 +24,7 @@ export default class ObstructionWitness {
   readonly retry: AdmissionRetryDisposition;
 
   constructor(fields: ObstructionWitnessFields) {
-    const checked = requirePresentFields(fields);
-    requireEvaluation(checked.evaluation);
+    const checked = requireAdmissionEvaluation(fields, 'ObstructionWitness');
     requireReason(checked.reason);
     requireRetry(checked.retry);
     requireNonEmptyString(checked.failedConditionRef, 'failedConditionRef');
@@ -42,19 +41,6 @@ export default class ObstructionWitness {
     this.failedConditionRef = checked.failedConditionRef;
     this.retry = checked.retry;
     Object.freeze(this);
-  }
-}
-
-function requirePresentFields(fields: ObstructionWitnessFields): ObstructionWitnessFields {
-  if (fields === null || fields === undefined) {
-    throw new WarpError('ObstructionWitness fields are required', 'E_VALIDATION');
-  }
-  return fields;
-}
-
-function requireEvaluation(evaluation: AdmissionEvaluation): void {
-  if (!(evaluation instanceof AdmissionEvaluation)) {
-    throw new WarpError('evaluation must be an AdmissionEvaluation', 'E_VALIDATION');
   }
 }
 

--- a/src/domain/admission/ObstructionWitness.ts
+++ b/src/domain/admission/ObstructionWitness.ts
@@ -1,0 +1,71 @@
+import WarpError from '../errors/WarpError.ts';
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+import AdmissionEvaluation from './AdmissionEvaluation.ts';
+import AdmissionObstructionReason from './AdmissionObstructionReason.ts';
+import AdmissionRetryDisposition from './AdmissionRetryDisposition.ts';
+import { freezeAdmissionRefs } from './admissionValidation.ts';
+
+export type ObstructionWitnessFields = {
+  readonly evaluation: AdmissionEvaluation;
+  readonly reason: AdmissionObstructionReason;
+  readonly suppliedEvidenceRefs: readonly string[];
+  readonly requiredEvidenceRefs: readonly string[];
+  readonly failedConditionRef: string;
+  readonly retry: AdmissionRetryDisposition;
+};
+
+/** Evidence that a proposal cannot pass the destination admission gates. */
+export default class ObstructionWitness {
+  readonly evaluation: AdmissionEvaluation;
+  readonly reason: AdmissionObstructionReason;
+  readonly suppliedEvidenceRefs: readonly string[];
+  readonly requiredEvidenceRefs: readonly string[];
+  readonly failedConditionRef: string;
+  readonly retry: AdmissionRetryDisposition;
+
+  constructor(fields: ObstructionWitnessFields) {
+    const checked = requirePresentFields(fields);
+    requireEvaluation(checked.evaluation);
+    requireReason(checked.reason);
+    requireRetry(checked.retry);
+    requireNonEmptyString(checked.failedConditionRef, 'failedConditionRef');
+    this.evaluation = checked.evaluation;
+    this.reason = checked.reason;
+    this.suppliedEvidenceRefs = freezeAdmissionRefs(
+      checked.suppliedEvidenceRefs,
+      'suppliedEvidenceRefs'
+    );
+    this.requiredEvidenceRefs = freezeAdmissionRefs(
+      checked.requiredEvidenceRefs,
+      'requiredEvidenceRefs'
+    );
+    this.failedConditionRef = checked.failedConditionRef;
+    this.retry = checked.retry;
+    Object.freeze(this);
+  }
+}
+
+function requirePresentFields(fields: ObstructionWitnessFields): ObstructionWitnessFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('ObstructionWitness fields are required', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+function requireEvaluation(evaluation: AdmissionEvaluation): void {
+  if (!(evaluation instanceof AdmissionEvaluation)) {
+    throw new WarpError('evaluation must be an AdmissionEvaluation', 'E_VALIDATION');
+  }
+}
+
+function requireReason(reason: AdmissionObstructionReason): void {
+  if (!(reason instanceof AdmissionObstructionReason)) {
+    throw new WarpError('reason must be an AdmissionObstructionReason', 'E_VALIDATION');
+  }
+}
+
+function requireRetry(retry: AdmissionRetryDisposition): void {
+  if (!(retry instanceof AdmissionRetryDisposition)) {
+    throw new WarpError('retry must be an AdmissionRetryDisposition', 'E_VALIDATION');
+  }
+}

--- a/src/domain/admission/PluralAdmission.ts
+++ b/src/domain/admission/PluralAdmission.ts
@@ -1,0 +1,19 @@
+import WarpError from '../errors/WarpError.ts';
+import PluralAdmissionPosture from './PluralAdmissionPosture.ts';
+import PluralityWitness from './PluralityWitness.ts';
+
+/** Concurrent non-interfering coordinates lawfully retained as plural. */
+export default class PluralAdmission {
+  readonly kind: 'plural' = 'plural';
+  readonly witness: PluralityWitness;
+  readonly residual: PluralAdmissionPosture;
+
+  constructor(witness: PluralityWitness) {
+    if (!(witness instanceof PluralityWitness)) {
+      throw new WarpError('witness must be a PluralityWitness', 'E_VALIDATION');
+    }
+    this.witness = witness;
+    this.residual = new PluralAdmissionPosture(witness.retainedCoordinateRefs);
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/PluralAdmissionPosture.ts
+++ b/src/domain/admission/PluralAdmissionPosture.ts
@@ -1,0 +1,12 @@
+import { freezeAdmissionRefs } from './admissionValidation.ts';
+
+/** Lawfully retained coordinates after concurrent non-interfering admission. */
+export default class PluralAdmissionPosture {
+  readonly kind: 'plural' = 'plural';
+  readonly coordinateRefs: readonly string[];
+
+  constructor(coordinateRefs: readonly string[]) {
+    this.coordinateRefs = freezeAdmissionRefs(coordinateRefs, 'coordinateRefs', 2);
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/PluralityWitness.ts
+++ b/src/domain/admission/PluralityWitness.ts
@@ -1,7 +1,7 @@
 import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
-import AdmissionEvaluation from './AdmissionEvaluation.ts';
-import { freezeAdmissionRefs } from './admissionValidation.ts';
+import type AdmissionEvaluation from './AdmissionEvaluation.ts';
+import { freezeAdmissionRefs, requireAdmissionEvaluation } from './admissionValidation.ts';
 
 export type PluralityWitnessFields = {
   readonly evaluation: AdmissionEvaluation;
@@ -45,18 +45,13 @@ export default class PluralityWitness {
 }
 
 function requireFields(fields: PluralityWitnessFields): PluralityWitnessFields {
-  if (fields === null || fields === undefined) {
-    throw new WarpError('PluralityWitness fields are required', 'E_VALIDATION');
-  }
-  if (!(fields.evaluation instanceof AdmissionEvaluation)) {
-    throw new WarpError('evaluation must be an AdmissionEvaluation', 'E_VALIDATION');
-  }
-  requireNonEmptyString(fields.localCoordinateRef, 'localCoordinateRef');
-  requireNonEmptyString(fields.incomingCoordinateRef, 'incomingCoordinateRef');
-  if (fields.localCoordinateRef === fields.incomingCoordinateRef) {
+  const checked = requireAdmissionEvaluation(fields, 'PluralityWitness');
+  requireNonEmptyString(checked.localCoordinateRef, 'localCoordinateRef');
+  requireNonEmptyString(checked.incomingCoordinateRef, 'incomingCoordinateRef');
+  if (checked.localCoordinateRef === checked.incomingCoordinateRef) {
     throw new WarpError('Plural admission requires distinct coordinates', 'E_VALIDATION');
   }
-  return fields;
+  return checked;
 }
 
 function requireRetainedCoordinates(fields: PluralityWitnessFields): readonly string[] {

--- a/src/domain/admission/PluralityWitness.ts
+++ b/src/domain/admission/PluralityWitness.ts
@@ -1,0 +1,74 @@
+import WarpError from '../errors/WarpError.ts';
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+import AdmissionEvaluation from './AdmissionEvaluation.ts';
+import { freezeAdmissionRefs } from './admissionValidation.ts';
+
+export type PluralityWitnessFields = {
+  readonly evaluation: AdmissionEvaluation;
+  readonly localCoordinateRef: string;
+  readonly incomingCoordinateRef: string;
+  readonly retainedCoordinateRefs: readonly string[];
+  readonly derivationEvidenceRef: string;
+  readonly footprintComparisonRef: string;
+  readonly concurrencyEvidenceRef: string;
+  readonly nonInterferenceEvidenceRef: string;
+};
+
+/** Evidence that concurrent coordinates may lawfully coexist without interference. */
+export default class PluralityWitness {
+  readonly evaluation: AdmissionEvaluation;
+  readonly localCoordinateRef: string;
+  readonly incomingCoordinateRef: string;
+  readonly retainedCoordinateRefs: readonly string[];
+  readonly derivationEvidenceRef: string;
+  readonly footprintComparisonRef: string;
+  readonly concurrencyEvidenceRef: string;
+  readonly nonInterferenceEvidenceRef: string;
+
+  constructor(fields: PluralityWitnessFields) {
+    const checked = requireFields(fields);
+    const retainedCoordinateRefs = requireRetainedCoordinates(checked);
+    requireNonEmptyString(checked.derivationEvidenceRef, 'derivationEvidenceRef');
+    requireNonEmptyString(checked.footprintComparisonRef, 'footprintComparisonRef');
+    requireNonEmptyString(checked.concurrencyEvidenceRef, 'concurrencyEvidenceRef');
+    requireNonEmptyString(checked.nonInterferenceEvidenceRef, 'nonInterferenceEvidenceRef');
+    this.evaluation = checked.evaluation;
+    this.localCoordinateRef = checked.localCoordinateRef;
+    this.incomingCoordinateRef = checked.incomingCoordinateRef;
+    this.retainedCoordinateRefs = retainedCoordinateRefs;
+    this.derivationEvidenceRef = checked.derivationEvidenceRef;
+    this.footprintComparisonRef = checked.footprintComparisonRef;
+    this.concurrencyEvidenceRef = checked.concurrencyEvidenceRef;
+    this.nonInterferenceEvidenceRef = checked.nonInterferenceEvidenceRef;
+    Object.freeze(this);
+  }
+}
+
+function requireFields(fields: PluralityWitnessFields): PluralityWitnessFields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError('PluralityWitness fields are required', 'E_VALIDATION');
+  }
+  if (!(fields.evaluation instanceof AdmissionEvaluation)) {
+    throw new WarpError('evaluation must be an AdmissionEvaluation', 'E_VALIDATION');
+  }
+  requireNonEmptyString(fields.localCoordinateRef, 'localCoordinateRef');
+  requireNonEmptyString(fields.incomingCoordinateRef, 'incomingCoordinateRef');
+  if (fields.localCoordinateRef === fields.incomingCoordinateRef) {
+    throw new WarpError('Plural admission requires distinct coordinates', 'E_VALIDATION');
+  }
+  return fields;
+}
+
+function requireRetainedCoordinates(fields: PluralityWitnessFields): readonly string[] {
+  const retained = freezeAdmissionRefs(fields.retainedCoordinateRefs, 'retainedCoordinateRefs', 2);
+  if (
+    !retained.includes(fields.localCoordinateRef) ||
+    !retained.includes(fields.incomingCoordinateRef)
+  ) {
+    throw new WarpError(
+      'retainedCoordinateRefs must include the local and incoming coordinates',
+      'E_VALIDATION'
+    );
+  }
+  return retained;
+}

--- a/src/domain/admission/UnchangedAdmissionPosture.ts
+++ b/src/domain/admission/UnchangedAdmissionPosture.ts
@@ -1,0 +1,13 @@
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+
+/** Destination frontier after an obstruction prevents admission. */
+export default class UnchangedAdmissionPosture {
+  readonly kind: 'unchanged' = 'unchanged';
+  readonly frontierRef: string;
+
+  constructor(frontierRef: string) {
+    requireNonEmptyString(frontierRef, 'frontierRef');
+    this.frontierRef = frontierRef;
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/UnsettledConflictAdmissionPosture.ts
+++ b/src/domain/admission/UnsettledConflictAdmissionPosture.ts
@@ -1,0 +1,13 @@
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+
+/** Contested relation retained without admitting the proposed suffix. */
+export default class UnsettledConflictAdmissionPosture {
+  readonly kind: 'unsettled-conflict' = 'unsettled-conflict';
+  readonly conflictRef: string;
+
+  constructor(conflictRef: string) {
+    requireNonEmptyString(conflictRef, 'conflictRef');
+    this.conflictRef = conflictRef;
+    Object.freeze(this);
+  }
+}

--- a/src/domain/admission/admissionValidation.ts
+++ b/src/domain/admission/admissionValidation.ts
@@ -1,5 +1,18 @@
 import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+import AdmissionEvaluation from './AdmissionEvaluation.ts';
+
+export function requireAdmissionEvaluation<
+  Fields extends { readonly evaluation: AdmissionEvaluation },
+>(fields: Fields, witnessName: string): Fields {
+  if (fields === null || fields === undefined) {
+    throw new WarpError(`${witnessName} fields are required`, 'E_VALIDATION');
+  }
+  if (!(fields.evaluation instanceof AdmissionEvaluation)) {
+    throw new WarpError('evaluation must be an AdmissionEvaluation', 'E_VALIDATION');
+  }
+  return fields;
+}
 
 export function freezeAdmissionRefs(
   values: readonly string[],

--- a/src/domain/admission/admissionValidation.ts
+++ b/src/domain/admission/admissionValidation.ts
@@ -1,0 +1,30 @@
+import WarpError from '../errors/WarpError.ts';
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+
+export function freezeAdmissionRefs(
+  values: readonly string[],
+  field: string,
+  minimumDistinctValues = 0
+): readonly string[] {
+  requireArray(values, field);
+
+  const checked: string[] = [];
+  values.forEach((value, index) => {
+    requireNonEmptyString(value, `${field}[${index}]`);
+    checked.push(value);
+  });
+  const distinct = [...new Set(checked)].sort();
+  if (distinct.length < minimumDistinctValues) {
+    throw new WarpError(
+      `${field} must contain at least ${String(minimumDistinctValues)} distinct values`,
+      'E_VALIDATION'
+    );
+  }
+  return Object.freeze(distinct);
+}
+
+function requireArray(values: readonly string[], field: string): void {
+  if (!Array.isArray(values)) {
+    throw new WarpError(`${field} must be an array`, 'E_VALIDATION');
+  }
+}

--- a/src/domain/admission/matchAdmission.ts
+++ b/src/domain/admission/matchAdmission.ts
@@ -1,0 +1,33 @@
+import WarpError from '../errors/WarpError.ts';
+import type { AdmissionOutcome } from './AdmissionOutcome.ts';
+import ConflictAdmission from './ConflictAdmission.ts';
+import DerivedAdmission from './DerivedAdmission.ts';
+import ObstructedAdmission from './ObstructedAdmission.ts';
+import PluralAdmission from './PluralAdmission.ts';
+
+export type AdmissionMatcher<TResult> = Readonly<{
+  derived: (outcome: DerivedAdmission) => TResult;
+  plural: (outcome: PluralAdmission) => TResult;
+  conflict: (outcome: ConflictAdmission) => TResult;
+  obstruction: (outcome: ObstructedAdmission) => TResult;
+}>;
+
+/** Applies an exhaustive handler set without a default branch. */
+export default function matchAdmission<TResult>(
+  outcome: AdmissionOutcome,
+  matcher: AdmissionMatcher<TResult>
+): TResult {
+  if (outcome instanceof DerivedAdmission) {
+    return matcher.derived(outcome);
+  }
+  if (outcome instanceof PluralAdmission) {
+    return matcher.plural(outcome);
+  }
+  if (outcome instanceof ConflictAdmission) {
+    return matcher.conflict(outcome);
+  }
+  if (outcome instanceof ObstructedAdmission) {
+    return matcher.obstruction(outcome);
+  }
+  throw new WarpError('outcome must be an AdmissionOutcome', 'E_VALIDATION');
+}

--- a/src/domain/settlement/SettlementPlan.ts
+++ b/src/domain/settlement/SettlementPlan.ts
@@ -1,0 +1,55 @@
+import WarpError from '../errors/WarpError.ts';
+import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+
+export type SettlementPlanFields = {
+  readonly planDigest: string;
+  readonly sourceLaneId: string;
+  readonly targetLaneId: string;
+  readonly sourceFrontierRef: string;
+  readonly targetFrontierRef: string;
+  readonly proposalDigest: string;
+  readonly lawDigest: string;
+  readonly policyDigest: string;
+};
+
+/** Non-authoritative settlement proposal bound to exact lanes, frontiers, and law. */
+export default class SettlementPlan {
+  readonly invalidationRule: 'any-bound-input-change' = 'any-bound-input-change';
+  readonly planDigest: string;
+  readonly sourceLaneId: string;
+  readonly targetLaneId: string;
+  readonly sourceFrontierRef: string;
+  readonly targetFrontierRef: string;
+  readonly proposalDigest: string;
+  readonly lawDigest: string;
+  readonly policyDigest: string;
+
+  constructor(fields: SettlementPlanFields) {
+    if (fields === null || fields === undefined) {
+      throw new WarpError('SettlementPlan fields are required', 'E_VALIDATION');
+    }
+    requireNonEmptyString(fields.planDigest, 'planDigest');
+    requireNonEmptyString(fields.sourceLaneId, 'sourceLaneId');
+    requireNonEmptyString(fields.targetLaneId, 'targetLaneId');
+    requireNonEmptyString(fields.sourceFrontierRef, 'sourceFrontierRef');
+    requireNonEmptyString(fields.targetFrontierRef, 'targetFrontierRef');
+    requireNonEmptyString(fields.proposalDigest, 'proposalDigest');
+    requireNonEmptyString(fields.lawDigest, 'lawDigest');
+    requireNonEmptyString(fields.policyDigest, 'policyDigest');
+    if (fields.sourceLaneId === fields.targetLaneId) {
+      throw new WarpError(
+        'SettlementPlan requires distinct source and target lanes',
+        'E_VALIDATION'
+      );
+    }
+    this.planDigest = fields.planDigest;
+    this.sourceLaneId = fields.sourceLaneId;
+    this.targetLaneId = fields.targetLaneId;
+    this.sourceFrontierRef = fields.sourceFrontierRef;
+    this.targetFrontierRef = fields.targetFrontierRef;
+    this.proposalDigest = fields.proposalDigest;
+    this.lawDigest = fields.lawDigest;
+    this.policyDigest = fields.policyDigest;
+    Object.freeze(this);
+  }
+}

--- a/test/unit/domain/admission/AdmissionOutcome.test.ts
+++ b/test/unit/domain/admission/AdmissionOutcome.test.ts
@@ -218,23 +218,20 @@ describe('AdmissionOutcome', () => {
     expect(AdmissionObstructionReason.staleBasis('continuum.stale-plan').family).toBe(
       'stale-basis'
     );
+    expect(AdmissionObstructionReason.capabilityDenied('continuum.capability-denied').family).toBe(
+      'capability-denied'
+    );
     expect(
-      new AdmissionObstructionReason('capability-denied', 'continuum.capability-denied').family
-    ).toBe('capability-denied');
-    expect(
-      new AdmissionObstructionReason('unsupported-evidence', 'continuum.unsupported-evidence')
-        .family
+      AdmissionObstructionReason.unsupportedEvidence('continuum.unsupported-evidence').family
     ).toBe('unsupported-evidence');
     expect(
-      new AdmissionObstructionReason('law-violation', 'LabMachine.v1.CooldownBlocksReservation')
-        .family
+      AdmissionObstructionReason.lawViolation('LabMachine.v1.CooldownBlocksReservation').family
     ).toBe('law-violation');
+    expect(AdmissionObstructionReason.budgetExceeded('continuum.budget-exceeded').family).toBe(
+      'budget-exceeded'
+    );
     expect(
-      new AdmissionObstructionReason('budget-exceeded', 'continuum.budget-exceeded').family
-    ).toBe('budget-exceeded');
-    expect(
-      new AdmissionObstructionReason('unsupported-contract', 'continuum.unsupported-contract')
-        .family
+      AdmissionObstructionReason.unsupportedContract('continuum.unsupported-contract').family
     ).toBe('unsupported-contract');
   });
 

--- a/test/unit/domain/admission/AdmissionOutcome.test.ts
+++ b/test/unit/domain/admission/AdmissionOutcome.test.ts
@@ -1,0 +1,534 @@
+import { describe, expect, it } from 'vitest';
+
+import AdmissionEvaluation from '../../../../src/domain/admission/AdmissionEvaluation.ts';
+import AdmissionObstructionReason from '../../../../src/domain/admission/AdmissionObstructionReason.ts';
+import AdmissionRetryDisposition from '../../../../src/domain/admission/AdmissionRetryDisposition.ts';
+import AdmissionRuntimeFailure from '../../../../src/domain/admission/AdmissionRuntimeFailure.ts';
+import AdvancedAdmissionPosture from '../../../../src/domain/admission/AdvancedAdmissionPosture.ts';
+import CompletedAdmissionExecution from '../../../../src/domain/admission/CompletedAdmissionExecution.ts';
+import ConflictAdmission from '../../../../src/domain/admission/ConflictAdmission.ts';
+import ConflictWitness from '../../../../src/domain/admission/ConflictWitness.ts';
+import DerivationWitness from '../../../../src/domain/admission/DerivationWitness.ts';
+import DerivedAdmission from '../../../../src/domain/admission/DerivedAdmission.ts';
+import FailedAdmissionExecution from '../../../../src/domain/admission/FailedAdmissionExecution.ts';
+import ObstructedAdmission from '../../../../src/domain/admission/ObstructedAdmission.ts';
+import ObstructionWitness from '../../../../src/domain/admission/ObstructionWitness.ts';
+import PluralAdmission from '../../../../src/domain/admission/PluralAdmission.ts';
+import PluralAdmissionPosture from '../../../../src/domain/admission/PluralAdmissionPosture.ts';
+import PluralityWitness from '../../../../src/domain/admission/PluralityWitness.ts';
+import UnchangedAdmissionPosture from '../../../../src/domain/admission/UnchangedAdmissionPosture.ts';
+import UnsettledConflictAdmissionPosture from '../../../../src/domain/admission/UnsettledConflictAdmissionPosture.ts';
+import { freezeAdmissionRefs } from '../../../../src/domain/admission/admissionValidation.ts';
+import matchAdmission from '../../../../src/domain/admission/matchAdmission.ts';
+import WarpError from '../../../../src/domain/errors/WarpError.ts';
+
+function evaluation(): AdmissionEvaluation {
+  return new AdmissionEvaluation({
+    sourceParticipantId: 'participant:source',
+    destinationRuntimeId: 'runtime:destination',
+    sourceBasisRef: 'frontier:source:7',
+    destinationBasisRef: 'frontier:destination:11',
+    proposalDigest: 'sha256:proposal',
+    lawDigest: 'sha256:law',
+    profileDigest: 'sha256:profile',
+    evaluationCoordinateRef: 'coordinate:destination:11',
+  });
+}
+
+function derivationWitness(): DerivationWitness {
+  return new DerivationWitness({
+    evaluation: evaluation(),
+    admittedSuffixRef: 'suffix:source:8',
+    resultingFrontierRef: 'frontier:destination:12',
+    authorityEvidenceRef: 'evidence:authority',
+    directExtensionEvidenceRef: 'evidence:direct-extension',
+  });
+}
+
+function pluralityWitness(): PluralityWitness {
+  return new PluralityWitness({
+    evaluation: evaluation(),
+    localCoordinateRef: 'coordinate:local',
+    incomingCoordinateRef: 'coordinate:incoming',
+    retainedCoordinateRefs: ['coordinate:third', 'coordinate:incoming', 'coordinate:local'],
+    derivationEvidenceRef: 'evidence:derivation',
+    footprintComparisonRef: 'evidence:footprint-comparison',
+    concurrencyEvidenceRef: 'evidence:concurrency',
+    nonInterferenceEvidenceRef: 'evidence:non-interference',
+  });
+}
+
+function conflictWitness(): ConflictWitness {
+  return new ConflictWitness({
+    evaluation: evaluation(),
+    conflictRef: 'conflict:reservation-overlap',
+    claimRefs: ['claim:remote', 'claim:local'],
+    overlappingFootprintRefs: ['footprint:laser:14:10-14:30'],
+    contestedDomain: 'laser://north-cutter',
+    derivationEvidenceRef: 'evidence:derivation',
+    overlapEvidenceRef: 'evidence:overlap',
+    resolutionProcedureRefs: ['procedure:reschedule', 'procedure:priority'],
+  });
+}
+
+function obstructionWitness(): ObstructionWitness {
+  return new ObstructionWitness({
+    evaluation: evaluation(),
+    reason: AdmissionObstructionReason.invalidDerivation('continuum.invalid-signature'),
+    suppliedEvidenceRefs: ['evidence:signature:invalid'],
+    requiredEvidenceRefs: ['evidence:signature:valid'],
+    failedConditionRef: 'condition:source-derivation-honest',
+    retry: AdmissionRetryDisposition.withEvidence(),
+  });
+}
+
+describe('AdmissionOutcome', () => {
+  it('binds every outcome to its required witness and residual posture', () => {
+    const derived = new DerivedAdmission(derivationWitness());
+    const plural = new PluralAdmission(pluralityWitness());
+    const conflict = new ConflictAdmission(conflictWitness());
+    const obstruction = new ObstructedAdmission(obstructionWitness());
+
+    expect(derived.kind).toBe('derived');
+    expect(derived.residual.kind).toBe('advanced');
+    expect(derived.residual.frontierRef).toBe('frontier:destination:12');
+    expect(plural.kind).toBe('plural');
+    expect(plural.residual.coordinateRefs).toEqual([
+      'coordinate:incoming',
+      'coordinate:local',
+      'coordinate:third',
+    ]);
+    expect(conflict.kind).toBe('conflict');
+    expect(conflict.residual.conflictRef).toBe('conflict:reservation-overlap');
+    expect(obstruction.kind).toBe('obstruction');
+    expect(obstruction.residual.frontierRef).toBe('frontier:destination:11');
+    expect(obstruction.witness.reason.family).toBe('invalid-derivation');
+    expect(obstruction.witness.retry.value).toBe('with-evidence');
+    expect(
+      [
+        derived,
+        plural,
+        conflict,
+        obstruction,
+        derived.witness,
+        plural.witness,
+        conflict.witness,
+        obstruction.witness,
+        derived.residual,
+        plural.residual,
+        conflict.residual,
+        obstruction.residual,
+      ].every(Object.isFrozen)
+    ).toBe(true);
+  });
+
+  it('keeps plural admission distinct from conflict and preserves plurality', () => {
+    const witness = pluralityWitness();
+    const outcome = new PluralAdmission(witness);
+
+    expect(outcome).toBeInstanceOf(PluralAdmission);
+    expect(outcome).not.toBeInstanceOf(ConflictAdmission);
+    expect(witness.localCoordinateRef).toBe('coordinate:local');
+    expect(witness.incomingCoordinateRef).toBe('coordinate:incoming');
+    expect(witness.derivationEvidenceRef).toBe('evidence:derivation');
+    expect(witness.footprintComparisonRef).toBe('evidence:footprint-comparison');
+    expect(witness.concurrencyEvidenceRef).toBe('evidence:concurrency');
+    expect(witness.nonInterferenceEvidenceRef).toBe('evidence:non-interference');
+    expect(Object.isFrozen(witness.retainedCoordinateRefs)).toBe(true);
+  });
+
+  it('retains bounded conflict facts for resolution without admitting the proposal', () => {
+    const witness = conflictWitness();
+    const outcome = new ConflictAdmission(witness);
+
+    expect(outcome.residual.kind).toBe('unsettled-conflict');
+    expect(witness.claimRefs).toEqual(['claim:local', 'claim:remote']);
+    expect(witness.overlappingFootprintRefs).toEqual(['footprint:laser:14:10-14:30']);
+    expect(witness.contestedDomain).toBe('laser://north-cutter');
+    expect(witness.derivationEvidenceRef).toBe('evidence:derivation');
+    expect(witness.overlapEvidenceRef).toBe('evidence:overlap');
+    expect(witness.resolutionProcedureRefs).toEqual(['procedure:priority', 'procedure:reschedule']);
+  });
+
+  it('matches all four admission variants exhaustively without a default handler', () => {
+    const labels = [
+      matchAdmission(new DerivedAdmission(derivationWitness()), {
+        derived: (outcome) => outcome.kind,
+        plural: (outcome) => outcome.kind,
+        conflict: (outcome) => outcome.kind,
+        obstruction: (outcome) => outcome.kind,
+      }),
+      matchAdmission(new PluralAdmission(pluralityWitness()), {
+        derived: (outcome) => outcome.kind,
+        plural: (outcome) => outcome.kind,
+        conflict: (outcome) => outcome.kind,
+        obstruction: (outcome) => outcome.kind,
+      }),
+      matchAdmission(new ConflictAdmission(conflictWitness()), {
+        derived: (outcome) => outcome.kind,
+        plural: (outcome) => outcome.kind,
+        conflict: (outcome) => outcome.kind,
+        obstruction: (outcome) => outcome.kind,
+      }),
+      matchAdmission(new ObstructedAdmission(obstructionWitness()), {
+        derived: (outcome) => outcome.kind,
+        plural: (outcome) => outcome.kind,
+        conflict: (outcome) => outcome.kind,
+        obstruction: (outcome) => outcome.kind,
+      }),
+    ];
+
+    expect(labels).toEqual(['derived', 'plural', 'conflict', 'obstruction']);
+  });
+
+  it('separates completed causal classifications from runtime failures', () => {
+    const outcomes = [
+      new DerivedAdmission(derivationWitness()),
+      new PluralAdmission(pluralityWitness()),
+      new ConflictAdmission(conflictWitness()),
+      new ObstructedAdmission(obstructionWitness()),
+    ];
+    const completed = outcomes.map((outcome) => new CompletedAdmissionExecution(outcome));
+    const failure = new AdmissionRuntimeFailure('E_ADMISSION_IO', 'history port unavailable');
+    const failed = new FailedAdmissionExecution(failure);
+
+    expect(completed.map((execution) => execution.status)).toEqual([
+      'completed',
+      'completed',
+      'completed',
+      'completed',
+    ]);
+    expect(completed.map((execution) => execution.outcome.kind)).toEqual([
+      'derived',
+      'plural',
+      'conflict',
+      'obstruction',
+    ]);
+    expect(failed.status).toBe('failed');
+    expect(failed.failure).toBe(failure);
+    expect(Object.isFrozen(failure)).toBe(true);
+    expect(Object.isFrozen(failed)).toBe(true);
+  });
+
+  it('models every retry disposition and validates obstruction families', () => {
+    expect(AdmissionRetryDisposition.afterChange().value).toBe('after-change');
+    expect(AdmissionRetryDisposition.withEvidence().value).toBe('with-evidence');
+    expect(AdmissionRetryDisposition.never().value).toBe('never');
+    expect(AdmissionRetryDisposition.unknown().value).toBe('unknown');
+    expect(AdmissionObstructionReason.staleBasis('continuum.stale-plan').family).toBe(
+      'stale-basis'
+    );
+    expect(
+      new AdmissionObstructionReason('capability-denied', 'continuum.capability-denied').family
+    ).toBe('capability-denied');
+    expect(
+      new AdmissionObstructionReason('unsupported-evidence', 'continuum.unsupported-evidence')
+        .family
+    ).toBe('unsupported-evidence');
+    expect(
+      new AdmissionObstructionReason('law-violation', 'LabMachine.v1.CooldownBlocksReservation')
+        .family
+    ).toBe('law-violation');
+    expect(
+      new AdmissionObstructionReason('budget-exceeded', 'continuum.budget-exceeded').family
+    ).toBe('budget-exceeded');
+    expect(
+      new AdmissionObstructionReason('unsupported-contract', 'continuum.unsupported-contract')
+        .family
+    ).toBe('unsupported-contract');
+  });
+
+  it('rejects malformed evaluations, witnesses, postures, and outcomes', () => {
+    expect(
+      () =>
+        new AdmissionEvaluation(
+          // @ts-expect-error runtime guard for JavaScript callers
+          undefined
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new AdmissionEvaluation(
+          // @ts-expect-error runtime guard for JavaScript callers
+          null
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new AdmissionEvaluation({
+          sourceParticipantId: '',
+          destinationRuntimeId: 'runtime:destination',
+          sourceBasisRef: 'frontier:source',
+          destinationBasisRef: 'frontier:destination',
+          proposalDigest: 'sha256:proposal',
+          lawDigest: 'sha256:law',
+          profileDigest: 'sha256:profile',
+          evaluationCoordinateRef: 'coordinate:destination',
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new DerivationWitness(
+          // @ts-expect-error runtime guard for JavaScript callers
+          undefined
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new DerivationWitness({
+          // @ts-expect-error runtime guard for JavaScript callers
+          evaluation: {},
+          admittedSuffixRef: 'suffix:source',
+          resultingFrontierRef: 'frontier:destination',
+          authorityEvidenceRef: 'evidence:authority',
+          directExtensionEvidenceRef: 'evidence:direct-extension',
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new PluralityWitness(
+          // @ts-expect-error runtime guard for JavaScript callers
+          null
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new PluralityWitness({
+          // @ts-expect-error runtime guard for JavaScript callers
+          evaluation: {},
+          localCoordinateRef: 'coordinate:local',
+          incomingCoordinateRef: 'coordinate:incoming',
+          retainedCoordinateRefs: ['coordinate:local', 'coordinate:incoming'],
+          derivationEvidenceRef: 'evidence:derivation',
+          footprintComparisonRef: 'evidence:footprints',
+          concurrencyEvidenceRef: 'evidence:concurrency',
+          nonInterferenceEvidenceRef: 'evidence:non-interference',
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new PluralityWitness({
+          evaluation: evaluation(),
+          localCoordinateRef: 'coordinate:same',
+          incomingCoordinateRef: 'coordinate:same',
+          retainedCoordinateRefs: ['coordinate:same', 'coordinate:third'],
+          derivationEvidenceRef: 'evidence:derivation',
+          footprintComparisonRef: 'evidence:footprints',
+          concurrencyEvidenceRef: 'evidence:concurrency',
+          nonInterferenceEvidenceRef: 'evidence:non-interference',
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new PluralityWitness({
+          evaluation: evaluation(),
+          localCoordinateRef: 'coordinate:local',
+          incomingCoordinateRef: 'coordinate:incoming',
+          retainedCoordinateRefs: ['coordinate:local'],
+          derivationEvidenceRef: 'evidence:derivation',
+          footprintComparisonRef: 'evidence:footprints',
+          concurrencyEvidenceRef: 'evidence:concurrency',
+          nonInterferenceEvidenceRef: 'evidence:non-interference',
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new PluralityWitness({
+          evaluation: evaluation(),
+          localCoordinateRef: 'coordinate:local',
+          incomingCoordinateRef: 'coordinate:incoming',
+          retainedCoordinateRefs: ['coordinate:incoming', 'coordinate:third'],
+          derivationEvidenceRef: 'evidence:derivation',
+          footprintComparisonRef: 'evidence:footprints',
+          concurrencyEvidenceRef: 'evidence:concurrency',
+          nonInterferenceEvidenceRef: 'evidence:non-interference',
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new PluralityWitness({
+          evaluation: evaluation(),
+          localCoordinateRef: 'coordinate:local',
+          incomingCoordinateRef: 'coordinate:incoming',
+          retainedCoordinateRefs: ['coordinate:local', 'coordinate:third'],
+          derivationEvidenceRef: 'evidence:derivation',
+          footprintComparisonRef: 'evidence:footprints',
+          concurrencyEvidenceRef: 'evidence:concurrency',
+          nonInterferenceEvidenceRef: 'evidence:non-interference',
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ConflictWitness(
+          // @ts-expect-error runtime guard for JavaScript callers
+          undefined
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ConflictWitness({
+          // @ts-expect-error runtime guard for JavaScript callers
+          evaluation: {},
+          conflictRef: 'conflict:test',
+          claimRefs: ['claim:a', 'claim:b'],
+          overlappingFootprintRefs: ['footprint:a'],
+          contestedDomain: 'domain:test',
+          derivationEvidenceRef: 'evidence:derivation',
+          overlapEvidenceRef: 'evidence:overlap',
+          resolutionProcedureRefs: [],
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ConflictWitness({
+          evaluation: evaluation(),
+          conflictRef: 'conflict:test',
+          claimRefs: ['claim:a'],
+          overlappingFootprintRefs: ['footprint:a'],
+          contestedDomain: 'domain:test',
+          derivationEvidenceRef: 'evidence:derivation',
+          overlapEvidenceRef: 'evidence:overlap',
+          resolutionProcedureRefs: [],
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ConflictWitness({
+          evaluation: evaluation(),
+          conflictRef: 'conflict:test',
+          claimRefs: ['claim:a', 'claim:b'],
+          overlappingFootprintRefs: [],
+          contestedDomain: 'domain:test',
+          derivationEvidenceRef: 'evidence:derivation',
+          overlapEvidenceRef: 'evidence:overlap',
+          resolutionProcedureRefs: [],
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ObstructionWitness(
+          // @ts-expect-error runtime guard for JavaScript callers
+          null
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ObstructionWitness({
+          // @ts-expect-error runtime guard for JavaScript callers
+          evaluation: {},
+          reason: AdmissionObstructionReason.invalidDerivation('continuum.invalid'),
+          suppliedEvidenceRefs: [],
+          requiredEvidenceRefs: [],
+          failedConditionRef: 'condition:test',
+          retry: AdmissionRetryDisposition.never(),
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ObstructionWitness({
+          evaluation: evaluation(),
+          // @ts-expect-error runtime guard for JavaScript callers
+          reason: 'invalid',
+          suppliedEvidenceRefs: [],
+          requiredEvidenceRefs: [],
+          failedConditionRef: 'condition:test',
+          retry: AdmissionRetryDisposition.never(),
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ObstructionWitness({
+          evaluation: evaluation(),
+          reason: AdmissionObstructionReason.invalidDerivation('continuum.invalid'),
+          suppliedEvidenceRefs: [],
+          requiredEvidenceRefs: [],
+          failedConditionRef: 'condition:test',
+          // @ts-expect-error runtime guard for JavaScript callers
+          retry: 'never',
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new DerivedAdmission(
+          // @ts-expect-error runtime guard for JavaScript callers
+          pluralityWitness()
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new PluralAdmission(
+          // @ts-expect-error runtime guard for JavaScript callers
+          derivationWitness()
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ConflictAdmission(
+          // @ts-expect-error runtime guard for JavaScript callers
+          obstructionWitness()
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new ObstructedAdmission(
+          // @ts-expect-error runtime guard for JavaScript callers
+          conflictWitness()
+        )
+    ).toThrow(WarpError);
+    expect(() =>
+      matchAdmission(
+        // @ts-expect-error runtime guard for JavaScript callers
+        {},
+        {
+          derived: (outcome) => outcome.kind,
+          plural: (outcome) => outcome.kind,
+          conflict: (outcome) => outcome.kind,
+          obstruction: (outcome) => outcome.kind,
+        }
+      )
+    ).toThrow(WarpError);
+  });
+
+  it('rejects malformed execution wrappers and value objects', () => {
+    expect(
+      () =>
+        new CompletedAdmissionExecution(
+          // @ts-expect-error runtime guard for JavaScript callers
+          {}
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new FailedAdmissionExecution(
+          // @ts-expect-error runtime guard for JavaScript callers
+          {}
+        )
+    ).toThrow(WarpError);
+    expect(() => new AdmissionRuntimeFailure('', 'message')).toThrow(WarpError);
+    expect(() => new AdmissionRuntimeFailure('E_TEST', '')).toThrow(WarpError);
+    expect(() => new AdmissionRetryDisposition('later')).toThrow(WarpError);
+    expect(() => new AdmissionObstructionReason('unknown', 'reason')).toThrow(WarpError);
+    expect(() => new AdmissionObstructionReason('law-violation', '')).toThrow(WarpError);
+    expect(() => new AdmissionObstructionReason('law-violation', 'unqualified')).toThrow(WarpError);
+    expect(() => new AdmissionObstructionReason('law-violation', '.missing')).toThrow(WarpError);
+    expect(() => new AdmissionObstructionReason('law-violation', 'missing.')).toThrow(WarpError);
+  });
+
+  it('rejects malformed residual postures and reference collections', () => {
+    expect(() => new AdvancedAdmissionPosture('')).toThrow(WarpError);
+    expect(() => new UnchangedAdmissionPosture('')).toThrow(WarpError);
+    expect(() => new UnsettledConflictAdmissionPosture('')).toThrow(WarpError);
+    expect(() => new PluralAdmissionPosture(['coordinate:only'])).toThrow(WarpError);
+    expect(() => new PluralAdmissionPosture(['coordinate:a', ''])).toThrow(WarpError);
+    expect(() =>
+      freezeAdmissionRefs(
+        // @ts-expect-error runtime guard for JavaScript callers
+        null,
+        'refs'
+      )
+    ).toThrow(WarpError);
+    expect(() => freezeAdmissionRefs(['valid', ''], 'refs')).toThrow(WarpError);
+    expect(() => freezeAdmissionRefs(['same', 'same'], 'refs', 2)).toThrow(WarpError);
+    expect(freezeAdmissionRefs(['b', 'a', 'a'], 'refs')).toEqual(['a', 'b']);
+  });
+});

--- a/test/unit/domain/settlement/SettlementPlan.test.ts
+++ b/test/unit/domain/settlement/SettlementPlan.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import WarpError from '../../../../src/domain/errors/WarpError.ts';
+import SettlementPlan from '../../../../src/domain/settlement/SettlementPlan.ts';
+
+function plan(): SettlementPlan {
+  return new SettlementPlan({
+    planDigest: 'sha256:plan',
+    sourceLaneId: 'lane:draft',
+    targetLaneId: 'lane:main',
+    sourceFrontierRef: 'frontier:draft:7',
+    targetFrontierRef: 'frontier:main:11',
+    proposalDigest: 'sha256:proposal',
+    lawDigest: 'sha256:law',
+    policyDigest: 'sha256:policy',
+  });
+}
+
+describe('SettlementPlan', () => {
+  it('is immutable, non-authoritative, and bound to exact causal inputs', () => {
+    const value = plan();
+
+    expect(value.invalidationRule).toBe('any-bound-input-change');
+    expect(value.planDigest).toBe('sha256:plan');
+    expect(value.sourceLaneId).toBe('lane:draft');
+    expect(value.targetLaneId).toBe('lane:main');
+    expect(value.sourceFrontierRef).toBe('frontier:draft:7');
+    expect(value.targetFrontierRef).toBe('frontier:main:11');
+    expect(value.proposalDigest).toBe('sha256:proposal');
+    expect(value.lawDigest).toBe('sha256:law');
+    expect(value.policyDigest).toBe('sha256:policy');
+    expect(Object.isFrozen(value)).toBe(true);
+  });
+
+  it('rejects malformed plans and same-lane settlement', () => {
+    expect(
+      () =>
+        new SettlementPlan(
+          // @ts-expect-error runtime guard for JavaScript callers
+          undefined
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new SettlementPlan(
+          // @ts-expect-error runtime guard for JavaScript callers
+          null
+        )
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new SettlementPlan({
+          planDigest: '',
+          sourceLaneId: 'lane:draft',
+          targetLaneId: 'lane:main',
+          sourceFrontierRef: 'frontier:draft:7',
+          targetFrontierRef: 'frontier:main:11',
+          proposalDigest: 'sha256:proposal',
+          lawDigest: 'sha256:law',
+          policyDigest: 'sha256:policy',
+        })
+    ).toThrow(WarpError);
+    expect(
+      () =>
+        new SettlementPlan({
+          planDigest: 'sha256:plan',
+          sourceLaneId: 'lane:main',
+          targetLaneId: 'lane:main',
+          sourceFrontierRef: 'frontier:main:7',
+          targetFrontierRef: 'frontier:main:11',
+          proposalDigest: 'sha256:proposal',
+          lawDigest: 'sha256:law',
+          policyDigest: 'sha256:policy',
+        })
+    ).toThrow(WarpError);
+  });
+});


### PR DESCRIPTION
## Summary

- define the closed `derived | plural | conflict | obstruction` admission algebra as runtime-backed classes
- require a distinct typed witness and residual posture for every admission variant
- keep runtime execution failures outside the causal outcome union
- add a non-authoritative `SettlementPlan` bound to exact lanes, frontiers, proposal, law, and policy
- correct the README and architecture doctrine so CRDT join is a domain settlement law, not a universal merge claim

## Scope

This is the contract checkpoint for #765. It does not expose the new types from package root or classify live writes/imports yet; #765 remains open for the semantic-matrix classifier and runtime integration.

Refs #765
Refs #712

## Verification

- `npm run lint`
- `npm run lint:semgrep`
- `npm run typecheck`
- `npm run lint:md:code`
- `npm run lint:docs-topology`
- focused admission/settlement tests: 11 passed
- focused coverage: 100% statements, branches, functions, and lines
- pre-push stable unit shards: 577 files passed, 1 skipped; 7,115 tests passed, 2 skipped

## Review posture

Self-review found one anti-sludge false positive for the semantic retry value `unknown`; the two exact lines now carry narrow inline suppressions explaining that they are value vocabulary, not the TypeScript `unknown` type. No unresolved self-review findings remain.