### PR TITLE
Replay targeted cold edge properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retained property root can answer. The targeted reducer keeps only one
   node's winning LWW property bag and does not construct `WarpState`, graph
   adjacency, receipts, diffs, provenance, hashes, or snapshots.
+- Changed cold live edge-property reads to prove both endpoints and the edge
+  through retained liveness roots, then replay only matching `EdgeAdd` and
+  `EdgePropSet` operations at the exact coordinate. The targeted reducer keeps
+  one edge's birth event and winning LWW property bag so values from before an
+  edge rebirth remain hidden without whole-state projection.
 
 ### Removed
 

--- a/docs/topics/cas-first-memoized-materialization.md
+++ b/docs/topics/cas-first-memoized-materialization.md
@@ -128,16 +128,17 @@ The bounded-memory read path is optic/worldline/query work over a sharded or
 streamed basis. The state cache is the replay-skipping compatibility bridge for
 legacy materialization and checkpoint flows.
 
-`RuntimeHost.hasNode()` and `RuntimeHost.getNodeProps()` consume the handle-first
-path directly when the runtime uses the built-in trie-backed state session and
-matching materialization reader. On an exact retained-coordinate hit, node
-liveness opens only the required trie path through a bounded page cache. A
-property read uses the node's full BLAKE3 route key to resolve one per-node
-property shard by exact bundle member path. The schema-v2 shard envelope stores
-the property bag as sorted key/value entries, preserving legal keys such as
-`__proto__` without treating them as object structure. Writes reject an encoded
-shard over 16 MiB; reads enforce the same byte ceiling plus CBOR container,
-depth, and item limits before general decoding. The reader owns no cache.
+`RuntimeHost.hasNode()`, `RuntimeHost.getNodeProps()`, and
+`RuntimeHost.getEdgeProps()` consume the handle-first path directly when the
+runtime uses the built-in trie-backed state session and matching materialization
+reader. On an exact retained-coordinate hit, node or edge liveness opens only
+the required trie path through a bounded page cache. A node-property read uses
+the node's full BLAKE3 route key to resolve one per-node property shard by exact
+bundle member path. The schema-v2 shard envelope stores the property bag as
+sorted key/value entries, preserving legal keys such as `__proto__` without
+treating them as object structure. Writes reject an encoded shard over 16 MiB;
+reads enforce the same byte ceiling plus CBOR container, depth, and item limits
+before general decoding. The reader owns no cache.
 
 Both exact paths release their operation borrow without hydrating `WarpState`,
 building adjacency, publishing a state snapshot, or populating `_cachedState`.
@@ -153,7 +154,11 @@ coordinate and reduces only matching `NodePropSet` operations into the
 requested node's LWW property bag. That targeted reducer does not hydrate
 `WarpState`, hash or publish state, or build graph-wide indexes. A later
 compatibility or property-root construction operation can replace the partial
-entry with a complete descriptor.
+entry with a complete descriptor. A cold edge-property read similarly proves
+both endpoint nodes and the edge through retained liveness roots, then reduces
+only matching `EdgeAdd` and `EdgePropSet` operations. Tracking the latest
+matching edge birth preserves the existing rule that properties older than an
+edge rebirth are hidden.
 
 Once assembled, a newly built property root joins the operation's expiring
 git-cas workspace before state hashing and final promotion, so the completed
@@ -228,13 +233,15 @@ lost payload bytes, or run Git garbage collection.
 ## Current Limitations
 
 - RuntimeHost exact node-liveness and node-property reads consume the
-  handle-first result when the built-in trie session and reader pair is active.
-  Cold node liveness now produces a partial retained handle through bounded
-  node/edge replay. A cold property read reduces one proven-live node's property
-  bag without whole-state projection, but `PatchCollector` can still buffer one
-  writer chain while producing that coordinate stream. Custom session openers,
-  neighborhoods, list reads, checkpoint creation, and other compatibility
-  operations still own process-resident whole state.
+  handle-first result when the built-in trie session and reader pair is active;
+  exact edge-property reads do the same after proving both endpoint nodes and
+  the edge live. Cold node liveness now produces a partial retained handle
+  through bounded node/edge replay. A cold node- or edge-property read reduces
+  only one proven-live target without whole-state projection, but
+  `PatchCollector` can still buffer one writer chain while producing that
+  coordinate stream. Custom session openers, neighborhoods, list reads,
+  checkpoint creation, and other compatibility operations still own
+  process-resident whole state.
 - Exact state-cache hits bypass replay, but full materialization still hydrates
   a full `WarpState`, scans retained node/edge tries, and builds full adjacency.
 - Retained exact and predecessor resume load a complete canonical `WarpState`

--- a/src/domain/RuntimeHost.ts
+++ b/src/domain/RuntimeHost.ts
@@ -439,6 +439,10 @@ export default class RuntimeHost {
     return this._materializeController.readLiveNodeProperties(nodeId);
   }
 
+  _readLiveEdgeProperties(edge: { from: string; to: string; label: string }) {
+    return this._materializeController.readLiveEdgeProperties(edge);
+  }
+
   /** Releases local runtime resources without changing admitted history. */
   close(): Promise<void> {
     this._closePromise ??= this._materializations.close();

--- a/src/domain/materialization/TrieMaterializationReader.ts
+++ b/src/domain/materialization/TrieMaterializationReader.ts
@@ -1,6 +1,8 @@
 import type CodecPort from '../../ports/CodecPort.ts';
 import type IndexStorePort from '../../ports/IndexStorePort.ts';
-import MaterializationReadPort from '../../ports/MaterializationReadPort.ts';
+import MaterializationReadPort, {
+  type MaterializationEdgeTarget,
+} from '../../ports/MaterializationReadPort.ts';
 import BundleHandle from '../storage/BundleHandle.ts';
 import WarpError from '../errors/WarpError.ts';
 import PageCache from '../orset/trie/PageCache.ts';
@@ -14,6 +16,7 @@ import {
   materializationPropertyShardPath,
   MATERIALIZATION_PROPERTY_SHARD_LIMITS,
 } from './MaterializationPropertyProfile.ts';
+import { encodeEdgeKey } from '../services/KeyCodec.ts';
 
 const MAX_RESIDENT_READ_PAGES = 256;
 
@@ -49,20 +52,16 @@ export default class TrieMaterializationReader extends MaterializationReadPort {
   }
 
   override async hasNode(nodeAliveRoot: BundleHandle, nodeId: string): Promise<boolean> {
-    if (!(nodeAliveRoot instanceof BundleHandle)) {
-      throw new WarpError(
-        'Materialization node-liveness root must be a BundleHandle',
-        'E_MATERIALIZATION_RESUME'
-      );
-    }
-    const cursor = new TrieCursor({
-      rootOid: nodeAliveRoot.toString(),
-      store: this.#store,
-      geometry: this.#geometry,
-      codec: this.#codec,
-      pageCache: this.#pageCache,
-    });
+    const cursor = this.#openLivenessRoot(nodeAliveRoot, 'node');
     return await cursor.contains(nodeId);
+  }
+
+  override async hasEdge(
+    edgeAliveRoot: BundleHandle,
+    edge: MaterializationEdgeTarget,
+  ): Promise<boolean> {
+    const cursor = this.#openLivenessRoot(edgeAliveRoot, 'edge');
+    return await cursor.contains(encodeEdgeKey(edge.from, edge.to, edge.label));
   }
 
   override async getNodeProperties(
@@ -90,6 +89,25 @@ export default class TrieMaterializationReader extends MaterializationReadPort {
       materializationPropertyShardKey,
     );
     return shard.get(nodeId) ?? null;
+  }
+
+  #openLivenessRoot(
+    root: BundleHandle,
+    kind: 'node' | 'edge',
+  ): TrieCursor {
+    if (!(root instanceof BundleHandle)) {
+      throw new WarpError(
+        `Materialization ${kind}-liveness root must be a BundleHandle`,
+        'E_MATERIALIZATION_RESUME',
+      );
+    }
+    return new TrieCursor({
+      rootOid: root.toString(),
+      store: this.#store,
+      geometry: this.#geometry,
+      codec: this.#codec,
+      pageCache: this.#pageCache,
+    });
   }
 }
 

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -31,6 +31,7 @@ import type {
   WarpStateSnapshotProvenancePosture,
 } from '../../../ports/WarpStateCachePort.ts';
 import type MaterializationWorkspacePort from '../../../ports/MaterializationWorkspacePort.ts';
