### PR TITLE
Retain bounded live liveness materializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operation-local instead of shared across materializations. This bounds
   mutated-page residency only; removal of whole-state projection remains
   tracked by #738.
+- Changed cold live-handle resolution to stream only node and edge liveness
+  into bounded git-cas pages. Partial materialization handles carry
+  `stateHash: null`, cannot masquerade as whole-state snapshots, and avoid
+  constructing `WarpState`, adjacency, properties, receipts, diffs,
+  provenance, or a state-cache snapshot.
 
 ### Removed
 
@@ -73,6 +78,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compatibility barrel, and their compatibility-only examples and tests.
 - Removed the v18 graph-first package exports rather than carrying a deprecated
   second application API through v19.
+- Removed migration and cleanup support for unreleased materialization
+  descriptor schemas v2 through v4. Schema v5 is the first release contract;
+  stale derived-cache entries miss and rebuild from authoritative WARP history.
 
 ### Fixed
 

--- a/docs/topics/cas-first-memoized-materialization.md
+++ b/docs/topics/cas-first-memoized-materialization.md
@@ -98,14 +98,17 @@ Until cache payloads carry provenance indexes, that derived snapshot retains a
 degraded provenance posture rather than claiming support for the cached prefix.
 
 Retained materializations can now satisfy the same two resume cases without a
-separate state-cache hit. Descriptor schema v4 retains a canonical replay basis
-beside the node, edge, and property roots. An exact retained hit validates and
-loads that basis, reuses the retained roots, and performs no patch replay. When
-there is no exact hit, the adapter inspects at most 1,024 current-schema cache
-entries in pages of 100. It validates their descriptors and coordinates, checks
-causal ancestry, and resumes the newest compatible predecessor by replaying only
-the suffix. Receipt-producing reads still use the ordinary replay path, as do
-diff-producing predecessor reads.
+separate state-cache hit. A complete descriptor retains a canonical replay
+basis beside the node, edge, and property roots. An exact retained hit validates
+and loads that basis, reuses the retained roots, and performs no patch replay.
+Descriptor schema v5 also admits explicitly partial handles: `stateHash: null`
+means the roots can answer only the reads whose root status is retained or
+empty, and the handle cannot resume a whole-state snapshot. When there is no
+exact hit, the adapter inspects at most 1,024 current-schema cache entries in
+pages of 100. It validates their descriptors and coordinates, checks causal
+ancestry, and resumes the newest compatible complete predecessor by replaying
+only the suffix. Receipt-producing reads still use the ordinary replay path, as
+do diff-producing predecessor reads.
 
 ### 3. Fall back to replay and publish
 
@@ -140,23 +143,23 @@ Both exact paths release their operation borrow without hydrating `WarpState`,
 building adjacency, publishing a state snapshot, or populating `_cachedState`.
 The runtime storage adapter keeps one git-cas acquisition for the current
 coordinate, retires it after in-flight readers finish when the coordinate
-changes, and releases it from `RuntimeHost.close()`. A cold handle miss still
-performs the current materialization path before retaining and reading the new
-roots. Once assembled, a newly built property root joins the operation's
-expiring git-cas workspace before state hashing and final promotion, so the
-completed root remains reachable throughout promotion. A custom
-state-session opener owns its root storage and
-encoding, so git-warp does not pair it with the default reader and instead
-preserves the compatibility fallback.
+changes, and releases it from `RuntimeHost.close()`. On a cold handle miss, the
+built-in session now streams only node and edge OR-Set operations into bounded
+git-cas pages and retains those roots as a partial handle. It does not construct
+`WarpState`, adjacency, property registers, receipts, diffs, provenance, or a
+state-cache snapshot. A later compatibility or property operation can replace
+that partial entry with a complete descriptor.
 
-The replay-basis contract advances the retained-materialization descriptor and
-coordinate cache key to schema v4. A v4 exact miss leaves corresponding legacy
-entries anchored until replacement succeeds. Successful v4 retention then
-removes incompatible v2 and v3 anchors through the git-cas cache API. Legacy
-descriptors may still be structurally valid, but they cannot satisfy the v4 root
-profile because their property or replay-basis root may be unavailable. New v4
-descriptors reject either root as unavailable; an empty graph still records the
-property root as explicitly empty.
+Once assembled, a newly built property root joins the operation's expiring
+git-cas workspace before state hashing and final promotion, so the completed
+root remains reachable throughout promotion. A custom state-session opener owns
+its root storage and encoding, so git-warp does not pair it with the default
+reader and instead preserves the compatibility fallback.
+
+Schema v5 is the first release contract for retained-materialization
+descriptors. Earlier v2, v3, and v4 profiles were unreleased derived-cache
+formats; v19 does not decode or migrate them. A current-key miss rebuilds from
+authoritative WARP history.
 
 ## `git-cas` Encapsulation
 
@@ -221,20 +224,23 @@ lost payload bytes, or run Git garbage collection.
 
 - RuntimeHost exact node-liveness and node-property reads consume the
   handle-first result when the built-in trie session and reader pair is active.
-  Custom session openers, neighborhoods, list reads, checkpoint creation, and
-  other compatibility operations still own process-resident whole state.
+  Cold node liveness now produces a partial retained handle through bounded
+  node/edge replay. Cold properties, custom session openers, neighborhoods,
+  list reads, checkpoint creation, and other compatibility operations still own
+  process-resident whole state.
 - Exact state-cache hits bypass replay, but full materialization still hydrates
   a full `WarpState`, scans retained node/edge tries, and builds full adjacency.
 - Retained exact and predecessor resume load a complete canonical `WarpState`
   replay basis before they reuse roots or replay a suffix. This eliminates
   redundant prefix replay but is still a whole-state compatibility bridge, not
   the bounded-memory observer representation.
-- Retained materialization descriptors currently carry node/edge trie roots and
-  a per-node property-shard root plus the full-state replay basis. Frontier,
-  edge-birth, adjacency,
-  provenance-support, and roaring roots remain explicitly unavailable until
-  their paged representations land. Cold property-root construction still
-  projects a complete `WarpState`; only exact retained reads avoid that state.
+- Complete retained materialization descriptors carry node/edge trie roots, a
+  per-node property-shard root, and the full-state replay basis. Partial cold
+  handles carry node/edge roots and mark the remaining roots unavailable.
+  Frontier, edge-birth, adjacency, provenance-support, and roaring roots remain
+  explicitly unavailable until their paged representations land. Cold
+  property-root construction still projects a complete `WarpState`; only
+  exact retained property reads avoid that state.
 - One node's complete encoded property bag must currently fit within the 16 MiB
   shard limit. Property-key pagination or a property trie is not yet available.
 - The first property-root profile stores one bundle member per property-bearing

