### PR TITLE
feat: stream many-observer readings

### DIFF
--- a/docs/topics/api/README.md
+++ b/docs/topics/api/README.md
@@ -175,6 +175,16 @@ const observer = users.observers.roleOf({
 });
 ```
 
+Finite and streamed domain queries may return a `many` Observer. Generated
+builders represent its work as a lazy reading-plan factory, not as a
+precomputed array of results:
+
+```typescript
+const observer = users.observers.rolesOf({
+  subjects: selectedUserIds,
+});
+```
+
 An Observer contains or references the formal machinery needed to execute the
 request honestly:
 
@@ -208,6 +218,12 @@ An Observation starts when any of the following first demands execution:
 
 All three paths join the same execution. They must never start duplicate
 runtime work.
+
+One Observation pins one causal Tick before it emits its first Reading. A
+`many` Observer advances its reading-plan source once per downstream iterator
+demand, executes that bounded read against the pinned Tick, and yields before
+requesting the next plan. It therefore preserves real async-iteration
+backpressure rather than filling an operation-local result queue.
 
 The first demand also selects Reading delivery:
 

--- a/src/application/RuntimeActivity.ts
+++ b/src/application/RuntimeActivity.ts
@@ -2,6 +2,9 @@ import WarpError from '../domain/errors/WarpError.ts';
 
 type RuntimeState = 'open' | 'closing' | 'closed';
 type ReleaseLocalResources = () => Promise<void>;
+export type RuntimeActivityLease = Readonly<{
+  release(): void;
+}>;
 
 export default class RuntimeActivity {
   readonly #active = new Set<Promise<unknown>>();
@@ -11,12 +14,27 @@ export default class RuntimeActivity {
   run<T>(operation: () => Promise<T>): Promise<T> {
     this.#assertOpen();
     const active = Promise.resolve().then(operation);
-    this.#active.add(active);
-    void active.then(
-      () => this.#active.delete(active),
-      () => this.#active.delete(active),
-    );
+    this.#track(active);
     return active;
+  }
+
+  acquire(): RuntimeActivityLease {
+    this.#assertOpen();
+    let finish: (() => void) | null = null;
+    const active = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    this.#track(active);
+    let released = false;
+    return Object.freeze({
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        finish?.();
+      },
+    });
   }
 
   close(release: ReleaseLocalResources): Promise<void> {
@@ -35,6 +53,14 @@ export default class RuntimeActivity {
     } finally {
       this.#state = 'closed';
     }
+  }
+
+  #track(active: Promise<unknown>): void {
+    this.#active.add(active);
+    void active.then(
+      () => this.#active.delete(active),
+      () => this.#active.delete(active),
+    );
   }
 
   #assertOpen(): void {

--- a/src/application/RuntimeLaneAdapter.ts
+++ b/src/application/RuntimeLaneAdapter.ts
@@ -1,5 +1,6 @@
 import type ReadingResult from '../domain/api/ReadingResult.ts';
 import type Timeline from '../domain/api/Timeline.ts';
+import type TimelineView from '../domain/api/TimelineView.ts';
 import { requireTimelineRuntime } from '../domain/api/TimelineRuntime.ts';
 import Lane from '../domain/api/Lane.ts';
 import { bindLaneRuntime } from '../domain/api/LaneRuntime.ts';
@@ -7,14 +8,26 @@ import type { ObservationExecution } from '../domain/api/Observation.ts';
 import type Observer from '../domain/api/Observer.ts';
 import {
   decodeObserverValue,
-  requireObserverReading,
+  observerReadings,
 } from '../domain/api/ObserverRuntime.ts';
 import ObservationReceipt from '../domain/api/ObservationReceipt.ts';
 import Reading, { type ReadingValue } from '../domain/api/ObservedReading.ts';
 import type ReadReceipt from '../domain/api/ReadReceipt.ts';
+import type Tick from '../domain/api/Tick.ts';
 import WarpError from '../domain/errors/WarpError.ts';
 import WarpStream from '../domain/stream/WarpStream.ts';
 import type RuntimeActivity from './RuntimeActivity.ts';
+import type { RuntimeActivityLease } from './RuntimeActivity.ts';
+
+type ReceiptSettlement = Readonly<{
+  promise: Promise<ObservationReceipt>;
+  reject(reason: unknown): void;
+  resolve(receipt: ObservationReceipt): void;
+}>;
+type ReadTarget = Pick<Timeline, 'read'> | Pick<TimelineView, 'read'>;
+type ReadingStreamOutcome =
+  | Readonly<{ kind: 'completed'; receipt: ReadReceipt | null }>
+  | Readonly<{ kind: 'settled' }>;
 
 export function createWorldlineLane(
   timeline: Timeline,
@@ -42,30 +55,132 @@ async function startObserver<TValue extends ReadingValue>(
   observer: Observer<TValue>,
   activity: RuntimeActivity,
 ): Promise<ObservationExecution<TValue>> {
-  return await activity.run(async () => {
-    await prepareBoundedBasis(timeline);
-    const result = await timeline.read(requireObserverReading(observer));
-    const reading = readingFrom(timeline.name, observer, result);
+  const lease = activity.acquire();
+  try {
+    const hasBoundedBasis = await prepareBoundedBasis(timeline);
+    const tick = hasBoundedBasis ? await timeline.tick() : null;
+    const settlement = createReceiptSettlement();
     return Object.freeze({
-      readings: reading === null
-        ? WarpStream.from<Reading<TValue>>([])
-        : WarpStream.of(reading),
-      receipt: Promise.resolve(
-        observationReceiptFrom(timeline, observer, result.receipt),
-      ),
+      readings: WarpStream.from(streamReadings({
+        lease,
+        observer,
+        settlement,
+        tick,
+        timeline,
+        target: tick === null ? timeline : timeline.at(tick),
+      })),
+      receipt: settlement.promise,
     });
-  });
+  } catch (error) {
+    lease.release();
+    throw error;
+  }
 }
 
-async function prepareBoundedBasis(timeline: Timeline): Promise<void> {
+async function prepareBoundedBasis(timeline: Timeline): Promise<boolean> {
   try {
     await requireTimelineRuntime(timeline).prepareOpticBasis();
+    return true;
   } catch (error) {
     if (!(error instanceof WarpError) || error.code !== 'E_OPTIC_NO_BOUNDED_BASIS') {
       throw error;
     }
     // The bounded reader converts this operational condition into its Receipt.
+    return false;
   }
+}
+
+async function* streamReadings<TValue extends ReadingValue>(options: {
+  readonly lease: RuntimeActivityLease;
+  readonly observer: Observer<TValue>;
+  readonly settlement: ReceiptSettlement;
+  readonly target: ReadTarget;
+  readonly tick: Tick | null;
+  readonly timeline: Timeline;
+}): AsyncIterable<Reading<TValue>> {
+  let completed = false;
+  try {
+    const outcome = yield* acceptedReadings(options);
+    completeReadingStream(options, outcome);
+    completed = true;
+  } catch (error) {
+    options.settlement.reject(error);
+    completed = true;
+    throw error;
+  } finally {
+    finishReadingStream(options, completed);
+    options.lease.release();
+  }
+}
+
+async function* acceptedReadings<TValue extends ReadingValue>(options: {
+  readonly observer: Observer<TValue>;
+  readonly settlement: ReceiptSettlement;
+  readonly target: ReadTarget;
+  readonly timeline: Timeline;
+}): AsyncGenerator<Reading<TValue>, ReadingStreamOutcome> {
+  let lastReceipt: ReadReceipt | null = null;
+  for await (const plan of observerReadings(options.observer)) {
+    const result = await options.target.read(plan);
+    lastReceipt = result.receipt;
+    const reading = readingFrom(options.timeline.name, options.observer, result);
+    if (reading === null) {
+      options.settlement.resolve(
+        observationReceiptFrom(options.timeline, options.observer, result.receipt),
+      );
+      return Object.freeze({ kind: 'settled' });
+    }
+    yield reading;
+  }
+  return Object.freeze({ kind: 'completed', receipt: lastReceipt });
+}
+
+function completeReadingStream<TValue extends ReadingValue>(
+  options: {
+    readonly observer: Observer<TValue>;
+    readonly settlement: ReceiptSettlement;
+    readonly tick: Tick | null;
+    readonly timeline: Timeline;
+  },
+  outcome: ReadingStreamOutcome,
+): void {
+  if (outcome.kind === 'settled') {
+    return;
+  }
+  options.settlement.resolve(outcome.receipt === null
+    ? emptyObservationReceipt(options.timeline, options.observer, options.tick)
+    : observationReceiptFrom(options.timeline, options.observer, outcome.receipt));
+}
+
+function finishReadingStream<TValue extends ReadingValue>(
+  options: {
+    readonly observer: Observer<TValue>;
+    readonly settlement: ReceiptSettlement;
+    readonly tick: Tick | null;
+    readonly timeline: Timeline;
+  },
+  completed: boolean,
+): void {
+  if (!completed) {
+    options.settlement.resolve(
+      cancelledObservationReceipt(options.timeline, options.observer, options.tick),
+    );
+  }
+}
+
+function createReceiptSettlement(): ReceiptSettlement {
+  let rejectPromise: (reason: unknown) => void = () => undefined;
+  let resolvePromise: (receipt: ObservationReceipt) => void = () => undefined;
+  const promise = new Promise<ObservationReceipt>((resolve, reject) => {
+    rejectPromise = reject;
+    resolvePromise = resolve;
+  });
+  void promise.catch(() => undefined);
+  return Object.freeze({
+    promise,
+    reject: rejectPromise,
+    resolve: resolvePromise,
+  });
 }
 
 function readingFrom<TValue extends ReadingValue>(
@@ -80,6 +195,65 @@ function readingFrom<TValue extends ReadingValue>(
     evidence: requireEvidence(result.receipt),
     lane,
     value: decodeObserverValue(observer, result.value),
+  });
+}
+
+function emptyObservationReceipt(
+  timeline: Timeline,
+  observer: Observer,
+  tick: Tick | null,
+): ObservationReceipt {
+  if (tick === null) {
+    return missingBasisObservationReceipt(timeline, observer);
+  }
+  return new ObservationReceipt({
+    evidence: tickEvidence(tick),
+    lane: timeline.name,
+    observer,
+    status: 'completed',
+    writer: timeline.writer,
+  });
+}
+
+function cancelledObservationReceipt(
+  timeline: Timeline,
+  observer: Observer,
+  tick: Tick | null,
+): ObservationReceipt {
+  const fields = {
+    lane: timeline.name,
+    observer,
+    reason: 'consumer_cancelled',
+    status: 'obstructed',
+    writer: timeline.writer,
+  } as const;
+  return new ObservationReceipt(
+    tick === null ? fields : { ...fields, evidence: tickEvidence(tick) },
+  );
+}
+
+function missingBasisObservationReceipt(
+  timeline: Timeline,
+  observer: Observer,
+): ObservationReceipt {
+  return new ObservationReceipt({
+    lane: timeline.name,
+    observer,
+    reason: 'missing_bounded_basis',
+    status: 'obstructed',
+    writer: timeline.writer,
+  });
+}
+
+function tickEvidence(tick: Tick): {
+  readonly basis: Readonly<{ readonly id: string }>;
+  readonly support: readonly Readonly<{ readonly id: string }>[];
+  readonly tick: Tick;
+} {
+  return Object.freeze({
+    basis: Object.freeze({ id: tick.id }),
+    support: Object.freeze([]),
+    tick,
   });
 }
 

--- a/src/domain/api/ObserverRuntime.ts
+++ b/src/domain/api/ObserverRuntime.ts
@@ -3,7 +3,21 @@ import LegacyReading from './Reading.ts';
 import Observer from './Observer.ts';
 import type { ReadingValue } from './ObservedReading.ts';
 
-const OBSERVER_READINGS = new WeakMap<Observer, LegacyReading>();
+export type ObserverReadingSource =
+  | Iterable<LegacyReading>
+  | AsyncIterable<LegacyReading>;
+
+type ObserverPlan =
+  | Readonly<{
+      cardinality: 'exactly-one';
+      reading: LegacyReading;
+    }>
+  | Readonly<{
+      cardinality: 'many';
+      readings: () => ObserverReadingSource;
+    }>;
+
+const OBSERVER_PLANS = new WeakMap<Observer, ObserverPlan>();
 
 export function createObserver<TValue extends ReadingValue>(
   id: string,
@@ -18,7 +32,33 @@ export function createObserver<TValue extends ReadingValue>(
     decode,
     id,
   });
-  OBSERVER_READINGS.set(observer, reading);
+  OBSERVER_PLANS.set(observer, Object.freeze({
+    cardinality: 'exactly-one',
+    reading,
+  }));
+  return observer;
+}
+
+export function createManyObserver<TValue extends ReadingValue>(
+  id: string,
+  readings: () => ObserverReadingSource,
+  decode: (value: ReadingValue) => TValue,
+): Observer<TValue> {
+  if (typeof readings !== 'function') {
+    throw new WarpError(
+      'Many Observer requires a bounded reading-plan factory',
+      'E_OBSERVER_PLAN',
+    );
+  }
+  const observer = new Observer<TValue>({
+    cardinality: 'many',
+    decode,
+    id,
+  });
+  OBSERVER_PLANS.set(observer, Object.freeze({
+    cardinality: 'many',
+    readings,
+  }));
   return observer;
 }
 
@@ -30,12 +70,30 @@ export function decodeObserverValue<TValue extends ReadingValue>(
 }
 
 export function requireObserverReading(observer: Observer): LegacyReading {
-  const reading = OBSERVER_READINGS.get(observer);
-  if (reading === undefined) {
+  const plan = requireObserverPlan(observer);
+  if (plan.cardinality !== 'exactly-one') {
+    throw new WarpError(
+      'Observer does not contain an exactly-one reading plan',
+      'E_OBSERVER_PLAN_UNAVAILABLE',
+    );
+  }
+  return plan.reading;
+}
+
+export function observerReadings(observer: Observer): ObserverReadingSource {
+  const plan = requireObserverPlan(observer);
+  return plan.cardinality === 'exactly-one'
+    ? Object.freeze([plan.reading])
+    : plan.readings();
+}
+
+function requireObserverPlan(observer: Observer): ObserverPlan {
+  const plan = OBSERVER_PLANS.get(observer);
+  if (plan === undefined) {
     throw new WarpError(
       'Observer was not created by a supported SDK or chart builder',
       'E_OBSERVER_PLAN_UNAVAILABLE',
     );
   }
-  return reading;
+  return plan;
 }

--- a/src/domain/api/ObserverRuntime.ts
+++ b/src/domain/api/ObserverRuntime.ts
@@ -82,9 +82,17 @@ export function requireObserverReading(observer: Observer): LegacyReading {
 
 export function observerReadings(observer: Observer): ObserverReadingSource {
   const plan = requireObserverPlan(observer);
-  return plan.cardinality === 'exactly-one'
-    ? Object.freeze([plan.reading])
-    : plan.readings();
+  if (plan.cardinality === 'exactly-one') {
+    return Object.freeze([plan.reading]);
+  }
+  const source = plan.readings();
+  if (!isObserverReadingSource(source)) {
+    throw new WarpError(
+      'Many Observer reading-plan factory did not return an iterable source',
+      'E_OBSERVER_PLAN',
+    );
+  }
+  return source;
 }
 
 function requireObserverPlan(observer: Observer): ObserverPlan {
@@ -96,4 +104,17 @@ function requireObserverPlan(observer: Observer): ObserverPlan {
     );
   }
   return plan;
+}
+
+function isObserverReadingSource(
+  source: ObserverReadingSource | null | undefined,
+): source is ObserverReadingSource {
+  if (source === null || source === undefined) {
+    return false;
+  }
+  const candidate = source as Partial<
+    Iterable<LegacyReading> & AsyncIterable<LegacyReading>
+  >;
+  return typeof candidate[Symbol.iterator] === 'function'
+    || typeof candidate[Symbol.asyncIterator] === 'function';
 }

--- a/test/type-check/generated-users.ts
+++ b/test/type-check/generated-users.ts
@@ -1,5 +1,8 @@
 import Intent from '../../src/domain/api/Intent.ts';
-import { createObserver } from '../../src/domain/api/ObserverRuntime.ts';
+import {
+  createManyObserver,
+  createObserver,
+} from '../../src/domain/api/ObserverRuntime.ts';
 import LegacyReading from '../../src/domain/api/Reading.ts';
 
 export const users = Object.freeze({
@@ -20,6 +23,22 @@ export const users = Object.freeze({
         (value) => {
           if (typeof value !== 'string') {
             throw new TypeError('users.role-of expected a string');
+          }
+          return value;
+        },
+      );
+    },
+    rolesOf(fields: { readonly subjects: readonly string[] }) {
+      return createManyObserver<string>(
+        'users.roles-of',
+        function* () {
+          for (const subject of fields.subjects) {
+            yield LegacyReading.property({ subject, key: 'role' });
+          }
+        },
+        (value) => {
+          if (typeof value !== 'string') {
+            throw new TypeError('users.roles-of expected a string');
           }
           return value;
         },

--- a/test/type-check/v19-consumer.ts
+++ b/test/type-check/v19-consumer.ts
@@ -37,6 +37,14 @@ const emitted: Reading<string> = await observation.one();
 const support: SupportReport = emitted.support;
 const observationReceipt: ObservationReceipt = await observation.receipt;
 const receipt: Receipt = observationReceipt;
+const manyObservation: Observation<string> = lane.observe(users.observers.rolesOf({
+  subjects: ['user:alice', 'user:bob'],
+}));
+for await (const reading of manyObservation) {
+  const value: string = reading.value;
+  void value;
+}
+const manyReceipt: ObservationReceipt = await manyObservation.receipt;
 
 function admissionWitnessHandle(value: AdmissionOutcome): EvidenceHandle {
   switch (value.kind) {
@@ -83,4 +91,5 @@ void emitted.coordinate;
 void emitted.witnessRefs;
 void support;
 void receipt;
+void manyReceipt;
 await runtime.close();

--- a/test/unit/application/RuntimeActivity.test.ts
+++ b/test/unit/application/RuntimeActivity.test.ts
@@ -25,4 +25,33 @@ describe('RuntimeActivity', () => {
     await firstClose;
     expect(release).toHaveBeenCalledOnce();
   });
+
+  it('keeps close pending until an admitted lease is released', async () => {
+    const activity = new RuntimeActivity();
+    const lease = activity.acquire();
+    const release = vi.fn(async () => {});
+
+    const closing = activity.close(release);
+    expect(release).not.toHaveBeenCalled();
+    expect(() => activity.acquire()).toThrowError(
+      expect.objectContaining({ code: 'E_RUNTIME_CLOSED' }),
+    );
+
+    lease.release();
+    lease.release();
+    await closing;
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('forgets rejected work before releasing local resources', async () => {
+    const activity = new RuntimeActivity();
+    const failed = activity.run(async () => {
+      throw new Error('activity failed');
+    });
+    const release = vi.fn(async () => {});
+
+    await expect(failed).rejects.toThrow('activity failed');
+    await activity.close(release);
+    expect(release).toHaveBeenCalledOnce();
+  });
 });

--- a/test/unit/application/RuntimeLaneAdapter.test.ts
+++ b/test/unit/application/RuntimeLaneAdapter.test.ts
@@ -1,10 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { openWarp } from '../../../src/application/openWarp.ts';
 import RuntimeActivity from '../../../src/application/RuntimeActivity.ts';
 import { createWorldlineLane } from '../../../src/application/RuntimeLaneAdapter.ts';
 import Intent from '../../../src/domain/api/Intent.ts';
-import { createObserver } from '../../../src/domain/api/ObserverRuntime.ts';
+import {
+  createManyObserver,
+  createObserver,
+} from '../../../src/domain/api/ObserverRuntime.ts';
 import LegacyReading from '../../../src/domain/api/Reading.ts';
 import captureCoordinate from '../../../src/domain/api/captureCoordinate.ts';
 import { createBoundedReadBasis } from '../../helpers/BoundedReadBasis.ts';
@@ -83,6 +86,202 @@ describe('Runtime Lane adapter', () => {
     }
   });
 
+  it('streams a many Observer lazily against one pinned Tick', async () => {
+    const storage = MemoryStorage.create();
+    try {
+      const warp = await openWarp({ storage, writer: 'agent-1' });
+      const timeline = await warp.timeline('events');
+      const lane = createWorldlineLane(timeline, new RuntimeActivity());
+      const subjects = ['user:alice', 'user:bob', 'user:carol'];
+      for (const [index, subject] of subjects.entries()) {
+        await lane.write(Intent.addNode({ subject }));
+        await lane.write(Intent.setProperty({
+          subject,
+          key: 'rank',
+          value: index + 1,
+        }));
+      }
+      await createBoundedReadBasis(storage, 'events');
+      let planned = 0;
+      const observer = createManyObserver<number>(
+        'users.ranks',
+        function* () {
+          for (const subject of subjects) {
+            planned += 1;
+            yield LegacyReading.property({ subject, key: 'rank' });
+          }
+        },
+        (value) => {
+          if (typeof value !== 'number') {
+            throw new TypeError('users.ranks expected a number');
+          }
+          return value;
+        },
+      );
+      const observation = lane.observe(observer);
+      const iterator = observation[Symbol.asyncIterator]();
+
+      expect(planned).toBe(0);
+      const first = await iterator.next();
+      expect(first).toMatchObject({ done: false, value: { value: 1 } });
+      expect(planned).toBe(1);
+      const second = await iterator.next();
+      expect(second).toMatchObject({ done: false, value: { value: 2 } });
+      expect(planned).toBe(2);
+      const third = await iterator.next();
+      expect(third).toMatchObject({ done: false, value: { value: 3 } });
+      expect(planned).toBe(3);
+      await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+
+      const tickIds = [first, second, third].map((result) =>
+        result.done === false ? result.value.coordinate.tick?.id : undefined
+      );
+      expect(new Set(tickIds).size).toBe(1);
+      await expect(observation.receipt).resolves.toMatchObject({
+        observer,
+        status: 'completed',
+      });
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it('drains a receipt-first many Observer without collecting Readings', async () => {
+    const storage = MemoryStorage.create();
+    try {
+      const warp = await openWarp({ storage, writer: 'agent-1' });
+      const timeline = await warp.timeline('events');
+      const lane = createWorldlineLane(timeline, new RuntimeActivity());
+      const subjects = ['user:alice', 'user:bob', 'user:carol'];
+      for (const subject of subjects) {
+        await lane.write(Intent.addNode({ subject }));
+      }
+      await createBoundedReadBasis(storage, 'events');
+      let planned = 0;
+      let decoded = 0;
+      const observer = createManyObserver<boolean>(
+        'users.exist',
+        function* () {
+          for (const subject of subjects) {
+            planned += 1;
+            yield LegacyReading.nodeExists({ subject });
+          }
+        },
+        (value) => {
+          decoded += 1;
+          if (typeof value !== 'boolean') {
+            throw new TypeError('users.exist expected a boolean');
+          }
+          return value;
+        },
+      );
+      const observation = lane.observe(observer);
+
+      await expect(observation.receipt).resolves.toMatchObject({ status: 'completed' });
+      expect(planned).toBe(3);
+      expect(decoded).toBe(3);
+      await expect(observation[Symbol.asyncIterator]().next()).rejects.toMatchObject({
+        code: 'E_OBSERVATION_DRAINING',
+      });
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it('completes an empty many Observer with pinned-basis evidence', async () => {
+    const storage = MemoryStorage.create();
+    try {
+      const warp = await openWarp({ storage, writer: 'agent-1' });
+      const timeline = await warp.timeline('events');
+      const lane = createWorldlineLane(timeline, new RuntimeActivity());
+      await lane.write(Intent.addNode({ subject: 'user:alice' }));
+      await createBoundedReadBasis(storage, 'events');
+      const observer = createManyObserver<boolean>(
+        'users.empty',
+        () => [],
+        (value) => Boolean(value),
+      );
+      const observation = lane.observe(observer);
+
+      await expect(observation[Symbol.asyncIterator]().next()).resolves.toEqual({
+        done: true,
+        value: undefined,
+      });
+      await expect(observation.receipt).resolves.toMatchObject({
+        evidence: {
+          support: [],
+          tick: expect.objectContaining({ timeline: 'events' }),
+        },
+        status: 'completed',
+      });
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it('obstructs an empty many Observer when no bounded basis exists', async () => {
+    const storage = MemoryStorage.create();
+    try {
+      const warp = await openWarp({ storage, writer: 'agent-1' });
+      const timeline = await warp.timeline('events');
+      const lane = createWorldlineLane(timeline, new RuntimeActivity());
+      const observer = createManyObserver<boolean>(
+        'users.empty',
+        () => [],
+        (value) => Boolean(value),
+      );
+
+      await expect(lane.observe(observer).receipt).resolves.toMatchObject({
+        operation: 'observe',
+        reason: 'missing_bounded_basis',
+        status: 'obstructed',
+      });
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it('records consumer cancellation and releases Runtime activity', async () => {
+    const storage = MemoryStorage.create();
+    try {
+      const warp = await openWarp({ storage, writer: 'agent-1' });
+      const timeline = await warp.timeline('events');
+      const activity = new RuntimeActivity();
+      const lane = createWorldlineLane(timeline, activity);
+      await lane.write(Intent.addNode({ subject: 'user:alice' }));
+      await createBoundedReadBasis(storage, 'events');
+      const observer = createManyObserver<boolean>(
+        'users.exist',
+        function* () {
+          yield LegacyReading.nodeExists({ subject: 'user:alice' });
+          yield LegacyReading.nodeExists({ subject: 'user:bob' });
+        },
+        (value) => {
+          if (typeof value !== 'boolean') {
+            throw new TypeError('users.exist expected a boolean');
+          }
+          return value;
+        },
+      );
+      const observation = lane.observe(observer);
+      const iterator = observation[Symbol.asyncIterator]();
+      await iterator.next();
+      const release = vi.fn(async () => {});
+      const closing = activity.close(release);
+
+      expect(release).not.toHaveBeenCalled();
+      await iterator.return?.();
+      await expect(observation.receipt).resolves.toMatchObject({
+        reason: 'consumer_cancelled',
+        status: 'obstructed',
+      });
+      await closing;
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      await storage.close();
+    }
+  });
+
   it('rejects incompatible generated values as runtime failures', async () => {
     const storage = MemoryStorage.create();
     try {
@@ -130,5 +329,13 @@ describe('Runtime Lane adapter', () => {
     } finally {
       await storage.close();
     }
+  });
+
+  it('rejects a many Observer without a reading-plan factory', () => {
+    expect(() => createManyObserver(
+      'users.invalid',
+      undefined as never,
+      (value) => value,
+    )).toThrowError(expect.objectContaining({ code: 'E_OBSERVER_PLAN' }));
   });
 });

--- a/test/unit/domain/ObserverRuntime.test.ts
+++ b/test/unit/domain/ObserverRuntime.test.ts
@@ -69,6 +69,18 @@ describe('ObserverRuntime', () => {
     )).toThrowError(expect.objectContaining({ code: 'E_OBSERVER_PLAN' }));
   });
 
+  it('rejects a many factory that returns a non-iterable source', () => {
+    const observer = createManyObserver(
+      'users.invalid-many',
+      () => undefined as never,
+      (value) => value,
+    );
+
+    expect(() => observerReadings(observer)).toThrowError(
+      expect.objectContaining({ code: 'E_OBSERVER_PLAN' }),
+    );
+  });
+
   it('rejects an Observer that bypasses a supported plan builder', () => {
     const observer = new Observer({
       cardinality: 'exactly-one',

--- a/test/unit/domain/ObserverRuntime.test.ts
+++ b/test/unit/domain/ObserverRuntime.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import Observer from '../../../src/domain/api/Observer.ts';
+import {
+  createManyObserver,
+  createObserver,
+  decodeObserverValue,
+  observerReadings,
+  type ObserverReadingSource,
+  requireObserverReading,
+} from '../../../src/domain/api/ObserverRuntime.ts';
+import LegacyReading from '../../../src/domain/api/Reading.ts';
+
+async function collectReadings(
+  source: ObserverReadingSource,
+): Promise<LegacyReading[]> {
+  const readings: LegacyReading[] = [];
+  for await (const reading of source) {
+    readings.push(reading);
+  }
+  return readings;
+}
+
+describe('ObserverRuntime', () => {
+  it('preserves an exactly-one reading plan and decoder', async () => {
+    const reading = LegacyReading.nodeExists({ subject: 'user:alice' });
+    const observer = createObserver(
+      'users.exists',
+      reading,
+      (value) => Boolean(value),
+    );
+
+    expect(requireObserverReading(observer)).toBe(reading);
+    await expect(collectReadings(observerReadings(observer))).resolves.toEqual([
+      reading,
+    ]);
+    expect(decodeObserverValue(observer, true)).toBe(true);
+  });
+
+  it('creates a fresh async reading source for every many execution', async () => {
+    const reading = LegacyReading.nodeExists({ subject: 'user:alice' });
+    let executions = 0;
+    const observer = createManyObserver(
+      'users.exist',
+      async function* () {
+        executions += 1;
+        yield reading;
+      },
+      (value) => Boolean(value),
+    );
+
+    await expect(collectReadings(observerReadings(observer))).resolves.toEqual([
+      reading,
+    ]);
+    await expect(collectReadings(observerReadings(observer))).resolves.toEqual([
+      reading,
+    ]);
+    expect(executions).toBe(2);
+    expect(() => requireObserverReading(observer)).toThrowError(
+      expect.objectContaining({ code: 'E_OBSERVER_PLAN_UNAVAILABLE' }),
+    );
+  });
+
+  it('rejects an unbounded exactly-one plan', () => {
+    expect(() => createObserver(
+      'users.invalid',
+      {} as never,
+      (value) => value,
+    )).toThrowError(expect.objectContaining({ code: 'E_OBSERVER_PLAN' }));
+  });
+
+  it('rejects an Observer that bypasses a supported plan builder', () => {
+    const observer = new Observer({
+      cardinality: 'exactly-one',
+      decode: (value) => value,
+      id: 'users.unsupported',
+    });
+
+    expect(() => observerReadings(observer)).toThrowError(
+      expect.objectContaining({ code: 'E_OBSERVER_PLAN_UNAVAILABLE' }),
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/ports/**/*.ts', 'src/**/*.d.ts'],
       thresholds: {
-        lines: 92.93,
+        lines: 92.95,
         autoUpdate: shouldAutoUpdateCoverageRatchet(),
       },
     },


### PR DESCRIPTION
## Summary

- add internal/generated-SDK support for finite or async `many` Observer reading-plan factories while preserving the exactly-one API
- execute every Reading in one Observation against a single pinned Tick and advance the plan source only on downstream demand
- drain receipt-first observations without collecting Reading values, settle cancellation and empty-plan receipts explicitly, and hold Runtime shutdown until stream completion
- validate generated plan sources at the domain boundary and raise the line-coverage ratchet to 92.95%

## Issue

Refs #712
Prerequisite for #760
Depends on the cold bounded-materialization work tracked by #738.

## Test plan

- pre-push IRONCLAD gate: links, lint, source/test/policy/consumer typechecks, declaration surface, Markdown/code samples, docs topology, CAS invariants, and all stable unit shards
- coverage: 606 files passed, 1 skipped; 7,346 tests passed, 2 skipped; 92.95% lines
- publication surface: 0 errors, 0 warnings
- link check: 169 total, 147 valid, 22 intentionally excluded
- regression tests cover lazy sync/async plans, non-iterable factory rejection, receipt-first draining, pinned-Tick execution, empty plans, cancellation, and Runtime shutdown

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] If this PR touches persisted op formats, I linked the ADR 3 readiness issue (N/A: no persisted op formats)
- [x] If this PR touches wire compatibility, I confirmed canonical-only ops are still rejected on the wire pre-cutover (N/A: no wire changes)
- [x] If this PR touches schema constants, I confirmed patch and checkpoint namespaces remain distinct (N/A: no schema constants)