### PR TITLE
Classify v19 writes with admission outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added root `intent` builders, the runtime-backed `Intent` noun,
   `Timeline.write(intent)`, and `WriteReceipt` results with the public
-  `ReceiptOutcome` axis: `accepted`, `obstructed`, `conflicted`,
-  `underdetermined`, and `rejected`.
+  `AdmissionOutcome` axis: `derived`, `plural`, `conflict`, and `obstruction`.
+  Each variant carries its required typed witness and reports admission rather
+  than completed settlement.
 - Added root `reading` builders, the runtime-backed `Reading` noun,
   `Timeline.read(reading)`, and receipt-bearing `ReadingResult` values for
   first-use property and node-existence reads.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ const write = await events.write(
   })
 );
 
-if (write.outcome !== 'accepted') {
-  throw new Error(write.reason);
+if (write.outcome.kind === 'conflict' || write.outcome.kind === 'obstruction') {
+  throw new Error(write.reason ?? `write admission was ${write.outcome.kind}`);
 }
 
 const role = await events.read(

--- a/docs/migrations/v19/README.md
+++ b/docs/migrations/v19/README.md
@@ -15,7 +15,7 @@ oriented, while graph-shaped compatibility surfaces are removed.
 The migration target is:
 
 ```text
-Write intents. Read timelines. Keep receipts.
+Write intents. Observe lanes. Keep receipts.
 ```
 
 ## Migration Principle
@@ -116,21 +116,25 @@ const receipt = await events.write(
   })
 );
 
-switch (receipt.outcome) {
-  case 'accepted':
-    console.log(receipt.evidence?.basis.id);
+switch (receipt.outcome.kind) {
+  case 'derived':
+    console.log(receipt.evidence.basis.id);
     break;
-  case 'obstructed':
-  case 'conflicted':
-  case 'underdetermined':
-  case 'rejected':
-    console.log(receipt.reason ?? receipt.outcome);
+  case 'plural':
+    console.log('lawful plurality retained', receipt.outcome.witness);
+    break;
+  case 'conflict':
+    console.log('resolution required', receipt.outcome.witness);
+    break;
+  case 'obstruction':
+    console.log('repair or stop', receipt.outcome.witness);
     break;
 }
 ```
 
 `commit((patch) => ...)` is removed from the package contract. The write
-surface is `timeline.write(intent)`.
+surface is `timeline.write(intent)`. Its receipt reports admission, not a later
+settlement operation.
 
 ## Read Migration
 
@@ -251,8 +255,10 @@ and joins first.
 | `JoinReceipt`              | root type                            | returned on `JoinResult.receipt`                  |
 | `JoinResult`               | root type                            | returned by `previewJoin()` and `join()`          |
 | `StorageAdapter`           | root `WarpStorage`                   | opaque storage handle replaces persistence port   |
-| `ReadReceiptOutcome`       | root `ReadOutcome`                   | operation-specific outcome alias rename           |
-| `JoinReceiptOutcome`       | root `JoinOutcome`                   | operation-specific outcome alias rename           |
+| `ReceiptOutcome`           | removed                              | no generic cross-operation outcome axis           |
+| `WriteOutcome`             | root `AdmissionOutcome`              | closed causal classification with typed witnesses |
+| `ReadReceiptOutcome`       | receipt field only                   | transitional read status; no root alias           |
+| `JoinReceiptOutcome`       | receipt field only                   | transitional join status; no root alias           |
 | `EdgePropertyIntentFields` | removed                              | no edge-property intent ships in the v19 root     |
 | `GitGraphAdapter`          | `storage` `GitStorage.open({ cwd })` | plumbing and CAS composition are internal         |
 | `InMemoryGraphAdapter`     | removed                              | tests may use test helpers; apps use `GitStorage` |
@@ -275,7 +281,7 @@ and joins first.
 | `Braid`                    | removed                              | joins are first-use root                          |
 | Continuum evidence nouns   | removed                              | receipt evidence stays root-facing                |
 
-## Receipt Outcome Migration
+## Admission Outcome Migration
 
 Before, consumers often treated write success as a returned commit SHA or a
 thrown exception.
@@ -291,28 +297,31 @@ const receipt = await timeline.write(
   })
 );
 
-switch (receipt.outcome) {
-  case 'accepted':
-    console.log(receipt.evidence?.basis.id);
+switch (receipt.outcome.kind) {
+  case 'derived':
+    console.log(receipt.evidence.basis.id);
     break;
-  case 'obstructed':
-  case 'conflicted':
-  case 'underdetermined':
-  case 'rejected':
-    console.log(receipt.reason ?? receipt.outcome);
+  case 'plural':
+  case 'conflict':
+  case 'obstruction':
+    console.log(receipt.outcome.witness);
     break;
 }
 ```
 
-The allowed receipt outcome axis is:
+The closed admission outcome axis is:
 
 ```text
-accepted
-obstructed
-conflicted
-underdetermined
-rejected
+derived
+plural
+conflict
+obstruction
 ```
+
+Every variant requires its own witness type. Runtime failures such as I/O,
+corruption, and internal invariant violations reject outside this semantic
+union; they are not obstruction outcomes. Read and join receipts retain
+operation-specific transitional statuses until their final v19 surfaces land.
 
 Receipt provenance also changes shape:
 

--- a/docs/topics/api/README.md
+++ b/docs/topics/api/README.md
@@ -329,6 +329,11 @@ conflict
 obstruction
 ```
 
+Implementation checkpoint: the transitional `Timeline.write()` surface now
+returns this closed `AdmissionOutcome` union. Transitional read and join
+receipts still have operation-specific status strings; those are not admission
+classifications and are not root outcome aliases.
+
 These variants are disjoint causal relations, not success and failure labels:
 
 | Outcome       | Meaning                                                            | Residual posture               |

--- a/docs/topics/getting-started.md
+++ b/docs/topics/getting-started.md
@@ -52,16 +52,25 @@ const receipt = await audit.write(
   })
 );
 
-if (receipt.outcome === 'accepted') {
-  console.log(receipt.evidence?.basis.id);
-} else {
-  console.error(receipt.reason);
+switch (receipt.outcome.kind) {
+  case 'derived':
+    console.log(receipt.evidence.basis.id);
+    break;
+  case 'plural':
+    console.log('lawful plurality retained', receipt.outcome.residual.coordinates);
+    break;
+  case 'conflict':
+  case 'obstruction':
+    console.error(receipt.outcome.kind, receipt.outcome.witness);
+    break;
 }
 ```
 
 Every call writes one intent and returns a `WriteReceipt`. Treat
-`receipt.outcome` as the settlement result. Accepted writes carry opaque causal
-evidence handles; substrate identities are not part of normal control flow.
+`receipt.outcome` as the admission classification, not as completed settlement.
+The closed variants are `derived`, `plural`, `conflict`, and `obstruction`, and
+each carries its required witness. A direct write normally derives from the
+captured lane basis; substrate identities remain outside normal control flow.
 
 ## Read A Bounded Value
 

--- a/docs/topics/reference.md
+++ b/docs/topics/reference.md
@@ -36,53 +36,50 @@ reading @ index.ts#L16
 
 ### Type exports
 
-Source: `index.ts`. Count: 44.
+Source: `index.ts`. Count: 41.
 
 ```text
+AdmissionOutcome @ index.ts#L30
 DraftTimeline @ index.ts#L17
-EdgeIntentFields @ index.ts#L33
+EdgeIntentFields @ index.ts#L34
 Evidence @ index.ts#L22
 EvidenceHandle @ index.ts#L22
 Intent @ index.ts#L23
-IntentBuilders @ index.ts#L39
-IntentDescriptor @ index.ts#L34
-IntentKind @ index.ts#L35
-JoinMode @ index.ts#L40
-JoinOptions @ index.ts#L42
-JoinOutcome @ index.ts#L56
-JoinPolicy @ index.ts#L42
+IntentBuilders @ index.ts#L40
+IntentDescriptor @ index.ts#L35
+IntentKind @ index.ts#L36
+JoinMode @ index.ts#L41
+JoinOptions @ index.ts#L43
+JoinPolicy @ index.ts#L43
 JoinReceipt @ index.ts#L24
-JoinReceiptOptions @ index.ts#L40
+JoinReceiptOptions @ index.ts#L41
 JoinResult @ index.ts#L25
-JoinResultOptions @ index.ts#L41
-NeighborhoodReadingFields @ index.ts#L44
-NodeIntentFields @ index.ts#L36
-NodeReadingFields @ index.ts#L45
-OpenWarpOptions @ index.ts#L30
-PropertyIntentFields @ index.ts#L37
-PropertyReadingFields @ index.ts#L46
+JoinResultOptions @ index.ts#L42
+NeighborhoodReadingFields @ index.ts#L45
+NodeIntentFields @ index.ts#L37
+NodeReadingFields @ index.ts#L46
+OpenWarpOptions @ index.ts#L31
+PropertyIntentFields @ index.ts#L38
+PropertyReadingFields @ index.ts#L47
 Reading @ index.ts#L26
-ReadingBuilders @ index.ts#L51
-ReadingDescriptor @ index.ts#L48
-ReadingDirection @ index.ts#L47
-ReadingKind @ index.ts#L49
+ReadingBuilders @ index.ts#L52
+ReadingDescriptor @ index.ts#L49
+ReadingDirection @ index.ts#L48
+ReadingKind @ index.ts#L50
 ReadingResult @ index.ts#L27
-ReadingResultOptions @ index.ts#L52
-ReadingValue @ index.ts#L52
-ReadOutcome @ index.ts#L57
+ReadingResultOptions @ index.ts#L53
+ReadingValue @ index.ts#L53
 ReadReceipt @ index.ts#L28
-ReadReceiptOptions @ index.ts#L54
-Receipt @ index.ts#L53
-ReceiptOutcome @ index.ts#L58
-RepairHint @ index.ts#L61
+ReadReceiptOptions @ index.ts#L55
+Receipt @ index.ts#L54
+RepairHint @ index.ts#L56
 Tick @ index.ts#L20
 Timeline @ index.ts#L19
 TimelineView @ index.ts#L21
 Warp @ index.ts#L18
-WarpStorage @ index.ts#L31
-WriteOutcome @ index.ts#L59
+WarpStorage @ index.ts#L32
 WriteReceipt @ index.ts#L29
-WriteReceiptOptions @ index.ts#L62
+WriteReceiptOptions @ index.ts#L57
 ```
 
 ## Storage export surface

--- a/docs/topics/supported-outcome-settlement.md
+++ b/docs/topics/supported-outcome-settlement.md
@@ -16,7 +16,8 @@ git-warp should be able to expose substrate support for:
 - observer/query evidence posture;
 - strand-neighborhood facts;
 - support-tier fields supplied by higher layers;
-- explicit obstruction or underdetermined posture when support is missing.
+- explicit obstruction or evidence-deficient support posture when support is
+  missing.
 
 The consuming authority decides what those facts mean.
 

--- a/index.ts
+++ b/index.ts
@@ -27,6 +27,7 @@ export type { default as Reading } from './src/domain/api/Reading.ts';
 export type { default as ReadingResult } from './src/domain/api/ReadingResult.ts';
 export type { default as ReadReceipt } from './src/domain/api/ReadReceipt.ts';
 export type { default as WriteReceipt } from './src/domain/api/WriteReceipt.ts';
+export type { AdmissionOutcome } from './src/domain/api/AdmissionOutcome.ts';
 export type { OpenWarpOptions } from './src/application/openWarp.ts';
 export type { default as WarpStorage } from './src/application/WarpStorage.ts';
 export type {
@@ -52,11 +53,5 @@ export type { ReadingBuilders } from './src/domain/api/ReadingBuilders.ts';
 export type { ReadingResultOptions, ReadingValue } from './src/domain/api/ReadingResult.ts';
 export type { Receipt } from './src/domain/api/Receipt.ts';
 export type { ReadReceiptOptions } from './src/domain/api/ReadReceipt.ts';
-export type {
-  JoinOutcome,
-  ReadOutcome,
-  ReceiptOutcome,
-  WriteOutcome,
-} from './src/domain/api/ReceiptOutcome.ts';
 export type { RepairHint } from './src/domain/api/ReceiptSupport.ts';
 export type { WriteReceiptOptions } from './src/domain/api/WriteReceipt.ts';

--- a/src/domain/api/AdmissionOutcome.ts
+++ b/src/domain/api/AdmissionOutcome.ts
@@ -1,0 +1,95 @@
+import type { EvidenceHandle } from './Evidence.ts';
+
+export type AdmissionObstructionFamily =
+  | 'capability-denied'
+  | 'unsupported-evidence'
+  | 'law-violation'
+  | 'stale-basis'
+  | 'budget-exceeded'
+  | 'invalid-derivation'
+  | 'unsupported-contract';
+
+export type AdmissionRetryDisposition = 'after-change' | 'with-evidence' | 'never' | 'unknown'; // nosemgrep: ts-no-unknown-outside-adapters -- semantic value
+
+export type AdmissionEvaluation = Readonly<{
+  sourceParticipant: string;
+  destinationRuntime: string;
+  sourceBasis: EvidenceHandle;
+  destinationBasis: EvidenceHandle;
+  proposal: EvidenceHandle;
+  law: EvidenceHandle;
+  profile: EvidenceHandle;
+  coordinate: EvidenceHandle;
+}>;
+
+export type DerivationWitness = Readonly<{
+  evaluation: AdmissionEvaluation;
+  admittedSuffix: EvidenceHandle;
+  resultingFrontier: EvidenceHandle;
+  authorityEvidence: EvidenceHandle;
+  directExtensionEvidence: EvidenceHandle;
+}>;
+
+export type PluralityWitness = Readonly<{
+  evaluation: AdmissionEvaluation;
+  localCoordinate: EvidenceHandle;
+  incomingCoordinate: EvidenceHandle;
+  retainedCoordinates: readonly EvidenceHandle[];
+  derivationEvidence: EvidenceHandle;
+  footprintComparison: EvidenceHandle;
+  concurrencyEvidence: EvidenceHandle;
+  nonInterferenceEvidence: EvidenceHandle;
+}>;
+
+export type ConflictWitness = Readonly<{
+  evaluation: AdmissionEvaluation;
+  conflict: EvidenceHandle;
+  claims: readonly EvidenceHandle[];
+  overlappingFootprints: readonly EvidenceHandle[];
+  contestedDomain: string;
+  derivationEvidence: EvidenceHandle;
+  overlapEvidence: EvidenceHandle;
+  resolutionProcedures: readonly EvidenceHandle[];
+}>;
+
+export type ObstructionWitness = Readonly<{
+  evaluation: AdmissionEvaluation;
+  reason: Readonly<{
+    family: AdmissionObstructionFamily;
+    code: string;
+  }>;
+  suppliedEvidence: readonly EvidenceHandle[];
+  requiredEvidence: readonly EvidenceHandle[];
+  failedCondition: EvidenceHandle;
+  retry: Readonly<{ disposition: AdmissionRetryDisposition }>;
+}>;
+
+export type DerivedAdmission = Readonly<{
+  kind: 'derived';
+  witness: DerivationWitness;
+  residual: Readonly<{ kind: 'advanced'; frontier: EvidenceHandle }>;
+}>;
+
+export type PluralAdmission = Readonly<{
+  kind: 'plural';
+  witness: PluralityWitness;
+  residual: Readonly<{ kind: 'plural'; coordinates: readonly EvidenceHandle[] }>;
+}>;
+
+export type ConflictAdmission = Readonly<{
+  kind: 'conflict';
+  witness: ConflictWitness;
+  residual: Readonly<{ kind: 'unsettled-conflict'; conflict: EvidenceHandle }>;
+}>;
+
+export type ObstructedAdmission = Readonly<{
+  kind: 'obstruction';
+  witness: ObstructionWitness;
+  residual: Readonly<{ kind: 'unchanged'; frontier: EvidenceHandle }>;
+}>;
+
+export type AdmissionOutcome =
+  | DerivedAdmission
+  | PluralAdmission
+  | ConflictAdmission
+  | ObstructedAdmission;

--- a/src/domain/api/AdmissionOutcomeRuntime.ts
+++ b/src/domain/api/AdmissionOutcomeRuntime.ts
@@ -1,0 +1,178 @@
+import type DomainAdmissionEvaluation from '../admission/AdmissionEvaluation.ts';
+import type { AdmissionOutcome as DomainAdmissionOutcome } from '../admission/AdmissionOutcome.ts';
+import type ConflictAdmission from '../admission/ConflictAdmission.ts';
+import type DerivedAdmission from '../admission/DerivedAdmission.ts';
+import matchAdmission from '../admission/matchAdmission.ts';
+import type ObstructedAdmission from '../admission/ObstructedAdmission.ts';
+import type PluralAdmission from '../admission/PluralAdmission.ts';
+import WarpError from '../errors/WarpError.ts';
+import type {
+  AdmissionEvaluation,
+  AdmissionOutcome,
+  ConflictAdmission as PublicConflictAdmission,
+  DerivedAdmission as PublicDerivedAdmission,
+  ObstructedAdmission as PublicObstructedAdmission,
+  PluralAdmission as PublicPluralAdmission,
+} from './AdmissionOutcome.ts';
+import type { EvidenceHandle } from './Evidence.ts';
+
+const ISSUED_OUTCOMES = new WeakSet<object>();
+
+type ProjectionSession = {
+  readonly basis: EvidenceHandle;
+  readonly handles: Map<string, EvidenceHandle>;
+};
+
+export function projectAdmissionOutcome(
+  outcome: DomainAdmissionOutcome,
+  basis: EvidenceHandle
+): AdmissionOutcome {
+  const session = createProjectionSession(basis);
+  const projected = matchAdmission<AdmissionOutcome>(outcome, {
+    derived: (value) => projectDerivedAdmission(session, value),
+    plural: (value) => projectPluralAdmission(session, value),
+    conflict: (value) => projectConflictAdmission(session, value),
+    obstruction: (value) => projectObstructedAdmission(session, value),
+  });
+  ISSUED_OUTCOMES.add(projected);
+  return projected;
+}
+
+export function requireAdmissionOutcome(outcome: AdmissionOutcome): void {
+  if (typeof outcome !== 'object' || outcome === null || !ISSUED_OUTCOMES.has(outcome)) {
+    throw new WarpError('outcome must be an AdmissionOutcome', 'E_VALIDATION');
+  }
+}
+
+function createProjectionSession(basis: EvidenceHandle): ProjectionSession {
+  if (
+    typeof basis !== 'object' ||
+    basis === null ||
+    typeof basis.id !== 'string' ||
+    basis.id.length === 0
+  ) {
+    throw new WarpError('projection basis must be an evidence handle', 'E_VALIDATION');
+  }
+  return { basis, handles: new Map() };
+}
+
+function projectDerivedAdmission(
+  session: ProjectionSession,
+  outcome: DerivedAdmission
+): PublicDerivedAdmission {
+  const { witness } = outcome;
+  const evaluation = projectEvaluation(session, witness.evaluation);
+  const admittedSuffix = handle(session, witness.admittedSuffixRef);
+  const resultingFrontier = handle(session, witness.resultingFrontierRef);
+  const authorityEvidence = handle(session, witness.authorityEvidenceRef);
+  const directExtensionEvidence = handle(session, witness.directExtensionEvidenceRef);
+  return Object.freeze({
+    kind: outcome.kind,
+    witness: Object.freeze({
+      evaluation,
+      admittedSuffix,
+      resultingFrontier,
+      authorityEvidence,
+      directExtensionEvidence,
+    }),
+    residual: Object.freeze({ kind: outcome.residual.kind, frontier: resultingFrontier }),
+  });
+}
+
+function projectPluralAdmission(
+  session: ProjectionSession,
+  outcome: PluralAdmission
+): PublicPluralAdmission {
+  const { witness } = outcome;
+  const retainedCoordinates = handles(session, witness.retainedCoordinateRefs);
+  return Object.freeze({
+    kind: outcome.kind,
+    witness: Object.freeze({
+      evaluation: projectEvaluation(session, witness.evaluation),
+      localCoordinate: handle(session, witness.localCoordinateRef),
+      incomingCoordinate: handle(session, witness.incomingCoordinateRef),
+      retainedCoordinates,
+      derivationEvidence: handle(session, witness.derivationEvidenceRef),
+      footprintComparison: handle(session, witness.footprintComparisonRef),
+      concurrencyEvidence: handle(session, witness.concurrencyEvidenceRef),
+      nonInterferenceEvidence: handle(session, witness.nonInterferenceEvidenceRef),
+    }),
+    residual: Object.freeze({ kind: outcome.residual.kind, coordinates: retainedCoordinates }),
+  });
+}
+
+function projectConflictAdmission(
+  session: ProjectionSession,
+  outcome: ConflictAdmission
+): PublicConflictAdmission {
+  const { witness } = outcome;
+  const conflict = handle(session, witness.conflictRef);
+  return Object.freeze({
+    kind: outcome.kind,
+    witness: Object.freeze({
+      evaluation: projectEvaluation(session, witness.evaluation),
+      conflict,
+      claims: handles(session, witness.claimRefs),
+      overlappingFootprints: handles(session, witness.overlappingFootprintRefs),
+      contestedDomain: witness.contestedDomain,
+      derivationEvidence: handle(session, witness.derivationEvidenceRef),
+      overlapEvidence: handle(session, witness.overlapEvidenceRef),
+      resolutionProcedures: handles(session, witness.resolutionProcedureRefs),
+    }),
+    residual: Object.freeze({ kind: outcome.residual.kind, conflict }),
+  });
+}
+
+function projectObstructedAdmission(
+  session: ProjectionSession,
+  outcome: ObstructedAdmission
+): PublicObstructedAdmission {
+  const { witness } = outcome;
+  return Object.freeze({
+    kind: outcome.kind,
+    witness: Object.freeze({
+      evaluation: projectEvaluation(session, witness.evaluation),
+      reason: Object.freeze({ ...witness.reason }),
+      suppliedEvidence: handles(session, witness.suppliedEvidenceRefs),
+      requiredEvidence: handles(session, witness.requiredEvidenceRefs),
+      failedCondition: handle(session, witness.failedConditionRef),
+      retry: Object.freeze({ disposition: witness.retry.value }),
+    }),
+    residual: Object.freeze({
+      kind: outcome.residual.kind,
+      frontier: handle(session, outcome.residual.frontierRef),
+    }),
+  });
+}
+
+function projectEvaluation(
+  session: ProjectionSession,
+  evaluation: DomainAdmissionEvaluation
+): AdmissionEvaluation {
+  return Object.freeze({
+    sourceParticipant: evaluation.sourceParticipantId,
+    destinationRuntime: evaluation.destinationRuntimeId,
+    sourceBasis: handle(session, evaluation.sourceBasisRef),
+    destinationBasis: handle(session, evaluation.destinationBasisRef),
+    proposal: handle(session, evaluation.proposalDigest),
+    law: handle(session, evaluation.lawDigest),
+    profile: handle(session, evaluation.profileDigest),
+    coordinate: handle(session, evaluation.evaluationCoordinateRef),
+  });
+}
+
+function handles(session: ProjectionSession, values: readonly string[]): readonly EvidenceHandle[] {
+  return Object.freeze(values.map((value) => handle(session, value)));
+}
+
+function handle(session: ProjectionSession, reference: string): EvidenceHandle {
+  const existing = session.handles.get(reference);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const projected = Object.freeze({
+    id: `${session.basis.id}/admission/${session.handles.size}`,
+  });
+  session.handles.set(reference, projected);
+  return projected;
+}

--- a/src/domain/api/AdmissionOutcomeRuntime.ts
+++ b/src/domain/api/AdmissionOutcomeRuntime.ts
@@ -49,7 +49,7 @@ function createProjectionSession(basis: EvidenceHandle): ProjectionSession {
     typeof basis !== 'object' ||
     basis === null ||
     typeof basis.id !== 'string' ||
-    basis.id.length === 0
+    basis.id.trim().length === 0
   ) {
     throw new WarpError('projection basis must be an evidence handle', 'E_VALIDATION');
   }

--- a/src/domain/api/ApiRuntimeContext.ts
+++ b/src/domain/api/ApiRuntimeContext.ts
@@ -19,7 +19,7 @@ export type OpaqueIdPart = string | number;
 
 export type ApiRuntimeContext = {
   readonly createOpaqueId: (
-    namespace: 'tick' | 'evidence',
+    namespace: 'tick' | 'evidence' | 'admission',
     parts: readonly OpaqueIdPart[]
   ) => Promise<string>;
   readonly reserveRecoveryNonce: () => string;

--- a/src/domain/api/DraftTimelineRuntime.ts
+++ b/src/domain/api/DraftTimelineRuntime.ts
@@ -243,11 +243,11 @@ async function writeDraftIntent(fields: DraftWriteFields): Promise<WriteReceipt>
       return publication;
     },
   });