--- a/src/domain/materialization/MaterializationHandle.ts
+++ b/src/domain/materialization/MaterializationHandle.ts
@@ -10,7 +10,14 @@ export default class MaterializationHandle {
   readonly bundle: BundleHandle;
   readonly coordinate: MaterializationCoordinate;
   readonly roots: MaterializationRoots;
-  readonly stateHash: string;
+  /**
+   * Semantic hash of a complete WarpState replay basis.
+   *
+   * Partial materializations intentionally carry `null`: their retained roots
+   * can answer bounded reads, but must never masquerade as a whole-state
+   * snapshot.
+   */
+  readonly stateHash: string | null;
   readonly retention: StorageRetentionWitness;
 
   constructor(options: {
@@ -18,7 +25,7 @@ export default class MaterializationHandle {
     readonly bundle: BundleHandle;
     readonly coordinate: MaterializationCoordinate;
     readonly roots: MaterializationRoots;
-    readonly stateHash: string;
+    readonly stateHash: string | null;
     readonly retention: StorageRetentionWitness;
   }) {
     requireOptions(options);
@@ -30,7 +37,7 @@ export default class MaterializationHandle {
       'coordinate',
     );
     this.roots = requireInstance(options.roots, MaterializationRoots, 'roots');
-    this.stateHash = requireNonEmpty(options.stateHash, 'stateHash');
+    this.stateHash = requireOptionalStateHash(options.stateHash);
     this.retention = requireInstance(
       options.retention,
       StorageRetentionWitness,
@@ -57,6 +64,10 @@ function requireNonEmpty(value: string, field: string): string {
     throw handleError(`${field} must be a non-empty string`);
   }
   return value;
+}
+
+function requireOptionalStateHash(value: string | null): string | null {
+  return value === null ? null : requireNonEmpty(value, 'stateHash');
 }
 
 function requireOptions(options: object): void {

--- a/src/domain/orset/session/StateSession.ts
+++ b/src/domain/orset/session/StateSession.ts
@@ -222,6 +222,16 @@ export default class StateSession {
     return roots;
   }
 
+  /**
+   * Terminates a failed session without flushing or retaining its pending pages.
+   *
+   * The workspace owns cleanup for any pages already staged before the failure.
+   */
+  abort(): void {
+    this.#closed = true;
+    this.#closePrepared = false;
+  }
+
   async prepareClose(): Promise<StateSessionPreparedClose> {
     this.#assertOpen();
     this.#closePrepared = true;

--- a/src/domain/services/JoinReducerSession.ts
+++ b/src/domain/services/JoinReducerSession.ts
@@ -131,6 +131,38 @@ export async function applyWithReceiptInSession(
   return result.receipt;
 }
 
+/**
+ * Applies only the page-backed OR-Set portion of a patch.
+ *
+ * This is the bounded cold-read reducer: it deliberately does not allocate
+ * property registers, edge-birth metadata, receipts, diffs, or a frontier
+ * projection.
+ */
+export async function applyLivenessInSession(
+  session: StateSession,
+  patch: PatchLike, // nosemgrep: ts-no-like-types -- 0025C
+): Promise<void> {
+  for (const rawOp of patch.ops) {
+    const op = normalizeRawOp(rawOp);
+    if (!(op instanceof Op)) {
+      continue;
+    }
+    op.validate();
+    if (op instanceof NodeAdd) {
+      await session.addNode(op.node, op.dot);
+    } else if (op instanceof NodeRemove) {
+      await session.removeNode(op.node, new Set(op.observedDots));
+    } else if (op instanceof EdgeAdd) {
+      await session.addEdge(encodeEdgeKey(op.from, op.to, op.label), op.dot);
+    } else if (op instanceof EdgeRemove) {
+      await session.removeEdge(
+        encodeEdgeKey(op.from, op.to, op.label),
+        new Set(op.observedDots),
+      );
+    }
+  }
+}
+
 export function reducePatchesInSession(
   patches: SessionPatchSource,
   frame: ReducerSessionFrame,

--- a/src/domain/services/controllers/BoundedLiveMaterialization.ts
+++ b/src/domain/services/controllers/BoundedLiveMaterialization.ts
@@ -87,18 +87,23 @@ async function buildBoundedMaterialization(args: {
     { nodeAliveRootOid: null, edgeAliveRootOid: null },
     { workspace },
   );
-  const patchCount = await replayLiveness(session, deps, coordinate);
-  if (patchCount === 0) {
-    await session.close();
-    await workspace.release();
-    return null;
+  try {
+    const patchCount = await replayLiveness(session, deps, coordinate);
+    if (patchCount === 0) {
+      await session.close();
+      await workspace.release();
+      return null;
+    }
+    return await retainPreparedLiveness({
+      session,
+      coordinate,
+      workspace,
+      patchCount,
+    });
+  } catch (raw) {
+    session.abort();
+    throw raw;
   }
-  return await retainPreparedLiveness({
-    session,
-    coordinate,
-    workspace,
-    patchCount,
-  });
 }
 
 async function replayLiveness(

--- a/src/domain/services/controllers/BoundedLiveMaterialization.ts
+++ b/src/domain/services/controllers/BoundedLiveMaterialization.ts
@@ -1,0 +1,179 @@
+import type MaterializationCoordinate from '../../materialization/MaterializationCoordinate.ts';
+import LiveMaterializationResolution from '../../materialization/LiveMaterializationResolution.ts';
+import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
+import MaterializationRoot from '../../materialization/MaterializationRoot.ts';
+import MaterializationRoots from '../../materialization/MaterializationRoots.ts';
+import BundleHandle from '../../storage/BundleHandle.ts';
+import WarpError from '../../errors/WarpError.ts';
+import type StateSession from '../../orset/session/StateSession.ts';
+import type MaterializationWorkspacePort from '../../../ports/MaterializationWorkspacePort.ts';
+import { applyLivenessInSession } from '../JoinReducerSession.ts';
+import type { MaterializeDeps } from './MaterializeDeps.ts';
+import type { MaterializeSessionOpener } from './MaterializeSessionBridge.ts';
+import {
+  releaseAcquisitionAfterFailure,
+  releaseWorkspaceAfterFailure,
+} from './MaterializationWorkspaceCleanup.ts';
+
+export type BoundedLiveMaterializationResult = Readonly<{
+  materialization: Awaited<
+    ReturnType<MaterializeDeps['materializations']['retain']>
+  >;
+  patchCount: number;
+}>;
+
+export async function resolveBoundedLiveMaterialization(args: {
+  readonly deps: MaterializeDeps;
+  readonly coordinate: MaterializationCoordinate;
+}): Promise<LiveMaterializationResolution | null> {
+  const bounded = await retainBoundedLiveMaterialization(args);
+  if (bounded === null) {
+    return null;
+  }
+  const acquired = await args.deps.materializations.acquireExact(args.coordinate);
+  if (acquired === null) {
+    throw resolutionError('newly retained bounded handle could not be acquired');
+  }
+  try {
+    requireSameHandle(bounded.materialization, acquired.materialization);
+    return new LiveMaterializationResolution({
+      materialization: acquired.materialization,
+      source: 'materialized',
+      replayedPatchCount: bounded.patchCount,
+      release: async () => await acquired.release(),
+    });
+  } catch (raw) {
+    await releaseAcquisitionAfterFailure(acquired, args.deps.logger);
+    throw raw;
+  }
+}
+
+/**
+ * Replays only node/edge OR-Set state into bounded CAS pages and retains those
+ * roots as a partial materialization. No WarpState or whole-graph adjacency is
+ * constructed.
+ */
+export async function retainBoundedLiveMaterialization(args: {
+  readonly deps: MaterializeDeps;
+  readonly coordinate: MaterializationCoordinate;
+}): Promise<BoundedLiveMaterializationResult | null> {
+  const { deps, coordinate } = args;
+  const { openStateSession } = deps;
+  if (openStateSession === undefined) {
+    return null;
+  }
+  const workspace = await deps.materializations.openWorkspace(coordinate);
+  try {
+    return await buildBoundedMaterialization({
+      deps,
+      coordinate,
+      workspace,
+      openStateSession,
+    });
+  } catch (raw) {
+    await releaseWorkspaceAfterFailure(workspace, deps.logger);
+    throw raw;
+  }
+}
+
+async function buildBoundedMaterialization(args: {
+  readonly deps: MaterializeDeps;
+  readonly coordinate: MaterializationCoordinate;
+  readonly workspace: MaterializationWorkspacePort;
+  readonly openStateSession: MaterializeSessionOpener;
+}): Promise<BoundedLiveMaterializationResult | null> {
+  const { deps, coordinate, workspace, openStateSession } = args;
+  const session = await openStateSession(
+    { nodeAliveRootOid: null, edgeAliveRootOid: null },
+    { workspace },
+  );
+  const patchCount = await replayLiveness(session, deps, coordinate);
+  if (patchCount === 0) {
+    await session.close();
+    await workspace.release();
+    return null;
+  }
+  return await retainPreparedLiveness({
+    session,
+    coordinate,
+    workspace,
+    patchCount,
+  });
+}
+
+async function replayLiveness(
+  session: StateSession,
+  deps: MaterializeDeps,
+  coordinate: MaterializationCoordinate,
+): Promise<number> {
+  let patchCount = 0;
+  for await (const entry of deps.patches.streamForFrontier(
+    coordinate.frontier(),
+    coordinate.ceiling,
+  )) {
+    patchCount += 1;
+    await applyLivenessInSession(session, entry.patch);
+  }
+  return patchCount;
+}
+
+async function retainPreparedLiveness(args: {
+  readonly session: StateSession;
+  readonly coordinate: MaterializationCoordinate;
+  readonly workspace: MaterializationWorkspacePort;
+  readonly patchCount: number;
+}): Promise<BoundedLiveMaterializationResult> {
+  const { session, coordinate, workspace, patchCount } = args;
+  const prepared = await session.prepareClose();
+  const materialization = await workspace.promote({
+    coordinate,
+    roots: livenessRoots(prepared.roots),
+    stateHash: null,
+  });
+  prepared.accept(materialization.retention);
+  await workspace.release();
+  return Object.freeze({ materialization, patchCount });
+}
+
+function livenessRoots(roots: {
+  readonly nodeAliveRootOid: string | null;
+  readonly edgeAliveRootOid: string | null;
+}): MaterializationRoots {
+  return new MaterializationRoots({
+    adjacency: MaterializationRoot.unavailable(),
+    edgeAlive: sessionRoot(roots.edgeAliveRootOid),
+    edgeBirths: MaterializationRoot.unavailable(),
+    frontier: MaterializationRoot.unavailable(),
+    nodeAlive: sessionRoot(roots.nodeAliveRootOid),
+    properties: MaterializationRoot.unavailable(),
+    provenanceSupport: MaterializationRoot.unavailable(),
+    replayBasis: MaterializationRoot.unavailable(),
+    roaringIndexes: MaterializationRoot.unavailable(),
+  });
+}
+
+function sessionRoot(token: string | null): MaterializationRoot {
+  return token === null
+    ? MaterializationRoot.empty()
+    : MaterializationRoot.retained(new BundleHandle(token));
+}
+
+function requireSameHandle(
+  expected: MaterializationHandle,
+  acquired: MaterializationHandle,
+): void {
+  if (
+    !acquired.coordinate.equals(expected.coordinate)
+    || acquired.stateHash !== expected.stateHash
+    || !acquired.bundle.equals(expected.bundle)
+  ) {
+    throw resolutionError('newly retained handle changed before it could be acquired');
+  }
+}
+
+function resolutionError(message: string): WarpError {
+  return new WarpError(
+    `Materialization resolution ${message}`,
+    'E_MATERIALIZATION_RESUME',
+  );
+}

--- a/src/domain/services/controllers/MaterializationRetention.ts
+++ b/src/domain/services/controllers/MaterializationRetention.ts
@@ -27,17 +27,30 @@ function resolveExistingMaterialization(
   stateHash: string,
 ): MaterializationHandle | undefined {
   const retained = params.materialization;
-  if (retained === undefined) {
+  if (!isWholeStateMaterialization(retained)) {
     return undefined;
   }
-  if (retained.stateHash !== stateHash) {
-    throw retentionError('retained handle state hash does not match resumed state');
-  }
+  requireMatchingStateHash(retained, stateHash);
   if (!rootsMatch(params, retained)) {
     return undefined;
   }
   params.reduced.acceptMaterialization?.(retained.retention);
   return retained;
+}
+
+function isWholeStateMaterialization(
+  retained: MaterializationHandle | undefined,
+): retained is MaterializationHandle & { readonly stateHash: string } {
+  return retained !== undefined && retained.stateHash !== null;
+}
+
+function requireMatchingStateHash(
+  retained: MaterializationHandle & { readonly stateHash: string },
+  stateHash: string,
+): void {
+  if (retained.stateHash !== stateHash) {
+    throw retentionError('retained handle state hash does not match resumed state');
+  }
 }
 
 function rootsMatch(

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -285,9 +285,13 @@ export default class MaterializeController {
     }
     const coordinate = new MaterializationCoordinate(snapshot.coordinate);
     const acquisition = await this._deps.materializations.acquireExact(coordinate);
+    const retained = acquisition?.materialization ?? null;
+    if (retained?.stateHash === null) {
+      await acquisition?.release();
+      return null;
+    }
     let result: MaterializeResult;
     try {
-      const retained = acquisition?.materialization ?? null;
       if (retained !== null && retained.stateHash !== snapshot.stateHash) {
         throw materializationResumeError('retained handle and snapshot state hashes differ');
       }

--- a/src/domain/services/controllers/MaterializeLiveStrategy.ts
+++ b/src/domain/services/controllers/MaterializeLiveStrategy.ts
@@ -27,6 +27,8 @@ import { snapshotPublicationForReceipts } from './MaterializeSnapshotPublication
 import { releaseAcquisitionAfterFailure } from './MaterializationWorkspaceCleanup.ts';
 import RetainedMaterializationResumeStrategy from './RetainedMaterializationResumeStrategy.ts';
 import { isNonEmptyPatchSha } from './MaterializeHelpers.ts';
+import { resolveBoundedLiveMaterialization } from './BoundedLiveMaterialization.ts';
+import { materializedResolution } from './MaterializedLiveResolution.ts';
 
 export default class MaterializeLiveStrategy {
   private readonly runtime: MaterializeStrategyRuntime;
@@ -118,6 +120,13 @@ export default class MaterializeLiveStrategy {
     coordinate: WarpStateCoordinate,
     materializationCoordinate: MaterializationCoordinate,
   ): Promise<LiveMaterializationResolution> {
+    const bounded = await resolveBoundedLiveMaterialization({
+      deps: this.runtime.deps,
+      coordinate: materializationCoordinate,
+    });
+    if (bounded !== null) {
+      return bounded;
+    }
     const result = await this.replayCurrentCoordinate(coordinate, {
       receipts: false,
       wantDiff: false,
@@ -452,28 +461,6 @@ function retainedResolution(
     materialization: retained,
     source: 'retained',
     replayedPatchCount: 0,
-    release: async () => await acquired.release(),
-  });
-}
-
-function materializedResolution(
-  result: MaterializeResult,
-  acquired: MaterializationAcquisition,
-): LiveMaterializationResolution {
-  if (result.materialization === undefined) {
-    throw resolutionError('non-empty coordinate did not produce a retained handle');
-  }
-  if (
-    !acquired.materialization.coordinate.equals(result.materialization.coordinate)
-    || acquired.materialization.stateHash !== result.materialization.stateHash
-    || !acquired.materialization.bundle.equals(result.materialization.bundle)
-  ) {
-    throw resolutionError('newly retained handle changed before it could be acquired');
-  }
-  return new LiveMaterializationResolution({
-    materialization: acquired.materialization,
-    source: 'materialized',
-    replayedPatchCount: result.patchCount,
     release: async () => await acquired.release(),
   });
 }

--- a/src/domain/services/controllers/MaterializedLiveResolution.ts
+++ b/src/domain/services/controllers/MaterializedLiveResolution.ts
@@ -1,0 +1,41 @@
+import LiveMaterializationResolution from '../../materialization/LiveMaterializationResolution.ts';
+import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
+import WarpError from '../../errors/WarpError.ts';
+import type { MaterializationAcquisition } from '../../../ports/MaterializationStorePort.ts';
+import type { MaterializeResult } from './MaterializeController.ts';
+
+export function materializedResolution(
+  result: MaterializeResult,
+  acquired: MaterializationAcquisition,
+): LiveMaterializationResolution {
+  if (result.materialization === undefined) {
+    throw resolutionError('non-empty coordinate did not produce a retained handle');
+  }
+  requireSameHandle(result.materialization, acquired.materialization);
+  return new LiveMaterializationResolution({
+    materialization: acquired.materialization,
+    source: 'materialized',
+    replayedPatchCount: result.patchCount,
+    release: async () => await acquired.release(),
+  });
+}
+
+function requireSameHandle(
+  expected: MaterializationHandle,
+  acquired: MaterializationHandle,
+): void {
+  if (
+    !acquired.coordinate.equals(expected.coordinate)
+    || acquired.stateHash !== expected.stateHash
+    || !acquired.bundle.equals(expected.bundle)
+  ) {
+    throw resolutionError('newly retained handle changed before it could be acquired');
+  }
+}
+
+function resolutionError(message: string): WarpError {
+  return new WarpError(
+    `Materialization resolution ${message}`,
+    'E_MATERIALIZATION_RESUME',
+  );
+}

--- a/src/infrastructure/adapters/GitCasMaterializationDescriptor.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationDescriptor.ts
@@ -9,18 +9,18 @@ import MaterializationRoots, {
 import type BundleHandle from '../../domain/storage/BundleHandle.ts';
 import WarpError from '../../domain/errors/WarpError.ts';
 
-export const MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION = 4;
+export const MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION = 5;
 
 export type DecodedMaterializationDescriptor = Readonly<{
   coordinate: MaterializationCoordinate;
-  stateHash: string;
+  stateHash: string | null;
   laneName: string;
   rootStatuses: ReadonlyMap<MaterializationRootName, MaterializationRootStatus>;
 }>;
 
 export function materializationDescriptorData(input: {
   coordinate: MaterializationCoordinate;
-  stateHash: string;
+  stateHash: string | null;
   laneName: string;
   roots: MaterializationRoots;
 }): object {
@@ -51,10 +51,13 @@ export function decodeMaterializationDescriptor(
   }
   const coordinateValue = value['coordinate'];
   requireRecord(coordinateValue, 'descriptor.coordinate');
+  const stateHash = requireOptionalStateHash(value['stateHash']);
+  const rootStatuses = decodeRootStatuses(value['roots']);
+  requireReplayBasisHash(stateHash, rootStatuses);
   return Object.freeze({
     laneName: requireNonEmpty(value['laneName'], 'descriptor.laneName'),
-    stateHash: requireNonEmpty(value['stateHash'], 'descriptor.stateHash'),
-    rootStatuses: decodeRootStatuses(value['roots']),
+    stateHash,
+    rootStatuses,
     coordinate: new MaterializationCoordinate({
       frontier: decodeFrontier(coordinateValue['frontier']),
       ceiling: requireCeiling(coordinateValue['ceiling']),
@@ -122,15 +125,24 @@ function decodeRootStatuses(
   for (const name of MATERIALIZATION_ROOT_NAMES) {
     requireRootStatus(statuses, name);
   }
-  requireCurrentPropertyRoot(statuses);
+  requireAvailableRoot(statuses);
   return statuses;
 }
 
-function requireCurrentPropertyRoot(
+function requireAvailableRoot(
   statuses: ReadonlyMap<MaterializationRootName, MaterializationRootStatus>,
 ): void {
-  if (statuses.get('properties') === 'unavailable') {
-    throw descriptorError('current materialization descriptor requires a property root');
+  if ([...statuses.values()].every((status) => status === 'unavailable')) {
+    throw descriptorError('descriptor must provide at least one materialization root');
+  }
+}
+
+function requireReplayBasisHash(
+  stateHash: string | null,
+  statuses: ReadonlyMap<MaterializationRootName, MaterializationRootStatus>,
+): void {
+  if (stateHash === null && statuses.get('replay-basis') === 'retained') {
+    throw descriptorError('partial materialization cannot retain a replay basis');
   }
 }
 
@@ -221,6 +233,10 @@ function requireNonEmpty(value: unknown, field: string): string {
     throw descriptorError(`${field} must be a non-empty string`);
   }
   return value;
+}
+
+function requireOptionalStateHash(value: unknown): string | null {
+  return value === null ? null : requireNonEmpty(value, 'descriptor.stateHash');
 }
 
 function arrayValue(values: readonly unknown[], index: number): unknown {

--- a/src/infrastructure/adapters/GitCasMaterializationReplayBasis.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationReplayBasis.ts
@@ -71,6 +71,9 @@ export default class GitCasMaterializationReplayBasis {
     if (root.status !== 'retained' || root.handle === null) {
       return null;
     }
+    if (materialization.stateHash === null) {
+      throw storageError('partial materialization cannot contain a replay basis');
+    }
     const member = await this.#cas.bundles.getMemberReference({
       handle: root.handle.toString(),
       path: REPLAY_BASIS_PATH,

--- a/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
@@ -36,14 +36,10 @@ import GitCasMaterializationReplayBasis, {
   replaceReplayBasisRoot,
 } from './GitCasMaterializationReplayBasis.ts';
 import GitCasMaterializationCacheKey from './GitCasMaterializationCacheKey.ts';
-import type {
-  GitCasMaterializationFacade,
-  MaterializationCacheSet,
-} from './GitCasMaterializationStoreTypes.ts';
+import type { GitCasMaterializationFacade } from './GitCasMaterializationStoreTypes.ts';
 import {
   releaseCacheAcquisitionAfterFailure,
   requireDescriptorSize,
-  requireExpectedAcquisition,
   requireStoredMaterialization,
   requireWorkspaceStage,
 } from './GitCasMaterializationStoreWitness.ts';
@@ -64,7 +60,6 @@ const CACHE_NAMESPACE = 'git-warp/materializations';
 const WORKSPACE_NAMESPACE = 'git-warp/materializations';
 const WORKSPACE_TTL_MS = 2 * 60 * 60 * 1000;
 const MAX_DESCRIPTOR_BYTES = 1024 * 1024;
-const LEGACY_MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSIONS = Object.freeze([2, 3]);
 
 export type { GitCasMaterializationFacade } from './GitCasMaterializationStoreTypes.ts';
 
@@ -170,7 +165,7 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
     request: RetainMaterializationRequest,
   ): Promise<MaterializationHandle> {
     requireRetainRequest(request);
-    const stateHash = requireNonEmpty(request.stateHash, 'stateHash');
+    const { stateHash } = request;
     const roots = request.replayBasis === undefined
       ? request.roots
       : replaceReplayBasisRoot(
@@ -197,7 +192,7 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
   async #stageWorkspaceBundle(
     workspace: GitCasStagingWorkspace,
     request: RetainMaterializationRequest,
-    stateHash: string,
+    stateHash: string | null,
   ): Promise<WorkspaceRetainedBundle> {
     const descriptorBytes = this.#codec.encode(materializationDescriptorData({
       coordinate: request.coordinate,
@@ -234,30 +229,7 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
       options: { retention: 'evictable' },
     });
     const retention = requireStoredMaterialization(promoted.destination, expectedHandle);
-    await this.#cleanLegacyAfterPromotion({ cache, cacheKey, expectedHandle, coordinate });
     return adaptGitCasRetentionWitness(retention.toJSON());
-  }
-
-  async #cleanLegacyAfterPromotion(args: {
-    cache: MaterializationCacheSet;
-    cacheKey: string;
-    expectedHandle: string;
-    coordinate: MaterializationCoordinate;
-  }): Promise<void> {
-    const acquisition = await args.cache.acquire(args.cacheKey);
-    if (acquisition === null) {
-      throw storageError('git-cas lost the retained materialization before legacy cleanup');
-    }
-    await completeWithCleanup(
-      async () => {
-        requireExpectedAcquisition(acquisition, args.expectedHandle);
-        await this.#removeLegacyEntries(args.cache, args.coordinate);
-      },
-      async () => {
-        await acquisition.release();
-      },
-      'Legacy materialization cleanup and acquisition release both failed',
-    );
   }
 
   override async acquireExact(
@@ -455,15 +427,6 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
       stateHash: descriptor.stateHash,
       retention: adaptGitCasRetentionWitness(retention.toJSON()),
     });
-  }
-
-  async #removeLegacyEntries(
-    cache: MaterializationCacheSet,
-    coordinate: MaterializationCoordinate,
-  ): Promise<void> {
-    for (const schemaVersion of LEGACY_MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSIONS) {
-      await cache.remove(await this.#cacheKeys.forCoordinate(coordinate, schemaVersion));
-    }
   }
 
   async #readDescriptor(handle: PageHandle): Promise<DecodedMaterializationDescriptor> {

--- a/src/infrastructure/adapters/GitCasMaterializationStoreValidation.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreValidation.ts
@@ -9,14 +9,25 @@ export function requireRetainRequest(request: RetainMaterializationRequest): voi
   }
   requireCoordinate(request.coordinate);
   requireRetainRoots(request.roots);
+  requireRetainStateHash(request);
 }
 
 function requireRetainRoots(roots: MaterializationRoots): void {
   if (!(roots instanceof MaterializationRoots)) {
     throw storageError('retain request roots have an invalid runtime identity');
   }
-  if (roots.properties.status === 'unavailable') {
-    throw storageError('current materialization profile requires a property root');
+  if (roots.entries().every(([, root]) => root.status === 'unavailable')) {
+    throw storageError('retain request must provide at least one materialization root');
+  }
+}
+
+function requireRetainStateHash(request: RetainMaterializationRequest): void {
+  if (request.stateHash !== null) {
+    requireNonEmpty(request.stateHash, 'stateHash');
+    return;
+  }
+  if (request.replayBasis !== undefined || request.roots.replayBasis.status === 'retained') {
+    throw storageError('partial materialization cannot retain a whole-state replay basis');
   }
 }
 

--- a/src/infrastructure/adapters/GitCasMaterializationStoreValidation.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreValidation.ts
@@ -24,10 +24,20 @@ function requireRetainRoots(roots: MaterializationRoots): void {
 function requireRetainStateHash(request: RetainMaterializationRequest): void {
   if (request.stateHash !== null) {
     requireNonEmpty(request.stateHash, 'stateHash');
+    requireCompleteReplayBasis(request);
     return;
   }
   if (request.replayBasis !== undefined || request.roots.replayBasis.status === 'retained') {
     throw storageError('partial materialization cannot retain a whole-state replay basis');
+  }
+}
+
+function requireCompleteReplayBasis(request: RetainMaterializationRequest): void {
+  if (
+    request.replayBasis === undefined
+    && request.roots.replayBasis.status !== 'retained'
+  ) {
+    throw storageError('complete materialization requires a whole-state replay basis');
   }
 }
 

--- a/src/infrastructure/adapters/GitCasMaterializationStoreWitness.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreWitness.ts
@@ -47,15 +47,6 @@ export function requireStoredMaterialization(
   return stored.witness;
 }
 
-export function requireExpectedAcquisition(
-  acquisition: CacheAcquisition,
-  expectedHandle: string,
-): void {
-  if (acquisition.hit.handle.toString() !== expectedHandle) {
-    throw storageError('git-cas acquired an unexpected materialization before legacy cleanup');
-  }
-}
-
 export function requireDescriptorSize(bytes: Uint8Array): void {
   if (bytes.byteLength > 1024 * 1024) {
     throw storageError('materialization descriptor exceeds its byte limit');

--- a/src/ports/MaterializationWorkspacePort.ts
+++ b/src/ports/MaterializationWorkspacePort.ts
@@ -14,7 +14,7 @@ export type MaterializationWorkspaceRoots = Readonly<{
 export type PromoteMaterializationRequest = Readonly<{
   coordinate: MaterializationCoordinate;
   roots: MaterializationRoots;
-  stateHash: string;
+  stateHash: string | null;
   replayBasis?: WarpState;
 }>;
 

--- a/test/integration/infrastructure/adapters/GitCasMaterializationStoreAdapter.integration.test.ts
+++ b/test/integration/infrastructure/adapters/GitCasMaterializationStoreAdapter.integration.test.ts
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import MaterializationCoordinate from '../../../../src/domain/materialization/MaterializationCoordinate.ts';
 import MaterializationRoot from '../../../../src/domain/materialization/MaterializationRoot.ts';
 import MaterializationRoots from '../../../../src/domain/materialization/MaterializationRoots.ts';
+import { createEmptyState } from '../../../../src/domain/services/JoinReducer.ts';
+import { computeStateHash } from '../../../../src/domain/services/state/StateSerializer.ts';
 import BundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
 import GitCasRepositoryAdapter from '../../../../src/infrastructure/adapters/GitCasRepositoryAdapter.ts';
 import GitCasTrieStoreAdapter from '../../../../src/infrastructure/adapters/GitCasTrieStoreAdapter.ts';
@@ -55,10 +57,12 @@ describe('GitCasMaterializationStoreAdapter integration', () => {
     });
     const trieFixture = await createTrieRoot(harness.cas);
     const rootFixture = await createRoots(harness.cas, trieFixture);
+    const replayBasis = createEmptyState();
     const retained = await harness.materializations.retain({
       coordinate,
       roots: rootFixture.roots,
-      stateHash: 'state-hash',
+      replayBasis,
+      stateHash: await stateHash(replayBasis),
     });
 
     const reopenedCas = createCas(harness.plumbing);
@@ -88,7 +92,7 @@ describe('GitCasMaterializationStoreAdapter integration', () => {
 
       expect(resolved.bundle.equals(retained.bundle)).toBe(true);
       expect(resolved.roots.entries().map(([name, root]) => rootSignature(name, root)))
-        .toEqual(rootFixture.roots.entries().map(([name, root]) => rootSignature(name, root)));
+        .toEqual(retained.roots.entries().map(([name, root]) => rootSignature(name, root)));
       expect(await reopenedTrie.readLeaf(child)).toEqual(trieFixture.bytes);
       expect(unreachable).not.toContain(GitCasBundleHandle.parse(retained.bundle.toString()).oid);
       for (const oid of rootFixture.retainedOids) {
@@ -116,12 +120,15 @@ describe('GitCasMaterializationStoreAdapter integration', () => {
 
   it('keeps a replaced generation reachable until its runtime lease closes', async () => {
     const coordinate = workspaceCoordinate();
+    const replayBasis = createEmptyState();
+    const retainedStateHash = await stateHash(replayBasis);
     const firstTrie = await createTrieRoot(harness.cas, 7);
     const firstRoots = await createRoots(harness.cas, firstTrie, 0);
     const first = await harness.materializations.retain({
       coordinate,
       roots: firstRoots.roots,
-      stateHash: 'first-state-hash',
+      replayBasis,
+      stateHash: retainedStateHash,
     });
     const acquisition = await harness.materializations.acquireExact(coordinate);
     if (acquisition === null) {
@@ -133,7 +140,8 @@ describe('GitCasMaterializationStoreAdapter integration', () => {
     const second = await harness.materializations.retain({
       coordinate,
       roots: secondRoots.roots,
-      stateHash: 'second-state-hash',
+      replayBasis,
+      stateHash: retainedStateHash,
     });
 
     await expireAllReflogs(harness.path);
@@ -397,6 +405,13 @@ function workspaceCoordinate(): MaterializationCoordinate {
   return new MaterializationCoordinate({
     frontier: new Map([['writer-a', 'a'.repeat(40)]]),
     ceiling: null,
+  });
+}
+
+async function stateHash(state: ReturnType<typeof createEmptyState>): Promise<string> {
+  return await computeStateHash(state, {
+    codec: defaultCodec,
+    crypto: new NodeCryptoAdapter(),
   });
 }
 

--- a/test/unit/domain/materialization/MaterializationIdentity.test.ts
+++ b/test/unit/domain/materialization/MaterializationIdentity.test.ts
@@ -199,6 +199,20 @@ describe('MaterializationHandle', () => {
     expect(Object.isFrozen(handle)).toBe(true);
   });
 
+  it('marks a partial materialization by omitting a whole-state hash', () => {
+    const bundle = bundleHandle('partial-materialization');
+    const handle = new MaterializationHandle({
+      laneName: 'events',
+      bundle,
+      coordinate: exactCoordinate(),
+      roots: materializationRoots(),
+      stateHash: null,
+      retention: retentionWitness(bundle),
+    });
+
+    expect(handle.stateHash).toBeNull();
+  });
+
   it.each([
     ['laneName', ''],
     ['bundle', new StorageHandle('not-a-bundle')],

--- a/test/unit/domain/orset/session/StateSession.test.ts
+++ b/test/unit/domain/orset/session/StateSession.test.ts
@@ -294,6 +294,19 @@ describe("StateSession", () => {
       expect(session.dirtyPageCount()).toBeGreaterThan(0);
       expect(await session.nodeContains("node:retryable")).toBe(true);
     });
+
+    it("aborts a failed session without retaining its pending pages", async () => {
+      const workspace = new RecordingWorkspace();
+      const { session } = await openSession({ workspace, maxDirtyPages: 1_000 });
+      await session.addNode("node:aborted", new Dot("alice", 1));
+
+      session.abort();
+
+      expect(workspace.checkpoints).toEqual([]);
+      await expect(session.nodeContains("node:aborted"))
+        .rejects.toBeInstanceOf(StateSessionError);
+      await expect(session.close()).rejects.toBeInstanceOf(StateSessionError);
+    });
   });
 
   describe("edge cases", () => {

--- a/test/unit/domain/services/JoinReducer.stateSession.test.ts
+++ b/test/unit/domain/services/JoinReducer.stateSession.test.ts
@@ -118,6 +118,36 @@ function expectReduceV5State(result: ReturnType<typeof reducePatches>) {
 
 describe("JoinReducer session-backed path", () => {
   describe("golden path", () => {
+    it("replays only page-backed liveness for bounded materialization", async () => {
+      const { applyLivenessInSession } = await loadJoinReducerSessionModule();
+      const { session } = await openSession();
+      const removedNodeDot = new Dot("alice", 1);
+      const liveNodeDot = new Dot("alice", 2);
+      const removedEdgeDot = new Dot("alice", 3);
+
+      await applyLivenessInSession(session, makePatch("alice", 1, [
+        nodeAdd("node:removed", removedNodeDot),
+        nodeAdd("node:live", liveNodeDot),
+        edgeAdd("node:removed", "node:live", "knows", removedEdgeDot),
+        propSet("node:live", "ignored", "no register allocation"),
+      ]));
+      await applyLivenessInSession(session, makePatch("alice", 2, [
+        nodeRemove("node:removed", [Dot.encode(removedNodeDot)]),
+        edgeRemove(
+          "node:removed",
+          "node:live",
+          "knows",
+          [Dot.encode(removedEdgeDot)],
+        ),
+      ]));
+
+      await expect(session.nodeContains("node:removed")).resolves.toBe(false);
+      await expect(session.nodeContains("node:live")).resolves.toBe(true);
+      await expect(session.edgeContains("node:removed\0node:live\0knows"))
+        .resolves.toBe(false);
+      await session.close();
+    });
+
     it("replays mixed patches through one session-backed reducer frame", async () => {
       const { ReducerSessionFrame, reducePatchesInSession } =
         await loadJoinReducerSessionModule();

--- a/test/unit/domain/services/controllers/BoundedLiveMaterialization.test.ts
+++ b/test/unit/domain/services/controllers/BoundedLiveMaterialization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import PatchCollector, {
   type CheckpointData,
@@ -36,6 +36,10 @@ const coordinate = new MaterializationCoordinate({
 });
 
 describe('BoundedLiveMaterialization', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('fails closed when a newly retained handle cannot be acquired', async () => {
     const materializations = new InMemoryMaterializationStore();
     vi.spyOn(materializations, 'acquireExact').mockResolvedValue(null);
@@ -61,6 +65,39 @@ describe('BoundedLiveMaterialization', () => {
       coordinate,
     })).rejects.toBe(failure);
 
+    expect(materializations.workspaces[0]?.released).toBe(true);
+  });
+
+  it('aborts the session and releases its workspace when liveness replay fails', async () => {
+    const materializations = new InMemoryMaterializationStore();
+    const failure = new Error('patch replay failed');
+    const abort = vi.spyOn(StateSession.prototype, 'abort');
+    const deps = createDeps(materializations);
+    vi.spyOn(deps.patches, 'loadPatchChain').mockRejectedValue(failure);
+
+    await expect(retainBoundedLiveMaterialization({ deps, coordinate }))
+      .rejects.toBe(failure);
+
+    expect(abort).toHaveBeenCalledOnce();
+    expect(materializations.workspaces[0]?.released).toBe(true);
+  });
+
+  it('aborts the session and preserves a workspace promotion failure', async () => {
+    const materializations = new InMemoryMaterializationStore();
+    const failure = new Error('workspace promotion failed');
+    const openWorkspace = materializations.openWorkspace.bind(materializations);
+    vi.spyOn(materializations, 'openWorkspace').mockImplementation(async (requested) => {
+      const workspace = await openWorkspace(requested);
+      vi.spyOn(workspace, 'promote').mockRejectedValue(failure);
+      return workspace;
+    });
+    const abort = vi.spyOn(StateSession.prototype, 'abort');
+    const deps = createDeps(materializations);
+
+    await expect(retainBoundedLiveMaterialization({ deps, coordinate }))
+      .rejects.toBe(failure);
+
+    expect(abort).toHaveBeenCalledOnce();
     expect(materializations.workspaces[0]?.released).toBe(true);
   });
 

--- a/test/unit/domain/services/controllers/BoundedLiveMaterialization.test.ts
+++ b/test/unit/domain/services/controllers/BoundedLiveMaterialization.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import PatchCollector, {
+  type CheckpointData,
+  type PatchWithSha,
+} from '../../../../../src/domain/capabilities/PatchCollector.ts';
+import { Dot } from '../../../../../src/domain/crdt/Dot.ts';
+import MaterializationCoordinate from '../../../../../src/domain/materialization/MaterializationCoordinate.ts';
+import StateSession from '../../../../../src/domain/orset/session/StateSession.ts';
+import PageCache from '../../../../../src/domain/orset/trie/PageCache.ts';
+import TrieGeometry from '../../../../../src/domain/orset/trie/TrieGeometry.ts';
+import {
+  resolveBoundedLiveMaterialization,
+  retainBoundedLiveMaterialization,
+} from '../../../../../src/domain/services/controllers/BoundedLiveMaterialization.ts';
+import type {
+  MaterializeDeps,
+} from '../../../../../src/domain/services/controllers/MaterializeController.ts';
+import MaterializeController from '../../../../../src/domain/services/controllers/MaterializeController.ts';
+import { createEmptyState } from '../../../../../src/domain/services/JoinReducer.ts';
+import Patch from '../../../../../src/domain/types/Patch.ts';
+import NodeAdd from '../../../../../src/domain/types/ops/NodeAdd.ts';
+import cborCodec from '../../../../../src/infrastructure/codecs/CborCodec.ts';
+import InMemoryCheckpointStore from '../../../../helpers/InMemoryCheckpointStore.ts';
+import InMemoryMaterializationStore from '../../../../helpers/InMemoryMaterializationStore.ts';
+import { InMemoryTrieStore } from '../../../../helpers/trieHelpers.ts';
+import type MaterializationWorkspacePort from '../../../../../src/ports/MaterializationWorkspacePort.ts';
+import WarpStateCachePort, {
+  type WarpStateCoordinate,
+  type WarpStateSnapshotRecord,
+} from '../../../../../src/ports/WarpStateCachePort.ts';
+
+const coordinate = new MaterializationCoordinate({
+  frontier: new Map([['writer', 'tip']]),
+  ceiling: null,
+});
+
+describe('BoundedLiveMaterialization', () => {
+  it('fails closed when a newly retained handle cannot be acquired', async () => {
+    const materializations = new InMemoryMaterializationStore();
+    vi.spyOn(materializations, 'acquireExact').mockResolvedValue(null);
+
+    await expect(resolveBoundedLiveMaterialization({
+      deps: createDeps(materializations),
+      coordinate,
+    })).rejects.toMatchObject({
+      code: 'E_MATERIALIZATION_RESUME',
+      message: expect.stringContaining('could not be acquired'),
+    });
+  });
+
+  it('releases the staging workspace when session opening fails', async () => {
+    const materializations = new InMemoryMaterializationStore();
+    const failure = new Error('session open failed');
+
+    await expect(retainBoundedLiveMaterialization({
+      deps: createDeps(
+        materializations,
+        vi.fn().mockRejectedValue(failure),
+      ),
+      coordinate,
+    })).rejects.toBe(failure);
+
+    expect(materializations.workspaces[0]?.released).toBe(true);
+  });
+
+  it('releases a partial acquisition before using an exact whole-state snapshot', async () => {
+    const materializations = new InMemoryMaterializationStore();
+    const deps = createDeps(materializations);
+    const bounded = await resolveBoundedLiveMaterialization({ deps, coordinate });
+    await bounded?.release();
+    deps.getStateCache = () => new ExactSnapshotCache();
+
+    const result = await new MaterializeController(deps).materialize();
+
+    expect(result.state.nodeAlive.contains('snapshot-node')).toBe(true);
+    expect(materializations.acquisitions.at(-1)?.released).toBe(true);
+  });
+});
+
+function createDeps(
+  materializations: InMemoryMaterializationStore,
+  openStateSession = defaultSessionOpener(),
+): MaterializeDeps {
+  return {
+    logger: {
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    },
+    codec: cborCodec,
+    crypto: {
+      hash: vi.fn().mockResolvedValue('hash'),
+      hmac: vi.fn().mockResolvedValue(new Uint8Array([1])),
+      timingSafeEqual: vi.fn().mockReturnValue(false),
+    },
+    persistence: { readRef: vi.fn().mockResolvedValue(null) },
+    checkpointStore: new InMemoryCheckpointStore(),
+    materializations,
+    patches: new SinglePatchCollector(),
+    graphCloner: { openReadOnly: vi.fn() },
+    graphName: 'test-graph',
+    openStateSession,
+  };
+}
+
+function defaultSessionOpener() {
+  const store = new InMemoryTrieStore();
+  const pageCache = new PageCache({ maxResident: 8 });
+  return async (
+    roots: {
+      readonly nodeAliveRootOid: string | null;
+      readonly edgeAliveRootOid: string | null;
+    },
+    options: { readonly workspace: MaterializationWorkspacePort },
+  ): Promise<StateSession> => await StateSession.open({
+    ...roots,
+    store,
+    codec: cborCodec,
+    geometry: TrieGeometry.default16way(),
+    pageCache,
+    maxDirtyPages: 1,
+    workspace: options.workspace,
+  });
+}
+
+class SinglePatchCollector extends PatchCollector {
+  readonly #entry: PatchWithSha = {
+    patch: new Patch({
+      writer: 'writer',
+      lamport: 1,
+      context: {},
+      ops: [new NodeAdd('node', Dot.create('writer', 1))],
+      reads: [],
+      writes: ['node'],
+    }),
+    sha: 'tip',
+  };
+
+  override discoverWriters(): Promise<string[]> {
+    return Promise.resolve(['writer']);
+  }
+
+  override loadWriterPatches(_writerId: string): Promise<PatchWithSha[]> {
+    return Promise.resolve([this.#entry]);
+  }
+
+  override loadCheckpoint(): Promise<CheckpointData | null> {
+    return Promise.resolve(null);
+  }
+
+  override loadPatchesSince(_checkpoint: CheckpointData): Promise<PatchWithSha[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadPatchChain(_toSha: string, _fromSha?: string | null): Promise<PatchWithSha[]> {
+    return Promise.resolve([this.#entry]);
+  }
+
+  override getFrontier(): Promise<Map<string, string>> {
+    return Promise.resolve(coordinate.frontier());
+  }
+}
+
+class ExactSnapshotCache extends WarpStateCachePort {
+  override getExact(_coordinate: WarpStateCoordinate): Promise<WarpStateSnapshotRecord> {
+    const state = createEmptyState();
+    state.nodeAlive.add('snapshot-node', Dot.create('snapshot', 1));
+    return Promise.resolve({
+      snapshotId: 'snapshot',
+      coordinate: { frontier: coordinate.frontier(), ceiling: null },
+      retention: 'evictable',
+      provenancePosture: 'degraded',
+      stateHash: 'snapshot-hash',
+      payloadRef: 'snapshot-payload',
+      createdAt: '1970-01-01T00:00:00.000Z',
+      state,
+    });
+  }
+
+  override getBestCompatiblePredecessor(): Promise<null> {
+    return Promise.resolve(null);
+  }
+
+  override put(snapshot: WarpStateSnapshotRecord): Promise<WarpStateSnapshotRecord> {
+    return Promise.resolve(snapshot);
+  }
+
+  override pin(_snapshotId: string): Promise<WarpStateSnapshotRecord> {
+    throw new Error('not used');
+  }
+
+  override publishCheckpointHead(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  override resolveCheckpointHead(): Promise<null> {
+    return Promise.resolve(null);
+  }
+
+  override pruneEvictable(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/test/unit/domain/services/controllers/MaterializeController.liveNodeRead.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.liveNodeRead.test.ts
@@ -12,6 +12,7 @@ import MaterializationRoots from '../../../../../src/domain/materialization/Mate
 import MaterializeController, {
   type MaterializeDeps,
 } from '../../../../../src/domain/services/controllers/MaterializeController.ts';
+import { retainBoundedLiveMaterialization } from '../../../../../src/domain/services/controllers/BoundedLiveMaterialization.ts';
 import BundleHandle from '../../../../../src/domain/storage/BundleHandle.ts';
 import cborCodec from '../../../../../src/infrastructure/codecs/CborCodec.ts';
 import InMemoryCheckpointStore from '../../../../helpers/InMemoryCheckpointStore.ts';
@@ -141,6 +142,17 @@ describe('MaterializeController live node reads', () => {
     await expect(fixture.controller.readLiveNodePresence('node:retained')).resolves.toBeNull();
 
     expect(fixture.materializations.exactLookups).toHaveLength(0);
+  });
+
+  it('declines bounded cold replay when no state session is configured', async () => {
+    const fixture = await createFixture({ retain: false });
+
+    await expect(retainBoundedLiveMaterialization({
+      deps: fixture.deps,
+      coordinate: new MaterializationCoordinate({ frontier: FRONTIER, ceiling: null }),
+    })).resolves.toBeNull();
+
+    expect(fixture.materializations.workspaces).toHaveLength(0);
   });
 
   it('falls back and releases when the retained node root is unavailable', async () => {

--- a/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
@@ -653,7 +653,8 @@ describe("MaterializeController — state session integration", () => {
 
     expect(resolution.source).toBe("materialized");
     expect(resolution.replayedPatchCount).toBe(1);
-    expect(resolution.materialization?.stateHash).toBeNull();
+    expect(resolution.materialization).toBeInstanceOf(MaterializationHandle);
+    expect(resolution.materialization).toMatchObject({ stateHash: null });
     expect(fixtures.materializations.retainedRequests).toHaveLength(1);
     expect(fixtures.patches.collectForFrontier).toHaveBeenCalledOnce();
     expect(fixtures.stateCache.getExact).not.toHaveBeenCalled();

--- a/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
@@ -653,12 +653,13 @@ describe("MaterializeController — state session integration", () => {
 
     expect(resolution.source).toBe("materialized");
     expect(resolution.replayedPatchCount).toBe(1);
-    expect(resolution.materialization).not.toBeNull();
+    expect(resolution.materialization?.stateHash).toBeNull();
     expect(fixtures.materializations.retainedRequests).toHaveLength(1);
     expect(fixtures.patches.collectForFrontier).toHaveBeenCalledOnce();
     expect(fixtures.stateCache.getExact).not.toHaveBeenCalled();
     expect(fixtures.stateCache.getBestCompatiblePredecessor).not.toHaveBeenCalled();
     expect(fixtures.stateCache.put).not.toHaveBeenCalled();
+    expect(fixtures.deps.crypto.hash).not.toHaveBeenCalled();
     expect(fixtures.materializations.acquisitions).toHaveLength(1);
     expect(fixtures.materializations.acquisitions[0]?.released).toBe(false);
     await resolution.release();

--- a/test/unit/domain/services/controllers/MaterializedLiveResolution.test.ts
+++ b/test/unit/domain/services/controllers/MaterializedLiveResolution.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import MaterializationCoordinate from '../../../../../src/domain/materialization/MaterializationCoordinate.ts';
+import MaterializationHandle from '../../../../../src/domain/materialization/MaterializationHandle.ts';
+import MaterializationRoot from '../../../../../src/domain/materialization/MaterializationRoot.ts';
+import MaterializationRoots from '../../../../../src/domain/materialization/MaterializationRoots.ts';
+import { materializedResolution } from '../../../../../src/domain/services/controllers/MaterializedLiveResolution.ts';
+import type { MaterializeResult } from '../../../../../src/domain/services/controllers/MaterializeController.ts';
+import BundleHandle from '../../../../../src/domain/storage/BundleHandle.ts';
+import StorageRetentionWitness, {
+  StorageRetentionRoot,
+} from '../../../../../src/domain/storage/StorageRetentionWitness.ts';
+import type { MaterializationAcquisition } from '../../../../../src/ports/MaterializationStorePort.ts';
+
+describe('materializedResolution', () => {
+  it('returns and releases an acquisition that matches the published result', async () => {
+    const handle = materializationHandle('same');
+    const release = vi.fn().mockResolvedValue(undefined);
+    const resolution = materializedResolution(
+      materializeResult(handle),
+      acquisition(handle, release),
+    );
+
+    expect(resolution.materialization).toBe(handle);
+    expect(resolution.source).toBe('materialized');
+    expect(resolution.replayedPatchCount).toBe(3);
+    await resolution.release();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a non-empty result without a retained handle', () => {
+    expect(() => materializedResolution(
+      materializeResult(undefined),
+      acquisition(materializationHandle('acquired'), vi.fn()),
+    )).toThrowError(/did not produce a retained handle/u);
+  });
+
+  it('rejects an acquisition whose retained identity changed', () => {
+    expect(() => materializedResolution(
+      materializeResult(materializationHandle('expected')),
+      acquisition(materializationHandle('changed'), vi.fn()),
+    )).toThrowError(/changed before it could be acquired/u);
+  });
+});
+
+function materializeResult(
+  materialization: MaterializationHandle | undefined,
+): MaterializeResult {
+  return {
+    materialization,
+    patchCount: 3,
+  } as MaterializeResult;
+}
+
+function acquisition(
+  materialization: MaterializationHandle,
+  release: () => Promise<void>,
+): MaterializationAcquisition {
+  return Object.freeze({
+    materialization,
+    acquiredAt: '1970-01-01T00:00:00.000Z',
+    release,
+  });
+}
+
+function materializationHandle(suffix: string): MaterializationHandle {
+  const bundle = new BundleHandle(`materialization:${suffix}`);
+  return new MaterializationHandle({
+    laneName: 'events',
+    bundle,
+    coordinate: new MaterializationCoordinate({
+      frontier: new Map([['writer', 'patch']]),
+      ceiling: null,
+    }),
+    roots: partialRoots(),
+    stateHash: null,
+    retention: new StorageRetentionWitness({
+      handle: bundle,
+      policy: 'evictable',
+      reachability: 'anchored',
+      root: new StorageRetentionRoot({
+        kind: 'cache-set',
+        namespace: 'git-warp/materializations',
+        locator: 'refs/cas/caches/git-warp/materializations',
+        generation: `generation:${suffix}`,
+        path: 'root',
+      }),
+      observedAt: '1970-01-01T00:00:00.000Z',
+    }),
+  });
+}
+
+function partialRoots(): MaterializationRoots {
+  return new MaterializationRoots({
+    adjacency: MaterializationRoot.unavailable(),
+    edgeAlive: MaterializationRoot.empty(),
+    edgeBirths: MaterializationRoot.unavailable(),
+    frontier: MaterializationRoot.unavailable(),
+    nodeAlive: MaterializationRoot.empty(),
+    properties: MaterializationRoot.unavailable(),
+    provenanceSupport: MaterializationRoot.unavailable(),
+    replayBasis: MaterializationRoot.unavailable(),
+    roaringIndexes: MaterializationRoot.unavailable(),
+  });
+}

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.lifecycle.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.lifecycle.test.ts
@@ -9,15 +9,12 @@ import GitCasMaterializationStoreAdapter, {
 import type {
   GitCasStagingWorkspace,
 } from '../../../../src/infrastructure/adapters/GitCasMaterializationWorkspace.ts';
-import { materializationCoordinateData } from '../../../../src/infrastructure/adapters/GitCasMaterializationDescriptor.ts';
 import NodeCryptoAdapter from '../../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
 import defaultCodec from '../../../../src/infrastructure/codecs/CborCodec.ts';
 import InMemoryBlobStorageAdapter from '../../../helpers/InMemoryBlobStorageAdapter.ts';
 import InMemoryGitCasFacade from '../../../helpers/InMemoryGitCasFacade.ts';
 import InMemoryGraphAdapter from '../../../helpers/InMemoryGraphAdapter.ts';
 
-const CACHE_NAMESPACE = 'git-warp/materializations';
-const CURRENT_CACHE_KEY_PATTERN = /^v4:[0-9a-f]{64}:[0-9a-f]{64}$/u;
 const ROOT_COUNT = 9;
 
 describe('GitCasMaterializationStoreAdapter lifecycle', () => {
@@ -131,79 +128,6 @@ describe('GitCasMaterializationStoreAdapter lifecycle', () => {
     });
   });
 
-  it('keeps matching legacy cache anchors until the v4 profile is retained', async () => {
-    const harness = await createHarness();
-    const coordinate = exactCoordinate();
-    const roots = await createRoots(harness.cas);
-    const retained = await harness.adapter.retain({ coordinate, roots, stateHash: 'state-hash' });
-    const cache = await harness.cas.caches.open({ namespace: CACHE_NAMESPACE });
-    const v4Key = requireSingleCacheKey(harness.cas);
-    const v2Key = await cacheKeyForSchema(coordinate, 2);
-    const v3Key = await cacheKeyForSchema(coordinate, 3);
-    await cache.put(v2Key, retained.bundle.toString());
-    await cache.put(v3Key, retained.bundle.toString());
-    await cache.remove(v4Key);
-
-    await expect(harness.adapter.acquireExact(coordinate)).resolves.toBeNull();
-    expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toEqual([v2Key, v3Key]);
-
-    await harness.adapter.retain({ coordinate, roots, stateHash: 'replacement-state-hash' });
-    expect(requireSingleCacheKey(harness.cas)).toMatch(CURRENT_CACHE_KEY_PATTERN);
-  });
-
-  it('removes matching legacy cache anchors after direct v4 retention', async () => {
-    const harness = await createHarness();
-    const coordinate = exactCoordinate();
-    const roots = await createRoots(harness.cas);
-    const retained = await harness.adapter.retain({ coordinate, roots, stateHash: 'state-hash' });
-    const cache = await harness.cas.caches.open({ namespace: CACHE_NAMESPACE });
-    const v4Key = requireSingleCacheKey(harness.cas);
-    const v2Key = await cacheKeyForSchema(coordinate, 2);
-    const v3Key = await cacheKeyForSchema(coordinate, 3);
-    await cache.put(v2Key, retained.bundle.toString());
-    await cache.put(v3Key, retained.bundle.toString());
-    await cache.remove(v4Key);
-
-    const replacement = await harness.adapter.retain({
-      coordinate,
-      roots,
-      stateHash: 'replacement-state-hash',
-    });
-    const acquisition = await harness.adapter.acquireExact(coordinate);
-
-    expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toEqual([
-      expect.stringMatching(CURRENT_CACHE_KEY_PATTERN),
-    ]);
-    expect(replacement.retention.root.generation)
-      .toBe(acquisition?.materialization.retention.root.generation);
-    await acquisition?.release();
-  });
-
-  it('keeps legacy anchors when the exact v4 target cannot be acquired', async () => {
-    const harness = await createHarness();
-    const coordinate = exactCoordinate();
-    const roots = await createRoots(harness.cas);
-    const original = await harness.adapter.retain({ coordinate, roots, stateHash: 'state-hash' });
-    const cache = await harness.cas.caches.open({ namespace: CACHE_NAMESPACE });
-    const v4Key = requireSingleCacheKey(harness.cas);
-    const v2Key = await cacheKeyForSchema(coordinate, 2);
-    const v3Key = await cacheKeyForSchema(coordinate, 3);
-    await cache.put(v2Key, original.bundle.toString());
-    await cache.put(v3Key, original.bundle.toString());
-    await cache.remove(v4Key);
-
-    await expect(adapterFor(withoutCacheAcquisition(harness.cas)).retain({
-      coordinate,
-      roots,
-      stateHash: 'replacement-state-hash',
-    })).rejects.toMatchObject({
-      code: 'E_MATERIALIZATION_STORAGE',
-      message: expect.stringContaining('before legacy cleanup'),
-    });
-
-    expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toContain(v2Key);
-    expect(harness.cas.readCacheKeys(CACHE_NAMESPACE)).toContain(v3Key);
-  });
 });
 
 async function createHarness(): Promise<Readonly<{
@@ -224,27 +148,6 @@ function adapterFor(cas: GitCasMaterializationFacade): GitCasMaterializationStor
     crypto: new NodeCryptoAdapter(),
     laneName: 'events',
   });
-}
-
-function withoutCacheAcquisition(cas: InMemoryGitCasFacade): GitCasMaterializationFacade {
-  return {
-    assets: cas.assets,
-    bundles: cas.bundles,
-    pages: cas.pages,
-    caches: {
-      open: async (options) => {
-        const cache = await cas.caches.open(options);
-        return {
-          ref: cache.ref,
-          acquire: async () => null,
-          inspect: async (inspectOptions) => await cache.inspect(inspectOptions),
-          put: async (key, handle, entryOptions) => await cache.put(key, handle, entryOptions),
-          remove: async (key) => await cache.remove(key),
-        };
-      },
-    },
-    workspaces: cas.workspaces,
-  };
 }
 
 async function createRoots(cas: InMemoryGitCasFacade): Promise<MaterializationRoots> {
@@ -286,25 +189,4 @@ function exactCoordinate(): MaterializationCoordinate {
     ]),
     ceiling: 12,
   });
-}
-
-async function cacheKeyForSchema(
-  coordinate: MaterializationCoordinate,
-  schemaVersion: number,
-): Promise<string> {
-  const encoded = defaultCodec.encode({
-    schemaVersion,
-    laneName: 'events',
-    coordinate: materializationCoordinateData(coordinate),
-  });
-  return `v${String(schemaVersion)}:${await new NodeCryptoAdapter().hash('sha256', encoded)}`;
-}
-
-function requireSingleCacheKey(cas: InMemoryGitCasFacade): string {
-  const keys = cas.readCacheKeys(CACHE_NAMESPACE);
-  const key = keys[0];
-  if (keys.length !== 1 || key === undefined) {
-    throw new Error('Expected exactly one materialization cache key');
-  }
-  return key;
 }

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.resume.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.resume.test.ts
@@ -80,12 +80,12 @@ describe('GitCasMaterializationStoreAdapter retained resume', () => {
     await harness.adapter.close();
   });
 
-  it('excludes compatible predecessors without a retained replay basis', async () => {
+  it('excludes partial compatible predecessors without a retained replay basis', async () => {
     const harness = await createHarness();
     await harness.adapter.retain({
       coordinate: exactCoordinate(),
       roots: rootsWithoutReplayBasis(await createRoots(harness.cas)),
-      stateHash: 'predecessor-state-hash',
+      stateHash: null,
     });
 
     const acquisition = await harness.adapter.acquireBestCompatiblePredecessor(

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreAdapter.test.ts
@@ -71,7 +71,7 @@ describe('GitCasMaterializationStoreAdapter', () => {
     expect(members.map(([path]) => path)).toEqual(['meta/descriptor', ...ROOT_PATHS]);
     const cacheKeys = harness.cas.readCacheKeys(CACHE_NAMESPACE);
     expect(cacheKeys).toHaveLength(1);
-    expect(cacheKeys[0]).toMatch(/^v4:[0-9a-f]{64}:[0-9a-f]{64}$/u);
+    expect(cacheKeys[0]).toMatch(/^v5:[0-9a-f]{64}:[0-9a-f]{64}$/u);
     expect(cacheKeys[0]?.length).toBeLessThan(1024);
     expect(harness.cas.readActiveCacheAcquisitionCount()).toBe(1);
     await acquisition?.release();
@@ -176,13 +176,14 @@ describe('GitCasMaterializationStoreAdapter', () => {
     const retained = await harness.adapter.retain({
       coordinate: exactCoordinate(),
       roots,
-      stateHash: 'partial-state-hash',
+      stateHash: null,
     });
     const resolved = await acquireReleaseAndClose(harness.adapter, exactCoordinate());
 
     expect(harness.cas.readBundleMembers(retained.bundle.toString()).map(([path]) => path))
       .toEqual(['meta/descriptor', 'roots/node-alive']);
     expect(resolved?.roots.nodeAlive.status).toBe('retained');
+    expect(resolved?.stateHash).toBeNull();
     expect(resolved?.roots.nodeAlive.handle?.toString()).toBe(nodeBundle.handle.toString());
     expect(resolved?.roots.edgeAlive.status).toBe('empty');
     expect(resolved?.roots.properties.status).toBe('empty');
@@ -377,6 +378,11 @@ describe('GitCasMaterializationStoreAdapter', () => {
       'unknown root status name',
     ],
     [
+      'non-string root status name',
+      descriptor({ roots: [[1, 'retained']] }),
+      'unknown root status name',
+    ],
+    [
       'root status value',
       descriptor({ roots: replaceRootStatus(rootStatusFixture(), 'adjacency', 'missing') }),
       'invalid adjacency root status',
@@ -392,12 +398,13 @@ describe('GitCasMaterializationStoreAdapter', () => {
       'no adjacency root status',
     ],
     [
-      'unavailable current property root',
-      descriptor({ roots: replaceRootStatus(rootStatusFixture(), 'properties', 'unavailable') }),
-      'requires a property root',
+      'entirely unavailable root profile',
+      descriptor({ roots: rootStatusFixture().map(([name]) => [name ?? '', 'unavailable']) }),
+      'at least one materialization root',
     ],
     ['lane', descriptor({ laneName: '' }), 'laneName must be a non-empty string'],
     ['state hash', descriptor({ stateHash: '' }), 'stateHash must be a non-empty string'],
+    ['partial replay basis', descriptor({ stateHash: null }), 'cannot retain a replay basis'],
   ])('rejects an invalid %s', async (_case, value, message) => {
     const harness = await retainedHarness();
     replaceDescriptor(harness, value);
@@ -488,14 +495,13 @@ describe('GitCasMaterializationStoreAdapter', () => {
     if (nodeAlive === null) {
       throw new Error('Expected retained node-alive test root');
     }
-    await expect(harness.adapter.retain({
+    const partial = await harness.adapter.retain({
       coordinate: exactCoordinate(),
       roots: unavailablePropertyRoots(nodeAlive),
-      stateHash: 'state-hash',
-    })).rejects.toMatchObject({
-      code: 'E_MATERIALIZATION_STORAGE',
-      message: expect.stringContaining('requires a property root'),
+      stateHash: null,
     });
+    expect(partial.stateHash).toBeNull();
+    expect(partial.roots.properties.status).toBe('unavailable');
     await expect(Reflect.apply(harness.adapter.acquireExact, harness.adapter, [{
       frontier: new Map(),
       ceiling: null,
@@ -709,7 +715,7 @@ function exactCoordinate(): MaterializationCoordinate {
 
 function descriptor(overrides: Record<string, object | string | number | null> = {}): object {
   return {
-    schemaVersion: 4,
+    schemaVersion: 5,
     laneName: 'events',
     stateHash: 'state-hash',
     roots: rootStatusFixture(),

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreValidation.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreValidation.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import MaterializationCoordinate from '../../../../src/domain/materialization/MaterializationCoordinate.ts';
+import MaterializationRoot from '../../../../src/domain/materialization/MaterializationRoot.ts';
+import MaterializationRoots from '../../../../src/domain/materialization/MaterializationRoots.ts';
+import BundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
+import { requireRetainRequest } from '../../../../src/infrastructure/adapters/GitCasMaterializationStoreValidation.ts';
+
+const coordinate = new MaterializationCoordinate({
+  frontier: new Map([['writer', 'patch']]),
+  ceiling: null,
+});
+
+describe('GitCasMaterializationStoreValidation', () => {
+  it('accepts a partial liveness materialization without a state hash', () => {
+    expect(() => requireRetainRequest({
+      coordinate,
+      roots: rootsWith({
+        nodeAlive: MaterializationRoot.retained(new BundleHandle('node-root')),
+      }),
+      stateHash: null,
+    })).not.toThrow();
+  });
+
+  it('rejects a materialization that cannot answer any read', () => {
+    expect(() => requireRetainRequest({
+      coordinate,
+      roots: rootsWith({}),
+      stateHash: null,
+    })).toThrowError(/at least one materialization root/u);
+  });
+
+  it('rejects a partial handle that claims a whole-state replay basis', () => {
+    expect(() => requireRetainRequest({
+      coordinate,
+      roots: rootsWith({
+        replayBasis: MaterializationRoot.retained(new BundleHandle('basis-root')),
+      }),
+      stateHash: null,
+    })).toThrowError(/cannot retain a whole-state replay basis/u);
+  });
+});
+
+function rootsWith(overrides: {
+  readonly nodeAlive?: MaterializationRoot;
+  readonly replayBasis?: MaterializationRoot;
+}): MaterializationRoots {
+  return new MaterializationRoots({
+    adjacency: MaterializationRoot.unavailable(),
+    edgeAlive: MaterializationRoot.unavailable(),
+    edgeBirths: MaterializationRoot.unavailable(),
+    frontier: MaterializationRoot.unavailable(),
+    nodeAlive: overrides.nodeAlive ?? MaterializationRoot.unavailable(),
+    properties: MaterializationRoot.unavailable(),
+    provenanceSupport: MaterializationRoot.unavailable(),
+    replayBasis: overrides.replayBasis ?? MaterializationRoot.unavailable(),
+    roaringIndexes: MaterializationRoot.unavailable(),
+  });
+}

--- a/test/unit/infrastructure/adapters/GitCasMaterializationStoreValidation.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasMaterializationStoreValidation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import MaterializationCoordinate from '../../../../src/domain/materialization/MaterializationCoordinate.ts';
 import MaterializationRoot from '../../../../src/domain/materialization/MaterializationRoot.ts';
 import MaterializationRoots from '../../../../src/domain/materialization/MaterializationRoots.ts';
+import { createEmptyState } from '../../../../src/domain/services/JoinReducer.ts';
 import BundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
 import { requireRetainRequest } from '../../../../src/infrastructure/adapters/GitCasMaterializationStoreValidation.ts';
 
@@ -38,6 +39,37 @@ describe('GitCasMaterializationStoreValidation', () => {
       }),
       stateHash: null,
     })).toThrowError(/cannot retain a whole-state replay basis/u);
+  });
+
+  it('accepts a complete materialization with a replay basis to stage', () => {
+    expect(() => requireRetainRequest({
+      coordinate,
+      roots: rootsWith({
+        nodeAlive: MaterializationRoot.retained(new BundleHandle('node-root')),
+      }),
+      replayBasis: createEmptyState(),
+      stateHash: 'state-hash',
+    })).not.toThrow();
+  });
+
+  it('accepts a complete materialization with an already retained replay basis', () => {
+    expect(() => requireRetainRequest({
+      coordinate,
+      roots: rootsWith({
+        replayBasis: MaterializationRoot.retained(new BundleHandle('basis-root')),
+      }),
+      stateHash: 'state-hash',
+    })).not.toThrow();
+  });
+
+  it('rejects a complete materialization without any replay basis', () => {
+    expect(() => requireRetainRequest({
+      coordinate,
+      roots: rootsWith({
+        nodeAlive: MaterializationRoot.retained(new BundleHandle('node-root')),
+      }),
+      stateHash: 'state-hash',
+    })).toThrowError(/requires a whole-state replay basis/u);
   });
 });
 


### PR DESCRIPTION
## Summary

- stream cold live node and edge liveness into page-bounded git-cas state sessions without constructing `WarpState` or adjacency
- retain partial materialization handles with `stateHash: null` so bounded roots cannot masquerade as whole-state snapshots
- establish descriptor schema v5 as the first release contract and remove migration and cleanup support for unreleased v2-v4 cache profiles

## Issue

Refs #738

## Test plan

- `npm run typecheck`
- `npm run lint`
- `npm run test:coverage:ci` (609 files, 7,357 tests; 92.95% lines)
- `npm run test:local` (six stable shards, 589 files, 7,188 tests)
- `npx vitest run test/integration` (21 files, 103 tests)
- markdown, docs topology, source-version, consumer, publication-surface, and link gates
- full pre-push IRONCLAD M9 gate

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] If this PR touches persisted op formats, I linked the ADR 3 readiness issue
- [x] If this PR touches wire compatibility, I confirmed canonical-only ops are still rejected on the wire pre-cutover
- [x] If this PR touches schema constants, I confirmed patch and checkpoint namespaces remain distinct