### PR TITLE
Replay targeted cold node properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `stateHash: null`, cannot masquerade as whole-state snapshots, and avoid
   constructing `WarpState`, adjacency, properties, receipts, diffs,
   provenance, or a state-cache snapshot.
+- Changed cold live node-property reads to replay only the requested node's
+  `NodePropSet` registers at the partial handle's exact coordinate when no
+  retained property root can answer. The targeted reducer keeps only one
+  node's winning LWW property bag and does not construct `WarpState`, graph
+  adjacency, receipts, diffs, provenance, hashes, or snapshots.
 
 ### Removed
 
@@ -98,11 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   roots, once assembled, remain pinned by the operation workspace until final
   promotion.
   The flat property-root profile also rejects more than 100,000 shards before
-  asset staging. Materialization descriptor/cache schema v3 replaces incomplete
-  v2 entries and removes the
-  corresponding legacy cache anchor through git-cas only after successful v3
-  retention. Schema-v3 materializations require the property root to be either
-  retained or explicitly empty; they reject `unavailable` property roots.
+  asset staging. Complete materializations record the property root as retained
+  or explicitly empty in descriptor schema v5; partial cold-liveness handles
+  may mark it unavailable until a property root is built.
 - Exact state-cache hits now retain and reopen coordinate-keyed materialization
   descriptors through the `git-cas` cache API. Repeated materialization,
   including through a fresh runtime adapter, resumes the retained node/edge

--- a/docs/topics/cas-first-memoized-materialization.md
+++ b/docs/topics/cas-first-memoized-materialization.md
@@ -147,8 +147,13 @@ changes, and releases it from `RuntimeHost.close()`. On a cold handle miss, the
 built-in session now streams only node and edge OR-Set operations into bounded
 git-cas pages and retains those roots as a partial handle. It does not construct
 `WarpState`, adjacency, property registers, receipts, diffs, provenance, or a
-state-cache snapshot. A later compatibility or property operation can replace
-that partial entry with a complete descriptor.
+state-cache snapshot. When that partial handle proves the requested node is
+live but has no usable property root, the runtime streams the handle's exact
+coordinate and reduces only matching `NodePropSet` operations into the
+requested node's LWW property bag. That targeted reducer does not hydrate
+`WarpState`, hash or publish state, or build graph-wide indexes. A later
+compatibility or property-root construction operation can replace the partial
+entry with a complete descriptor.
 
 Once assembled, a newly built property root joins the operation's expiring
 git-cas workspace before state hashing and final promotion, so the completed
@@ -225,9 +230,11 @@ lost payload bytes, or run Git garbage collection.
 - RuntimeHost exact node-liveness and node-property reads consume the
   handle-first result when the built-in trie session and reader pair is active.
   Cold node liveness now produces a partial retained handle through bounded
-  node/edge replay. Cold properties, custom session openers, neighborhoods,
-  list reads, checkpoint creation, and other compatibility operations still own
-  process-resident whole state.
+  node/edge replay. A cold property read reduces one proven-live node's property
+  bag without whole-state projection, but `PatchCollector` can still buffer one
+  writer chain while producing that coordinate stream. Custom session openers,
+  neighborhoods, list reads, checkpoint creation, and other compatibility
+  operations still own process-resident whole state.
 - Exact state-cache hits bypass replay, but full materialization still hydrates
   a full `WarpState`, scans retained node/edge tries, and builds full adjacency.
 - Retained exact and predecessor resume load a complete canonical `WarpState`

--- a/src/domain/services/controllers/MaterializeLiveStrategy.ts
+++ b/src/domain/services/controllers/MaterializeLiveStrategy.ts
@@ -12,6 +12,7 @@ import type {
   CheckpointData,
   PatchWithSha,
 } from '../../capabilities/PatchCollector.ts';
+import type PatchCollector from '../../capabilities/PatchCollector.ts';
 import type WarpStateCachePort from '../../../ports/WarpStateCachePort.ts';
 import type MaterializationReadPort from '../../../ports/MaterializationReadPort.ts';
 import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
@@ -29,6 +30,7 @@ import RetainedMaterializationResumeStrategy from './RetainedMaterializationResu
 import { isNonEmptyPatchSha } from './MaterializeHelpers.ts';
 import { resolveBoundedLiveMaterialization } from './BoundedLiveMaterialization.ts';
 import { materializedResolution } from './MaterializedLiveResolution.ts';