-  if (receipt.outcome !== 'accepted') {
+  if (receipt.outcome.kind !== 'derived') {
     return receipt;
   }
   if (draftPatchSha === undefined) {
-    throw new WarpError('Accepted draft write is missing its patch SHA', 'E_DRAFT_WRITE_RECEIPT');
+    throw new WarpError('Derived draft write is missing its patch SHA', 'E_DRAFT_WRITE_RECEIPT');
   }
   fields.state.draftPatchShas.push(draftPatchSha);
   fields.state.intents.push(fields.intent);

--- a/src/domain/api/DraftTimelineRuntime.ts
+++ b/src/domain/api/DraftTimelineRuntime.ts
@@ -243,11 +243,11 @@ async function writeDraftIntent(fields: DraftWriteFields): Promise<WriteReceipt>
       return publication;
     },
   });
-  if (receipt.outcome.kind !== 'derived') {
+  if (receipt.outcome.kind === 'conflict' || receipt.outcome.kind === 'obstruction') {
     return receipt;
   }
   if (draftPatchSha === undefined) {
-    throw new WarpError('Derived draft write is missing its patch SHA', 'E_DRAFT_WRITE_RECEIPT');
+    throw new WarpError('Admitted draft write is missing its patch SHA', 'E_DRAFT_WRITE_RECEIPT');
   }
   fields.state.draftPatchShas.push(draftPatchSha);
   fields.state.intents.push(fields.intent);

--- a/src/domain/api/JoinReceipt.ts
+++ b/src/domain/api/JoinReceipt.ts
@@ -3,10 +3,13 @@ import { requireNonEmptyString } from '../utils/scalarValidation.ts';
 import DraftTimeline from './DraftTimeline.ts';
 import type Evidence from './Evidence.ts';
 import { freezeOptionalEvidence } from './EvidenceRuntime.ts';
-import { RECEIPT_OUTCOMES, type JoinOutcome } from './ReceiptOutcome.ts';
+import {
+  READ_JOIN_RECEIPT_OUTCOMES,
+  type ReadJoinReceiptOutcome,
+} from './ReceiptOutcome.ts';
 
 export type JoinMode = 'preview' | 'join';
-export type JoinReceiptOutcome = JoinOutcome;
+export type JoinReceiptOutcome = ReadJoinReceiptOutcome;
 
 type JoinReceiptFields = {
   readonly timeline: string;
@@ -30,7 +33,7 @@ export type JoinReceiptOptions = JoinReceiptFields &
   );
 
 const JOIN_MODES: ReadonlySet<JoinMode> = new Set(['preview', 'join']);
-const JOIN_RECEIPT_OUTCOMES: ReadonlySet<JoinReceiptOutcome> = RECEIPT_OUTCOMES;
+const JOIN_RECEIPT_OUTCOMES: ReadonlySet<JoinReceiptOutcome> = READ_JOIN_RECEIPT_OUTCOMES;
 
 export default class JoinReceipt {
   readonly draft: DraftTimeline;

--- a/src/domain/api/ReadReceipt.ts
+++ b/src/domain/api/ReadReceipt.ts
@@ -3,10 +3,13 @@ import { requireNonEmptyString } from '../utils/scalarValidation.ts';
 import type Evidence from './Evidence.ts';
 import { freezeOptionalEvidence } from './EvidenceRuntime.ts';
 import Reading from './Reading.ts';
-import { RECEIPT_OUTCOMES, type ReadOutcome } from './ReceiptOutcome.ts';
+import {
+  READ_JOIN_RECEIPT_OUTCOMES,
+  type ReadJoinReceiptOutcome,
+} from './ReceiptOutcome.ts';
 import { freezeRepairHints, type RepairHint } from './ReceiptSupport.ts';
 
-export type ReadReceiptOutcome = ReadOutcome;
+export type ReadReceiptOutcome = ReadJoinReceiptOutcome;
 
 type ReadReceiptFields = {
   readonly timeline: string;
@@ -29,7 +32,7 @@ export type ReadReceiptOptions = ReadReceiptFields &
       }
   );
 
-const READ_RECEIPT_OUTCOMES: ReadonlySet<ReadReceiptOutcome> = RECEIPT_OUTCOMES;
+const READ_RECEIPT_OUTCOMES: ReadonlySet<ReadReceiptOutcome> = READ_JOIN_RECEIPT_OUTCOMES;
 
 export default class ReadReceipt {
   readonly evidence: Evidence | undefined;

--- a/src/domain/api/ReceiptOutcome.ts
+++ b/src/domain/api/ReceiptOutcome.ts
@@ -1,15 +1,11 @@
-export type ReceiptOutcome =
+export type ReadJoinReceiptOutcome =
   | 'accepted'
   | 'obstructed'
   | 'conflicted'
   | 'underdetermined'
   | 'rejected';
 
-export type WriteOutcome = ReceiptOutcome;
-export type ReadOutcome = ReceiptOutcome;
-export type JoinOutcome = ReceiptOutcome;
-
-export const RECEIPT_OUTCOMES: ReadonlySet<ReceiptOutcome> = new Set([
+export const READ_JOIN_RECEIPT_OUTCOMES: ReadonlySet<ReadJoinReceiptOutcome> = new Set([
   'accepted',
   'obstructed',
   'conflicted',

--- a/src/domain/api/WriteAdmissionRuntime.ts
+++ b/src/domain/api/WriteAdmissionRuntime.ts
@@ -1,0 +1,211 @@
+import AdmissionClassifier from '../admission/AdmissionClassifier.ts';
+import AdmissionEvaluation from '../admission/AdmissionEvaluation.ts';
+import type AdmissionObstructionReason from '../admission/AdmissionObstructionReason.ts';
+import type AdmissionRetryDisposition from '../admission/AdmissionRetryDisposition.ts';
+import DerivationWitness from '../admission/DerivationWitness.ts';
+import type DerivedAdmission from '../admission/DerivedAdmission.ts';
+import type ObstructedAdmission from '../admission/ObstructedAdmission.ts';
+import ObstructionWitness from '../admission/ObstructionWitness.ts';
+import type WarpWorldline from '../WarpWorldline.ts';
+import WarpError from '../errors/WarpError.ts';
+import type { PatchBuilderCausalBasis } from '../services/admission/PatchBuilderCausalBasis.ts';
+import { missingBoundedBasisCoordinateRef } from '../services/admission/GraphCoordinateRef.ts';
+import type { PatchCommitResult } from '../types/PatchCommitResult.ts';
+import { canonicalStringify } from '../utils/canonicalStringify.ts';
+import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
+import type Evidence from './Evidence.ts';
+import type Intent from './Intent.ts';
+
+const classifier = new AdmissionClassifier();
+const GRAPH_INTENT_ADMISSION_LAW = 'git-warp:admission-law/graph-intent/v1';
+const TIMELINE_WRITE_ADMISSION_PROFILE = 'git-warp:admission-profile/timeline-write/v1';
+
+type WriteAdmissionFields = {
+  readonly runtime: WarpWorldline;
+  readonly context: ApiRuntimeContext;
+  readonly intent: Intent;
+  readonly basis: PatchBuilderCausalBasis;
+};
+
+type PreparedWriteAdmissionFields = WriteAdmissionFields & {
+  readonly evaluation: AdmissionEvaluation;
+};
+
+type ObstructedWriteAdmissionFields = PreparedWriteAdmissionFields & {
+  readonly obstruction: WriteObstruction;
+  readonly recoveryEvidence: Evidence;
+};
+
+export type WriteObstruction = Readonly<{
+  reason: AdmissionObstructionReason;
+  retry: AdmissionRetryDisposition;
+  condition: string;
+  requiredEvidence: string;
+  destinationHeadSha?: string | null;
+}>;
+
+export function createDerivedWriteAdmission(
+  fields: PreparedWriteAdmissionFields & { readonly publication: PatchCommitResult }
+): DerivedAdmission {
+  assertPublishedWriter(fields);
+  assertEvaluationMatchesBasis(fields);
+  const publicationRef = patchPublicationRef(fields.basis, fields.publication.sha);
+  return classifier.classify(
+    new DerivationWitness({
+      evaluation: fields.evaluation,
+      admittedSuffixRef: publicationRef,
+      resultingFrontierRef: patchJournalFrontierRef(fields.basis, fields.publication.sha),
+      authorityEvidenceRef: runtimeWriterBindingRef(fields.runtime.writerId),
+      directExtensionEvidenceRef: publicationRef,
+    })
+  );
+}
+
+export async function createObstructedWriteAdmission(
+  fields: ObstructedWriteAdmissionFields
+): Promise<ObstructedAdmission> {
+  const evaluation = evaluationAtDestination(fields);
+  const failedConditionRef = await fields.context.createOpaqueId('admission', [
+    'failed-condition',
+    fields.obstruction.condition,
+    canonicalStringify(fields.intent.descriptor),
+  ]);
+  const requiredEvidenceRef = await fields.context.createOpaqueId('admission', [
+    'required-evidence',
+    fields.obstruction.requiredEvidence,
+    fields.runtime.worldlineName,
+  ]);
+  const suppliedEvidenceRefs = [
+    evaluation.evaluationCoordinateRef,
+    fields.recoveryEvidence.basis.id,
+    ...fields.recoveryEvidence.support.map(({ id }) => id),
+  ];
+  return classifier.classify(
+    new ObstructionWitness({
+      evaluation,
+      reason: fields.obstruction.reason,
+      suppliedEvidenceRefs: [...new Set(suppliedEvidenceRefs)],
+      requiredEvidenceRefs: [requiredEvidenceRef],
+      failedConditionRef,
+      retry: fields.obstruction.retry,
+    })
+  );
+}
+
+export async function prepareWriteAdmission(
+  fields: WriteAdmissionFields
+): Promise<AdmissionEvaluation> {
+  assertBasisIdentity(fields);
+  const sourceBasisRef = patchJournalFrontierRef(fields.basis, fields.basis.expectedParentSha);
+  const [proposalDigest, lawDigest, profileDigest] = await Promise.all([
+    fields.context.createOpaqueId('admission', [
+      'proposal',
+      canonicalStringify(fields.intent.descriptor),
+    ]),
+    fields.context.createOpaqueId('admission', [
+      'law',
+      GRAPH_INTENT_ADMISSION_LAW,
+      fields.intent.kind,
+    ]),
+    fields.context.createOpaqueId('admission', ['profile', TIMELINE_WRITE_ADMISSION_PROFILE]),
+  ]);
+  return new AdmissionEvaluation({
+    sourceParticipantId: fields.runtime.writerId,
+    destinationRuntimeId: timelineRuntimeRef(fields.basis),
+    sourceBasisRef,
+    destinationBasisRef: sourceBasisRef,
+    proposalDigest,
+    lawDigest,
+    profileDigest,
+    evaluationCoordinateRef: resolveEvaluationCoordinateRef(fields, sourceBasisRef),
+  });
+}
+
+function resolveEvaluationCoordinateRef(
+  fields: WriteAdmissionFields,
+  sourceBasisRef: string
+): string {
+  if (fields.basis.evaluationCoordinateRef !== null) {
+    return fields.basis.evaluationCoordinateRef;
+  }
+  if (fields.intent.kind === 'node.add' || fields.intent.kind === 'edge.add') {
+    return sourceBasisRef;
+  }
+  return missingBoundedBasisCoordinateRef(fields.runtime.worldlineName);
+}
+
+function evaluationAtDestination(fields: ObstructedWriteAdmissionFields): AdmissionEvaluation {
+  const { destinationHeadSha } = fields.obstruction;
+  if (destinationHeadSha === undefined) {
+    return fields.evaluation;
+  }
+  return new AdmissionEvaluation({
+    ...fields.evaluation,
+    destinationBasisRef: patchJournalFrontierRef(fields.basis, destinationHeadSha),
+  });
+}
+
+function assertEvaluationMatchesBasis(fields: PreparedWriteAdmissionFields): void {
+  const basisRef = patchJournalFrontierRef(fields.basis, fields.basis.expectedParentSha);
+  if (
+    fields.evaluation.destinationRuntimeId !== timelineRuntimeRef(fields.basis) ||
+    fields.evaluation.sourceBasisRef !== basisRef ||
+    fields.evaluation.destinationBasisRef !== basisRef
+  ) {
+    throw new WarpError(
+      'Prepared write admission does not match its publication basis',
+      'E_WRITE_ADMISSION_BASIS'
+    );
+  }
+}
+
+function assertPublishedWriter(
+  fields: WriteAdmissionFields & { readonly publication: PatchCommitResult }
+): void {
+  if (fields.publication.patch.writer !== fields.basis.writerId) {
+    throw new WarpError(
+      'Published patch writer does not match its captured admission basis',
+      'E_WRITE_ADMISSION_PUBLICATION'
+    );
+  }
+}
+
+function assertBasisIdentity(fields: WriteAdmissionFields): void {
+  if (
+    fields.basis.graphName !== fields.runtime.worldlineName ||
+    fields.basis.participantId !== fields.runtime.writerId
+  ) {
+    throw new WarpError(
+      'Write admission basis does not belong to the target timeline writer',
+      'E_WRITE_ADMISSION_BASIS'
+    );
+  }
+}
+
+function patchJournalRuntimeRef(basis: PatchBuilderCausalBasis): string {
+  return `warp:patch-journal/${patchJournalIdentityPath(basis)}`;
+}
+
+function timelineRuntimeRef(basis: PatchBuilderCausalBasis): string {
+  return `warp:timeline-runtime/${[basis.graphName, basis.participantId]
+    .map((value) => encodeURIComponent(value))
+    .join('/')}`;
+}
+
+function patchJournalFrontierRef(basis: PatchBuilderCausalBasis, commitId: string | null): string {
+  return `${patchJournalRuntimeRef(basis)}/frontier/${
+    commitId === null ? 'empty' : encodeURIComponent(commitId)
+  }`;
+}
+
+function patchPublicationRef(basis: PatchBuilderCausalBasis, commitId: string): string {
+  return `${patchJournalRuntimeRef(basis)}/publication/${encodeURIComponent(commitId)}`;
+}
+
+function patchJournalIdentityPath(basis: PatchBuilderCausalBasis): string {
+  return [basis.graphName, basis.writerId].map((value) => encodeURIComponent(value)).join('/');
+}
+
+function runtimeWriterBindingRef(writerId: string): string {
+  return `warp:runtime-writer-binding/${encodeURIComponent(writerId)}`;
+}

--- a/src/domain/api/WriteAdmissionRuntime.ts
+++ b/src/domain/api/WriteAdmissionRuntime.ts
@@ -15,10 +15,12 @@ import { canonicalStringify } from '../utils/canonicalStringify.ts';
 import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
 import type Evidence from './Evidence.ts';
 import type Intent from './Intent.ts';
+import type { IntentKind } from './Intent.ts';
 
 const classifier = new AdmissionClassifier();
 const GRAPH_INTENT_ADMISSION_LAW = 'git-warp:admission-law/graph-intent/v1';
 const TIMELINE_WRITE_ADMISSION_PROFILE = 'git-warp:admission-profile/timeline-write/v1';
+const BASIS_INDEPENDENT_INTENT_KINDS: ReadonlySet<IntentKind> = new Set(['node.add', 'edge.add']);
 
 type WriteAdmissionFields = {
   readonly runtime: WarpWorldline;
@@ -128,7 +130,7 @@ function resolveEvaluationCoordinateRef(
   if (fields.basis.evaluationCoordinateRef !== null) {
     return fields.basis.evaluationCoordinateRef;
   }
-  if (fields.intent.kind === 'node.add' || fields.intent.kind === 'edge.add') {
+  if (BASIS_INDEPENDENT_INTENT_KINDS.has(fields.intent.kind)) {
     return sourceBasisRef;
   }
   return missingBoundedBasisCoordinateRef(fields.runtime.worldlineName);

--- a/src/domain/api/WriteReceipt.ts
+++ b/src/domain/api/WriteReceipt.ts
@@ -1,37 +1,28 @@
 import WarpError from '../errors/WarpError.ts';
 import { requireNonEmptyString } from '../utils/scalarValidation.ts';
+import type { AdmissionOutcome } from './AdmissionOutcome.ts';
+import { requireAdmissionOutcome } from './AdmissionOutcomeRuntime.ts';
 import type Evidence from './Evidence.ts';
-import { freezeOptionalEvidence } from './EvidenceRuntime.ts';
+import { freezeEvidence } from './EvidenceRuntime.ts';
 import Intent from './Intent.ts';
-import { RECEIPT_OUTCOMES, type WriteOutcome } from './ReceiptOutcome.ts';
 import { freezeRepairHints, type RepairHint } from './ReceiptSupport.ts';
 
 type WriteReceiptFields = {
   readonly timeline: string;
   readonly writer: string;
   readonly intent: Intent;
+  readonly outcome: AdmissionOutcome;
+  readonly evidence: Evidence;
   readonly repairHints?: readonly RepairHint[];
 };
 
-export type WriteReceiptOptions = WriteReceiptFields &
-  (
-    | {
-        readonly outcome: 'accepted';
-        readonly evidence: Evidence;
-        readonly reason?: never;
-      }
-    | {
-        readonly outcome: Exclude<WriteOutcome, 'accepted'>;
-        readonly evidence?: never;
-        readonly reason: string;
-      }
-  );
+export type WriteReceiptOptions = WriteReceiptFields;
 
 export default class WriteReceipt {
-  readonly evidence: Evidence | undefined;
+  readonly evidence: Evidence;
   readonly intent: Intent;
   readonly operation: 'write' = 'write';
-  readonly outcome: WriteOutcome;
+  readonly outcome: AdmissionOutcome;
   readonly repairHints: readonly RepairHint[];
   readonly reason: string | undefined;
   readonly timeline: string;
@@ -45,9 +36,10 @@ export default class WriteReceipt {
     this.writer = fields.writer;
     this.intent = fields.intent;
     this.outcome = fields.outcome;
-    this.evidence = freezeOptionalEvidence(fields.evidence, 'writeReceipt.evidence');
+    this.evidence = freezeEvidence(fields.evidence, 'writeReceipt.evidence');
     this.repairHints = freezeRepairHints(fields.repairHints ?? []);
-    this.reason = fields.reason;
+    this.reason =
+      fields.outcome.kind === 'obstruction' ? fields.outcome.witness.reason.code : undefined;
     Object.freeze(this);
   }
 }
@@ -57,7 +49,6 @@ function validateWriteReceiptFields(fields: WriteReceiptOptions): void {
   requireNonEmptyString(fields.writer, 'writeReceipt.writer');
   validateIntent(fields.intent);
   validateWriteOutcome(fields.outcome);
-  validateWriteSettlement(fields);
 }
 
 function validateIntent(intent: Intent): void {
@@ -66,29 +57,8 @@ function validateIntent(intent: Intent): void {
   }
 }
 
-function validateWriteOutcome(outcome: WriteOutcome): void {
-  if (!RECEIPT_OUTCOMES.has(outcome)) {
-    throw new WarpError('WriteReceipt outcome is unsupported', 'E_WRITE_RECEIPT_OUTCOME');
-  }
-}
-
-function validateWriteSettlement(fields: WriteReceiptOptions): void {
-  if (fields.outcome === 'accepted') {
-    if (fields.evidence === undefined) {
-      throw new WarpError('Accepted WriteReceipt requires evidence', 'E_WRITE_RECEIPT_EVIDENCE');
-    }
-    if (fields.reason !== undefined) {
-      throw new WarpError('Accepted WriteReceipt cannot carry a reason', 'E_WRITE_RECEIPT_REASON');
-    }
-    return;
-  }
-  requireNonEmptyString(fields.reason, 'writeReceipt.reason');
-  if (fields.evidence !== undefined) {
-    throw new WarpError(
-      'Unaccepted WriteReceipt cannot carry evidence',
-      'E_WRITE_RECEIPT_EVIDENCE'
-    );
-  }
+function validateWriteOutcome(outcome: AdmissionOutcome): void {
+  requireAdmissionOutcome(outcome);
 }
 
 function requireWriteReceiptOptions(

--- a/src/domain/api/WriteRuntime.ts
+++ b/src/domain/api/WriteRuntime.ts
@@ -33,7 +33,7 @@ type IntentWriteFields = {
   readonly commit: IntentCommit;
 };
 
-type AcceptedWriteFields = Omit<IntentWriteFields, 'commit'> & {
+type PublishedWriteFields = Omit<IntentWriteFields, 'commit'> & {
   readonly publication: PatchCommitResult;
   readonly recoveryEvidence: Evidence;
 };
@@ -160,7 +160,7 @@ function missingPublishedBasisError(): WarpError {
 }
 
 async function derivedWriteReceipt(
-  fields: AcceptedWriteFields & {
+  fields: PublishedWriteFields & {
     readonly basis: PatchBuilderCausalBasis;
     readonly evaluation: AdmissionEvaluation;
   }
@@ -178,7 +178,7 @@ async function derivedWriteReceipt(
   return receipt;
 }
 
-async function committedWriteEvidence(fields: AcceptedWriteFields): Promise<Evidence> {
+async function committedWriteEvidence(fields: PublishedWriteFields): Promise<Evidence> {
   try {
     return await createWriteEvidence({
       runtime: fields.runtime,

--- a/src/domain/api/WriteRuntime.ts
+++ b/src/domain/api/WriteRuntime.ts
@@ -1,14 +1,28 @@
 import type { default as WarpWorldline, WarpWorldlinePatchBuild } from '../WarpWorldline.ts';
 import WarpError from '../errors/WarpError.ts';
+import WriterError from '../errors/WriterError.ts';
+import AdmissionObstructionReason from '../admission/AdmissionObstructionReason.ts';
+import AdmissionRetryDisposition from '../admission/AdmissionRetryDisposition.ts';
+import {
+  readPatchBuilderCausalBasis,
+  type PatchBuilderCausalBasis,
+} from '../services/admission/PatchBuilderCausalBasis.ts';
 import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
+import { projectAdmissionOutcome } from './AdmissionOutcomeRuntime.ts';
 import type Evidence from './Evidence.ts';
 import { createWriteEvidence, createWriteRecoveryEvidence } from './EvidenceRuntime.ts';
 import type Intent from './Intent.ts';
 import { applyIntentToPatch } from './IntentRuntime.ts';
-import type { WriteOutcome } from './ReceiptOutcome.ts';
 import type { RepairHint } from './ReceiptSupport.ts';
 import WriteReceipt from './WriteReceipt.ts';
 import type { PatchCommitResult } from '../types/PatchCommitResult.ts';
+import type AdmissionEvaluation from '../admission/AdmissionEvaluation.ts';
+import {
+  createDerivedWriteAdmission,
+  createObstructedWriteAdmission,
+  prepareWriteAdmission,
+  type WriteObstruction,
+} from './WriteAdmissionRuntime.ts';
 
 type IntentCommit = (build: WarpWorldlinePatchBuild) => Promise<PatchCommitResult>;
 
@@ -24,10 +38,27 @@ type AcceptedWriteFields = Omit<IntentWriteFields, 'commit'> & {
   readonly recoveryEvidence: Evidence;
 };
 
-type OperationalWriteFailure = {
-  readonly outcome: Exclude<WriteOutcome, 'accepted' | 'underdetermined'>;
-  readonly reason: string;
+type OperationalWriteFailure = WriteObstruction & {
   readonly repairHints: readonly RepairHint[];
+};
+
+type WriteAttempt = {
+  basis?: PatchBuilderCausalBasis;
+  evaluation?: AdmissionEvaluation;
+};
+
+type PreparedWriteAttempt = Required<WriteAttempt>;
+
+type FailedWriteFields = {
+  readonly write: IntentWriteFields;
+  readonly attempt: WriteAttempt;
+  readonly recoveryEvidence: Evidence;
+  readonly error: WarpError;
+};
+
+type ObstructionReceiptFields = Omit<FailedWriteFields, 'attempt' | 'error'> & {
+  readonly prepared: PreparedWriteAttempt;
+  readonly obstruction: OperationalWriteFailure;
 };
 
 const MATERIALIZE_HINT = Object.freeze([
@@ -37,41 +68,111 @@ const MATERIALIZE_HINT = Object.freeze([
   }),
 ]);
 export async function executeIntentWrite(fields: IntentWriteFields): Promise<WriteReceipt> {
-  const { runtime, context, intent, commit } = fields;
+  const { runtime, context, intent } = fields;
   const recoveryEvidence = await createWriteRecoveryEvidence(runtime, context);
+  const attempt: WriteAttempt = {};
   let publication: PatchCommitResult;
   try {
-    publication = await commit((patch) => {
-      applyIntentToPatch(intent, patch);
-    });
+    publication = await publishIntentWrite(fields, attempt);
   } catch (error) {
     if (!(error instanceof WarpError)) {
       throw error;
     }
-    const failure = operationalWriteFailure(error);
-    if (failure === null) {
-      throw error;
-    }
-    const receipt = new WriteReceipt({
-      timeline: runtime.worldlineName,
-      writer: runtime.writerId,
-      intent,
-      ...failure,
-    });
-    context.bindReceipt(receipt, { operation: 'write', patchSha: undefined });
-    return receipt;
+    return await obstructedWriteReceipt({ write: fields, attempt, recoveryEvidence, error });
   }
-  return await acceptedWriteReceipt({ runtime, context, intent, publication, recoveryEvidence });
+  const prepared = requirePreparedWriteAttempt(attempt, missingPublishedBasisError());
+  return await derivedWriteReceipt({
+    runtime,
+    context,
+    intent,
+    publication,
+    recoveryEvidence,
+    ...prepared,
+  });
 }
 
-async function acceptedWriteReceipt(fields: AcceptedWriteFields): Promise<WriteReceipt> {
+async function publishIntentWrite(
+  fields: IntentWriteFields,
+  attempt: WriteAttempt
+): Promise<PatchCommitResult> {
+  return await fields.commit(async (patch) => {
+    attempt.basis = readPatchBuilderCausalBasis(patch);
+    attempt.evaluation = await prepareWriteAdmission({ ...fields, basis: attempt.basis });
+    applyIntentToPatch(fields.intent, patch);
+  });
+}
+
+async function obstructedWriteReceipt(fields: FailedWriteFields): Promise<WriteReceipt> {
+  const { write, attempt, recoveryEvidence, error } = fields;
+  const failure = operationalWriteFailure(error);
+  if (failure === null) {
+    throw error;
+  }
+  const prepared = requirePreparedWriteAttempt(attempt, error);
+  const receipt = await createObstructionReceipt({
+    write,
+    prepared,
+    recoveryEvidence,
+    obstruction: failure,
+  });
+  write.context.bindReceipt(receipt, { operation: 'write', patchSha: undefined });
+  return receipt;
+}
+
+async function createObstructionReceipt(fields: ObstructionReceiptFields): Promise<WriteReceipt> {
+  const { write, prepared, recoveryEvidence, obstruction } = fields;
+  const { runtime, context, intent } = write;
+  return new WriteReceipt({
+    timeline: runtime.worldlineName,
+    writer: runtime.writerId,
+    intent,
+    outcome: projectAdmissionOutcome(
+      await createObstructedWriteAdmission({
+        runtime,
+        context,
+        intent,
+        recoveryEvidence,
+        obstruction,
+        ...prepared,
+      }),
+      recoveryEvidence.basis
+    ),
+    evidence: recoveryEvidence,
+    repairHints: obstruction.repairHints,
+  });
+}
+
+function requirePreparedWriteAttempt(
+  attempt: WriteAttempt,
+  error: WarpError
+): PreparedWriteAttempt {
+  if (attempt.basis === undefined) {
+    throw error;
+  }
+  if (attempt.evaluation === undefined) {
+    throw error;
+  }
+  return { basis: attempt.basis, evaluation: attempt.evaluation };
+}
+
+function missingPublishedBasisError(): WarpError {
+  return new WarpError('Published write is missing its admission basis', 'E_WRITE_ADMISSION_BASIS');
+}
+
+async function derivedWriteReceipt(
+  fields: AcceptedWriteFields & {
+    readonly basis: PatchBuilderCausalBasis;
+    readonly evaluation: AdmissionEvaluation;
+  }
+): Promise<WriteReceipt> {
   const { runtime, context, intent, publication } = fields;
+  const evidence = await committedWriteEvidence(fields);
   const receipt = new WriteReceipt({
     timeline: runtime.worldlineName,
     writer: runtime.writerId,
     intent,
-    outcome: 'accepted',
-    evidence: await committedWriteEvidence(fields),
+    outcome: projectAdmissionOutcome(createDerivedWriteAdmission(fields), evidence.basis),
+    evidence,
   });
   context.bindReceipt(receipt, { operation: 'write', patchSha: publication.sha });
   return receipt;
@@ -93,17 +194,60 @@ async function committedWriteEvidence(fields: AcceptedWriteFields): Promise<Evid
 
 function operationalWriteFailure(error: WarpError): OperationalWriteFailure | null {
   if (error.code === 'E_PATCH_NO_STATE') {
-    return {
-      outcome: 'obstructed',
-      reason: 'missing_write_basis',
-      repairHints: MATERIALIZE_HINT,
-    };
+    return missingWriteBasisFailure();
   }
   if (error.code === 'E_PATCH_DELETE_WITH_DATA') {
-    return { outcome: 'conflicted', reason: 'attached_data', repairHints: [] };
+    return attachedDataFailure();
   }
   if (error.code === 'E_PATCH_ENTITY_NOT_FOUND') {
-    return { outcome: 'rejected', reason: 'entity_not_found', repairHints: [] };
+    return missingEntityFailure();
   }
-  return null;
+  return writerCasFailure(error);
+}
+
+function missingWriteBasisFailure(): OperationalWriteFailure {
+  return {
+    reason: AdmissionObstructionReason.unsupportedEvidence('git-warp.write.missing-bounded-basis'),
+    retry: AdmissionRetryDisposition.afterChange(),
+    condition: 'missing-bounded-write-basis',
+    requiredEvidence: 'bounded-write-basis',
+    repairHints: MATERIALIZE_HINT,
+  };
+}
+
+function attachedDataFailure(): OperationalWriteFailure {
+  return {
+    reason: AdmissionObstructionReason.lawViolation('git-warp.write.delete-with-attached-data'),
+    retry: AdmissionRetryDisposition.afterChange(),
+    condition: 'delete-target-has-attached-data',
+    requiredEvidence: 'detached-write-target',
+    repairHints: [],
+  };
+}
+
+function missingEntityFailure(): OperationalWriteFailure {
+  return {
+    reason: AdmissionObstructionReason.lawViolation('git-warp.write.entity-not-found'),
+    retry: AdmissionRetryDisposition.afterChange(),
+    condition: 'write-target-does-not-exist',
+    requiredEvidence: 'existing-write-target',
+    repairHints: [],
+  };
+}
+
+function writerCasFailure(error: WarpError): OperationalWriteFailure | null {
+  if (!(error instanceof WriterError) || error.code !== 'WRITER_CAS_CONFLICT') {
+    return null;
+  }
+  if (error.actualSha === undefined) {
+    return null;
+  }
+  return {
+    reason: AdmissionObstructionReason.staleBasis('git-warp.write.writer-frontier-advanced'),
+    retry: AdmissionRetryDisposition.afterChange(),
+    condition: 'writer-frontier-advanced',
+    requiredEvidence: 'current-writer-basis',
+    destinationHeadSha: error.actualSha,
+    repairHints: MATERIALIZE_HINT,
+  };
 }

--- a/src/domain/services/PatchBuilder.ts
+++ b/src/domain/services/PatchBuilder.ts
@@ -37,6 +37,7 @@ import {
   type ContentInput,
   type ContentMetadataInput,
 } from './PatchBuilderContent.ts';
+import { capturePatchBuilderCausalBasis } from './admission/PatchBuilderCausalBasis.ts';
 import { requireCommitMessageCodec } from './codec/CommitMessageCodecRequirement.ts';
 import { commitPatch } from './PatchCommitter.ts';
 import type { PatchCommitResult } from '../types/PatchCommitResult.ts';
@@ -57,6 +58,8 @@ type PatchBuilderOptions = {
   lamport: number;
   versionVector: VersionVector;
   getCurrentState: () => WarpState | null;
+  evaluationCoordinateRef?: string;
+  admissionParticipantId?: string;
   expectedParentSha?: string | null;
   targetRefPath?: string;
   onCommitSuccess?: ((result: PatchCommitResult) => void | Promise<void>) | null;
@@ -109,6 +112,16 @@ export class PatchBuilder {
     this._commitMessageCodec = options.commitMessageCodec ?? null;
     this._logger = options.logger ?? nullLogger;
     this._assetStorage = options.assetStorage ?? null;
+    capturePatchBuilderCausalBasis(
+      this,
+      {
+        graphName: options.graphName,
+        writerId: options.writerId,
+        participantId: options.admissionParticipantId ?? options.writerId,
+        expectedParentSha: this._expectedParentSha,
+        evaluationCoordinateRef: options.evaluationCoordinateRef ?? null,
+      }
+    );
   }
 
   // ── State access ───────────────────────────────────────────────────

--- a/src/domain/services/admission/BoundedIntentGuardReader.ts
+++ b/src/domain/services/admission/BoundedIntentGuardReader.ts
@@ -4,9 +4,12 @@ import type ReadIdentity from '../optic/ReadIdentity.ts';
 import type { PrecommitGuard } from '../../types/WarpIntentDescriptor.ts';
 import type { PropValue } from '../../types/PropValue.ts';
 import { canonicalStringify } from '../../utils/canonicalStringify.ts';
-import { compareStrings } from '../../utils/StringComparison.ts';
 import type { WorldlineOptions } from '../../capabilities/QueryCapability.ts';
 import WarpError from '../../errors/WarpError.ts';
+import {
+  graphFrontierCoordinateRef,
+  missingCheckpointCoordinateRef,
+} from './GraphCoordinateRef.ts';
 
 export type BoundedIntentGuardReading = Readonly<{
   value: PropValue | undefined;
@@ -54,35 +57,16 @@ export async function captureBoundedIntentGuardReader(
   if (checkpointSha === null) {
     return new BoundedIntentGuardReader(
       source.worldline(),
-      missingBoundedBasisCoordinateRef(source._graphName),
+      missingCheckpointCoordinateRef(source._graphName),
     );
   }
   const frontier = await source.getFrontier();
-  return new BoundedIntentGuardReader(source.worldline({
-    source: { kind: 'coordinate', checkpointSha, frontier },
-  }), checkpointTailCoordinateRef(source._graphName, checkpointSha, frontier));
-}
-
-function checkpointTailCoordinateRef(
-  worldline: string,
-  checkpointSha: string,
-  frontier: ReadonlyMap<string, string>,
-): string {
-  const frontierEntries = [...frontier]
-    .sort(([left], [right]) => compareStrings(left, right))
-    .map(([writerId, patchSha]) => ({ writerId, patchSha }));
-  return `warp:graph-coordinate:${canonicalStringify({
-    worldline,
-    checkpointSha,
-    frontier: frontierEntries,
-  })}`;
-}
-
-function missingBoundedBasisCoordinateRef(worldline: string): string {
-  return `warp:graph-coordinate:${canonicalStringify({
-    worldline,
-    basis: 'missing-checkpoint',
-  })}`;
+  return new BoundedIntentGuardReader(
+    source.worldline({
+      source: { kind: 'coordinate', checkpointSha, frontier },
+    }),
+    graphFrontierCoordinateRef(source._graphName, frontier, checkpointSha),
+  );
 }
 
 function guardPropertyKey(guard: PrecommitGuard): string {

--- a/src/domain/services/admission/GraphCoordinateRef.ts
+++ b/src/domain/services/admission/GraphCoordinateRef.ts
@@ -1,0 +1,48 @@
+import { canonicalStringify } from '../../utils/canonicalStringify.ts';
+import { compareStrings } from '../../utils/StringComparison.ts';
+
+/** Stable causal coordinate for one materialized graph frontier. */
+export function graphFrontierCoordinateRef(
+  worldline: string,
+  frontier: ReadonlyMap<string, string>,
+  checkpointSha?: string
+): string {
+  const frontierEntries = [...frontier]
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([writerId, patchSha]) => ({ writerId, patchSha }));
+  const coordinate =
+    checkpointSha === undefined
+      ? { worldline, frontier: frontierEntries }
+      : { worldline, checkpointSha, frontier: frontierEntries };
+  return `warp:graph-coordinate:${canonicalStringify(coordinate)}`;
+}
+
+/** Explicitly records that no bounded graph basis was available. */
+export function missingBoundedBasisCoordinateRef(worldline: string): string {
+  return missingBasisCoordinateRef(worldline, 'missing-bounded-basis');
+}
+
+/** Preserves the established guard-read coordinate when no checkpoint exists. */
+export function missingCheckpointCoordinateRef(worldline: string): string {
+  return missingBasisCoordinateRef(worldline, 'missing-checkpoint');
+}
+
+function missingBasisCoordinateRef(worldline: string, basis: string): string {
+  return `warp:graph-coordinate:${canonicalStringify({
+    worldline,
+    basis,
+  })}`;
+}
+
+/** Stable coordinate for the exact patch sequence materialized by one strand. */
+export function strandPatchCoordinateRef(
+  worldline: string,
+  strandId: string,
+  patchShas: readonly string[]
+): string {
+  return `warp:strand-coordinate:${canonicalStringify({
+    worldline,
+    strandId,
+    patchShas,
+  })}`;
+}

--- a/src/domain/services/admission/PatchBuilderCausalBasis.ts
+++ b/src/domain/services/admission/PatchBuilderCausalBasis.ts
@@ -1,0 +1,29 @@
+import PatchError from '../../errors/PatchError.ts';
+import type { PatchBuilder } from '../PatchBuilder.ts';
+
+export type PatchBuilderCausalBasis = Readonly<{
+  graphName: string;
+  writerId: string;
+  participantId: string;
+  expectedParentSha: string | null;
+  evaluationCoordinateRef: string | null;
+}>;
+
+const PATCH_BUILDER_CAUSAL_BASES = new WeakMap<PatchBuilder, PatchBuilderCausalBasis>();
+
+export function capturePatchBuilderCausalBasis(
+  builder: PatchBuilder,
+  basis: PatchBuilderCausalBasis
+): void {
+  PATCH_BUILDER_CAUSAL_BASES.set(builder, Object.freeze({ ...basis }));
+}
+
+export function readPatchBuilderCausalBasis(builder: PatchBuilder): PatchBuilderCausalBasis {
+  const basis = PATCH_BUILDER_CAUSAL_BASES.get(builder);
+  if (basis === undefined) {
+    throw new PatchError('PatchBuilder causal basis is unavailable', {
+      code: 'E_PATCH_CAUSAL_BASIS',
+    });
+  }
+  return basis;
+}

--- a/src/domain/services/controllers/PatchController.ts
+++ b/src/domain/services/controllers/PatchController.ts
@@ -38,6 +38,7 @@ import type { PatchCommitResult } from '../../types/PatchCommitResult.ts';
 import type { AuditReceiptService } from '../audit/AuditReceiptService.ts';
 import type { MaterializedStateUpdateOptions } from '../../capabilities/MaterializedStateUpdate.ts';
 import { E_NO_STATE_MSG, E_STALE_STATE_MSG } from './QueryStateMessages.ts';
+import { graphFrontierCoordinateRef } from '../admission/GraphCoordinateRef.ts';
 
 // ── PatchHost ─────────────────────────────────────────────────────────────────
 
@@ -149,6 +150,10 @@ export default class PatchController {
       onCommitSuccess: (commitOpts) => this._onPatchCommitted(h._writerId, commitOpts),
       commitMessageCodec: h._commitMessageCodec,
     };
+
+    if (h._cachedFrontier !== null && h._cachedFrontier !== undefined) {
+      opts.evaluationCoordinateRef = graphFrontierCoordinateRef(h._graphName, h._cachedFrontier);
+    }
 
     if (h._patchJournal !== null && h._patchJournal !== undefined) {
       opts.patchJournal = h._patchJournal;

--- a/src/domain/services/strand/StrandPatchService.ts
+++ b/src/domain/services/strand/StrandPatchService.ts
@@ -17,6 +17,7 @@ import type GraphPersistencePort from '../../../ports/GraphPersistencePort.ts';
 import type VersionVector from '../../crdt/VersionVector.ts';
 import type CommitMessageCodecPort from '../../../ports/CommitMessageCodecPort.ts';
 import type { PatchCommitResult } from '../../types/PatchCommitResult.ts';
+import { strandPatchCoordinateRef } from '../admission/GraphCoordinateRef.ts';
 
 export type CommittedPatchResult = { patch: Patch; sha: string };
 export type PatchCommitSuccessHandler = (result: CommittedPatchResult) => Promise<void>;
@@ -38,6 +39,7 @@ type PatchBuilderOptionsParams = {
   lamport: number;
   versionVector: VersionVector;
   getCurrentState: () => WarpState | null;
+  evaluationCoordinateRef?: string;
   expectedParentSha: string | null;
   targetRefPath?: string;
   onCommitSuccess?: PatchCommitSuccessHandler;
@@ -45,6 +47,7 @@ type PatchBuilderOptionsParams = {
 
 type WarpRuntime = {
   _graphName: string;
+  _writerId: string;
   _persistence: GraphPersistencePort;
   _patchInProgress: boolean;
   _maxObservedLamport: number;
@@ -239,6 +242,7 @@ export default class StrandPatchService {
     lamport,
     versionVector,
     getCurrentState,
+    evaluationCoordinateRef,
     expectedParentSha,
     targetRefPath,
     onCommitSuccess,
@@ -247,6 +251,7 @@ export default class StrandPatchService {
       persistence: this._graph._persistence,
       graphName: this._graph._graphName,
       writerId: descriptor.overlay.overlayId,
+      admissionParticipantId: this._graph._writerId,
       lamport,
       versionVector,
       getCurrentState,
@@ -254,6 +259,9 @@ export default class StrandPatchService {
       onDeleteWithData: this._graph._onDeleteWithData,
       commitMessageCodec: this._graph._commitMessageCodec,
     };
+    if (evaluationCoordinateRef !== undefined) {
+      pbOpts.evaluationCoordinateRef = evaluationCoordinateRef;
+    }
     if (targetRefPath !== undefined) {
       pbOpts.targetRefPath = targetRefPath;
     }
@@ -332,6 +340,11 @@ export default class StrandPatchService {
       lamport: maxPatchLamport(allPatches) + 1,
       versionVector: state.observedFrontier,
       getCurrentState: () => strandState,
+      evaluationCoordinateRef: strandPatchCoordinateRef(
+        this._graph._graphName,
+        descriptor.strandId,
+        allPatches.map(({ sha }) => sha)
+      ),
       expectedParentSha: descriptor.overlay.headPatchSha ?? null,
       targetRefPath: overlayRef,
       onCommitSuccess: async (result: CommittedPatchResult) => {

--- a/src/domain/services/strand/createStrandCoordinator.ts
+++ b/src/domain/services/strand/createStrandCoordinator.ts
@@ -56,6 +56,7 @@ type StrandMaterializationDiagnosticBag = object;
  */
 export type StrandCoordinatorGraphRuntime = {
   _graphName: string;
+  _writerId: string;
   _persistence: GraphPersistencePort;
   _crypto: CryptoPort;
   _loadPatchChainFromSha(sha: string): Promise<Array<{ patch: Patch; sha: string }>>;

--- a/test/integration/application/GitStorage.integration.test.ts
+++ b/test/integration/application/GitStorage.integration.test.ts
@@ -23,7 +23,7 @@ describe('GitStorage public composition', () => {
 
       const receipt = await timeline.write(intent.node.add({ subject: 'user:alice' }));
 
-      expect(receipt.outcome).toBe('accepted');
+      expect(receipt.outcome.kind).toBe('derived');
       expect(receipt.timeline).toBe('events');
       expect(await repository.persistence.listRefs('refs/warp/events/writers/')).toEqual([
         'refs/warp/events/writers/agent-1',

--- a/test/type-check/v19-consumer.ts
+++ b/test/type-check/v19-consumer.ts
@@ -8,23 +8,21 @@ import {
   intent,
   openWarp,
   reading,
+  type AdmissionOutcome,
   type DraftTimeline,
   type Evidence,
   type EvidenceHandle,
   type Intent,
-  type JoinOutcome,
   type JoinReceipt,
   type JoinResult,
   type JoinOptions,
   type JoinPolicy,
   type NeighborhoodReadingFields,
   type OpenWarpOptions,
-  type ReadOutcome,
   type Reading,
   type ReadingResult,
   type ReadingValue,
   type ReadReceipt,
-  type ReceiptOutcome,
   type RepairHint,
   type Tick,
   type Timeline,
@@ -32,7 +30,6 @@ import {
   type Warp,
   type WarpStorage,
   type WriteReceipt,
-  type WriteOutcome,
 } from '../../index.ts';
 import { GitStorage } from '../../storage.ts';
 
@@ -59,7 +56,8 @@ const writeIntent: Intent = intent.property.set({
   value: 'admin',
 });
 const receipt: WriteReceipt = await timeline.write(writeIntent);
-const outcome: WriteOutcome = receipt.outcome;
+const outcome: AdmissionOutcome = receipt.outcome;
+const writeEvidence: Evidence = receipt.evidence;
 const readRequest: Reading = reading.property({
   subject: 'user:alice',
   key: 'role',
@@ -76,7 +74,7 @@ const historicalResult: ReadingResult = await historical.read(readRequest);
 const convenienceValue: ReadingValue = await timeline.readValue(readRequest);
 const readValue: ReadingValue = readResult.value;
 const readReceipt: ReadReceipt = readResult.receipt;
-const readOutcome: ReadOutcome = readReceipt.outcome;
+const readOutcome = readReceipt.outcome;
 const readEvidence: Evidence | undefined = readReceipt.evidence;
 const evidenceBasis: EvidenceHandle | undefined = readEvidence?.basis;
 const repairHints: readonly RepairHint[] = readReceipt.repairHints;
@@ -87,17 +85,22 @@ const joinOptions: JoinOptions = { policy: joinPolicy };
 const preview: JoinResult = await timeline.previewJoin(draft, joinOptions);
 const joined: JoinResult = await timeline.join(draft);
 const joinReceipt: JoinReceipt = joined.receipt;
-const joinOutcome: JoinOutcome = joinReceipt.outcome;
-const acceptedOutcome: ReceiptOutcome = 'accepted';
+const joinOutcome = joinReceipt.outcome;
 
-// @ts-expect-error receipt outcomes do not expose operation names.
-const operationOutcome: ReceiptOutcome = 'write';
-
-// @ts-expect-error read receipt outcomes do not expose operation names.
-const readOperationOutcome: ReadOutcome = 'read';
-
-// @ts-expect-error resolved is not a receipt outcome in the v19 contract.
-const retiredReadOutcome: ReadOutcome = 'resolved';
+function admissionWitnessHandle(value: AdmissionOutcome): EvidenceHandle {
+  switch (value.kind) {
+    case 'derived':
+      return value.witness.resultingFrontier;
+    case 'plural':
+      return value.witness.localCoordinate;
+    case 'conflict':
+      return value.witness.conflict;
+    case 'obstruction':
+      return value.witness.failedCondition;
+  }
+  const unreachable: never = value;
+  return unreachable;
+}
 
 // @ts-expect-error previewJoin is a dedicated method, not a dryRun boolean trap.
 await timeline.previewJoin(draft, { dryRun: true });
@@ -124,16 +127,14 @@ void timelineName;
 void timelineWriter;
 void historicalResult;
 void outcome;
-void acceptedOutcome;
-void operationOutcome;
+void admissionWitnessHandle(outcome);
+void writeEvidence;
 void readValue;
 void convenienceValue;
 void neighborhoodRequest;
 void readOutcome;
 void readEvidence;
 void evidenceBasis;
-void readOperationOutcome;
-void retiredReadOutcome;
 void repairHints;
 void draftReceipt;
 void preview;

--- a/test/unit/domain/AdmissionOutcomeRuntime.test.ts
+++ b/test/unit/domain/AdmissionOutcomeRuntime.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import AdmissionEvaluation from '../../../src/domain/admission/AdmissionEvaluation.ts';
+import ConflictAdmission from '../../../src/domain/admission/ConflictAdmission.ts';
+import ConflictWitness from '../../../src/domain/admission/ConflictWitness.ts';
+import PluralAdmission from '../../../src/domain/admission/PluralAdmission.ts';
+import PluralityWitness from '../../../src/domain/admission/PluralityWitness.ts';
+import {
+  projectAdmissionOutcome,
+  requireAdmissionOutcome,
+} from '../../../src/domain/api/AdmissionOutcomeRuntime.ts';
+import {
+  testDerivedIntentAdmissionReceipt,
+  testObstructedIntentAdmissionReceipt,
+} from '../../helpers/intentAdmission.ts';
+
+const EVALUATION = new AdmissionEvaluation({
+  sourceParticipantId: 'participant:source',
+  destinationRuntimeId: 'runtime:destination',
+  sourceBasisRef: 'frontier:source:7',
+  destinationBasisRef: 'frontier:destination:11',
+  proposalDigest: 'proposal:8',
+  lawDigest: 'law:reservation',
+  profileDigest: 'profile:continuum',
+  evaluationCoordinateRef: 'coordinate:destination:11',
+});
+const PROJECTION_BASIS = Object.freeze({ id: 'evidence:admission-projection' });
+
+describe('AdmissionOutcomeRuntime', () => {
+  it('projects all four domain variants into the closed public algebra', () => {
+    const derived = projectAdmissionOutcome(
+      testDerivedIntentAdmissionReceipt('derived').outcome,
+      PROJECTION_BASIS
+    );
+    const plural = projectAdmissionOutcome(
+      new PluralAdmission(
+        new PluralityWitness({
+          evaluation: EVALUATION,
+          localCoordinateRef: 'coordinate:local',
+          incomingCoordinateRef: 'coordinate:incoming',
+          retainedCoordinateRefs: ['coordinate:local', 'coordinate:incoming'],
+          derivationEvidenceRef: 'evidence:derivation',
+          footprintComparisonRef: 'evidence:footprints',
+          concurrencyEvidenceRef: 'evidence:concurrency',
+          nonInterferenceEvidenceRef: 'evidence:non-interference',
+        })
+      ),
+      PROJECTION_BASIS
+    );
+    const conflict = projectAdmissionOutcome(
+      new ConflictAdmission(
+        new ConflictWitness({
+          evaluation: EVALUATION,
+          conflictRef: 'conflict:reservation-overlap',
+          claimRefs: ['claim:local', 'claim:incoming'],
+          overlappingFootprintRefs: ['footprint:reservation-slot'],
+          contestedDomain: 'reservation-slot',
+          derivationEvidenceRef: 'evidence:derivation',
+          overlapEvidenceRef: 'evidence:overlap',
+          resolutionProcedureRefs: ['procedure:reschedule'],
+        })
+      ),
+      PROJECTION_BASIS
+    );
+    const obstruction = projectAdmissionOutcome(
+      testObstructedIntentAdmissionReceipt('obstructed').outcome,
+      PROJECTION_BASIS
+    );
+
+    expect([derived.kind, plural.kind, conflict.kind, obstruction.kind]).toEqual([
+      'derived',
+      'plural',
+      'conflict',
+      'obstruction',
+    ]);
+    if (plural.kind !== 'plural' || conflict.kind !== 'conflict') {
+      throw new Error('projection must preserve plural and conflict variants');
+    }
+    expect(plural.witness.localCoordinate.id).toMatch(/^evidence:/);
+    expect(plural.witness.incomingCoordinate.id).toMatch(/^evidence:/);
+    expect(plural.witness.retainedCoordinates.map(({ id }) => id)).toEqual(
+      expect.arrayContaining([
+        plural.witness.localCoordinate.id,
+        plural.witness.incomingCoordinate.id,
+      ])
+    );
+    expect(plural.residual.coordinates).toBe(plural.witness.retainedCoordinates);
+    expect(conflict.witness.contestedDomain).toBe('reservation-slot');
+    expect(conflict.witness.claims).toHaveLength(2);
+    expect(conflict.witness.overlappingFootprints).toHaveLength(1);
+    expect(conflict.witness.resolutionProcedures).toHaveLength(1);
+    expect(conflict.residual.conflict).toBe(conflict.witness.conflict);
+    expect(JSON.stringify(plural)).not.toContain('coordinate:local');
+    expect(JSON.stringify(conflict)).not.toContain('claim:local');
+  });
+
+  it('issues deeply immutable storage-neutral outcomes', () => {
+    const outcome = projectAdmissionOutcome(
+      testDerivedIntentAdmissionReceipt('immutable').outcome,
+      PROJECTION_BASIS
+    );
+
+    expect(Object.isFrozen(outcome)).toBe(true);
+    expect(Object.isFrozen(outcome.witness)).toBe(true);
+    expect(Object.isFrozen(outcome.witness.evaluation)).toBe(true);
+    expect(Object.isFrozen(outcome.witness.evaluation.sourceBasis)).toBe(true);
+    expect(outcome.witness.evaluation.sourceBasis.id).toMatch(/^evidence:/);
+    expect(outcome.witness.evaluation.sourceBasis.id).not.toContain('frontier:');
+    expect(outcome.witness.evaluation).not.toHaveProperty('sourceBasisRef');
+    expect(outcome.witness).not.toHaveProperty('resultingFrontierRef');
+  });
+
+  it('rejects structurally similar values not issued by the runtime', () => {
+    expect(() =>
+      requireAdmissionOutcome({
+        kind: 'derived',
+        witness: {},
+        residual: {},
+      } as never)
+    ).toThrow('outcome must be an AdmissionOutcome');
+  });
+});

--- a/test/unit/domain/DraftTimelineRuntime.test.ts
+++ b/test/unit/domain/DraftTimelineRuntime.test.ts
@@ -17,6 +17,7 @@ import { intent } from '../../../src/domain/api/IntentBuilders.ts';
 import type { PatchCommitResult } from '../../../src/domain/types/PatchCommitResult.ts';
 import { testDerivedIntentAdmissionReceipt } from '../../helpers/intentAdmission.ts';
 import { testRetentionWitness } from '../../helpers/storageRetention.ts';
+import { createPatchBuilder } from './services/PatchBuilderTestHarness.ts';
 
 type RuntimeOptions = {
   readonly commitPatch?: (build: WarpWorldlinePatchBuild) => Promise<string>;
@@ -48,24 +49,54 @@ function createRuntimeContext(options: RuntimeContextOptions = {}): {
 function createRuntime(options: RuntimeOptions = {}): WarpWorldline {
   const commitPatch = options.commitPatch ?? (async () => 'commit-1');
   const patchDraft = options.patchDraft ?? (async (name) => `${name}-draft-patch`);
+  let liveHead: string | null = null;
+  const draftHeads = new Map<string, string>();
+  const commitLive = async (build: WarpWorldlinePatchBuild): Promise<PatchCommitResult> => {
+    const builder = createPatchBuilder({
+      graphName: 'events',
+      writerId: 'agent-1',
+      expectedParentSha: liveHead,
+      evaluationCoordinateRef: `warp:test-coordinate:live:${liveHead ?? 'empty'}`,
+    });
+    await build(builder);
+    const sha = await commitPatch(build);
+    liveHead = sha;
+    return testPatchPublication(sha, builder.build());
+  };
+  const commitDraft = async (
+    name: string,
+    build: WarpWorldlinePatchBuild
+  ): Promise<PatchCommitResult> => {
+    const expectedHead = draftHeads.get(name) ?? null;
+    const builder = createPatchBuilder({
+      graphName: 'events',
+      writerId: name,
+      admissionParticipantId: 'agent-1',
+      expectedParentSha: expectedHead,
+      evaluationCoordinateRef: `warp:test-coordinate:${name}:${expectedHead ?? 'empty'}`,
+    });
+    await build(builder);
+    const sha = await patchDraft(name, build);
+    draftHeads.set(name, sha);
+    return testPatchPublication(sha, builder.build());
+  };
   return new WarpWorldline({
     worldlineName: 'events',
     writerId: 'agent-1',
-    commitPatch,
-    commitPatchWithEvidence: async (build) => testPatchPublication(await commitPatch(build)),
+    commitPatch: async (build) => (await commitLive(build)).sha,
+    commitPatchWithEvidence: commitLive,
     createDraft: async () => undefined,
     createWorldline: () => {
       throw new Error('ProjectionHandle is not used by DraftTimelineRuntime tests');
     },
-    patchDraft,
-    patchDraftWithEvidence: async (name, build) =>
-      testPatchPublication(await patchDraft(name, build)),
+    patchDraft: async (name, build) => (await commitDraft(name, build)).sha,
+    patchDraftWithEvidence: commitDraft,
     previewDraftJoin: options.previewDraftJoin ?? (async (name) => [`${name}-preview-patch`]),
     admitIntent: async (descriptor) => testDerivedIntentAdmissionReceipt(descriptor.intentId),
   });
 }
 
-function testPatchPublication(sha: string): PatchCommitResult {
+function testPatchPublication(sha: string, patch: Patch): PatchCommitResult {
   const retention = testRetentionWitness(sha);
   return Object.freeze({
     sha,
@@ -80,12 +111,7 @@ function testPatchPublication(sha: string): PatchCommitResult {
       }),
     }),
     retention,
-    patch: new Patch({
-      writer: 'agent-1',
-      lamport: 0,
-      context: {},
-      ops: [],
-    }),
+    patch,
   });
 }
 
@@ -132,7 +158,7 @@ describe('DraftTimelineRuntime', () => {
     expect(commitAttempts).toBe(1);
   });
 
-  it('returns an accepted draft-write receipt when canonical evidence hashing fails', async () => {
+  it('returns a derived draft-write receipt when canonical evidence hashing fails', async () => {
     let draftCommitted = false;
     let draftCommits = 0;
     const runtime = createRuntime({
@@ -159,8 +185,16 @@ describe('DraftTimelineRuntime', () => {
 
     const receipt = await draft.write(intent.node.add({ subject: 'user:alice' }));
 
-    expect(receipt.outcome).toBe('accepted');
+    expect(receipt.outcome.kind).toBe('derived');
+    if (receipt.outcome.kind !== 'derived') {
+      throw new Error('published draft write must remain derived');
+    }
     expect(receipt.evidence?.support).toEqual([]);
+    expect(
+      receipt.outcome.witness.evaluation.sourceBasis.id.startsWith(
+        `${receipt.evidence.basis.id}/admission/`
+      )
+    ).toBe(true);
     expect(draftCommits).toBe(1);
     expect(provenance.at(-1)).toEqual({
       operation: 'write',
@@ -246,13 +280,7 @@ describe('DraftTimelineRuntime', () => {
     });
 
     await draft.write(intent.node.add({ subject: 'user:alice' }));
-    await draft.write(
-      intent.property.set({
-        subject: 'user:alice',
-        key: 'role',
-        value: 'admin',
-      })
-    );
+    await draft.write(intent.node.add({ subject: 'team:ops' }));
 
     const failedJoin = await joinDraftTimeline(runtime, draft, { policy: 'deterministic' });
     const retryJoin = await joinDraftTimeline(runtime, draft, { policy: 'deterministic' });

--- a/test/unit/domain/ReceiptDiagnostics.test.ts
+++ b/test/unit/domain/ReceiptDiagnostics.test.ts
@@ -3,12 +3,19 @@ import { describe, expect, it } from 'vitest';
 import { inspectReceipt } from '../../../diagnostics.ts';
 import { openWarp } from '../../../src/application/openWarp.ts';
 import { createApiRuntimeContext } from '../../../src/application/ReceiptProvenanceRegistry.ts';
+import { projectAdmissionOutcome } from '../../../src/domain/api/AdmissionOutcomeRuntime.ts';
 import { intent } from '../../../src/domain/api/IntentBuilders.ts';
 import { reading } from '../../../src/domain/api/ReadingBuilders.ts';
 import WriteReceipt from '../../../src/domain/api/WriteReceipt.ts';
 import NodeCryptoAdapter from '../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
 import MemoryStorage from '../../helpers/MemoryStorage.ts';
 import { createBoundedReadBasis } from '../../helpers/BoundedReadBasis.ts';
+import { testObstructedIntentAdmissionReceipt } from '../../helpers/intentAdmission.ts';
+
+const RECOVERY_EVIDENCE = Object.freeze({
+  basis: Object.freeze({ id: 'evidence:recovery' }),
+  support: Object.freeze([]),
+});
 
 describe('receipt diagnostics', () => {
   it('uses collision-safe typed framing for opaque identity inputs', async () => {
@@ -47,7 +54,7 @@ describe('receipt diagnostics', () => {
 
     expect(inspection).toMatchObject({
       operation: 'write',
-      outcome: 'accepted',
+      outcome: receipt.outcome,
       timeline: 'events',
       writer: 'agent-1',
       reason: undefined,
@@ -71,9 +78,10 @@ describe('receipt diagnostics', () => {
 
     const inspection = inspectReceipt(receipt, { storage });
 
-    expect(receipt.outcome).not.toBe('accepted');
+    expect(receipt.outcome.kind).toBe('obstruction');
     expect(inspection.objectIds).toEqual([]);
-    expect(inspection.evidence).toBe('absent');
+    expect(inspection.evidence).toBe('present');
+    expect(receipt.evidence.support).toEqual([]);
   });
 
   it('recovers full bounded-read provenance without exposing it on evidence', async () => {
@@ -153,8 +161,11 @@ describe('receipt diagnostics', () => {
       timeline: 'events',
       writer: 'agent-1',
       intent: intent.node.add({ subject: 'user:alice' }),
-      outcome: 'rejected',
-      reason: 'not_admitted',
+      outcome: projectAdmissionOutcome(
+        testObstructedIntentAdmissionReceipt('manual-receipt').outcome,
+        RECOVERY_EVIDENCE.basis
+      ),
+      evidence: RECOVERY_EVIDENCE,
     });
 
     expect(() => inspectReceipt(receipt, { storage })).toThrow(
@@ -164,14 +175,17 @@ describe('receipt diagnostics', () => {
 
   it('binds raw receipt provenance exactly once', () => {
     const storage = MemoryStorage.create();
+    const context = createApiRuntimeContext(storage, new NodeCryptoAdapter());
     const receipt = new WriteReceipt({
       timeline: 'events',
       writer: 'agent-1',
       intent: intent.node.add({ subject: 'user:alice' }),
-      outcome: 'rejected',
-      reason: 'not_admitted',
+      outcome: projectAdmissionOutcome(
+        testObstructedIntentAdmissionReceipt('manual-receipt').outcome,
+        RECOVERY_EVIDENCE.basis
+      ),
+      evidence: RECOVERY_EVIDENCE,
     });
-    const context = createApiRuntimeContext(storage, new NodeCryptoAdapter());
     const provenance = { operation: 'write' as const, patchSha: undefined };
 
     context.bindReceipt(receipt, provenance);

--- a/test/unit/domain/ReceiptOutcome.test.ts
+++ b/test/unit/domain/ReceiptOutcome.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import DraftTimeline from '../../../src/domain/api/DraftTimeline.ts';
+import { projectAdmissionOutcome } from '../../../src/domain/api/AdmissionOutcomeRuntime.ts';
 import { intent } from '../../../src/domain/api/IntentBuilders.ts';
 import JoinReceipt from '../../../src/domain/api/JoinReceipt.ts';
-import { RECEIPT_OUTCOMES } from '../../../src/domain/api/ReceiptOutcome.ts';
+import { READ_JOIN_RECEIPT_OUTCOMES } from '../../../src/domain/api/ReceiptOutcome.ts';
 import WriteReceipt from '../../../src/domain/api/WriteReceipt.ts';
+import {
+  testDerivedIntentAdmissionReceipt,
+  testObstructedIntentAdmissionReceipt,
+} from '../../helpers/intentAdmission.ts';
 
 const EVIDENCE = Object.freeze({
   basis: Object.freeze({ id: 'evidence:basis' }),
@@ -12,8 +17,8 @@ const EVIDENCE = Object.freeze({
 });
 
 describe('receipt outcomes', () => {
-  it('locks the canonical outcome axis to the approved five values', () => {
-    expect([...RECEIPT_OUTCOMES]).toEqual([
+  it('quarantines the transitional read/join outcome axis to five values', () => {
+    expect([...READ_JOIN_RECEIPT_OUTCOMES]).toEqual([
       'accepted',
       'obstructed',
       'conflicted',
@@ -22,14 +27,14 @@ describe('receipt outcomes', () => {
     ]);
   });
 
-  it('shares the canonical write receipt outcomes with join receipts', () => {
+  it('keeps transitional join outcomes independent from write admission', () => {
     const draft = new DraftTimeline({
       name: 'try-admin-role',
       timeline: 'events',
       writer: 'agent-1',
     });
 
-    for (const outcome of RECEIPT_OUTCOMES) {
+    for (const outcome of READ_JOIN_RECEIPT_OUTCOMES) {
       const receipt =
         outcome === 'accepted'
           ? new JoinReceipt({
@@ -88,21 +93,37 @@ describe('receipt outcomes', () => {
     ).toThrow('joinReceipt.reason must be a non-empty string');
   });
 
-  it('represents rejected writes without inventing causal evidence', () => {
+  it('represents obstructed writes with typed witnesses and honest recovery evidence', () => {
+    const outcome = projectAdmissionOutcome(
+      testObstructedIntentAdmissionReceipt('manual-write', 'git-warp.test.policy-rejected').outcome,
+      EVIDENCE.basis
+    );
     const receipt = new WriteReceipt({
       timeline: 'events',
       writer: 'agent-1',
       intent: intent.node.add({ subject: 'user:alice' }),
-      outcome: 'rejected',
-      reason: 'policy_rejected',
+      outcome,
+      evidence: EVIDENCE,
     });
 
-    expect(receipt).toMatchObject({
-      operation: 'write',
-      outcome: 'rejected',
-      reason: 'policy_rejected',
-      evidence: undefined,
-    });
+    expect(receipt.operation).toBe('write');
+    expect(receipt.outcome).toBe(outcome);
+    expect(receipt.outcome.kind).toBe('obstruction');
+    expect(receipt.reason).toBe('git-warp.test.policy-rejected');
+    expect(receipt.evidence).toEqual(EVIDENCE);
+  });
+
+  it('rejects legacy string write outcomes at runtime', () => {
+    expect(
+      () =>
+        new WriteReceipt({
+          timeline: 'events',
+          writer: 'agent-1',
+          intent: intent.node.add({ subject: 'user:alice' }),
+          outcome: 'accepted' as never,
+          evidence: EVIDENCE,
+        })
+    ).toThrow('outcome must be an AdmissionOutcome');
   });
 
   it.each([
@@ -121,13 +142,17 @@ describe('receipt outcomes', () => {
       'writeReceipt.evidence.tick must be a Tick',
     ],
   ])('rejects malformed causal evidence %#', (evidence, message) => {
+    const outcome = projectAdmissionOutcome(
+      testDerivedIntentAdmissionReceipt('malformed-evidence').outcome,
+      EVIDENCE.basis
+    );
     expect(
       () =>
         new WriteReceipt({
           timeline: 'events',
           writer: 'agent-1',
           intent: intent.node.add({ subject: 'user:alice' }),
-          outcome: 'accepted',
+          outcome,
           evidence: evidence as never,
         })
     ).toThrow(message);

--- a/test/unit/domain/WarpFacade.test.ts
+++ b/test/unit/domain/WarpFacade.test.ts
@@ -260,7 +260,7 @@ describe('v19 Warp facade', () => {
     ).toThrow('Invalid writer ID: exceeds maximum length');
   });
 
-  it('writes public intents and returns accepted write receipts', async () => {
+  it('writes public intents and returns basis-bound derived receipts', async () => {
     const warp = await openWarp({
       storage: MemoryStorage.create(),
       writer: 'agent-1',
@@ -276,13 +276,34 @@ describe('v19 Warp facade', () => {
       })
     );
 
-    expect(nodeReceipt.outcome).toBe('accepted');
+    expect(nodeReceipt.outcome.kind).toBe('derived');
+    if (nodeReceipt.outcome.kind !== 'derived') {
+      throw new Error('node write must produce a derived admission');
+    }
     expect(nodeReceipt.operation).toBe('write');
     expect(nodeReceipt.intent.kind).toBe('node.add');
     expect(nodeReceipt.evidence?.basis.id).toMatch(/^evidence:/);
     expect(nodeReceipt.evidence?.support).toHaveLength(1);
     expect('patchSha' in nodeReceipt).toBe(false);
-    expect(propertyReceipt.outcome).toBe('accepted');
+    expect(nodeReceipt.outcome.witness.evaluation).toMatchObject({
+      sourceParticipant: 'agent-1',
+      destinationRuntime: 'warp:timeline-runtime/events/agent-1',
+    });
+    expect(nodeReceipt.outcome.witness.evaluation.sourceBasis.id).toMatch(/^evidence:/);
+    expect(
+      nodeReceipt.outcome.witness.evaluation.sourceBasis.id.startsWith(
+        `${nodeReceipt.evidence.basis.id}/admission/`
+      )
+    ).toBe(true);
+    expect(nodeReceipt.outcome.witness.evaluation.destinationBasis).toEqual(
+      nodeReceipt.outcome.witness.evaluation.sourceBasis
+    );
+    expect(nodeReceipt.outcome.witness.resultingFrontier.id).toMatch(/^evidence:/);
+    expect(nodeReceipt.outcome.witness.resultingFrontier).not.toEqual(
+      nodeReceipt.outcome.witness.evaluation.sourceBasis
+    );
+    expect(propertyReceipt.outcome.kind).toBe('derived');
+    expect(propertyReceipt.outcome.witness.evaluation.coordinate.id).toMatch(/^evidence:/);
     expect(propertyReceipt.intent.kind).toBe('property.set');
     expect(propertyReceipt.timeline).toBe('events');
     expect(propertyReceipt.writer).toBe('agent-1');
@@ -342,12 +363,18 @@ describe('v19 Warp facade', () => {
 
     const receipt = await timeline.write(intent.node.remove({ subject: 'user:alice' }));
 
-    expect(receipt).toMatchObject({
-      operation: 'write',
-      outcome: 'obstructed',
-      evidence: undefined,
-      reason: 'missing_write_basis',
+    expect(receipt.operation).toBe('write');
+    expect(receipt.outcome.kind).toBe('obstruction');
+    if (receipt.outcome.kind !== 'obstruction') {
+      throw new Error('state-dependent write without a basis must produce an obstruction');
+    }
+    expect(receipt.outcome.witness.reason).toMatchObject({
+      family: 'unsupported-evidence',
+      code: 'git-warp.write.missing-bounded-basis',
     });
+    expect(receipt.outcome.witness.retry.disposition).toBe('after-change');
+    expect(receipt.evidence.support).toEqual([]);
+    expect(receipt.reason).toBe('git-warp.write.missing-bounded-basis');
     expect(receipt.repairHints).toEqual([
       expect.objectContaining({ code: 'materialize_write_basis' }),
     ]);
@@ -542,7 +569,7 @@ describe('v19 Warp facade', () => {
     expect(draft.name).toBe('try-admin-role');
     expect(draft.timeline).toBe('events');
     expect(draft.writer).toBe('agent-1');
-    expect(draftWrite.outcome).toBe('accepted');
+    expect(draftWrite.outcome.kind).toBe('derived');
     expect(beforeJoin.value).toBeNull();
     expect(preview).toBeInstanceOf(JoinResult);
     expect(preview.receipt).toBeInstanceOf(JoinReceipt);

--- a/test/unit/domain/WriteRuntime.test.ts
+++ b/test/unit/domain/WriteRuntime.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  ApiRuntimeContext,
+  ReceiptProvenance,
+} from '../../../src/domain/api/ApiRuntimeContext.ts';
+import { intent } from '../../../src/domain/api/IntentBuilders.ts';
+import { executeIntentWrite } from '../../../src/domain/api/WriteRuntime.ts';
+import { Dot } from '../../../src/domain/crdt/Dot.ts';
+import WriterError from '../../../src/domain/errors/WriterError.ts';
+import { encodeEdgeKey } from '../../../src/domain/services/KeyCodec.ts';
+import type { PatchBuilder } from '../../../src/domain/services/PatchBuilder.ts';
+import WarpState from '../../../src/domain/services/state/WarpState.ts';
+import WarpWorldline from '../../../src/domain/WarpWorldline.ts';
+import { testDerivedIntentAdmissionReceipt } from '../../helpers/intentAdmission.ts';
+import { createPatchBuilder } from './services/PatchBuilderTestHarness.ts';
+
+describe('WriteRuntime admission classification', () => {
+  it('classifies writer CAS races as stale-basis obstructions', async () => {
+    const { context, provenance } = createContext();
+    const receipt = await executeIntentWrite({
+      runtime: createRuntime(),
+      context,
+      intent: intent.node.add({ subject: 'user:alice' }),
+      commit: async (build) => {
+        await build(builder({ expectedParentSha: 'old-head' }));
+        const error = new WriterError('writer advanced', { code: 'WRITER_CAS_CONFLICT' });
+        error.expectedSha = 'old-head';
+        error.actualSha = 'new-head';
+        throw error;
+      },
+    });
+
+    expect(receipt.outcome.kind).toBe('obstruction');
+    if (receipt.outcome.kind !== 'obstruction') {
+      throw new Error('writer CAS race must produce an obstruction');
+    }
+    expect(receipt.outcome.witness.reason).toMatchObject({
+      family: 'stale-basis',
+      code: 'git-warp.write.writer-frontier-advanced',
+    });
+    expect(receipt.outcome.witness.evaluation.sourceBasis.id).toMatch(/^evidence:/);
+    expect(receipt.outcome.witness.evaluation.destinationBasis.id).toMatch(/^evidence:/);
+    expect(receipt.outcome.witness.evaluation.sourceBasis).not.toEqual(
+      receipt.outcome.witness.evaluation.destinationBasis
+    );
+    expect(receipt.outcome.residual).toMatchObject({
+      kind: 'unchanged',
+      frontier: receipt.outcome.witness.evaluation.destinationBasis,
+    });
+    expect(provenance).toEqual([{ operation: 'write', patchSha: undefined }]);
+  });
+
+  it('classifies an attached-data deletion as a law obstruction, not conflict', async () => {
+    const state = stateWithAttachedEdge();
+    const receipt = await executeIntentWrite({
+      runtime: createRuntime(),
+      context: createContext().context,
+      intent: intent.node.remove({ subject: 'user:alice' }),
+      commit: async (build) => {
+        await build(
+          builder({
+            getCurrentState: () => state,
+            onDeleteWithData: 'reject',
+          })
+        );
+        throw new Error('unreachable publication');
+      },
+    });
+
+    expect(receipt.outcome.kind).toBe('obstruction');
+    if (receipt.outcome.kind !== 'obstruction') {
+      throw new Error('attached-data deletion must produce an obstruction');
+    }
+    expect(receipt.outcome.witness.reason).toMatchObject({
+      family: 'law-violation',
+      code: 'git-warp.write.delete-with-attached-data',
+    });
+    expect(receipt.outcome.witness.retry.disposition).toBe('after-change');
+  });
+
+  it('classifies a missing write target as a law obstruction, not rejection', async () => {
+    const receipt = await executeIntentWrite({
+      runtime: createRuntime(),
+      context: createContext().context,
+      intent: intent.node.remove({ subject: 'user:alice' }),
+      commit: async (build) => {
+        await build(builder({ getCurrentState: () => WarpState.empty() }));
+        throw new Error('unreachable publication');
+      },
+    });
+
+    expect(receipt.outcome.kind).toBe('obstruction');
+    if (receipt.outcome.kind !== 'obstruction') {
+      throw new Error('missing write target must produce an obstruction');
+    }
+    expect(receipt.outcome.witness.reason).toMatchObject({
+      family: 'law-violation',
+      code: 'git-warp.write.entity-not-found',
+    });
+  });
+
+  it('keeps operational failures outside the causal outcome union', async () => {
+    await expect(
+      executeIntentWrite({
+        runtime: createRuntime(),
+        context: createContext().context,
+        intent: intent.node.add({ subject: 'user:alice' }),
+        commit: async (build) => {
+          await build(builder());
+          throw new Error('storage unavailable');
+        },
+      })
+    ).rejects.toThrow('storage unavailable');
+  });
+
+  it('rejects a publication basis owned by another writer', async () => {
+    await expect(
+      executeIntentWrite({
+        runtime: createRuntime(),
+        context: createContext().context,
+        intent: intent.node.add({ subject: 'user:alice' }),
+        commit: async (build) => {
+          await build(builder({ writerId: 'agent-2' }));
+          throw new Error('unreachable publication');
+        },
+      })
+    ).rejects.toMatchObject({
+      code: 'E_WRITE_ADMISSION_BASIS',
+    });
+  });
+});
+
+function builder(overrides: Parameters<typeof createPatchBuilder>[0] = {}): PatchBuilder {
+  return createPatchBuilder({
+    graphName: 'events',
+    writerId: 'agent-1',
+    evaluationCoordinateRef: 'warp:test-coordinate:events',
+    ...overrides,
+  });
+}
+
+function stateWithAttachedEdge(): WarpState {
+  const state = WarpState.empty();
+  state.nodeAlive.add('user:alice', Dot.create('agent-1', 1));
+  state.nodeAlive.add('team:ops', Dot.create('agent-1', 2));
+  state.edgeAlive.add(
+    encodeEdgeKey('user:alice', 'team:ops', 'memberOf'),
+    Dot.create('agent-1', 3)
+  );
+  return state;
+}
+
+function createRuntime(): WarpWorldline {
+  return new WarpWorldline({
+    worldlineName: 'events',
+    writerId: 'agent-1',
+    commitPatch: async () => {
+      throw new Error('unused commit');
+    },
+    createWorldline: () => {
+      throw new Error('unused worldline');
+    },
+    admitIntent: async (descriptor) => testDerivedIntentAdmissionReceipt(descriptor.intentId),
+  });
+}
+
+function createContext(): {
+  readonly context: ApiRuntimeContext;
+  readonly provenance: ReceiptProvenance[];
+} {
+  const provenance: ReceiptProvenance[] = [];
+  return {
+    context: {
+      createOpaqueId: async (namespace, parts) => `${namespace}:${parts.join(':')}`,
+      reserveRecoveryNonce: () => 'write-runtime:1',
+      bindReceipt: (_receipt, receiptProvenance) => provenance.push(receiptProvenance),
+    },
+    provenance,
+  };
+}

--- a/test/unit/domain/services/controllers/StrandController.host-interface.test.ts
+++ b/test/unit/domain/services/controllers/StrandController.host-interface.test.ts
@@ -27,6 +27,7 @@ class StrandControllerCrypto extends CryptoPort {
 function createStrandHost(): StrandHost {
   return {
     _graphName: 'strand-host-interface',
+    _writerId: 'writer1',
     _persistence: new InMemoryGraphAdapter(),
     _crypto: new StrandControllerCrypto(),
     _loadPatchChainFromSha: async (_sha: string): Promise<Array<{ patch: Patch; sha: string }>> => [],

--- a/test/unit/scripts/v19-public-api-boundary.test.ts
+++ b/test/unit/scripts/v19-public-api-boundary.test.ts
@@ -7,6 +7,7 @@ const REPO_ROOT = new URL('../../../', import.meta.url);
 const ROOT_VALUE_EXPORTS = ['intent', 'openWarp', 'reading'] as const;
 
 const ROOT_TYPE_EXPORTS = [
+  'AdmissionOutcome',
   'DraftTimeline',
   'EdgeIntentFields',
   'Evidence',
@@ -16,7 +17,6 @@ const ROOT_TYPE_EXPORTS = [
   'IntentDescriptor',
   'IntentKind',
   'JoinMode',
-  'JoinOutcome',
   'JoinOptions',
   'JoinPolicy',
   'JoinReceipt',
@@ -29,7 +29,6 @@ const ROOT_TYPE_EXPORTS = [
   'OpenWarpOptions',
   'PropertyIntentFields',
   'PropertyReadingFields',
-  'ReadOutcome',
   'ReadReceipt',
   'ReadReceiptOptions',
   'Reading',
@@ -41,7 +40,6 @@ const ROOT_TYPE_EXPORTS = [
   'ReadingResultOptions',
   'ReadingValue',
   'Receipt',
-  'ReceiptOutcome',
   'RepairHint',
   'Tick',
   'Timeline',
@@ -49,7 +47,6 @@ const ROOT_TYPE_EXPORTS = [
   'Warp',
   'WarpStorage',
   'WriteReceipt',
-  'WriteOutcome',
   'WriteReceiptOptions',
 ] as const;
 


### PR DESCRIPTION
## Summary

- replace generic write statuses with a closed `derived | plural | conflict | obstruction` admission union
- require a distinct typed witness, explicit evaluation binding, and residual posture for every write result
- capture the exact graph or strand basis while exposing only storage-neutral evidence handles
- keep runtime failures outside causal outcomes and keep admission distinct from later settlement

## Issue

Refs #712
Refs #765

This is the write-admission child slice of the broader v19 Runtime, Lane, and Observation public API goalpost. It does not close #712.

## Semantics

- `derived` and `plural` are admitted outcomes with different causal topology
- `conflict` and `obstruction` remain operationally distinct and carry different recovery evidence
- plurality is a lawful terminal posture and is not automatically linearized
- draft writes retain derived and plural admissions; conflict and obstruction do not append
- public evidence handles reveal no Git object IDs, patch journals, or other substrate identities
- malformed input, process failures, and implementation defects reject outside the causal union

## Test plan

- [x] Full stable unit suite through the pre-push hook: 7,129 passed, 2 skipped
- [x] Focused admission/write suite: 64 passed
- [x] Git storage integration target
- [x] Node 22, Bun, and Deno CI matrix
- [x] Coverage threshold
- [x] Lint, Semgrep, type, consumer, and public-surface firewalls
- [x] Documentation topology, Markdown, links, and code samples
- [x] Release preflight, npm pack dry-run, and JSR publish dry-run

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] Persisted op formats are unchanged; an ADR 3 readiness issue is not required for this slice
- [x] Wire compatibility is unchanged; canonical-only wire behavior remains unchanged
- [x] Schema constants are unchanged; patch and checkpoint namespaces remain distinct

## Review

The branch received a clean second self-review after correcting three first-pass findings. CodeRabbit completed an assertive review; its remaining inline maintainability request is addressed in the follow-up commit.