+import type { MaterializationEdgeTarget } from '../../../ports/MaterializationReadPort.ts';
 import type { PatchWithSha } from '../../capabilities/PatchCollector.ts';
 import PatchEntry from '../../artifacts/PatchEntry.ts';
 import type WarpState from '../state/WarpState.ts';
@@ -170,6 +171,11 @@ export default class MaterializeController {
   }
   readLiveNodeProperties(nodeId: string): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
     return this._liveStrategy.readNodeProperties(nodeId);
+  }
+  readLiveEdgeProperties(
+    edge: MaterializationEdgeTarget,
+  ): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+    return this._liveStrategy.readEdgeProperties(edge);
   }
   /** Coordinate materialization — explicit frontier. */
   async materializeCoordinate(

--- a/src/domain/services/controllers/MaterializeLiveStrategy.ts
+++ b/src/domain/services/controllers/MaterializeLiveStrategy.ts
@@ -12,10 +12,8 @@ import type {
   CheckpointData,
   PatchWithSha,
 } from '../../capabilities/PatchCollector.ts';
-import type PatchCollector from '../../capabilities/PatchCollector.ts';
 import type WarpStateCachePort from '../../../ports/WarpStateCachePort.ts';
-import type MaterializationReadPort from '../../../ports/MaterializationReadPort.ts';
-import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
+import type { MaterializationEdgeTarget } from '../../../ports/MaterializationReadPort.ts';
 import type { PropValue } from '../../types/PropValue.ts';
 import type {
   WarpStateCoordinate,
@@ -30,7 +28,11 @@ import RetainedMaterializationResumeStrategy from './RetainedMaterializationResu
 import { isNonEmptyPatchSha } from './MaterializeHelpers.ts';
 import { resolveBoundedLiveMaterialization } from './BoundedLiveMaterialization.ts';
 import { materializedResolution } from './MaterializedLiveResolution.ts';
-import { replayTargetedNodeProperties } from './TargetedNodePropertyReplay.ts';
+import {
+  readMaterializedEdgeProperties,
+  readMaterializedNodePresence,
+  readMaterializedNodeProperties,
+} from './MaterializedLiveRead.ts';
 
 export default class MaterializeLiveStrategy {
   private readonly runtime: MaterializeStrategyRuntime;
@@ -78,7 +80,11 @@ export default class MaterializeLiveStrategy {
     const resolution = await this.resolveMaterialization();
     let presence: boolean | null;
     try {
-      presence = await readNodePresence(reader, resolution.materialization, nodeId);
+      presence = await readMaterializedNodePresence({
+        materialization: resolution.materialization,
+        nodeId,
+        reader,
+      });
     } catch (raw) {
       await releaseAcquisitionAfterFailure(resolution, this.runtime.deps.logger);
       throw raw;
@@ -97,9 +103,33 @@ export default class MaterializeLiveStrategy {
     const resolution = await this.resolveMaterialization();
     let properties: Readonly<Record<string, PropValue>> | null | undefined;
     try {
-      properties = await readNodeProperties({
+      properties = await readMaterializedNodeProperties({
         materialization: resolution.materialization,
         nodeId,
+        patches: this.runtime.deps.patches,
+        reader,
+      });
+    } catch (raw) {
+      await releaseAcquisitionAfterFailure(resolution, this.runtime.deps.logger);
+      throw raw;
+    }
+    await resolution.release();
+    return properties;
+  }
+
+  async readEdgeProperties(
+    edge: MaterializationEdgeTarget,
+  ): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+    const reader = this.runtime.deps.materializationRead;
+    if (reader === undefined) {
+      return undefined;
+    }
+    const resolution = await this.resolveMaterialization();
+    let properties: Readonly<Record<string, PropValue>> | null | undefined;
+    try {
+      properties = await readMaterializedEdgeProperties({
+        edge,
+        materialization: resolution.materialization,
         patches: this.runtime.deps.patches,
         reader,
       });
@@ -379,82 +409,6 @@ export default class MaterializeLiveStrategy {
       frontier: opts.coordinate.frontier,
     });
   }
-}
-
-async function readNodePresence(
-  reader: MaterializationReadPort,
-  materialization: MaterializationHandle | null,
-  nodeId: string,
-): Promise<boolean | null> {
-  if (materialization === null) {
-    return false;
-  }
-  const root = materialization.roots.nodeAlive;
-  if (root.status === 'unavailable') {
-    return null;
-  }
-  if (root.status === 'empty') {
-    return false;
-  }
-  if (root.handle === null) {
-    throw resolutionError('retained node-liveness root has no handle');
-  }
-  return await reader.hasNode(root.handle, nodeId);
-}
-
-async function readNodeProperties(options: {
-  readonly materialization: MaterializationHandle | null;
-  readonly nodeId: string;
-  readonly patches: PatchCollector;
-  readonly reader: MaterializationReadPort;
-}): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
-  const { materialization, nodeId, patches, reader } = options;
-  if (materialization === null) {
-    return null;
-  }
-  const presence = await readNodePresence(reader, materialization, nodeId);
-  if (presence === false) {
-    return null;
-  }
-  if (presence === null) {
-    return undefined;
-  }
-  const retained = await readPropertiesRoot(reader, materialization, nodeId);
-  if (retained !== undefined) {
-    return retained;
-  }
-  return await replayTargetedNodeProperties({
-    coordinate: materialization.coordinate,
-    nodeId,
-    patches,
-  });
-}
-
-async function readPropertiesRoot(
-  reader: MaterializationReadPort,
-  materialization: MaterializationHandle,
-  nodeId: string,
-): Promise<Readonly<Record<string, PropValue>> | undefined> {
-  const propertiesRoot = materialization.roots.properties;
-  if (propertiesRoot.status === 'unavailable') {
-    return undefined;
-  }
-  if (propertiesRoot.status === 'empty') {
-    return Object.freeze({});
-  }
-  return await readRetainedPropertiesRoot(reader, propertiesRoot, nodeId);
-}
-
-async function readRetainedPropertiesRoot(
-  reader: MaterializationReadPort,
-  propertiesRoot: MaterializationHandle['roots']['properties'],
-  nodeId: string,
-): Promise<Readonly<Record<string, PropValue>> | undefined> {
-  if (propertiesRoot.handle === null) {
-    throw resolutionError('retained properties root has no handle');
-  }
-  const properties = await reader.getNodeProperties(propertiesRoot.handle, nodeId);
-  return properties === undefined ? undefined : properties ?? Object.freeze({});
 }
 
 function emptyResolution(): LiveMaterializationResolution {

--- a/src/domain/services/controllers/MaterializedLiveRead.ts
+++ b/src/domain/services/controllers/MaterializedLiveRead.ts
@@ -1,0 +1,194 @@
+import type PatchCollector from '../../capabilities/PatchCollector.ts';
+import WarpError from '../../errors/WarpError.ts';
+import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
+import type { PropValue } from '../../types/PropValue.ts';
+import type MaterializationReadPort from '../../../ports/MaterializationReadPort.ts';
+import type { MaterializationEdgeTarget } from '../../../ports/MaterializationReadPort.ts';
+import { isLegacyEdgePropertyProjectionTarget } from '../LegacyPropertyProjectionTarget.ts';
+import { replayTargetedEdgeProperties } from './TargetedEdgePropertyReplay.ts';
+import { replayTargetedNodeProperties } from './TargetedNodePropertyReplay.ts';
+
+export async function readMaterializedNodePresence(options: {
+  readonly materialization: MaterializationHandle | null;
+  readonly nodeId: string;
+  readonly reader: MaterializationReadPort;
+}): Promise<boolean | null> {
+  const { materialization, nodeId, reader } = options;
+  if (materialization === null) {
+    return false;
+  }
+  const root = materialization.roots.nodeAlive;
+  if (root.status === 'unavailable') {
+    return null;
+  }
+  if (root.status === 'empty') {
+    return false;
+  }
+  if (root.handle === null) {
+    throw liveReadError('retained node-liveness root has no handle');
+  }
+  return await reader.hasNode(root.handle, nodeId);
+}
+
+export async function readMaterializedNodeProperties(options: {
+  readonly materialization: MaterializationHandle | null;
+  readonly nodeId: string;
+  readonly patches: PatchCollector;
+  readonly reader: MaterializationReadPort;
+}): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+  const { materialization, nodeId, patches, reader } = options;
+  if (materialization === null) {
+    return null;
+  }
+  const presence = await readMaterializedNodePresence({
+    materialization,
+    nodeId,
+    reader,
+  });
+  if (presence !== true) {
+    return propertyReadUnavailable(presence);
+  }
+  const retained = await readPropertiesRoot(reader, materialization, nodeId);
+  if (retained !== undefined) {
+    return retained;
+  }
+  return await replayTargetedNodeProperties({
+    coordinate: materialization.coordinate,
+    nodeId,
+    patches,
+  });
+}
+
+export async function readMaterializedEdgeProperties(options: {
+  readonly edge: MaterializationEdgeTarget;
+  readonly materialization: MaterializationHandle | null;
+  readonly patches: PatchCollector;
+  readonly reader: MaterializationReadPort;
+}): Promise<Readonly<Record<string, PropValue>> | null | undefined> {
+  const { edge, materialization, patches, reader } = options;
+  if (!isLegacyEdgePropertyProjectionTarget(edge) || materialization === null) {
+    return null;
+  }
+  const presence = await readVisibleEdgePresence({
+    edge,
+    materialization,
+    reader,
+  });
+  if (presence !== true) {
+    return propertyReadUnavailable(presence);
+  }
+  return await replayTargetedEdgeProperties({
+    coordinate: materialization.coordinate,
+    edge,
+    patches,
+  });
+}
+
+async function readVisibleEdgePresence(options: {
+  readonly edge: MaterializationEdgeTarget;
+  readonly materialization: MaterializationHandle;
+  readonly reader: MaterializationReadPort;
+}): Promise<boolean | null> {
+  const { edge, materialization, reader } = options;
+  const endpoints = await readEndpointPresence({
+    edge,
+    materialization,
+    reader,
+  });
+  if (endpoints !== true) {
+    return endpoints;
+  }
+  return await readEdgePresence(reader, materialization, edge);
+}
+
+async function readEndpointPresence(options: {
+  readonly edge: MaterializationEdgeTarget;
+  readonly materialization: MaterializationHandle;
+  readonly reader: MaterializationReadPort;
+}): Promise<boolean | null> {
+  const { edge, materialization, reader } = options;
+  const source = await readMaterializedNodePresence({
+    materialization,
+    nodeId: edge.from,
+    reader,
+  });
+  if (source !== true) {
+    return source;
+  }
+  return await readMaterializedNodePresence({
+    materialization,
+    nodeId: edge.to,
+    reader,
+  });
+}
+
+async function readEdgePresence(
+  reader: MaterializationReadPort,
+  materialization: MaterializationHandle,
+  edge: MaterializationEdgeTarget,
+): Promise<boolean | null> {
+  const root = materialization.roots.edgeAlive;
+  if (root.status === 'unavailable') {
+    return null;
+  }
+  if (root.status === 'empty') {
+    return false;
+  }
+  return await readRetainedEdgePresence(reader, root, edge);
+}
+
+async function readRetainedEdgePresence(
+  reader: MaterializationReadPort,
+  root: MaterializationHandle['roots']['edgeAlive'],
+  edge: MaterializationEdgeTarget,
+): Promise<boolean | null> {
+  if (root.handle === null) {
+    throw liveReadError('retained edge-liveness root has no handle');
+  }
+  if (reader.hasEdge === undefined) {
+    return null;
+  }
+  return await reader.hasEdge(root.handle, edge);
+}
+
+async function readPropertiesRoot(
+  reader: MaterializationReadPort,
+  materialization: MaterializationHandle,
+  nodeId: string,
+): Promise<Readonly<Record<string, PropValue>> | undefined> {
+  const propertiesRoot = materialization.roots.properties;
+  if (propertiesRoot.status === 'unavailable') {
+    return undefined;
+  }
+  if (propertiesRoot.status === 'empty') {
+    return Object.freeze({});
+  }
+  return await readRetainedPropertiesRoot(reader, propertiesRoot, nodeId);
+}
+
+async function readRetainedPropertiesRoot(
+  reader: MaterializationReadPort,
+  propertiesRoot: MaterializationHandle['roots']['properties'],
+  nodeId: string,
+): Promise<Readonly<Record<string, PropValue>> | undefined> {
+  if (propertiesRoot.handle === null) {
+    throw liveReadError('retained properties root has no handle');
+  }
+  const properties = await reader.getNodeProperties(
+    propertiesRoot.handle,
+    nodeId,
+  );
+  return properties === undefined
+    ? undefined
+    : properties ?? Object.freeze({});
+}
+
+function propertyReadUnavailable(
+  presence: false | null,
+): null | undefined {
+  return presence === false ? null : undefined;
+}
+
+function liveReadError(message: string): WarpError {
+  return new WarpError(message, 'E_MATERIALIZATION_RESUME');
+}

--- a/src/domain/services/controllers/QueryReads.ts
+++ b/src/domain/services/controllers/QueryReads.ts
@@ -183,8 +183,21 @@ function nodePropertyBagFromRecords(records: readonly VisibleNodePropertyRecord[
 }
 
 export async function getEdgePropsImpl(host: QueryReadHost, edge: { from: string; to: string; label: string }): Promise<PropertyBag | null> {
+  if (!isLegacyEdgePropertyProjectionTarget(edge)) { return null; }
+  const retained = await tryRetainedEdgeProps(host, edge);
+  if (retained !== undefined) { return retained; }
   const state = await ensureAndGetState(host);
   return edgePropsFromState(state, edge);
+}
+
+async function tryRetainedEdgeProps(
+  host: QueryReadHost,
+  edge: { from: string; to: string; label: string },
+): Promise<PropertyBag | null | undefined> {
+  if (host._readLiveEdgeProperties === undefined) { return undefined; }
+  const retained = await host._readLiveEdgeProperties(edge);
+  if (retained === undefined) { return undefined; }
+  return retained === null ? null : createSnapshotPropertyValues(retained);
 }
 
 function edgePropsFromState(state: WarpState, edge: { from: string; to: string; label: string }): PropertyBag | null {

--- a/src/domain/services/controllers/ReadGraphHost.ts
+++ b/src/domain/services/controllers/ReadGraphHost.ts
@@ -3,6 +3,7 @@ import type CommitMessageCodecPort from '../../../ports/CommitMessageCodecPort.t
 import type CommitPort from '../../../ports/CommitPort.ts';
 import type NeighborProviderPort from '../../../ports/NeighborProviderPort.ts';
 import type { NeighborEdge } from '../../../ports/NeighborProviderPort.ts';
+import type { MaterializationEdgeTarget } from '../../../ports/MaterializationReadPort.ts';
 import type WarpState from '../state/WarpState.ts';
 import type PropertyIndexReader from '../index/PropertyIndexReader.ts';
 import type { LogicalIndex } from '../index/logicalIndexHelpers.ts';
@@ -32,6 +33,9 @@ export type QueryReadHost = FreshStateHost & {
   _readLiveNodePresence?(nodeId: string): Promise<boolean | null>;
   _readLiveNodeProperties?(
     nodeId: string,
+  ): Promise<Readonly<Record<string, PropValue>> | null | undefined>;
+  _readLiveEdgeProperties?(
+    edge: MaterializationEdgeTarget,
   ): Promise<Readonly<Record<string, PropValue>> | null | undefined>;
   _propertyReader: PropertyIndexReader | null;
   _logicalIndex: LogicalIndex | null;

--- a/src/domain/services/controllers/TargetedEdgePropertyReplay.ts
+++ b/src/domain/services/controllers/TargetedEdgePropertyReplay.ts
@@ -1,0 +1,165 @@
+import type PatchCollector from '../../capabilities/PatchCollector.ts';
+import type { PatchWithSha } from '../../capabilities/PatchCollector.ts';
+import { LWWRegister } from '../../crdt/LWW.ts';
+import PatchError from '../../errors/PatchError.ts';
+import type MaterializationCoordinate from '../../materialization/MaterializationCoordinate.ts';
+import EdgeAdd from '../../types/ops/EdgeAdd.ts';
+import EdgePropSet from '../../types/ops/EdgePropSet.ts';
+import {
+  copyPropValue,
+  isPropValue,
+  type PropValue,
+} from '../../types/PropValue.ts';
+import {
+  compareEventIds,
+  EventId,
+} from '../../utils/EventId.ts';
+import { compareStrings } from '../../utils/StringComparison.ts';
+import { normalizeRawOp } from '../OpNormalizer.ts';
+import type { MaterializationEdgeTarget } from '../../../ports/MaterializationReadPort.ts';
+
+type PropertyRegisters = Map<string, LWWRegister<PropValue>>;
+
+type TargetedEdgeReplay = {
+  birthEvent: EventId | undefined;
+  readonly registers: PropertyRegisters;
+};
+
+/**
+ * Replays one live edge's birth and property registers at an exact
+ * materialization coordinate.
+ *
+ * The retained roots prove edge and endpoint liveness before this reducer
+ * runs. Its own resident state is proportional to one edge's property bag.
+ * PatchCollector may still buffer one writer chain while producing the stream.
+ */
+export async function replayTargetedEdgeProperties(options: {
+  readonly coordinate: MaterializationCoordinate;
+  readonly edge: MaterializationEdgeTarget;
+  readonly patches: PatchCollector;
+}): Promise<Readonly<Record<string, PropValue>>> {
+  const replay: TargetedEdgeReplay = {
+    birthEvent: undefined,
+    registers: new Map(),
+  };
+  const entries = options.patches.streamForFrontier(
+    options.coordinate.frontier(),
+    options.coordinate.ceiling,
+  );
+  for await (const entry of entries) {
+    applyTargetedPatchEntry(replay, entry, options.edge);
+  }
+  return freezeVisiblePropertyBag(replay);
+}
+
+function applyTargetedPatchEntry(
+  replay: TargetedEdgeReplay,
+  entry: PatchWithSha,
+  edge: MaterializationEdgeTarget,
+): void {
+  for (let opIndex = 0; opIndex < entry.patch.ops.length; opIndex += 1) {
+    const rawOp = entry.patch.ops[opIndex];
+    if (rawOp !== undefined) {
+      applyTargetedRawOp({
+        edge,
+        entry,
+        opIndex,
+        rawOp,
+        replay,
+      });
+    }
+  }
+}
+
+function applyTargetedRawOp(options: {
+  readonly edge: MaterializationEdgeTarget;
+  readonly entry: PatchWithSha;
+  readonly opIndex: number;
+  readonly rawOp: PatchWithSha['patch']['ops'][number];
+  readonly replay: TargetedEdgeReplay;
+}): void {
+  const { edge, entry, opIndex, rawOp, replay } = options;
+  const op = normalizeRawOp(rawOp);
+  if (op instanceof EdgeAdd && targetsEdge(op, edge)) {
+    recordBirthEvent(replay, eventIdFor(entry, opIndex));
+  } else if (op instanceof EdgePropSet && targetsEdge(op, edge)) {
+    recordProperty(replay.registers, op, eventIdFor(entry, opIndex));
+  }
+}
+
+function eventIdFor(entry: PatchWithSha, opIndex: number): EventId {
+  return new EventId(
+    entry.patch.lamport,
+    entry.patch.writer,
+    entry.sha,
+    opIndex,
+  );
+}
+
+function recordBirthEvent(replay: TargetedEdgeReplay, eventId: EventId): void {
+  if (
+    replay.birthEvent === undefined
+    || compareEventIds(eventId, replay.birthEvent) > 0
+  ) {
+    replay.birthEvent = eventId;
+  }
+}
+
+function recordProperty(
+  registers: PropertyRegisters,
+  op: EdgePropSet,
+  eventId: EventId,
+): void {
+  registers.set(
+    op.key,
+    LWWRegister.max(
+      registers.get(op.key),
+      new LWWRegister(eventId, requirePropValue(op)),
+    ),
+  );
+}
+
+function targetsEdge(
+  op: EdgeAdd | EdgePropSet,
+  edge: MaterializationEdgeTarget,
+): boolean {
+  return op.from === edge.from
+    && op.to === edge.to
+    && op.label === edge.label;
+}
+
+function requirePropValue(op: EdgePropSet): PropValue {
+  if (!isPropValue(op.value)) {
+    throw new PatchError(
+      'Targeted edge-property replay encountered an invalid property value',
+      {
+        context: {
+          from: op.from,
+          to: op.to,
+          label: op.label,
+          propertyKey: op.key,
+        },
+      },
+    );
+  }
+  return copyPropValue(op.value);
+}
+
+function freezeVisiblePropertyBag(
+  replay: TargetedEdgeReplay,
+): Readonly<Record<string, PropValue>> {
+  const entries = [...replay.registers.entries()]
+    .filter(([, register]) => isVisibleAfterBirth(register, replay.birthEvent))
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([key, register]) => [key, register.value] as const);
+  return Object.freeze(Object.fromEntries(entries));
+}
+
+function isVisibleAfterBirth(
+  register: LWWRegister<PropValue>,
+  birthEvent: EventId | undefined,
+): boolean {
+  return birthEvent === undefined
+    || register.eventId === null
+    || compareEventIds(register.eventId, birthEvent) >= 0;
+}

--- a/src/ports/MaterializationReadPort.ts
+++ b/src/ports/MaterializationReadPort.ts
@@ -1,9 +1,20 @@
 import type BundleHandle from '../domain/storage/BundleHandle.ts';
 import type { PropValue } from '../domain/types/PropValue.ts';
 
+export type MaterializationEdgeTarget = {
+  readonly from: string;
+  readonly to: string;
+  readonly label: string;
+};
+
 /** Bounded reads over independently retained materialization roots. */
 export default abstract class MaterializationReadPort {
   abstract hasNode(_nodeAliveRoot: BundleHandle, _nodeId: string): Promise<boolean>;
+
+  hasEdge?(
+    _edgeAliveRoot: BundleHandle,
+    _edge: MaterializationEdgeTarget,
+  ): Promise<boolean>;
 
   getNodeProperties(
     _propertiesRoot: BundleHandle,

--- a/test/unit/domain/materialization/TrieMaterializationReader.test.ts
+++ b/test/unit/domain/materialization/TrieMaterializationReader.test.ts
@@ -12,6 +12,7 @@ import PageCache from '../../../../src/domain/orset/trie/PageCache.ts';
 import TrieGeometry from '../../../../src/domain/orset/trie/TrieGeometry.ts';
 import BundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
 import { PropertyShard } from '../../../../src/domain/artifacts/PropertyShard.ts';
+import { encodeEdgeKey } from '../../../../src/domain/services/KeyCodec.ts';
 import WarpStream from '../../../../src/domain/stream/WarpStream.ts';
 import cborCodec from '../../../../src/infrastructure/codecs/CborCodec.ts';
 import MockIndexStorage from '../../../helpers/MockIndexStorage.ts';
@@ -41,6 +42,47 @@ describe('TrieMaterializationReader', () => {
     await expect(reader.hasNode(root, 'node:present')).resolves.toBe(true);
     const readsAfterFirstLookup = store.readCounts();
     await expect(reader.hasNode(root, 'node:missing')).resolves.toBe(false);
+
+    expect(store.writeCounts()).toEqual(writesBeforeRead);
+    const reads = store.readCounts();
+    expect(reads).toEqual(readsAfterFirstLookup);
+    expect(reads.leaf + reads.branch).toBeGreaterThan(0);
+    expect(reads.leaf + reads.branch).toBeLessThanOrEqual(4);
+  });
+
+  it('reads exact edge presence without writing or scanning the full trie', async () => {
+    const store = new InMemoryTrieStore();
+    const edge = {
+      from: 'node:source',
+      to: 'node:target',
+      label: 'rel',
+    };
+    const session = await StateSession.open({
+      nodeAliveRootOid: null,
+      edgeAliveRootOid: null,
+      store,
+      codec: cborCodec,
+      geometry: TrieGeometry.default16way(),
+      pageCache: new PageCache({ maxResident: 32 }),
+    });
+    await session.addEdge(
+      encodeEdgeKey(edge.from, edge.to, edge.label),
+      Dot.create('writer-1', 1),
+    );
+    const roots = await session.close();
+    if (roots.edgeAliveRootOid === null) {
+      throw new Error('Seed session did not write an edge root');
+    }
+    const writesBeforeRead = store.writeCounts();
+    const reader = new TrieMaterializationReader({ store, codec: cborCodec });
+    const root = new BundleHandle(roots.edgeAliveRootOid);
+
+    await expect(reader.hasEdge(root, edge)).resolves.toBe(true);
+    const readsAfterFirstLookup = store.readCounts();
+    await expect(reader.hasEdge(root, {
+      ...edge,
+      to: 'node:missing',
+    })).resolves.toBe(false);
 
     expect(store.writeCounts()).toEqual(writesBeforeRead);
     const reads = store.readCounts();
@@ -122,6 +164,10 @@ describe('TrieMaterializationReader', () => {
 
     await expect(Reflect.apply(reader.hasNode, reader, [null, 'node:present']))
       .rejects.toMatchObject({ code: 'E_MATERIALIZATION_RESUME' });
+    await expect(Reflect.apply(reader.hasEdge, reader, [
+      null,
+      { from: 'node:source', to: 'node:target', label: 'rel' },
+    ])).rejects.toMatchObject({ code: 'E_MATERIALIZATION_RESUME' });
     await expect(Reflect.apply(reader.getNodeProperties, reader, [null, 'node:present']))
       .rejects.toMatchObject({ code: 'E_MATERIALIZATION_RESUME' });
   });

--- a/test/unit/domain/services/controllers/MaterializeController.liveNodeRead.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.liveNodeRead.test.ts
@@ -4,6 +4,7 @@ import PatchCollector, {
   type CheckpointData,
   type PatchWithSha,
 } from '../../../../../src/domain/capabilities/PatchCollector.ts';
+import { Dot } from '../../../../../src/domain/crdt/Dot.ts';
 import MaterializationCoordinate from '../../../../../src/domain/materialization/MaterializationCoordinate.ts';
 import MaterializationRoot, {
   type MaterializationRootStatus,
@@ -15,6 +16,8 @@ import MaterializeController, {
 import { retainBoundedLiveMaterialization } from '../../../../../src/domain/services/controllers/BoundedLiveMaterialization.ts';
 import BundleHandle from '../../../../../src/domain/storage/BundleHandle.ts';
 import Patch from '../../../../../src/domain/types/Patch.ts';
+import EdgeAdd from '../../../../../src/domain/types/ops/EdgeAdd.ts';
+import EdgePropSet from '../../../../../src/domain/types/ops/EdgePropSet.ts';
 import NodePropSet from '../../../../../src/domain/types/ops/NodePropSet.ts';
 import cborCodec from '../../../../../src/infrastructure/codecs/CborCodec.ts';
 import InMemoryCheckpointStore from '../../../../helpers/InMemoryCheckpointStore.ts';
@@ -58,7 +61,7 @@ class RetainedOnlyPatchCollector extends PatchCollector {
   }
 }
 
-describe('MaterializeController live node reads', () => {
+describe('MaterializeController live retained reads', () => {
   it.each([true, false])(
     'reads retained node presence %s without projecting whole state',
     async (presence) => {
@@ -295,10 +298,157 @@ describe('MaterializeController live node reads', () => {
     expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
     expect(fixture.materializations.acquisitions[0]?.released).toBe(true);
   });
+
+  it('replays one live edge property bag without projecting whole state', async () => {
+    const edge = {
+      from: 'node:source',
+      to: 'node:target',
+      label: 'rel',
+    };
+    const fixture = await createFixture({
+      edgePresence: true,
+      edgeRootStatus: 'retained',
+      patchEntries: [
+        patchEntry({
+          lamport: 1,
+          ops: [
+            new EdgePropSet({
+              ...edge,
+              key: 'stale',
+              value: 'hidden',
+            }),
+          ],
+          sha: 'aaaa',
+          writer: 'writer-1',
+        }),
+        patchEntry({
+          lamport: 2,
+          ops: [
+            new EdgeAdd({
+              ...edge,
+              dot: Dot.create('writer-1', 1),
+            }),
+            new EdgePropSet({
+              ...edge,
+              key: 'status',
+              value: 'ready',
+            }),
+          ],
+          sha: 'bbbb',
+          writer: 'writer-1',
+        }),
+      ],
+    });
+
+    await expect(fixture.controller.readLiveEdgeProperties(edge))
+      .resolves.toEqual({ status: 'ready' });
+
+    expect(fixture.materializationRead.hasNode).toHaveBeenCalledTimes(2);
+    expect(fixture.hasEdge).toHaveBeenCalledWith(
+      fixture.edgeRoot,
+      edge,
+    );
+    expect(fixture.patches.loadedTips).toEqual(['tip-1']);
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+    expect(fixture.deps.crypto.hash).not.toHaveBeenCalled();
+    expect(fixture.deps.persistence.readRef).not.toHaveBeenCalled();
+    expect(fixture.deps.graphCloner.openReadOnly).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a missing retained edge without replay', async () => {
+    const edge = {
+      from: 'node:source',
+      to: 'node:target',
+      label: 'rel',
+    };
+    const fixture = await createFixture({
+      edgePresence: false,
+      edgeRootStatus: 'retained',
+    });
+
+    await expect(fixture.controller.readLiveEdgeProperties(edge))
+      .resolves.toBeNull();
+
+    expect(fixture.patches.loadedTips).toEqual([]);
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+  });
+
+  it('returns null when a retained edge endpoint is not live', async () => {
+    const fixture = await createFixture({
+      edgePresence: true,
+      edgeRootStatus: 'retained',
+      presence: false,
+    });
+
+    await expect(fixture.controller.readLiveEdgeProperties({
+      from: 'node:missing',
+      to: 'node:target',
+      label: 'rel',
+    })).resolves.toBeNull();
+
+    expect(fixture.hasEdge).not.toHaveBeenCalled();
+    expect(fixture.patches.loadedTips).toEqual([]);
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+  });
+
+  it('reports edge properties unavailable when the retained edge root is unavailable', async () => {
+    const fixture = await createFixture({
+      edgeRootStatus: 'unavailable',
+    });
+
+    await expect(fixture.controller.readLiveEdgeProperties({
+      from: 'node:source',
+      to: 'node:target',
+      label: 'rel',
+    })).resolves.toBeUndefined();
+
+    expect(fixture.hasEdge).not.toHaveBeenCalled();
+    expect(fixture.patches.loadedTips).toEqual([]);
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+  });
+
+  it('reports an exact edge read as unavailable when the reader has no edge support', async () => {
+    const fixture = await createFixture({
+      edgeReadUnsupported: true,
+      edgeRootStatus: 'retained',
+    });
+
+    await expect(fixture.controller.readLiveEdgeProperties({
+      from: 'node:source',
+      to: 'node:target',
+      label: 'rel',
+    })).resolves.toBeUndefined();
+
+    expect(fixture.hasEdge).not.toHaveBeenCalled();
+    expect(fixture.patches.loadedTips).toEqual([]);
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+  });
+
+  it('releases retained roots when targeted edge replay fails', async () => {
+    const replayFailure = new Error('targeted edge replay failed');
+    const fixture = await createFixture({
+      edgePresence: true,
+      edgeRootStatus: 'retained',
+      patchReadFailure: replayFailure,
+    });
+
+    await expect(fixture.controller.readLiveEdgeProperties({
+      from: 'node:source',
+      to: 'node:target',
+      label: 'rel',
+    })).rejects.toBe(replayFailure);
+
+    expect(fixture.materializations.acquisitions[0]?.releaseCalls).toBe(1);
+    expect(fixture.materializations.acquisitions[0]?.released).toBe(true);
+  });
 });
 
 async function createFixture(
   options: {
+    readonly edgePresence?: boolean;
+    readonly edgeReadFailure?: Error;
+    readonly edgeReadUnsupported?: boolean;
+    readonly edgeRootStatus?: MaterializationRootStatus;
     readonly frontier?: Map<string, string>;
     readonly materializationRead?: boolean;
     readonly patchEntries?: readonly PatchWithSha[];
@@ -319,11 +469,14 @@ async function createFixture(
   patches.chainFailure = options.patchReadFailure;
   const materializations = new InMemoryMaterializationStore();
   const nodeRoot = new BundleHandle('test:node-root');
+  const edgeRoot = new BundleHandle('test:edge-root');
   const propertyRoot = new BundleHandle('test:property-root');
   if (options.retain !== false && patches.frontier.size > 0) {
     await materializations.retain({
       coordinate: new MaterializationCoordinate({ frontier: patches.frontier, ceiling: null }),
       roots: rootsWithStatus({
+        edgeRoot,
+        edgeStatus: options.edgeRootStatus ?? 'empty',
         nodeStatus: options.rootStatus ?? 'retained',
         nodeRoot,
         propertyStatus: options.propertyRootStatus ?? 'unavailable',
@@ -346,7 +499,14 @@ async function createFixture(
   } else {
     getNodeProperties.mockRejectedValue(options.propertyReadFailure);
   }
+  const hasEdge = vi.fn();
+  if (options.edgeReadFailure === undefined) {
+    hasEdge.mockResolvedValue(options.edgePresence ?? false);
+  } else {
+    hasEdge.mockRejectedValue(options.edgeReadFailure);
+  }
   const materializationRead = {
+    ...(options.edgeReadUnsupported === true ? {} : { hasEdge }),
     hasNode,
     getNodeProperties,
   };
@@ -358,6 +518,8 @@ async function createFixture(
   return {
     controller,
     deps,
+    edgeRoot,
+    hasEdge,
     materializationRead,
     materializations,
     nodeRoot,
@@ -370,6 +532,10 @@ function createDeps(options: {
   readonly materializations: InMemoryMaterializationStore;
   readonly patches: PatchCollector;
   readonly materializationRead: {
+    hasEdge?(
+      edgeAliveRoot: BundleHandle,
+      edge: { readonly from: string; readonly to: string; readonly label: string },
+    ): Promise<boolean>;
     hasNode(nodeAliveRoot: BundleHandle, nodeId: string): Promise<boolean>;
     getNodeProperties(
       propertiesRoot: BundleHandle,
@@ -407,6 +573,8 @@ function withoutMaterializationRead(deps: MaterializeDeps): MaterializeDeps {
 }
 
 function rootsWithStatus(options: {
+  edgeStatus: MaterializationRootStatus;
+  edgeRoot: BundleHandle;
   nodeStatus: MaterializationRootStatus;
   nodeRoot: BundleHandle;
   propertyStatus: MaterializationRootStatus;
@@ -415,7 +583,12 @@ function rootsWithStatus(options: {
   const unavailable = MaterializationRoot.unavailable();
   return new MaterializationRoots({
     adjacency: unavailable,
-    edgeAlive: MaterializationRoot.empty(),
+    edgeAlive:
+      options.edgeStatus === 'retained'
+        ? MaterializationRoot.retained(options.edgeRoot)
+        : options.edgeStatus === 'empty'
+          ? MaterializationRoot.empty()
+          : unavailable,
     edgeBirths: unavailable,
     frontier: unavailable,
     nodeAlive:

--- a/test/unit/domain/services/controllers/QueryController.test.ts
+++ b/test/unit/domain/services/controllers/QueryController.test.ts
@@ -120,6 +120,7 @@ function createHost(state, overrides = {}) {
     _ensureFreshState: vi.fn().mockResolvedValue(undefined),
     _readLiveNodePresence: vi.fn().mockResolvedValue(null),
     _readLiveNodeProperties: vi.fn().mockResolvedValue(undefined),
+    _readLiveEdgeProperties: vi.fn().mockResolvedValue(undefined),
     _assetStorage: {
       open: vi.fn(() => chunks(new Uint8Array([1, 2, 3]))),
     },
@@ -353,6 +354,39 @@ describe('QueryController', () => {
       host._cachedState = s;
       const props = await ctrl.getEdgeProps('alice', 'bob', 'knows');
       expect(props).toEqual({ since: 2020 });
+    });
+
+    it('returns retained edge properties without requiring whole state', async () => {
+      host._cachedState = null;
+      host._readLiveEdgeProperties.mockResolvedValue({ since: 2020 });
+
+      await expect(ctrl.getEdgeProps('alice', 'bob', 'knows'))
+        .resolves.toEqual({ since: 2020 });
+
+      expect(host._readLiveEdgeProperties).toHaveBeenCalledWith({
+        from: 'alice',
+        to: 'bob',
+        label: 'knows',
+      });
+      expect(host._ensureFreshState).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid public edge target before retained lookup', async () => {
+      host._cachedState = null;
+
+      await expect(ctrl.getEdgeProps('', 'bob', 'knows')).resolves.toBeNull();
+
+      expect(host._readLiveEdgeProperties).not.toHaveBeenCalled();
+      expect(host._ensureFreshState).not.toHaveBeenCalled();
+    });
+
+    it('falls back to whole state when retained edge properties are unavailable', async () => {
+      host._readLiveEdgeProperties.mockResolvedValue(undefined);
+
+      await expect(ctrl.getEdgeProps('alice', 'bob', 'knows'))
+        .resolves.toEqual({});
+
+      expect(host._ensureFreshState).toHaveBeenCalledOnce();
     });
 
     it('filters out edge props older than edgeBirthEvent', async () => {

--- a/test/unit/domain/services/controllers/TargetedEdgePropertyReplay.test.ts
+++ b/test/unit/domain/services/controllers/TargetedEdgePropertyReplay.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+
+import PatchCollector, {
+  type CheckpointData,
+  type PatchWithSha,
+} from '../../../../../src/domain/capabilities/PatchCollector.ts';
+import { Dot } from '../../../../../src/domain/crdt/Dot.ts';
+import PatchError from '../../../../../src/domain/errors/PatchError.ts';
+import MaterializationCoordinate from '../../../../../src/domain/materialization/MaterializationCoordinate.ts';
+import { replayTargetedEdgeProperties } from '../../../../../src/domain/services/controllers/TargetedEdgePropertyReplay.ts';
+import Patch from '../../../../../src/domain/types/Patch.ts';
+import EdgeAdd from '../../../../../src/domain/types/ops/EdgeAdd.ts';
+import EdgePropSet from '../../../../../src/domain/types/ops/EdgePropSet.ts';
+import NodePropSet from '../../../../../src/domain/types/ops/NodePropSet.ts';
+
+const TARGET_EDGE = {
+  from: 'node:source',
+  to: 'node:target',
+  label: 'rel',
+} as const;
+
+class ChainPatchCollector extends PatchCollector {
+  readonly loadedTips: string[] = [];
+  readonly #chains: ReadonlyMap<string, readonly PatchWithSha[]>;
+
+  constructor(chains: ReadonlyMap<string, readonly PatchWithSha[]>) {
+    super();
+    this.#chains = chains;
+  }
+
+  override discoverWriters(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadWriterPatches(_writerId: string): Promise<PatchWithSha[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadCheckpoint(): Promise<CheckpointData | null> {
+    return Promise.resolve(null);
+  }
+
+  override loadPatchesSince(_checkpoint: CheckpointData): Promise<PatchWithSha[]> {
+    return Promise.resolve([]);
+  }
+
+  override loadPatchChain(
+    toSha: string,
+    _fromSha?: string | null,
+  ): Promise<PatchWithSha[]> {
+    this.loadedTips.push(toSha);
+    return Promise.resolve([...(this.#chains.get(toSha) ?? [])]);
+  }
+
+  override getFrontier(): Promise<Map<string, string>> {
+    return Promise.resolve(new Map());
+  }
+}
+
+describe('replayTargetedEdgeProperties', () => {
+  it('selects visible LWW winners at the exact frontier after edge rebirth', async () => {
+    const patches = new ChainPatchCollector(new Map([
+      ['tip-a', [
+        patchEntry({
+          lamport: 1,
+          ops: [
+            edgeProp('stale', 'hidden-by-rebirth'),
+            new NodePropSet(TARGET_EDGE.from, 'ignored', true),
+          ],
+          sha: 'aaaa',
+          writer: 'writer-a',
+        }),
+        patchEntry({
+          lamport: 3,
+          ops: [
+            edgeProp('status', 'writer-a'),
+            new EdgePropSet({
+              from: TARGET_EDGE.from,
+              to: 'node:other',
+              label: TARGET_EDGE.label,
+              key: 'status',
+              value: 'ignored-edge',
+            }),
+          ],
+          sha: 'cccc',
+          writer: 'writer-a',
+        }),
+        patchEntry({
+          lamport: 5,
+          ops: [edgeProp('status', 'above-ceiling')],
+          sha: 'eeee',
+          writer: 'writer-a',
+        }),
+      ]],
+      ['tip-b', [
+        patchEntry({
+          lamport: 2,
+          ops: [
+            new EdgeAdd({
+              ...TARGET_EDGE,
+              dot: Dot.create('writer-b', 1),
+            }),
+            edgeProp('born', 'visible'),
+          ],
+          sha: 'bbbb',
+          writer: 'writer-b',
+        }),
+        patchEntry({
+          lamport: 3,
+          ops: [edgeProp('status', 'writer-b')],
+          sha: 'dddd',
+          writer: 'writer-b',
+        }),
+      ]],
+    ]));
+
+    const properties = await replayTargetedEdgeProperties({
+      coordinate: coordinate(new Map([
+        ['writer-b', 'tip-b'],
+        ['writer-a', 'tip-a'],
+      ]), 4),
+      edge: TARGET_EDGE,
+      patches,
+    });
+
+    expect(properties).toEqual({
+      born: 'visible',
+      status: 'writer-b',
+    });
+    expect(patches.loadedTips).toEqual(['tip-a', 'tip-b']);
+  });
+
+  it('uses original operation indexes to order writes within one patch', async () => {
+    const patches = new ChainPatchCollector(new Map([
+      ['tip-a', [
+        patchEntry({
+          lamport: 2,
+          ops: [
+            new EdgeAdd({
+              ...TARGET_EDGE,
+              dot: Dot.create('writer-a', 1),
+            }),
+            edgeProp('status', 'first'),
+            new NodePropSet(TARGET_EDGE.from, 'ignored', true),
+            edgeProp('status', 'last'),
+          ],
+          sha: 'aaaa',
+          writer: 'writer-a',
+        }),
+      ]],
+    ]));
+
+    await expect(replayTargetedEdgeProperties({
+      coordinate: coordinate(new Map([['writer-a', 'tip-a']]), null),
+      edge: TARGET_EDGE,
+      patches,
+    })).resolves.toEqual({ status: 'last' });
+  });
+
+  it('returns a sorted frozen bag with a safe own __proto__ property', async () => {
+    const patches = new ChainPatchCollector(new Map([
+      ['tip-a', [
+        patchEntry({
+          lamport: 2,
+          ops: [
+            edgeProp('zeta', 3),
+            edgeProp('__proto__', 'safe'),
+            edgeProp('alpha', 1),
+          ],
+          sha: 'aaaa',
+          writer: 'writer-a',
+        }),
+      ]],
+    ]));
+
+    const properties = await replayTargetedEdgeProperties({
+      coordinate: coordinate(new Map([['writer-a', 'tip-a']]), null),
+      edge: TARGET_EDGE,
+      patches,
+    });
+
+    expect(Object.keys(properties)).toEqual(['__proto__', 'alpha', 'zeta']);
+    expect(Object.hasOwn(properties, '__proto__')).toBe(true);
+    expect(properties['__proto__']).toBe('safe');
+    expect(Object.getPrototypeOf(properties)).toBe(Object.prototype);
+    expect(Object.isFrozen(properties)).toBe(true);
+  });
+
+  it('returns an empty frozen bag when no target properties exist', async () => {
+    const properties = await replayTargetedEdgeProperties({
+      coordinate: coordinate(new Map(), null),
+      edge: TARGET_EDGE,
+      patches: new ChainPatchCollector(new Map()),
+    });
+
+    expect(properties).toEqual({});
+    expect(Object.isFrozen(properties)).toBe(true);
+  });
+
+  it('fails closed on an invalid property value', async () => {
+    const patches = new ChainPatchCollector(new Map([
+      ['tip-a', [
+        patchEntry({
+          lamport: 2,
+          ops: [edgeProp('invalid', undefined)],
+          sha: 'aaaa',
+          writer: 'writer-a',
+        }),
+      ]],
+    ]));
+
+    await expect(replayTargetedEdgeProperties({
+      coordinate: coordinate(new Map([['writer-a', 'tip-a']]), null),
+      edge: TARGET_EDGE,
+      patches,
+    })).rejects.toBeInstanceOf(PatchError);
+  });
+});
+
+function edgeProp(key: string, value: unknown): EdgePropSet {
+  return new EdgePropSet({
+    ...TARGET_EDGE,
+    key,
+    value,
+  });
+}
+
+function coordinate(
+  frontier: Map<string, string>,
+  ceiling: number | null,
+): MaterializationCoordinate {
+  return new MaterializationCoordinate({ frontier, ceiling });
+}
+
+function patchEntry(options: {
+  readonly lamport: number;
+  readonly ops: Patch['ops'];
+  readonly sha: string;
+  readonly writer: string;
+}): PatchWithSha {
+  return {
+    patch: new Patch({
+      schema: 3,
+      writer: options.writer,
+      lamport: options.lamport,
+      context: {},
+      ops: options.ops,
+    }),
+    sha: options.sha,
+  };
+}


### PR DESCRIPTION
## Summary

- add exact retained edge-liveness reads through the bounded trie page cache while keeping the new reader capability optional for custom implementations
- prove both endpoint nodes and the edge live, then replay only matching `EdgeAdd` and `EdgePropSet` operations at the partial handle exact coordinate
- preserve edge-rebirth visibility, deterministic LWW ordering, immutable public snapshot values, acquisition cleanup, and honest whole-state fallback without constructing `WarpState`

## Issue

Refs #738

This is an incremental bounded-read slice. It intentionally does not close #738: neighborhoods, list reads, checkpoint creation, and other compatibility operations still reconstruct whole state, and `PatchCollector` may still buffer one writer chain.

## Test plan

- focused trie, reducer, live-controller, and query tests (121 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run lint:md`
- `npm run lint:docs-topology`
- `npm run test:coverage:ci` (7,384 passed; 2 skipped; all ratchets held)
- `npx vitest run test/unit test/integration` (7,468 passed; 2 skipped)
- pre-push IRONCLAD static gates, consumer/public-surface checks, and stable-unit shards (all passed)
- `git diff --check`
- Graft structural review (no breaking changes detected)

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] If this PR touches persisted op formats, I linked the ADR 3 readiness issue
- [x] If this PR touches wire compatibility, I confirmed canonical-only ops are still rejected on the wire pre-cutover
- [x] If this PR touches schema constants, I confirmed patch and checkpoint namespaces remain distinct