+import { replayTargetedNodeProperties } from './TargetedNodePropertyReplay.ts';
 
 export default class MaterializeLiveStrategy {
   private readonly runtime: MaterializeStrategyRuntime;
@@ -95,7 +97,12 @@ export default class MaterializeLiveStrategy {
     const resolution = await this.resolveMaterialization();
     let properties: Readonly<Record<string, PropValue>> | null | undefined;
     try {
-      properties = await readNodeProperties(reader, resolution.materialization, nodeId);
+      properties = await readNodeProperties({
+        materialization: resolution.materialization,
+        nodeId,
+        patches: this.runtime.deps.patches,
+        reader,
+      });
     } catch (raw) {
       await releaseAcquisitionAfterFailure(resolution, this.runtime.deps.logger);
       throw raw;
@@ -395,11 +402,13 @@ async function readNodePresence(
   return await reader.hasNode(root.handle, nodeId);
 }
 
-async function readNodeProperties(
-  reader: MaterializationReadPort,
-  materialization: MaterializationHandle | null,
-  nodeId: string,
-): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+async function readNodeProperties(options: {
+  readonly materialization: MaterializationHandle | null;
+  readonly nodeId: string;
+  readonly patches: PatchCollector;
+  readonly reader: MaterializationReadPort;
+}): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+  const { materialization, nodeId, patches, reader } = options;
   if (materialization === null) {
     return null;
   }
@@ -410,7 +419,15 @@ async function readNodeProperties(
   if (presence === null) {
     return undefined;
   }
-  return await readPropertiesRoot(reader, materialization, nodeId);
+  const retained = await readPropertiesRoot(reader, materialization, nodeId);
+  if (retained !== undefined) {
+    return retained;
+  }
+  return await replayTargetedNodeProperties({
+    coordinate: materialization.coordinate,
+    nodeId,
+    patches,
+  });
 }
 
 async function readPropertiesRoot(

--- a/src/domain/services/controllers/TargetedNodePropertyReplay.ts
+++ b/src/domain/services/controllers/TargetedNodePropertyReplay.ts
@@ -1,0 +1,87 @@
+import type PatchCollector from '../../capabilities/PatchCollector.ts';
+import type { PatchWithSha } from '../../capabilities/PatchCollector.ts';
+import { LWWRegister } from '../../crdt/LWW.ts';
+import PatchError from '../../errors/PatchError.ts';
+import type MaterializationCoordinate from '../../materialization/MaterializationCoordinate.ts';
+import NodePropSet from '../../types/ops/NodePropSet.ts';
+import {
+  copyPropValue,
+  isPropValue,
+  type PropValue,
+} from '../../types/PropValue.ts';
+import { EventId } from '../../utils/EventId.ts';
+import { compareStrings } from '../../utils/StringComparison.ts';
+import { normalizeRawOp } from '../OpNormalizer.ts';
+
+type PropertyRegisters = Map<string, LWWRegister<PropValue>>;
+
+/**
+ * Replays only one live node's property registers at an exact materialization
+ * coordinate.
+ *
+ * This reducer never constructs WarpState, adjacency, receipts, diffs, or
+ * provenance. Its own resident state is proportional to the requested node's
+ * winning property bag. PatchCollector may still buffer one writer chain while
+ * producing the coordinate stream.
+ */
+export async function replayTargetedNodeProperties(options: {
+  readonly coordinate: MaterializationCoordinate;
+  readonly nodeId: string;
+  readonly patches: PatchCollector;
+}): Promise<Readonly<Record<string, PropValue>>> {
+  const registers: PropertyRegisters = new Map();
+  const entries = options.patches.streamForFrontier(
+    options.coordinate.frontier(),
+    options.coordinate.ceiling,
+  );
+  for await (const entry of entries) {
+    applyTargetedPatchEntry(registers, entry, options.nodeId);
+  }
+  return freezePropertyBag(registers);
+}
+
+function applyTargetedPatchEntry(
+  registers: PropertyRegisters,
+  entry: PatchWithSha,
+  nodeId: string,
+): void {
+  for (let opIndex = 0; opIndex < entry.patch.ops.length; opIndex += 1) {
+    const rawOp = entry.patch.ops[opIndex];
+    if (rawOp === undefined) {
+      continue;
+    }
+    const op = normalizeRawOp(rawOp);
+    if (!(op instanceof NodePropSet) || op.node !== nodeId) {
+      continue;
+    }
+    registers.set(
+      op.key,
+      LWWRegister.max(
+        registers.get(op.key),
+        new LWWRegister(
+          new EventId(entry.patch.lamport, entry.patch.writer, entry.sha, opIndex),
+          requirePropValue(op),
+        ),
+      ),
+    );
+  }
+}
+
+function requirePropValue(op: NodePropSet): PropValue {
+  if (!isPropValue(op.value)) {
+    throw new PatchError(
+      'Targeted node-property replay encountered an invalid property value',
+      { context: { nodeId: op.node, propertyKey: op.key } },
+    );
+  }
+  return copyPropValue(op.value);
+}
+
+function freezePropertyBag(
+  registers: ReadonlyMap<string, LWWRegister<PropValue>>,
+): Readonly<Record<string, PropValue>> {
+  const entries = [...registers.entries()]
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([key, register]) => [key, register.value] as const);
+  return Object.freeze(Object.fromEntries(entries));
+}

--- a/test/unit/domain/services/controllers/MaterializeController.liveNodeRead.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.liveNodeRead.test.ts
@@ -14,6 +14,8 @@ import MaterializeController, {
 } from '../../../../../src/domain/services/controllers/MaterializeController.ts';
 import { retainBoundedLiveMaterialization } from '../../../../../src/domain/services/controllers/BoundedLiveMaterialization.ts';
 import BundleHandle from '../../../../../src/domain/storage/BundleHandle.ts';
+import Patch from '../../../../../src/domain/types/Patch.ts';
+import NodePropSet from '../../../../../src/domain/types/ops/NodePropSet.ts';
 import cborCodec from '../../../../../src/infrastructure/codecs/CborCodec.ts';
 import InMemoryCheckpointStore from '../../../../helpers/InMemoryCheckpointStore.ts';
 import InMemoryMaterializationStore, {
@@ -24,6 +26,9 @@ const FRONTIER = new Map([['writer-1', 'tip-1']]);
 
 class RetainedOnlyPatchCollector extends PatchCollector {
   frontier = new Map(FRONTIER);
+  chain: PatchWithSha[] = [];
+  chainFailure: Error | undefined;
+  readonly loadedTips: string[] = [];
 
   override discoverWriters(): Promise<string[]> {
     return Promise.resolve([]);
@@ -41,8 +46,11 @@ class RetainedOnlyPatchCollector extends PatchCollector {
     return Promise.resolve([]);
   }
 
-  override loadPatchChain(_toSha: string, _fromSha?: string | null): Promise<PatchWithSha[]> {
-    return Promise.resolve([]);
+  override loadPatchChain(toSha: string, _fromSha?: string | null): Promise<PatchWithSha[]> {
+    this.loadedTips.push(toSha);
+    return this.chainFailure === undefined
+      ? Promise.resolve([...this.chain])
+      : Promise.reject(this.chainFailure);
   }
 
   override getFrontier(): Promise<Map<string, string>> {
@@ -208,27 +216,70 @@ describe('MaterializeController live node reads', () => {
     expect(fixture.materializationRead.getNodeProperties).not.toHaveBeenCalled();
   });
 
-  it('falls back after releasing an unavailable retained properties root', async () => {
+  it('returns an empty targeted replay after an unavailable retained properties root', async () => {
     const fixture = await createFixture({ propertyRootStatus: 'unavailable' });
 
     await expect(fixture.controller.readLiveNodeProperties('node:retained'))
-      .resolves.toBeUndefined();
+      .resolves.toEqual({});
 
     expect(fixture.materializationRead.getNodeProperties).not.toHaveBeenCalled();
+    expect(fixture.patches.loadedTips).toEqual(['tip-1']);
     expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
   });
 
-  it('falls back when the configured reader does not support property roots', async () => {
+  it('replays when the configured reader does not support property roots', async () => {
     const fixture = await createFixture({
       propertyRootStatus: 'retained',
       propertyReadUnsupported: true,
     });
 
     await expect(fixture.controller.readLiveNodeProperties('node:retained'))
-      .resolves.toBeUndefined();
+      .resolves.toEqual({});
 
     expect(fixture.materializationRead.getNodeProperties).toHaveBeenCalledOnce();
+    expect(fixture.patches.loadedTips).toEqual(['tip-1']);
     expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+  });
+
+  it('replays one live node property bag without projecting whole state', async () => {
+    const fixture = await createFixture({
+      patchEntries: [
+        patchEntry({
+          lamport: 2,
+          ops: [
+            new NodePropSet('node:retained', 'status', 'ready'),
+            new NodePropSet('node:other', 'status', 'ignored'),
+          ],
+          sha: 'aaaa',
+          writer: 'writer-1',
+        }),
+      ],
+      propertyRootStatus: 'unavailable',
+    });
+
+    await expect(fixture.controller.readLiveNodeProperties('node:retained'))
+      .resolves.toEqual({ status: 'ready' });
+
+    expect(fixture.materializationRead.getNodeProperties).not.toHaveBeenCalled();
+    expect(fixture.patches.loadedTips).toEqual(['tip-1']);
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+    expect(fixture.deps.crypto.hash).not.toHaveBeenCalled();
+    expect(fixture.deps.persistence.readRef).not.toHaveBeenCalled();
+    expect(fixture.deps.graphCloner.openReadOnly).not.toHaveBeenCalled();
+  });
+
+  it('releases retained roots when targeted property replay fails', async () => {
+    const replayFailure = new Error('targeted property replay failed');
+    const fixture = await createFixture({
+      patchReadFailure: replayFailure,
+      propertyRootStatus: 'unavailable',
+    });
+
+    await expect(fixture.controller.readLiveNodeProperties('node:retained'))
+      .rejects.toBe(replayFailure);
+
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+    expect(fixture.materializations.acquisitions[0]?.released).toBe(true);
   });
 
   it('releases retained roots when the bounded property read fails', async () => {
@@ -250,6 +301,8 @@ async function createFixture(
   options: {
     readonly frontier?: Map<string, string>;
     readonly materializationRead?: boolean;
+    readonly patchEntries?: readonly PatchWithSha[];
+    readonly patchReadFailure?: Error;
     readonly presence?: boolean;
     readonly properties?: Readonly<Record<string, string>>;
     readonly propertyReadFailure?: Error;
@@ -262,6 +315,8 @@ async function createFixture(
 ) {
   const patches = new RetainedOnlyPatchCollector();
   patches.frontier = new Map(options.frontier ?? FRONTIER);
+  patches.chain = [...(options.patchEntries ?? [])];
+  patches.chainFailure = options.patchReadFailure;
   const materializations = new InMemoryMaterializationStore();
   const nodeRoot = new BundleHandle('test:node-root');
   const propertyRoot = new BundleHandle('test:property-root');
@@ -274,7 +329,7 @@ async function createFixture(
         propertyStatus: options.propertyRootStatus ?? 'unavailable',
         propertyRoot,
       }),
-      stateHash: 'state-hash',
+      stateHash: null,
     });
   }
   const hasNode = vi.fn<(nodeAliveRoot: BundleHandle, nodeId: string) => Promise<boolean>>();
@@ -306,6 +361,7 @@ async function createFixture(
     materializationRead,
     materializations,
     nodeRoot,
+    patches,
     propertyRoot,
   };
 }
@@ -389,4 +445,22 @@ async function requireRetained(materializations: InMemoryMaterializationStore) {
   await acquisition.release();
   materializations.acquisitions.splice(0);
   return acquisition.materialization;
+}
+
+function patchEntry(options: {
+  readonly lamport: number;
+  readonly ops: Patch['ops'];
+  readonly sha: string;
+  readonly writer: string;
+}): PatchWithSha {
+  return {
+    patch: new Patch({
+      schema: 3,
+      writer: options.writer,
+      lamport: options.lamport,
+      context: {},
+      ops: options.ops,
+    }),
+    sha: options.sha,
+  };
 }

--- a/test/unit/domain/services/controllers/TargetedNodePropertyReplay.test.ts
+++ b/test/unit/domain/services/controllers/TargetedNodePropertyReplay.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+
+import PatchCollector, {
+  type CheckpointData,
+  type PatchWithSha,
+} from '../../../../../src/domain/capabilities/PatchCollector.ts';
+import PatchError from '../../../../../src/domain/errors/PatchError.ts';
+import MaterializationCoordinate from '../../../../../src/domain/materialization/MaterializationCoordinate.ts';
+import { replayTargetedNodeProperties } from '../../../../../src/domain/services/controllers/TargetedNodePropertyReplay.ts';
+import Patch from '../../../../../src/domain/types/Patch.ts';
+import EdgePropSet from '../../../../../src/domain/types/ops/EdgePropSet.ts';
+import NodePropSet from '../../../../../src/domain/types/ops/NodePropSet.ts';
+
+const TARGET_NODE = 'node:target';
+
+class ChainPatchCollector extends PatchCollector {
+  readonly loadedTips: string[] = [];
+  readonly chains: ReadonlyMap<string, readonly PatchWithSha[]>;
+
+  constructor(chains: ReadonlyMap<string, readonly PatchWithSha[]>) {
+    super();
+    this.chains = chains;
+  }
+
+  override discoverWriters(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadWriterPatches(_writerId: string): Promise<PatchWithSha[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadCheckpoint(): Promise<CheckpointData | null> {
+    return Promise.resolve(null);
+  }
+
+  override loadPatchesSince(_checkpoint: CheckpointData): Promise<PatchWithSha[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadPatchChain(toSha: string, _fromSha?: string | null): Promise<PatchWithSha[]> {
+    this.loadedTips.push(toSha);
+    return Promise.resolve([...(this.chains.get(toSha) ?? [])]);
+  }
+
+  override getFrontier(): Promise<Map<string, string>> {
+    return Promise.resolve(new Map());
+  }
+}
+
+describe('replayTargetedNodeProperties', () => {
+  it('selects LWW winners at the exact frontier and ignores unrelated operations', async () => {
+    const patches = new ChainPatchCollector(new Map([
+      ['tip-a', [
+        patchEntry({
+          lamport: 3,
+          ops: [
+            new NodePropSet(TARGET_NODE, 'status', 'writer-a'),
+            new NodePropSet('node:other', 'status', 'ignored-node'),
+            new EdgePropSet({
+              from: TARGET_NODE,
+              to: 'node:other',
+              label: 'rel',
+              key: 'status',
+              value: 'ignored-edge',
+            }),
+          ],
+          sha: 'aaaa',
+          writer: 'writer-a',
+        }),
+        patchEntry({
+          lamport: 5,
+          ops: [new NodePropSet(TARGET_NODE, 'status', 'above-ceiling')],
+          sha: 'cccc',
+          writer: 'writer-a',
+        }),
+      ]],
+      ['tip-b', [
+        patchEntry({
+          lamport: 3,
+          ops: [
+            new NodePropSet(TARGET_NODE, 'status', 'writer-b'),
+            new NodePropSet(TARGET_NODE, 'title', 'Target title'),
+          ],
+          sha: 'bbbb',
+          writer: 'writer-b',
+        }),
+      ]],
+    ]));
+
+    const properties = await replayTargetedNodeProperties({
+      coordinate: coordinate(new Map([
+        ['writer-b', 'tip-b'],
+        ['writer-a', 'tip-a'],
+      ]), 4),
+      nodeId: TARGET_NODE,
+      patches,
+    });
+
+    expect(properties).toEqual({
+      status: 'writer-b',
+      title: 'Target title',
+    });
+    expect(patches.loadedTips).toEqual(['tip-a', 'tip-b']);
+  });
+
+  it('uses the original operation index to order writes within one patch', async () => {
+    const patches = new ChainPatchCollector(new Map([
+      ['tip-a', [
+        patchEntry({
+          lamport: 2,
+          ops: [
+            new NodePropSet(TARGET_NODE, 'status', 'first'),
+            new NodePropSet('node:other', 'status', 'ignored'),
+            new NodePropSet(TARGET_NODE, 'status', 'last'),
+          ],
+          sha: 'aaaa',
+          writer: 'writer-a',
+        }),
+      ]],
+    ]));
+
+    await expect(replayTargetedNodeProperties({
+      coordinate: coordinate(new Map([['writer-a', 'tip-a']]), null),
+      nodeId: TARGET_NODE,
+      patches,
+    })).resolves.toEqual({ status: 'last' });
+  });
+
+  it('returns a sorted frozen bag with a safe own __proto__ property', async () => {
+    const patches = new ChainPatchCollector(new Map([
+      ['tip-a', [
+        patchEntry({
+          lamport: 2,
+          ops: [
+            new NodePropSet(TARGET_NODE, 'zeta', 3),
+            new NodePropSet(TARGET_NODE, '__proto__', 'safe'),
+            new NodePropSet(TARGET_NODE, 'alpha', 1),
+          ],
+          sha: 'aaaa',
+          writer: 'writer-a',
+        }),
+      ]],
+    ]));
+
+    const properties = await replayTargetedNodeProperties({
+      coordinate: coordinate(new Map([['writer-a', 'tip-a']]), null),
+      nodeId: TARGET_NODE,
+      patches,
+    });
+
+    expect(Object.keys(properties)).toEqual(['__proto__', 'alpha', 'zeta']);
+    expect(Object.hasOwn(properties, '__proto__')).toBe(true);
+    expect(properties['__proto__']).toBe('safe');
+    expect(Object.getPrototypeOf(properties)).toBe(Object.prototype);
+    expect(Object.isFrozen(properties)).toBe(true);
+  });
+
+  it('returns an empty frozen bag when no target properties exist', async () => {
+    const properties = await replayTargetedNodeProperties({
+      coordinate: coordinate(new Map(), null),
+      nodeId: TARGET_NODE,
+      patches: new ChainPatchCollector(new Map()),
+    });
+
+    expect(properties).toEqual({});
+    expect(Object.isFrozen(properties)).toBe(true);
+  });
+
+  it('fails closed on an invalid property value', async () => {
+    const patches = new ChainPatchCollector(new Map([
+      ['tip-a', [
+        patchEntry({
+          lamport: 2,
+          ops: [new NodePropSet(TARGET_NODE, 'invalid', undefined)],
+          sha: 'aaaa',
+          writer: 'writer-a',
+        }),
+      ]],
+    ]));
+
+    await expect(replayTargetedNodeProperties({
+      coordinate: coordinate(new Map([['writer-a', 'tip-a']]), null),
+      nodeId: TARGET_NODE,
+      patches,
+    })).rejects.toBeInstanceOf(PatchError);
+  });
+});
+
+function coordinate(
+  frontier: Map<string, string>,
+  ceiling: number | null,
+): MaterializationCoordinate {
+  return new MaterializationCoordinate({ frontier, ceiling });
+}
+
+function patchEntry(options: {
+  readonly lamport: number;
+  readonly ops: Patch['ops'];
+  readonly sha: string;
+  readonly writer: string;
+}): PatchWithSha {
+  return {
+    patch: new Patch({
+      schema: 3,
+      writer: options.writer,
+      lamport: options.lamport,
+      context: {},
+      ops: options.ops,
+    }),
+    sha: options.sha,
+  };
+}


### PR DESCRIPTION
## Summary

- replay only one proven-live node property bag when a partial materialization has no usable property root
- preserve exact-coordinate LWW ordering, safe property keys, immutable results, and acquisition cleanup without constructing `WarpState`
- document the remaining upstream `PatchCollector` writer-chain residency boundary and keep unreleased descriptor schemas out of the v19 contract

## Issue

Refs #738

This is an incremental bounded-read slice. It intentionally does not close #738: neighborhoods, list reads, checkpoint creation, and other compatibility operations still reconstruct whole state, and `PatchCollector` may still buffer one writer chain.

## Test plan

- `npx vitest run test/unit/domain/services/controllers/TargetedNodePropertyReplay.test.ts test/unit/domain/services/controllers/MaterializeController.liveNodeRead.test.ts` (23 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run test:coverage:ci` (7,371 passed; 2 skipped; all ratchets held)
- `npx vitest run test/unit test/integration` (7,453 passed; 2 skipped)
- pre-push IRONCLAD static gates and stable-unit shards (all passed)
- `git diff --check`

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] If this PR touches persisted op formats, I linked the ADR 3 readiness issue
- [x] If this PR touches wire compatibility, I confirmed canonical-only ops are still rejected on the wire pre-cutover
- [x] If this PR touches schema constants, I confirmed patch and checkpoint namespaces remain distinct