### PR TITLE
Persist sync replay protection in git-cas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CAS operations, then closed history, materialization, and CAS owners at
   application, CLI, migration, and test boundaries. This removes repeated
   `cat-file` and `mktree` process startup without leaking subprocesses.
+- Replay-store failures now produce a stable `REPLAY_STORE_UNAVAILABLE` HTTP
+  503 result without exposing adapter errors. Replay retention also sweeps
+  opportunistically on authenticated traffic at a bounded ten-minute cadence.
 - Live exact node-property reads now retain collision-safe property shards as
   an independently addressed materialization root. Each node uses its full
   BLAKE3 route key and a deterministic schema-v2 entry-bag envelope; writes and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EdgePropSet` operations at the exact coordinate. The targeted reducer keeps
   one edge's birth event and winning LWW property bag so values from before an
   edge rebirth remain hidden without whole-state projection.
+- Changed authenticated sync replay admission to an atomic, graph-scoped
+  git-cas `ExpiringSet`. Accepted nonces remain retained for WARP's fixed
+  ten-minute acceptance window across process restart, cannot be evicted under
+  capacity pressure, and become collectible only after expiry and sweep.
 
 ### Removed
 
@@ -91,6 +95,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed migration and cleanup support for unreleased materialization
   descriptor schemas v2 through v4. Schema v5 is the first release contract;
   stale derived-cache entries miss and rebuild from authoritative WARP history.
+- Removed `SyncAuthService`'s process-local nonce LRU, `nonceCapacity`,
+  `nonceEvictions`, and the inert public `auth.wallClockMs` option. Authenticated
+  serving now fails closed unless runtime storage supplies durable replay
+  protection.
 
 ### Fixed
 

--- a/docs/TECHNICAL_TEARDOWN.md
+++ b/docs/TECHNICAL_TEARDOWN.md
@@ -1438,8 +1438,11 @@ The replay reservation is stored in a graph-scoped git-cas `ExpiringSet`, not
 an in-process LRU. WARP supplies a fixed ten-minute TTL; git-cas atomically
 admits one concurrent writer, retains every live marker across restart without
 capacity eviction, and releases expired markers only when the collection is
-swept. If durable replay storage is unavailable, authenticated serving fails
-closed.
+swept. The adapter sweeps opportunistically before the first authenticated
+admission and again after each ten-minute maintenance interval; concurrent
+admissions share one in-flight sweep. If durable replay storage is unavailable,
+authenticated serving fails closed with `REPLAY_STORE_UNAVAILABLE` and HTTP
+503 without exposing the adapter failure.
 
 Auth mode can be `enforce` or `log-only`. In log-only mode failures are logged
 and counted but the request continues. This is useful for staged rollout, but it

--- a/docs/TECHNICAL_TEARDOWN.md
+++ b/docs/TECHNICAL_TEARDOWN.md
@@ -1414,25 +1414,32 @@ The server verifies:
 4. timestamp/Lamport format
 5. nonce format
 6. signature hex format
-7. Lamport freshness per key id
-8. known key id
-9. HMAC signature using timing-safe equality
-10. nonce not previously seen
+7. known key id
+8. HMAC signature using timing-safe equality
+9. Lamport freshness per key id
+10. atomic nonce admission in durable replay storage
 11. rate-limit allowance
 12. optional writer whitelist
 
 ```mermaid
 flowchart TD
     request["HTTP sync request"] --> headers["validate auth headers"]
-    headers --> freshness["validate Lamport freshness"]
-    freshness --> key["resolve key id"]
+    headers --> key["resolve key id"]
     key --> hmac["compute expected HMAC"]
     hmac --> compare["timingSafeEqual"]
-    compare --> nonce["reserve nonce"]
+    compare --> freshness["validate Lamport freshness"]
+    freshness --> nonce["atomically reserve nonce"]
     nonce --> rate["consume rate limit"]
     rate --> writers["check allowed writers"]
     writers --> allow["process sync request"]
 ```
+
+The replay reservation is stored in a graph-scoped git-cas `ExpiringSet`, not
+an in-process LRU. WARP supplies a fixed ten-minute TTL; git-cas atomically
+admits one concurrent writer, retains every live marker across restart without
+capacity eviction, and releases expired markers only when the collection is
+swept. If durable replay storage is unavailable, authenticated serving fails
+closed.
 
 Auth mode can be `enforce` or `log-only`. In log-only mode failures are logged
 and counted but the request continues. This is useful for staged rollout, but it

--- a/src/domain/RuntimeHost.ts
+++ b/src/domain/RuntimeHost.ts
@@ -70,6 +70,7 @@ import type IndexStorePort from '../ports/IndexStorePort.ts';
 import type IntentStorePort from '../ports/IntentStorePort.ts';
 import type MaterializationStorePort from '../ports/MaterializationStorePort.ts';
 import type RuntimeStorageProviderPort from '../ports/RuntimeStorageProviderPort.ts';
+import type SyncReplayProtectionPort from '../ports/SyncReplayProtectionPort.ts';
 import type { EffectPipeline } from './services/EffectPipeline.ts';
 import type WarpState from './services/state/WarpState.ts';
 import type SnapshotWarpState from './services/snapshot/SnapshotWarpState.ts';
@@ -258,6 +259,7 @@ export default class RuntimeHost {
   _stateHashService: StateHashService | null;
   _auditService: AuditReceiptService | null;
   _materializations: MaterializationStorePort;
+  _syncReplayProtection: SyncReplayProtectionPort | null;
   _closePromise: Promise<void> | null;
 
   /**
@@ -292,6 +294,7 @@ export default class RuntimeHost {
       indexStore,
       intentStore,
       materializations,
+      syncReplayProtection,
       viewService,
       stateHashService,
       auditService,
@@ -340,6 +343,7 @@ export default class RuntimeHost {
     this._auditSkipCount = 0;
     this._trustConfig = normalizeTrustConfig(trust);
     this._stateHashService = stateHashService || null;
+    this._syncReplayProtection = syncReplayProtection ?? null;
 
     this._createSyncTrustGate = (override) => {
       const config = normalizeTrustConfig(override ?? this._trustConfig);

--- a/src/domain/services/controllers/SyncControllerTypes.ts
+++ b/src/domain/services/controllers/SyncControllerTypes.ts
@@ -12,6 +12,7 @@ import type SyncCapability from '../../capabilities/SyncCapability.ts';
 import type SnapshotWarpState from '../snapshot/SnapshotWarpState.ts';
 import type SyncSecret from '../sync/SyncSecret.ts';
 import type { MaterializedStateUpdateOptions } from '../../capabilities/MaterializedStateUpdate.ts';
+import type SyncReplayProtectionPort from '../../../ports/SyncReplayProtectionPort.ts';
 
 /**
  * The host interface that SyncController depends on.
@@ -29,6 +30,7 @@ export interface SyncHost {
   _codec: CodecPort;
   _crypto: CryptoPort;
   _logger: LoggerPort | null;
+  _syncReplayProtection: SyncReplayProtectionPort | null;
   _patchJournal?: PatchJournalPort | null;
   _patchesSinceCheckpoint: number;
   _maxObservedLamport: number;

--- a/src/domain/services/controllers/SyncServerLauncher.ts
+++ b/src/domain/services/controllers/SyncServerLauncher.ts
@@ -77,6 +77,7 @@ export async function launchSyncServer(
     ? {
         ...auth,
         crypto: host._crypto,
+        replayProtection: requireReplayProtection(host),
         ...(host._logger ? { logger: host._logger } : {}),
       }
     : undefined;
@@ -94,6 +95,16 @@ export async function launchSyncServer(
   });
 
   return await httpServer.listen(port);
+}
+
+function requireReplayProtection(host: SyncHost) {
+  if (host._syncReplayProtection === null) {
+    throw new SyncError('Authenticated sync requires durable replay protection', {
+      code: 'E_SYNC_AUTH_REPLAY_STORE',
+      context: {},
+    });
+  }
+  return host._syncReplayProtection;
 }
 
 /**

--- a/src/domain/services/sync/HttpSyncServerHelpers.ts
+++ b/src/domain/services/sync/HttpSyncServerHelpers.ts
@@ -17,6 +17,7 @@ import type { SyncRateLimitConfig } from './SyncRateLimiter.ts';
 import type CryptoPort from '../../../ports/CryptoPort.ts';
 import type LoggerPort from '../../../ports/LoggerPort.ts';
 import type HttpServerPort from '../../../ports/HttpServerPort.ts';
+import type SyncReplayProtectionPort from '../../../ports/SyncReplayProtectionPort.ts';
 import type { SyncRequest } from './SyncProtocol.ts';
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -44,7 +45,11 @@ export const authSchema = z.object({
   ),
   crypto: z.custom<CryptoPort | undefined>((v) => v === undefined || (typeof v === 'object' && v !== null)).optional(),
   logger: z.custom<LoggerPort | undefined>((v) => v === undefined || (typeof v === 'object' && v !== null)).optional(),
-  wallClockMs: z.custom<(() => number) | undefined>((v) => v === undefined || typeof v === 'function').optional(),
+  replayProtection: z.custom<SyncReplayProtectionPort>(
+    (v) => v !== null && v !== undefined && typeof v === 'object'
+      && typeof Reflect.get(v, 'reserve') === 'function',
+    'auth.replayProtection must provide atomic reserve()',
+  ),
   rateLimit: z.object({
     capacity: z.number().int().positive(),
     refillTokensPerSecond: z.number().positive(),
@@ -293,7 +298,7 @@ interface AuthConfig {
   mode?: 'enforce' | 'log-only';
   crypto?: CryptoPort;
   logger?: LoggerPort;
-  wallClockMs?: () => number;
+  replayProtection: SyncReplayProtectionPort;
   allowedWriters?: string[];
   rateLimit?: SyncRateLimitConfig;
 }
@@ -304,7 +309,7 @@ function buildAuthConfig(auth: AuthSchemaInput, allowedWriters: string[] | undef
     mode: auth.mode,
     ...cryptoField(auth),
     ...loggerField(auth),
-    ...wallClockField(auth),
+    replayProtection: auth.replayProtection,
     ...rateLimitField(auth),
     ...allowedWritersField(allowedWriters),
   };
@@ -318,11 +323,6 @@ function cryptoField(auth: AuthSchemaInput): { readonly crypto?: CryptoPort } {
 function loggerField(auth: AuthSchemaInput): { readonly logger?: LoggerPort } {
   if (auth.logger === undefined) { return {}; }
   return { logger: auth.logger };
-}
-
-function wallClockField(auth: AuthSchemaInput): { readonly wallClockMs?: () => number } {
-  if (auth.wallClockMs === undefined) { return {}; }
-  return { wallClockMs: auth.wallClockMs };
 }
 
 function rateLimitField(auth: AuthSchemaInput): { readonly rateLimit?: SyncRateLimitConfig } {
@@ -420,7 +420,7 @@ export interface HttpSyncServerOptions {
     mode?: 'enforce' | 'log-only';
     crypto?: CryptoPort;
     logger?: LoggerPort;
-    wallClockMs?: () => number;
+    replayProtection: SyncReplayProtectionPort;
     rateLimit?: SyncRateLimitConfig;
   };
   unsafeAllowUnauthenticatedLocalhost?: boolean;

--- a/src/domain/services/sync/SyncAuthService.ts
+++ b/src/domain/services/sync/SyncAuthService.ts
@@ -105,6 +105,7 @@ function fail(reason: string, status: number): FailResult {
 interface AuthMetrics {
   authFailCount: number;
   replayRejectCount: number;
+  replayStoreFailures: number;
   clockSkewRejects: number;
   malformedRejects: number;
   logOnlyPassthroughs: number;
@@ -116,6 +117,7 @@ function _freshMetrics(): AuthMetrics {
   return {
     authFailCount: 0,
     replayRejectCount: 0,
+    replayStoreFailures: 0,
     clockSkewRejects: 0,
     malformedRejects: 0,
     logOnlyPassthroughs: 0,
@@ -281,16 +283,22 @@ export default class SyncAuthService {
   }
 
   private async _reserveNonce(keyId: string, nonce: string): Promise<FailResult | OkResult> {
-    const reservation = await this._replayProtection.reserve({
-      keyId,
-      nonce,
-      ttlMs: SYNC_REPLAY_ACCEPTANCE_WINDOW_MS,
-    });
-    if (!reservation.admitted) {
-      this._metrics.replayRejectCount += 1;
-      return fail('REPLAY', 403);
+    try {
+      const reservation = await this._replayProtection.reserve({
+        keyId,
+        nonce,
+        ttlMs: SYNC_REPLAY_ACCEPTANCE_WINDOW_MS,
+      });
+      if (!reservation.admitted) {
+        this._metrics.replayRejectCount += 1;
+        return fail('REPLAY', 403);
+      }
+      return { ok: true };
+    } catch {
+      this._metrics.replayStoreFailures += 1;
+      this._logger.error('sync auth: replay protection unavailable', { keyId });
+      return fail('REPLAY_STORE_UNAVAILABLE', 503);
     }
-    return { ok: true };
   }
 
   private _resolveKey(keyId: string): FailResult | (OkResult & { secret: SyncSecret }) {
@@ -389,7 +397,10 @@ export default class SyncAuthService {
 
     const nonceResult = await this._reserveNonce(keyId, nonce);
     if (!nonceResult.ok) {
-      return this._fail('replay detected', { keyId, nonce }, nonceResult);
+      if (nonceResult.reason === 'REPLAY') {
+        return this._fail('replay detected', { keyId, nonce }, nonceResult);
+      }
+      return this._fail('replay protection unavailable', { keyId }, nonceResult);
     }
 
     const rateLimitResult = this._consumeRateLimit(keyId);

--- a/src/domain/services/sync/SyncAuthService.ts
+++ b/src/domain/services/sync/SyncAuthService.ts
@@ -9,7 +9,6 @@
  * @module domain/services/sync/SyncAuthService
  */
 
-import LRUCache from '../../utils/LRUCache.ts';
 import nullLogger from '../../utils/nullLogger.ts';
 import { validateWriterId } from '../../utils/RefLayout.ts';
 import { hexEncode, hexDecode } from '../../utils/bytes.ts';
@@ -18,6 +17,7 @@ import { requireCrypto } from '../crypto/CryptoRequirement.ts';
 import type CryptoPort from '../../../ports/CryptoPort.ts';
 import type LoggerPort from '../../../ports/LoggerPort.ts';
 import type LogFields from '../../types/log/LogFields.ts';
+import type SyncReplayProtectionPort from '../../../ports/SyncReplayProtectionPort.ts';
 import SyncSecret from './SyncSecret.ts';
 import SyncRateLimiter, { type SyncRateLimitConfig } from './SyncRateLimiter.ts';
 const SIG_VERSION = '2';
@@ -25,7 +25,7 @@ const SIG_PREFIX = 'warp-v2';
 const HMAC_ALGO = 'sha256';
 export const SYNC_AUTH_SCHEME_HEADER = 'x-warp-auth-scheme';
 export const SHARED_SECRET_HMAC_SYNC_AUTH_SCHEME = 'shared-secret-hmac-sha256';
-const DEFAULT_NONCE_CAPACITY = 100_000;
+export const SYNC_REPLAY_ACCEPTANCE_WINDOW_MS = 10 * 60 * 1000;
 const NONCE_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SIG_HEX_LENGTH = 64;
 const HEX_PATTERN = /^[0-9a-f]+$/;
@@ -105,7 +105,6 @@ function fail(reason: string, status: number): FailResult {
 interface AuthMetrics {
   authFailCount: number;
   replayRejectCount: number;
-  nonceEvictions: number;
   clockSkewRejects: number;
   malformedRejects: number;
   logOnlyPassthroughs: number;
@@ -117,7 +116,6 @@ function _freshMetrics(): AuthMetrics {
   return {
     authFailCount: 0,
     replayRejectCount: 0,
-    nonceEvictions: 0,
     clockSkewRejects: 0,
     malformedRejects: 0,
     logOnlyPassthroughs: 0,
@@ -186,7 +184,7 @@ function _validateAllowedWriters(allowedWriters: string[] | undefined): Set<stri
 export interface SyncAuthServiceOptions {
   keys: Record<string, SyncSecret>;
   mode?: 'enforce' | 'log-only';
-  nonceCapacity?: number;
+  replayProtection: SyncReplayProtectionPort;
   crypto?: CryptoPort;
   logger?: LoggerPort;
   allowedWriters?: string[];
@@ -198,20 +196,36 @@ export default class SyncAuthService {
   private readonly _mode: 'enforce' | 'log-only';
   private readonly _crypto: CryptoPort;
   private readonly _logger: LoggerPort;
-  private readonly _nonceCache: LRUCache<string, boolean>;
+  private readonly _replayProtection: SyncReplayProtectionPort;
   private readonly _lastSeenLamport: Map<string, number>;
   private readonly _allowedWriters: Set<string> | null;
   private readonly _rateLimiter: SyncRateLimiter | null;
   private readonly _metrics: AuthMetrics;
 
   constructor(options: SyncAuthServiceOptions) {
-    const { keys, mode = 'enforce', nonceCapacity, crypto, logger, allowedWriters, rateLimit } = options ?? {};
+    const {
+      keys,
+      mode = 'enforce',
+      replayProtection,
+      crypto,
+      logger,
+      allowedWriters,
+      rateLimit,
+    } = options ?? {};
     _validateKeys(keys);
+    if (replayProtection === null
+      || replayProtection === undefined
+      || typeof replayProtection.reserve !== 'function') {
+      throw new SyncError(
+        'SyncAuthService requires durable replay protection',
+        { code: 'E_SYNC_AUTH_REPLAY_STORE' },
+      );
+    }
     this._keys = keys;
     this._mode = mode;
     this._crypto = requireCrypto(crypto, 'SyncAuthService');
     this._logger = logger ?? nullLogger;
-    this._nonceCache = new LRUCache(typeof nonceCapacity === 'number' && nonceCapacity > 0 ? nonceCapacity : DEFAULT_NONCE_CAPACITY);
+    this._replayProtection = replayProtection;
     this._lastSeenLamport = new Map();
     this._metrics = _freshMetrics();
     this._allowedWriters = _validateAllowedWriters(allowedWriters);
@@ -266,18 +280,16 @@ export default class SyncAuthService {
     return { ok: true };
   }
 
-  private _reserveNonce(nonce: string): FailResult | OkResult {
-    if (this._nonceCache.has(nonce)) {
+  private async _reserveNonce(keyId: string, nonce: string): Promise<FailResult | OkResult> {
+    const reservation = await this._replayProtection.reserve({
+      keyId,
+      nonce,
+      ttlMs: SYNC_REPLAY_ACCEPTANCE_WINDOW_MS,
+    });
+    if (!reservation.admitted) {
       this._metrics.replayRejectCount += 1;
       return fail('REPLAY', 403);
     }
-
-    const sizeBefore = this._nonceCache.size;
-    this._nonceCache.set(nonce, true);
-    if (this._nonceCache.size <= sizeBefore && sizeBefore >= this._nonceCache.maxSize) {
-      this._metrics.nonceEvictions += 1;
-    }
-
     return { ok: true };
   }
 
@@ -358,11 +370,6 @@ export default class SyncAuthService {
 
     const { timestamp, nonce, keyId, authScheme } = headerResult;
 
-    const freshnessResult = this._validateFreshness(timestamp, keyId);
-    if (!freshnessResult.ok) {
-      return this._fail('lamport freshness rejected', { keyId, timestamp }, freshnessResult);
-    }
-
     const keyResult = this._resolveKey(keyId);
     if (!keyResult.ok) {
       return this._fail('unrecognized key-id', { keyId }, keyResult);
@@ -375,7 +382,12 @@ export default class SyncAuthService {
       return this._fail('signature mismatch', { keyId }, sigResult);
     }
 
-    const nonceResult = this._reserveNonce(nonce);
+    const freshnessResult = this._validateFreshness(timestamp, keyId);
+    if (!freshnessResult.ok) {
+      return this._fail('lamport freshness rejected', { keyId, timestamp }, freshnessResult);
+    }
+
+    const nonceResult = await this._reserveNonce(keyId, nonce);
     if (!nonceResult.ok) {
       return this._fail('replay detected', { keyId, nonce }, nonceResult);
     }

--- a/src/domain/types/WarpOptions.ts
+++ b/src/domain/types/WarpOptions.ts
@@ -20,7 +20,6 @@ export type ServeOptions = {
     mode?: 'enforce' | 'log-only';
     crypto?: CryptoPort;
     logger?: LoggerPort;
-    wallClockMs?: () => number;
     rateLimit?: SyncRateLimitConfig;
   };
   unsafeAllowUnauthenticatedLocalhost?: boolean;

--- a/src/domain/warp/RuntimeHostBoot.ts
+++ b/src/domain/warp/RuntimeHostBoot.ts
@@ -40,6 +40,7 @@ import type EffectSinkPort from '../../ports/EffectSinkPort.ts';
 import type RuntimeStorageProviderPort from '../../ports/RuntimeStorageProviderPort.ts';
 import type SchedulerPort from '../../ports/SchedulerPort.ts';
 import type TrustCryptoPort from '../../ports/TrustCryptoPort.ts';
+import type SyncReplayProtectionPort from '../../ports/SyncReplayProtectionPort.ts';
 import type { EffectPipeline } from '../services/EffectPipeline.ts';
 import type { ExternalizationPolicy } from '../types/ExternalizationPolicy.ts';
 import GCPolicy, { type GCPolicyConfig } from '../services/GCPolicy.ts';
@@ -73,6 +74,7 @@ export type RuntimeHostConstructionOptions = {
   indexStore: IndexStorePort;
   intentStore: IntentStorePort;
   materializations: MaterializationStorePort;
+  syncReplayProtection?: SyncReplayProtectionPort;
   materializationRead?: MaterializationReadPort;
   viewService: MaterializedViewService;
   stateHashService?: StateHashService;
@@ -392,6 +394,9 @@ export async function resolveRuntimeHostConstructionOptions(
       indexStore: resolvedIndexStore,
       intentStore: storageServices.intents,
       materializations: storageServices.materializations,
+      ...(storageServices.syncReplayProtection === undefined
+        ? {}
+        : { syncReplayProtection: storageServices.syncReplayProtection }),
       ...(resolvedMaterializationRead === undefined
         ? {}
         : { materializationRead: resolvedMaterializationRead }),

--- a/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
+++ b/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
@@ -2,6 +2,7 @@ import ContentAddressableStore, {
   CborCodec,
   type AssetCapability,
   type BundleCapability,
+  type ExpiringSetCapability,
   type PublicationCapability,
 } from '@git-stunts/git-cas';
 import type AssetStoragePort from '../../ports/AssetStoragePort.ts';
@@ -31,6 +32,7 @@ import type { GitPlumbing } from './gitErrorClassification.ts';
 import LoggerObservabilityBridge from './LoggerObservabilityBridge.ts';
 import type GitTimelineHistoryAdapter from './GitTimelineHistoryAdapter.ts';
 import AdapterValidationError from '../../domain/errors/AdapterValidationError.ts';
+import GitCasSyncReplayProtectionAdapter from './GitCasSyncReplayProtectionAdapter.ts';
 
 type GitCasPolicy = {
   execute<T>(operation: () => Promise<T>): Promise<T>;
@@ -52,6 +54,7 @@ export type GitCasFacade = Pick<
   readonly caches: GitCasMaterializationFacade['caches'];
   readonly pages: GitCasMaterializationFacade['pages'];
   readonly workspaces: GitCasMaterializationFacade['workspaces'];
+  readonly expiringSets: Pick<ExpiringSetCapability, 'open'>;
   readonly publications: Pick<PublicationCapability, 'commit'>;
   readonly rootSets: {
     open(options: { readonly ref: string }): Promise<GitCasRootSetClient>;
@@ -117,6 +120,10 @@ export default class GitCasRepositoryAdapter implements RuntimeStorageProviderPo
         checkpoints: this._createCheckpointStore(request, content),
         indexes: this._createIndexStore(request, content),
         materializations,
+        syncReplayProtection: new GitCasSyncReplayProtectionAdapter({
+          cas: this._cas,
+          graphName: request.timelineName,
+        }),
         stateSnapshots: this._createStateSnapshots(request),
         trie: new GitCasTrieStoreAdapter({ cas: this._cas }),
       })

--- a/src/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.ts
+++ b/src/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.ts
@@ -1,0 +1,70 @@
+import type { ExpiringSetCapability } from '@git-stunts/git-cas';
+import type SyncReplayProtectionPort from '../../ports/SyncReplayProtectionPort.ts';
+import type {
+  SyncReplayReservation,
+  SyncReplayReservationRequest,
+  SyncReplaySweepResult,
+} from '../../ports/SyncReplayProtectionPort.ts';
+
+export type GitCasSyncReplayFacade = {
+  readonly expiringSets: Pick<ExpiringSetCapability, 'open'>;
+};
+
+type ReplaySet = Awaited<ReturnType<ExpiringSetCapability['open']>>;
+
+const REPLAY_NAMESPACE = 'git-warp.sync-replay';
+
+/**
+ * git-cas ExpiringSet-backed replay admission.
+ *
+ * git-cas owns atomicity, retention, reachability, and expiry-only release.
+ * WARP owns the replay identity and acceptance-window deadline.
+ */
+export default class GitCasSyncReplayProtectionAdapter implements SyncReplayProtectionPort {
+  private readonly _set: Promise<ReplaySet>;
+  private readonly _wallClockMs: () => number;
+  private readonly _graphName: string;
+
+  constructor(options: {
+    readonly cas: GitCasSyncReplayFacade;
+    readonly graphName: string;
+    readonly wallClockMs?: () => number;
+  }) {
+    this._set = options.cas.expiringSets.open({
+      namespace: REPLAY_NAMESPACE,
+    });
+    this._wallClockMs = options.wallClockMs ?? Date.now;
+    this._graphName = options.graphName;
+  }
+
+  async reserve(
+    request: SyncReplayReservationRequest,
+  ): Promise<SyncReplayReservation> {
+    const replaySet = await this._set;
+    const expiresAt = new Date(this._wallClockMs() + request.ttlMs).toISOString();
+    const result = await replaySet.addIfAbsent(replayIdentity(this._graphName, request), {
+      expiresAt,
+    });
+    return Object.freeze({
+      admitted: result.admitted,
+      expiresAt: result.marker?.expiresAt ?? expiresAt,
+      generation: result.generation,
+    });
+  }
+
+  async sweep(): Promise<SyncReplaySweepResult> {
+    const replaySet = await this._set;
+    const result = await replaySet.sweep();
+    return Object.freeze({
+      removed: result.removed,
+      generation: result.generation,
+    });
+  }
+}
+
+function replayIdentity(
+  graphName: string,
+  request: Pick<SyncReplayReservationRequest, 'keyId' | 'nonce'>,
+): string {
+  return JSON.stringify([1, graphName, request.keyId, request.nonce]);
+}

--- a/src/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.ts
+++ b/src/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.ts
@@ -13,6 +13,7 @@ export type GitCasSyncReplayFacade = {
 type ReplaySet = Awaited<ReturnType<ExpiringSetCapability['open']>>;
 
 const REPLAY_NAMESPACE = 'git-warp.sync-replay';
+const REPLAY_SWEEP_INTERVAL_MS = 10 * 60 * 1000;
 
 /**
  * git-cas ExpiringSet-backed replay admission.
@@ -24,15 +25,20 @@ export default class GitCasSyncReplayProtectionAdapter implements SyncReplayProt
   private readonly _set: Promise<ReplaySet>;
   private readonly _wallClockMs: () => number;
   private readonly _graphName: string;
+  private _nextSweepAtMs = 0;
+  private _sweepInFlight: Promise<SyncReplaySweepResult> | null = null;
 
   constructor(options: {
     readonly cas: GitCasSyncReplayFacade;
     readonly graphName: string;
     readonly wallClockMs?: () => number;
   }) {
-    this._set = options.cas.expiringSets.open({
+    const replaySet = options.cas.expiringSets.open({
       namespace: REPLAY_NAMESPACE,
     });
+    // Mark an eager open failure handled until a reserve or sweep caller awaits it.
+    replaySet.catch(() => {});
+    this._set = replaySet;
     this._wallClockMs = options.wallClockMs ?? Date.now;
     this._graphName = options.graphName;
   }
@@ -40,8 +46,12 @@ export default class GitCasSyncReplayProtectionAdapter implements SyncReplayProt
   async reserve(
     request: SyncReplayReservationRequest,
   ): Promise<SyncReplayReservation> {
+    const nowMs = this._wallClockMs();
+    if (nowMs >= this._nextSweepAtMs) {
+      await this.sweep();
+    }
     const replaySet = await this._set;
-    const expiresAt = new Date(this._wallClockMs() + request.ttlMs).toISOString();
+    const expiresAt = new Date(nowMs + request.ttlMs).toISOString();
     const result = await replaySet.addIfAbsent(replayIdentity(this._graphName, request), {
       expiresAt,
     });
@@ -53,8 +63,19 @@ export default class GitCasSyncReplayProtectionAdapter implements SyncReplayProt
   }
 
   async sweep(): Promise<SyncReplaySweepResult> {
+    if (this._sweepInFlight === null) {
+      this._sweepInFlight = this._sweepRetainedMarkers()
+        .finally(() => {
+          this._sweepInFlight = null;
+        });
+    }
+    return await this._sweepInFlight;
+  }
+
+  private async _sweepRetainedMarkers(): Promise<SyncReplaySweepResult> {
     const replaySet = await this._set;
     const result = await replaySet.sweep();
+    this._nextSweepAtMs = this._wallClockMs() + REPLAY_SWEEP_INTERVAL_MS;
     return Object.freeze({
       removed: result.removed,
       generation: result.generation,

--- a/src/ports/RuntimeStorageProviderPort.ts
+++ b/src/ports/RuntimeStorageProviderPort.ts
@@ -13,6 +13,7 @@ import type PatchJournalPort from './PatchJournalPort.ts';
 import type StrandStorePort from './StrandStorePort.ts';
 import type WarpStateCachePort from './WarpStateCachePort.ts';
 import type WarpStateCacheRetentionPort from './WarpStateCacheRetentionPort.ts';
+import type SyncReplayProtectionPort from './SyncReplayProtectionPort.ts';
 
 export type RuntimeStorageRequest = {
   readonly timelineName: string;
@@ -31,6 +32,7 @@ export type RuntimeStorageServices = {
   readonly indexes: IndexStorePort;
   readonly intents: IntentStorePort;
   readonly materializations: MaterializationStorePort;
+  readonly syncReplayProtection?: SyncReplayProtectionPort;
   readonly stateSnapshots?: WarpStateCachePort & WarpStateCacheRetentionPort;
   readonly trie?: TrieStorePort;
 };

--- a/src/ports/SyncReplayProtectionPort.ts
+++ b/src/ports/SyncReplayProtectionPort.ts
@@ -1,0 +1,27 @@
+export type SyncReplayReservationRequest = {
+  readonly keyId: string;
+  readonly nonce: string;
+  readonly ttlMs: number;
+};
+
+export type SyncReplayReservation = {
+  readonly admitted: boolean;
+  readonly expiresAt: string;
+  readonly generation: string | null;
+};
+
+export type SyncReplaySweepResult = {
+  readonly removed: number;
+  readonly generation: string | null;
+};
+
+/**
+ * Atomically retains authenticated sync nonces for one acceptance window.
+ *
+ * Implementations must not evict a reservation before its TTL elapses, and
+ * concurrent reservations for the same key-id/nonce pair must have one winner.
+ */
+export default interface SyncReplayProtectionPort {
+  reserve(request: SyncReplayReservationRequest): Promise<SyncReplayReservation>;
+  sweep(): Promise<SyncReplaySweepResult>;
+}

--- a/test/helpers/InMemorySyncReplayProtection.ts
+++ b/test/helpers/InMemorySyncReplayProtection.ts
@@ -1,0 +1,69 @@
+import type SyncReplayProtectionPort from '../../src/ports/SyncReplayProtectionPort.ts';
+import type {
+  SyncReplayReservation,
+  SyncReplayReservationRequest,
+  SyncReplaySweepResult,
+} from '../../src/ports/SyncReplayProtectionPort.ts';
+
+type RetainedReplay = {
+  readonly expiresAt: string;
+  readonly expiresAtMs: number;
+};
+
+/** Deterministic test authority for the SyncReplayProtectionPort contract. */
+export default class InMemorySyncReplayProtection implements SyncReplayProtectionPort {
+  private readonly _clock: () => number;
+  private readonly _entries = new Map<string, RetainedReplay>();
+  private _generation = 0;
+
+  constructor(clock: () => number = Date.now) {
+    this._clock = clock;
+  }
+
+  reserve(request: SyncReplayReservationRequest): Promise<SyncReplayReservation> {
+    const identity = replayIdentity(request);
+    const previous = this._entries.get(identity);
+    if (previous !== undefined && previous.expiresAtMs > this._clock()) {
+      return Promise.resolve(Object.freeze({
+        admitted: false,
+        expiresAt: previous.expiresAt,
+        generation: String(this._generation),
+      }));
+    }
+    const expiresAtMs = this._clock() + request.ttlMs;
+    const expiresAt = new Date(expiresAtMs).toISOString();
+    this._entries.set(identity, {
+      expiresAt,
+      expiresAtMs,
+    });
+    this._generation += 1;
+    return Promise.resolve(Object.freeze({
+      admitted: true,
+      expiresAt,
+      generation: String(this._generation),
+    }));
+  }
+
+  sweep(): Promise<SyncReplaySweepResult> {
+    let removed = 0;
+    for (const [identity, entry] of this._entries) {
+      if (entry.expiresAtMs <= this._clock()) {
+        this._entries.delete(identity);
+        removed += 1;
+      }
+    }
+    if (removed > 0) {
+      this._generation += 1;
+    }
+    return Promise.resolve(Object.freeze({
+      removed,
+      generation: String(this._generation),
+    }));
+  }
+}
+
+function replayIdentity(
+  request: Pick<SyncReplayReservationRequest, 'keyId' | 'nonce'>,
+): string {
+  return JSON.stringify([1, request.keyId, request.nonce]);
+}

--- a/test/helpers/MemoryRuntimeStorageAdapter.ts
+++ b/test/helpers/MemoryRuntimeStorageAdapter.ts
@@ -17,6 +17,7 @@ import type AssetStoragePort from '../../src/ports/AssetStoragePort.ts';
 import InMemoryBlobStorageAdapter from './InMemoryBlobStorageAdapter.ts';
 import InMemoryGitCasFacade from './InMemoryGitCasFacade.ts';
 import type InMemoryGraphAdapter from './InMemoryGraphAdapter.ts';
+import InMemorySyncReplayProtection from './InMemorySyncReplayProtection.ts';
 
 export type MemoryRuntimeStorageAdapterOptions = {
   readonly history: InMemoryGraphAdapter;
@@ -31,6 +32,7 @@ export default class MemoryRuntimeStorageAdapter implements RuntimeStorageProvid
   readonly #content: AssetStoragePort;
   readonly #cas: InMemoryGitCasFacade;
   readonly #encrypted: boolean;
+  readonly #syncReplayProtection = new Map<string, InMemorySyncReplayProtection>();
   readonly backing: InMemoryBlobStorageAdapter;
 
   constructor(options: MemoryRuntimeStorageAdapterOptions) {
@@ -98,7 +100,18 @@ export default class MemoryRuntimeStorageAdapter implements RuntimeStorageProvid
         crypto: request.crypto,
         laneName: request.timelineName,
       }),
+      syncReplayProtection: this.#replayProtection(request.timelineName),
     }));
+  }
+
+  #replayProtection(timelineName: string): InMemorySyncReplayProtection {
+    const existing = this.#syncReplayProtection.get(timelineName);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const created = new InMemorySyncReplayProtection();
+    this.#syncReplayProtection.set(timelineName, created);
+    return created;
   }
 }
 

--- a/test/integration/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.integration.test.ts
+++ b/test/integration/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.integration.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import Plumbing from '@git-stunts/plumbing';
+
+import GitCasRepositoryAdapter from '../../../../src/infrastructure/adapters/GitCasRepositoryAdapter.ts';
+import GitTimelineHistoryAdapter from '../../../../src/infrastructure/adapters/GitTimelineHistoryAdapter.ts';
+import NodeCryptoAdapter from '../../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
+import { DEFAULT_COMMIT_MESSAGE_CODEC } from '../../../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts';
+import { CborCodec } from '../../../../src/infrastructure/codecs/CborCodec.ts';
+import type SyncReplayProtectionPort from '../../../../src/ports/SyncReplayProtectionPort.ts';
+
+type OpenedStorage = {
+  readonly history: GitTimelineHistoryAdapter;
+  readonly repository: GitCasRepositoryAdapter;
+  readonly replay: SyncReplayProtectionPort;
+  close(): Promise<void>;
+};
+
+const opened: OpenedStorage[] = [];
+const tempDirectories: string[] = [];
+
+async function createRepository(): Promise<string> {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'git-warp-sync-replay-'));
+  tempDirectories.push(tempDirectory);
+  const plumbing = await Plumbing.createDefault({ cwd: tempDirectory });
+  await plumbing.execute({ args: ['init', '-q'] });
+  await plumbing.execute({ args: ['config', 'user.email', 'test@test.com'] });
+  await plumbing.execute({ args: ['config', 'user.name', 'Test'] });
+  return tempDirectory;
+}
+
+async function openStorage(tempDirectory: string): Promise<OpenedStorage> {
+  const plumbing = await Plumbing.createDefault({ cwd: tempDirectory });
+  const history = new GitTimelineHistoryAdapter({ plumbing });
+  const repository = new GitCasRepositoryAdapter({ plumbing, history });
+  const services = await repository.createRuntimeStorageServices({
+    timelineName: 'events',
+    codec: new CborCodec(),
+    crypto: new NodeCryptoAdapter(),
+    commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC,
+  });
+  const replay = services.syncReplayProtection;
+  if (replay === undefined) {
+    throw new Error('Git runtime storage must provide sync replay protection');
+  }
+  const result: OpenedStorage = {
+    history,
+    repository,
+    replay,
+    async close(): Promise<void> {
+      await repository.close();
+      await history.close();
+    },
+  };
+  opened.push(result);
+  return result;
+}
+
+afterEach(async () => {
+  const storages = opened.splice(0);
+  await Promise.allSettled(storages.map(async (storage) => await storage.close()));
+  const directories = tempDirectories.splice(0);
+  await Promise.all(directories.map(async (directory) => {
+    await rm(directory, { recursive: true, force: true });
+  }));
+});
+
+describe('GitCasSyncReplayProtectionAdapter integration', () => {
+  it('retains replay admission across repository process restart', async () => {
+    const repository = await createRepository();
+    const first = await openStorage(repository);
+    const request = {
+      keyId: 'default',
+      nonce: 'restart-proof',
+      ttlMs: 60_000,
+    };
+
+    await expect(first.replay.reserve(request)).resolves.toMatchObject({
+      admitted: true,
+    });
+    await first.close();
+    opened.splice(opened.indexOf(first), 1);
+
+    const restarted = await openStorage(repository);
+    await expect(restarted.replay.reserve(request)).resolves.toMatchObject({
+      admitted: false,
+    });
+  });
+
+  it('gives concurrent duplicate repository writers exactly one winner', async () => {
+    const repository = await createRepository();
+    const left = await openStorage(repository);
+    const right = await openStorage(repository);
+    const request = {
+      keyId: 'default',
+      nonce: 'concurrent-proof',
+      ttlMs: 60_000,
+    };
+
+    const results = await Promise.all([
+      left.replay.reserve(request),
+      right.replay.reserve(request),
+    ]);
+
+    expect(results.filter(result => result.admitted)).toHaveLength(1);
+    expect(results.filter(result => !result.admitted)).toHaveLength(1);
+  });
+});

--- a/test/unit/domain/services/HttpSyncServer.auth.test.ts
+++ b/test/unit/domain/services/HttpSyncServer.auth.test.ts
@@ -3,6 +3,7 @@ import HttpSyncServer from '../../../../src/domain/services/sync/HttpSyncServer.
 import { signSyncRequest } from '../../../../src/domain/services/sync/SyncAuthService.ts';
 import SyncSecret from '../../../../src/domain/services/sync/SyncSecret.ts';
 import { createMockCrypto } from '../../../helpers/mockPorts.ts';
+import InMemorySyncReplayProtection from '../../../helpers/InMemorySyncReplayProtection.ts';
 
 const SECRET = SyncSecret.fromString('test-secret');
 const KEY_ID = 'default';
@@ -106,7 +107,7 @@ describe('HttpSyncServer auth integration', () => {
         graph,
         host: '127.0.0.1',
         path: '/sync',
-        auth: { keys: KEYS, mode: 'enforce', crypto: TEST_CRYPTO },
+        auth: { keys: KEYS, mode: 'enforce', crypto: TEST_CRYPTO, replayProtection: new InMemorySyncReplayProtection() },
       }) as any));
       await server.listen(9999);
       handler = mockPort.getHandler();
@@ -222,7 +223,7 @@ describe('HttpSyncServer auth integration', () => {
         graph,
         host: '127.0.0.1',
         path: '/sync',
-        auth: { keys: KEYS, mode: 'log-only', crypto: TEST_CRYPTO },
+        auth: { keys: KEYS, mode: 'log-only', crypto: TEST_CRYPTO, replayProtection: new InMemorySyncReplayProtection() },
       }) as any));
       await server.listen(9999);
       handler = mockPort.getHandler();
@@ -329,7 +330,7 @@ describe('HttpSyncServer auth integration', () => {
         graph,
         host: '127.0.0.1',
         path: '/sync',
-        auth: { keys: KEYS, crypto: TEST_CRYPTO },
+        auth: { keys: KEYS, crypto: TEST_CRYPTO, replayProtection: new InMemorySyncReplayProtection() },
       }) as any));
       await server.listen(9999);
       const noModeHandler = noModeMockPort.getHandler();
@@ -351,7 +352,7 @@ describe('HttpSyncServer auth integration', () => {
         graph,
         host: '127.0.0.1',
         path: '/sync',
-        auth: { keys: KEYS, mode: 'typo', crypto: TEST_CRYPTO },
+        auth: { keys: KEYS, mode: 'typo', crypto: TEST_CRYPTO, replayProtection: new InMemorySyncReplayProtection() },
       }) as any))).toThrow(/HttpSyncServer config/);
     });
   });
@@ -368,7 +369,7 @@ describe('HttpSyncServer auth integration', () => {
         host: '127.0.0.1',
         path: '/sync',
         maxRequestBytes: 10,
-        auth: { keys: KEYS, mode: 'enforce', crypto: TEST_CRYPTO },
+        auth: { keys: KEYS, mode: 'enforce', crypto: TEST_CRYPTO, replayProtection: new InMemorySyncReplayProtection() },
       }) as any));
       await server.listen(9999);
       const oversizeHandler = oversizeMockPort.getHandler();
@@ -392,7 +393,7 @@ describe('HttpSyncServer auth integration', () => {
         host: '127.0.0.1',
         path: '/sync',
         maxRequestBytes: 10,
-        auth: { keys: KEYS, mode: 'enforce', crypto: TEST_CRYPTO },
+        auth: { keys: KEYS, mode: 'enforce', crypto: TEST_CRYPTO, replayProtection: new InMemorySyncReplayProtection() },
       }) as any));
       await server.listen(9999);
       const oversizeHandler = oversizeMockPort.getHandler();
@@ -414,7 +415,7 @@ describe('HttpSyncServer auth integration', () => {
       const server = new HttpSyncServer((({
         httpPort: mock.port,
         graph,
-        auth: { keys: KEYS, mode: 'log-only', crypto: TEST_CRYPTO },
+        auth: { keys: KEYS, mode: 'log-only', crypto: TEST_CRYPTO, replayProtection: new InMemorySyncReplayProtection() },
         allowedWriters: ['alice'],
       }) as any));
       await server.listen(9999);
@@ -438,7 +439,7 @@ describe('HttpSyncServer auth integration', () => {
       const server = new HttpSyncServer((({
         httpPort: mock.port,
         graph,
-        auth: { keys: KEYS, mode: 'enforce', crypto: TEST_CRYPTO },
+        auth: { keys: KEYS, mode: 'enforce', crypto: TEST_CRYPTO, replayProtection: new InMemorySyncReplayProtection() },
         allowedWriters: ['alice'],
       }) as any));
       await server.listen(9999);
@@ -468,6 +469,7 @@ describe('HttpSyncServer auth integration', () => {
           keys: KEYS,
           mode: 'enforce',
           crypto: TEST_CRYPTO,
+          replayProtection: new InMemorySyncReplayProtection(),
           rateLimit: {
             capacity: 1,
             refillTokensPerSecond: 1,
@@ -511,7 +513,13 @@ describe('HttpSyncServer auth integration', () => {
       const server = new HttpSyncServer((({
         httpPort: mock.port,
         graph,
-        auth: { keys: KEYS, mode: 'log-only', crypto: TEST_CRYPTO, logger },
+        auth: {
+          keys: KEYS,
+          mode: 'log-only',
+          crypto: TEST_CRYPTO,
+          replayProtection: new InMemorySyncReplayProtection(),
+          logger,
+        },
         allowedWriters: ['alice'],
       }) as any));
       await server.listen(9999);

--- a/test/unit/domain/services/HttpSyncServer.auth.test.ts
+++ b/test/unit/domain/services/HttpSyncServer.auth.test.ts
@@ -175,6 +175,33 @@ describe('HttpSyncServer auth integration', () => {
       expect(second.status).toBe(403);
     });
 
+    it('returns a stable 503 when durable replay storage is unavailable', async () => {
+      const server = new HttpSyncServer((({
+        httpPort: mockPort.port,
+        graph,
+        host: '127.0.0.1',
+        path: '/sync',
+        auth: {
+          keys: KEYS,
+          mode: 'enforce',
+          crypto: TEST_CRYPTO,
+          replayProtection: {
+            reserve: async () => { throw new Error('private adapter failure'); },
+            sweep: async () => ({ removed: 0, generation: null }),
+          },
+        },
+      }) as any));
+      await server.listen(9999);
+      const unavailableHandler = mockPort.getHandler();
+      const { body, headers } = await signedBody(VALID_SYNC_BODY);
+
+      const response = await unavailableHandler({ method: 'POST', url: '/sync', headers, body });
+      expect(response.status).toBe(503);
+      expect(JSON.parse(response.body).error).toBe('REPLAY_STORE_UNAVAILABLE');
+      expect(response.body).not.toContain('private adapter failure');
+      expect(graph.processSyncRequest).not.toHaveBeenCalled();
+    });
+
     it('returns 403 for stale lamport (non-increasing)', async () => {
       // First request succeeds at a high lamport
       const { body: body1, headers: headers1 } = await signedBody(VALID_SYNC_BODY);

--- a/test/unit/domain/services/HttpSyncServer.authorize.test.ts
+++ b/test/unit/domain/services/HttpSyncServer.authorize.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi } from 'vitest';
 import HttpSyncServer from '../../../../src/domain/services/sync/HttpSyncServer.ts';
 import SyncSecret from '../../../../src/domain/services/sync/SyncSecret.ts';
 import { createMockCrypto } from '../../../helpers/mockPorts.ts';
+import InMemorySyncReplayProtection from '../../../helpers/InMemorySyncReplayProtection.ts';
 
 function createMockHttpPort() {
   return {
@@ -33,6 +34,7 @@ function createMockGraph() {
 const SHA_A = 'a'.repeat(40);
 const TEST_KEYS = { default: SyncSecret.fromString('test-secret') };
 const TEST_CRYPTO = createMockCrypto();
+const TEST_REPLAY_PROTECTION = new InMemorySyncReplayProtection();
 
 describe('B1 — HttpSyncServer._authorize writer extraction', () => {
   it('extracts writer IDs from frontier keys for sync-requests', async () => {
@@ -50,6 +52,7 @@ describe('B1 — HttpSyncServer._authorize writer extraction', () => {
         keys: TEST_KEYS,
         mode: 'enforce',
         crypto: TEST_CRYPTO,
+        replayProtection: TEST_REPLAY_PROTECTION,
       },
     });
 
@@ -90,6 +93,7 @@ describe('B1 — HttpSyncServer._authorize writer extraction', () => {
         keys: TEST_KEYS,
         mode: 'enforce',
         crypto: TEST_CRYPTO,
+        replayProtection: TEST_REPLAY_PROTECTION,
       },
     });
     (server as any)._auth = mockAuth;
@@ -126,6 +130,7 @@ describe('B1 — HttpSyncServer._authorize writer extraction', () => {
         keys: TEST_KEYS,
         mode: 'enforce',
         crypto: TEST_CRYPTO,
+        replayProtection: TEST_REPLAY_PROTECTION,
       },
     });
     (server as any)._auth = mockAuth;

--- a/test/unit/domain/services/HttpSyncServer.test.ts
+++ b/test/unit/domain/services/HttpSyncServer.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import HttpSyncServer from '../../../../src/domain/services/sync/HttpSyncServer.ts';
 import SyncSecret from '../../../../src/domain/services/sync/SyncSecret.ts';
 import { createMockCrypto } from '../../../helpers/mockPorts.ts';
+import InMemorySyncReplayProtection from '../../../helpers/InMemorySyncReplayProtection.ts';
 
 const TEST_CRYPTO = createMockCrypto();
+const TEST_REPLAY_PROTECTION = new InMemorySyncReplayProtection();
 
 /** @param {any} value @returns {any} */
 function canonicalizeJson(value) {
@@ -138,6 +140,7 @@ describe('HttpSyncServer', () => {
           keys: { default: SyncSecret.fromString('secret') },
           mode: 'log-only',
           crypto: TEST_CRYPTO,
+          replayProtection: new InMemorySyncReplayProtection(),
         },
       }) as any))).toThrow(/non-local sync hosts require auth.mode "enforce"/);
     });
@@ -151,6 +154,7 @@ describe('HttpSyncServer', () => {
           keys: { default: SyncSecret.fromString('secret') },
           mode: 'enforce',
           crypto: TEST_CRYPTO,
+          replayProtection: new InMemorySyncReplayProtection(),
           rateLimit: {
             capacity: 10,
             refillTokensPerSecond: 1,
@@ -169,6 +173,7 @@ describe('HttpSyncServer', () => {
           keys: { default: SyncSecret.fromString('secret') },
           mode: 'enforce',
           crypto: TEST_CRYPTO,
+          replayProtection: new InMemorySyncReplayProtection(),
         },
       }) as any))).toThrow(/non-local sync hosts require auth.rateLimit/);
     });
@@ -419,7 +424,11 @@ describe('HttpSyncServer', () => {
       expect(() => new HttpSyncServer({
         httpPort: (createMockPort() as any),
         graph: { processSyncRequest: vi.fn() },
-        auth: { keys: { default: SyncSecret.fromString('secret') }, crypto: TEST_CRYPTO },
+        auth: {
+          keys: { default: SyncSecret.fromString('secret') },
+          crypto: TEST_CRYPTO,
+          replayProtection: TEST_REPLAY_PROTECTION,
+        },
         allowedWriters: ['alice'],
       })).not.toThrow();
     });

--- a/test/unit/domain/services/SyncAuthService.test.ts
+++ b/test/unit/domain/services/SyncAuthService.test.ts
@@ -5,8 +5,10 @@ import SyncAuthService, {
   signSyncRequest,
   canonicalizePath,
   buildCanonicalPayload,
+  SYNC_REPLAY_ACCEPTANCE_WINDOW_MS,
 } from '../../../../src/domain/services/sync/SyncAuthService.ts';
 import SyncSecret from '../../../../src/domain/services/sync/SyncSecret.ts';
+import InMemorySyncReplayProtection from '../../../helpers/InMemorySyncReplayProtection.ts';
 
 const SECRET_VALUE = 'test-secret-key-1234567890';
 const SECRET = SyncSecret.fromString(SECRET_VALUE);
@@ -63,8 +65,15 @@ async function buildSignedRequest(overrides: Record<string, string> = {}) {
   };
 }
 
-function makeService(opts: Record<string, unknown> = {}) {
+function createService(options: Record<string, unknown> | undefined): SyncAuthService {
   return new SyncAuthService({
+    replayProtection: new InMemorySyncReplayProtection(),
+    ...options,
+  } as unknown as ConstructorParameters<typeof SyncAuthService>[0]);
+}
+
+function makeService(opts: Record<string, unknown> = {}) {
+  return createService({
     keys: KEYS,
     crypto: defaultCrypto,
     ...opts,
@@ -194,7 +203,7 @@ describe('signSyncRequest', () => {
   });
 
   it('produces a signature verifiable by SyncAuthService', async () => {
-    const svc = new SyncAuthService({
+    const svc = createService({
       keys: KEYS,
       crypto: defaultCrypto,
     });
@@ -795,21 +804,6 @@ describe('Metrics', () => {
     expect(snap2.authFailCount).toBe(1);
   });
 
-  it('counts nonce evictions at capacity boundary', async () => {
-    const svc = makeService({ nonceCapacity: 2 });
-
-    // Fill the cache with 2 nonces (each needs increasing lamport)
-    const req1 = await buildSignedRequest();
-    await svc.verify(req1);
-    const req2 = await buildSignedRequest();
-    await svc.verify(req2);
-    expect(svc.getMetrics().nonceEvictions).toBe(0);
-
-    // Third request should trigger eviction
-    const req3 = await buildSignedRequest();
-    await svc.verify(req3);
-    expect(svc.getMetrics().nonceEvictions).toBe(1);
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -848,12 +842,12 @@ describe('verify() nonce ordering', () => {
     const r1 = await svc.verify(badReq);
     expect(r1).toEqual({ ok: false, reason: 'INVALID_SIGNATURE', status: 401 });
 
-    // Now send the original valid request with the same nonce and lamport
-    // Lamport was consumed even on sig failure, so this will get STALE_LAMPORT
-    // unless we build a new request with higher lamport
-    // Actually: _validateFreshness updates lastSeen even on failure? Let's check.
-    // Looking at the source: _validateFreshness sets lastSeen BEFORE returning ok.
-    // So the lamport IS consumed. We need a fresh request with higher lamport.
+    // Signature failures do not consume either the nonce or Lamport coordinate.
+    const r2 = await svc.verify(validReq);
+    expect(r2).toEqual({ ok: true });
+
+    // Reuse the now-reserved nonce with a higher Lamport coordinate so the
+    // replay authority, rather than the freshness gate, makes the decision.
     const body = validReq.body;
     const nonce = validReq.headers['x-warp-nonce'] ?? '';
     const higherLamport = String(Number(validReq.headers['x-warp-timestamp']) + 1);
@@ -870,7 +864,7 @@ describe('verify() nonce ordering', () => {
     const hmacBuf = await defaultCrypto.hmac('sha256', SECRET_VALUE, canonical);
     const signature = Buffer.from(hmacBuf).toString('hex');
 
-    const r2 = await svc.verify({
+    const r3 = await svc.verify({
       method: 'POST',
       url: '/sync',
       headers: {
@@ -883,33 +877,70 @@ describe('verify() nonce ordering', () => {
       },
       body,
     });
-    // Nonce was not consumed on the invalid-sig attempt, so this should succeed
-    expect(r2).toEqual({ ok: true });
-
-    // Now replay same nonce with even higher lamport — should be REPLAY
-    const evenHigher = String(Number(higherLamport) + 1);
-    const canonical3 = buildCanonicalPayload({
-      keyId: KEY_ID, method: 'POST', path: '/sync',
-      timestamp: evenHigher, nonce,
-      contentType: 'application/json', bodySha256,
-    });
-    const hmac3 = await defaultCrypto.hmac('sha256', SECRET_VALUE, canonical3);
-    const sig3 = Buffer.from(hmac3).toString('hex');
-
-    const r3 = await svc.verify({
-      method: 'POST',
-      url: '/sync',
-      headers: {
-        'content-type': 'application/json',
-        'x-warp-sig-version': '2',
-        'x-warp-key-id': KEY_ID,
-        'x-warp-timestamp': evenHigher,
-        'x-warp-nonce': nonce,
-        'x-warp-signature': sig3,
-      },
-      body,
-    });
     expect(r3).toEqual({ ok: false, reason: 'REPLAY', status: 403 });
+  });
+});
+
+describe('durable replay authority', () => {
+  it('retains an admitted nonce across service restart', async () => {
+    const replayProtection = new InMemorySyncReplayProtection();
+    const request = await buildSignedRequest();
+    const first = makeService({ replayProtection });
+    const restarted = makeService({ replayProtection });
+
+    expect(await first.verify(request)).toEqual({ ok: true });
+    expect(await restarted.verify(request)).toEqual({
+      ok: false,
+      reason: 'REPLAY',
+      status: 403,
+    });
+  });
+
+  it('gives concurrent duplicate admission exactly one winner', async () => {
+    const replayProtection = new InMemorySyncReplayProtection();
+    const request = await buildSignedRequest();
+    const left = makeService({ replayProtection });
+    const right = makeService({ replayProtection });
+
+    const results = await Promise.all([
+      left.verify(request),
+      right.verify(request),
+    ]);
+
+    expect(results.filter(result => result.ok)).toHaveLength(1);
+    expect(results.filter(result => !result.ok && result.reason === 'REPLAY')).toHaveLength(1);
+  });
+
+  it('allows an expired nonce only after the retention authority sweeps it', async () => {
+    const clock = makeManualClock();
+    const replayProtection = new InMemorySyncReplayProtection(clock.now);
+    const request = await buildSignedRequest();
+    const first = makeService({
+      replayProtection,
+    });
+
+    expect(await first.verify(request)).toEqual({ ok: true });
+    clock.advance(SYNC_REPLAY_ACCEPTANCE_WINDOW_MS + 1);
+    expect(await replayProtection.sweep()).toMatchObject({ removed: 1 });
+
+    const restarted = makeService({
+      replayProtection,
+    });
+    expect(await restarted.verify(request)).toEqual({ ok: true });
+  });
+
+  it('fails closed when the replay authority is unavailable', async () => {
+    const request = await buildSignedRequest();
+    const svc = makeService({
+      replayProtection: {
+        reserve: async () => {
+          throw new Error('replay store unavailable');
+        },
+        sweep: async () => ({ removed: 0, generation: null }),
+      },
+    });
+
+    await expect(svc.verify(request)).rejects.toThrow('replay store unavailable');
   });
 });
 
@@ -917,20 +948,29 @@ describe('verify() nonce ordering', () => {
 // Constructor
 // ---------------------------------------------------------------------------
 describe('Constructor', () => {
+  it('rejects missing durable replay protection', () => {
+    expect(() => new SyncAuthService({
+      keys: syncKeys({ k: 's' }),
+      crypto: defaultCrypto,
+    } as ConstructorParameters<typeof SyncAuthService>[0])).toThrow(
+      'requires durable replay protection',
+    );
+  });
+
   it('rejects empty keys map', () => {
-    expect(() => new SyncAuthService({ keys: {} })).toThrow('non-empty keys map');
+    expect(() => createService({ keys: {} })).toThrow('non-empty keys map');
   });
 
   it('rejects missing keys option', () => {
-    expect(() => new SyncAuthService({} as any)).toThrow('non-empty keys map');
+    expect(() => createService({} as any)).toThrow('non-empty keys map');
   });
 
   it('rejects undefined options', () => {
-    expect(() => new SyncAuthService((undefined as any))).toThrow('non-empty keys map');
+    expect(() => createService((undefined as any))).toThrow('non-empty keys map');
   });
 
   it('defaults optional params without throwing', () => {
-    const svc = new SyncAuthService({ keys: syncKeys({ k: 's' }), crypto: defaultCrypto });
+    const svc = createService({ keys: syncKeys({ k: 's' }), crypto: defaultCrypto });
     expect(svc.mode).toBe('enforce');
     expect(svc.getMetrics().authFailCount).toBe(0);
   });
@@ -941,7 +981,7 @@ describe('Constructor', () => {
 // ---------------------------------------------------------------------------
 describe('verifyWriters()', () => {
   it('allows all writers when allowedWriters is not set', async () => {
-    const auth = new SyncAuthService({
+    const auth = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
     });
@@ -950,7 +990,7 @@ describe('verifyWriters()', () => {
   });
 
   it('allows listed writers', async () => {
-    const auth = new SyncAuthService({
+    const auth = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       allowedWriters: ['alice', 'bob'],
@@ -960,7 +1000,7 @@ describe('verifyWriters()', () => {
   });
 
   it('rejects unlisted writers with FORBIDDEN_WRITER 403', async () => {
-    const auth = new SyncAuthService({
+    const auth = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       allowedWriters: ['alice'],
@@ -974,7 +1014,7 @@ describe('verifyWriters()', () => {
   });
 
   it('increments forbiddenWriterRejects metric', async () => {
-    const auth = new SyncAuthService({
+    const auth = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       allowedWriters: ['alice'],
@@ -984,7 +1024,7 @@ describe('verifyWriters()', () => {
   });
 
   it('validates writer IDs at construction time', () => {
-    expect(() => new SyncAuthService({
+    expect(() => createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       allowedWriters: ['valid', 'a/b'],
@@ -992,7 +1032,7 @@ describe('verifyWriters()', () => {
   });
 
   it('rejects empty allowedWriters array', () => {
-    expect(() => new SyncAuthService({
+    expect(() => createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       allowedWriters: [],
@@ -1015,7 +1055,7 @@ describe('mode-agnostic validation', () => {
   });
 
   it('verifyWriters() returns { ok: false } in log-only mode (caller decides enforcement)', () => {
-    const svc = new SyncAuthService({
+    const svc = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       mode: 'log-only',
@@ -1034,7 +1074,7 @@ describe('mode-agnostic validation', () => {
 // ---------------------------------------------------------------------------
 describe('enforceWriters()', () => {
   it('rejects forbidden writers in enforce mode', () => {
-    const svc = new SyncAuthService({
+    const svc = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       mode: 'enforce',
@@ -1049,7 +1089,7 @@ describe('enforceWriters()', () => {
   });
 
   it('allows forbidden writers through in log-only mode', () => {
-    const svc = new SyncAuthService({
+    const svc = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       mode: 'log-only',
@@ -1060,7 +1100,7 @@ describe('enforceWriters()', () => {
   });
 
   it('increments logOnlyPassthroughs in log-only mode', () => {
-    const svc = new SyncAuthService({
+    const svc = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       mode: 'log-only',
@@ -1071,7 +1111,7 @@ describe('enforceWriters()', () => {
   });
 
   it('still increments forbiddenWriterRejects metric in log-only mode', () => {
-    const svc = new SyncAuthService({
+    const svc = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       mode: 'log-only',
@@ -1082,7 +1122,7 @@ describe('enforceWriters()', () => {
   });
 
   it('allows listed writers in any mode', () => {
-    const svc = new SyncAuthService({
+    const svc = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       mode: 'enforce',
@@ -1092,7 +1132,7 @@ describe('enforceWriters()', () => {
   });
 
   it('passes through when no allowedWriters configured', () => {
-    const svc = new SyncAuthService({
+    const svc = createService({
       keys: syncKeys({ default: 'secret123' }),
       crypto: defaultCrypto,
       mode: 'enforce',

--- a/test/unit/domain/services/SyncAuthService.test.ts
+++ b/test/unit/domain/services/SyncAuthService.test.ts
@@ -9,6 +9,7 @@ import SyncAuthService, {
 } from '../../../../src/domain/services/sync/SyncAuthService.ts';
 import SyncSecret from '../../../../src/domain/services/sync/SyncSecret.ts';
 import InMemorySyncReplayProtection from '../../../helpers/InMemorySyncReplayProtection.ts';
+import { createMockLogger } from '../../../helpers/mockPorts.ts';
 
 const SECRET_VALUE = 'test-secret-key-1234567890';
 const SECRET = SyncSecret.fromString(SECRET_VALUE);
@@ -931,7 +932,9 @@ describe('durable replay authority', () => {
 
   it('fails closed when the replay authority is unavailable', async () => {
     const request = await buildSignedRequest();
+    const logger = createMockLogger();
     const svc = makeService({
+      logger,
       replayProtection: {
         reserve: async () => {
           throw new Error('replay store unavailable');
@@ -940,7 +943,19 @@ describe('durable replay authority', () => {
       },
     });
 
-    await expect(svc.verify(request)).rejects.toThrow('replay store unavailable');
+    await expect(svc.verify(request)).resolves.toEqual({
+      ok: false,
+      reason: 'REPLAY_STORE_UNAVAILABLE',
+      status: 503,
+    });
+    expect(svc.getMetrics()).toMatchObject({
+      authFailCount: 1,
+      replayStoreFailures: 1,
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      'sync auth: replay protection unavailable',
+      { keyId: KEY_ID },
+    );
   });
 });
 

--- a/test/unit/domain/services/SyncSecret.test.ts
+++ b/test/unit/domain/services/SyncSecret.test.ts
@@ -6,6 +6,7 @@ import SyncAuthService, {
   signSyncRequest,
 } from '../../../../src/domain/services/sync/SyncAuthService.ts';
 import SyncSecret from '../../../../src/domain/services/sync/SyncSecret.ts';
+import InMemorySyncReplayProtection from '../../../helpers/InMemorySyncReplayProtection.ts';
 
 describe('SyncSecret', () => {
   it('redacts accidental string, JSON, and inspect output', () => {
@@ -22,6 +23,7 @@ describe('SyncSecret', () => {
     const service = new SyncAuthService({
       keys: { default: secret },
       crypto: defaultCrypto,
+      replayProtection: new InMemorySyncReplayProtection(),
     });
     const body = new TextEncoder().encode('verify-me');
     const headers = await signSyncRequest(
@@ -52,6 +54,7 @@ describe('SyncSecret', () => {
       // @ts-expect-error Runtime guard mirrors the public type boundary.
       keys: { default: 'test-secret-key-1234567890' },
       crypto: defaultCrypto,
+      replayProtection: new InMemorySyncReplayProtection(),
     })).toThrow('SyncAuthService requires SyncSecret values');
   });
 });

--- a/test/unit/infrastructure/adapters/GitCasRepositoryAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasRepositoryAdapter.test.ts
@@ -132,6 +132,9 @@ describe('GitCasRepositoryAdapter', () => {
       caches: highLevelCas.caches,
       pages: highLevelCas.pages,
       workspaces: highLevelCas.workspaces,
+      expiringSets: {
+        open: vi.fn(async () => ({} as any)),
+      },
       publications: highLevelCas.publications,
       rootSets: { open: vi.fn(async () => rootSet) },
       readManifest: vi.fn(),
@@ -166,6 +169,7 @@ describe('GitCasRepositoryAdapter', () => {
     });
     expect(services.materializations).toBeInstanceOf(GitCasMaterializationStoreAdapter);
     expect(services.trie).toBeInstanceOf(GitCasTrieStoreAdapter);
+    expect(services.syncReplayProtection).toBeDefined();
 
     plumbing.execute
       .mockResolvedValueOnce('f'.repeat(40))

--- a/test/unit/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.test.ts
@@ -34,6 +34,7 @@ describe('GitCasSyncReplayProtectionAdapter', () => {
       JSON.stringify([1, 'events', 'key|with|separators', 'nonce']),
       { expiresAt: new Date(61_000).toISOString() },
     );
+    expect(sweep).toHaveBeenCalledOnce();
     expect(reservation).toEqual({
       admitted: true,
       expiresAt: new Date(61_000).toISOString(),
@@ -43,6 +44,7 @@ describe('GitCasSyncReplayProtectionAdapter', () => {
       removed: 2,
       generation: 'generation-2',
     });
+    expect(sweep).toHaveBeenCalledTimes(2);
   });
 
   it('returns the retained marker deadline when duplicate admission loses', async () => {
@@ -73,5 +75,55 @@ describe('GitCasSyncReplayProtectionAdapter', () => {
       expiresAt: retainedExpiry,
       generation: 'generation-existing',
     });
+  });
+
+  it('sweeps opportunistically at a bounded production cadence', async () => {
+    let nowMs = 1_000;
+    const addIfAbsent = vi.fn(async (_key: string, options: { expiresAt: string }) => ({
+      admitted: true,
+      generation: 'generation-add',
+      marker: { expiresAt: options.expiresAt },
+    }));
+    const sweep = vi.fn(async () => ({ removed: 0, generation: null }));
+    const adapter = new GitCasSyncReplayProtectionAdapter({
+      cas: {
+        expiringSets: {
+          open: (async () => ({ addIfAbsent, sweep })) as any,
+        },
+      },
+      graphName: 'events',
+      wallClockMs: () => nowMs,
+    });
+    const request = { keyId: 'default', nonce: 'nonce', ttlMs: 60_000 };
+
+    await adapter.reserve(request);
+    nowMs += 60_000;
+    await adapter.reserve(request);
+    expect(sweep).toHaveBeenCalledOnce();
+
+    nowMs += 10 * 60 * 1000;
+    await adapter.reserve(request);
+    expect(sweep).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles eager open rejection without hiding it from callers', async () => {
+    const openFailure = new Error('open failed');
+    const opening = Promise.reject(openFailure);
+    const catchSpy = vi.spyOn(opening, 'catch');
+    const adapter = new GitCasSyncReplayProtectionAdapter({
+      cas: {
+        expiringSets: {
+          open: (() => opening) as any,
+        },
+      },
+      graphName: 'events',
+    });
+
+    expect(catchSpy).toHaveBeenCalledOnce();
+    await expect(adapter.reserve({
+      keyId: 'default',
+      nonce: 'nonce',
+      ttlMs: 60_000,
+    })).rejects.toBe(openFailure);
   });
 });

--- a/test/unit/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import GitCasSyncReplayProtectionAdapter from '../../../../src/infrastructure/adapters/GitCasSyncReplayProtectionAdapter.ts';
+
+describe('GitCasSyncReplayProtectionAdapter', () => {
+  it('opens one graph-scoped set and delegates an unambiguous replay identity', async () => {
+    const addIfAbsent = vi.fn(async (_key: string, options: { expiresAt: string }) => ({
+      admitted: true,
+      generation: 'generation-1',
+      marker: { expiresAt: options.expiresAt },
+    }));
+    const sweep = vi.fn(async () => ({
+      removed: 2,
+      generation: 'generation-2',
+    }));
+    const open = vi.fn(async () => ({ addIfAbsent, sweep }));
+    const adapter = new GitCasSyncReplayProtectionAdapter({
+      cas: { expiringSets: { open: open as any } },
+      graphName: 'events',
+      wallClockMs: () => 1_000,
+    });
+
+    const reservation = await adapter.reserve({
+      keyId: 'key|with|separators',
+      nonce: 'nonce',
+      ttlMs: 60_000,
+    });
+
+    expect(open).toHaveBeenCalledOnce();
+    expect(open).toHaveBeenCalledWith({
+      namespace: 'git-warp.sync-replay',
+    });
+    expect(addIfAbsent).toHaveBeenCalledWith(
+      JSON.stringify([1, 'events', 'key|with|separators', 'nonce']),
+      { expiresAt: new Date(61_000).toISOString() },
+    );
+    expect(reservation).toEqual({
+      admitted: true,
+      expiresAt: new Date(61_000).toISOString(),
+      generation: 'generation-1',
+    });
+    expect(await adapter.sweep()).toEqual({
+      removed: 2,
+      generation: 'generation-2',
+    });
+  });
+
+  it('returns the retained marker deadline when duplicate admission loses', async () => {
+    const retainedExpiry = '2026-07-25T03:00:00.000Z';
+    const adapter = new GitCasSyncReplayProtectionAdapter({
+      cas: {
+        expiringSets: {
+          open: (async () => ({
+            addIfAbsent: async () => ({
+              admitted: false,
+              generation: 'generation-existing',
+              marker: { expiresAt: retainedExpiry },
+            }),
+            sweep: async () => ({ removed: 0, generation: null }),
+          })) as any,
+        },
+      },
+      graphName: 'events',
+      wallClockMs: () => 0,
+    });
+
+    await expect(adapter.reserve({
+      keyId: 'default',
+      nonce: 'duplicate',
+      ttlMs: 1,
+    })).resolves.toEqual({
+      admitted: false,
+      expiresAt: retainedExpiry,
+      generation: 'generation-existing',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- replace `SyncAuthService` process-local nonce LRU with a required atomic replay-protection port
- bind Git-backed runtimes to git-cas `ExpiringSet` storage through the repository-scoped facade
- retain accepted nonces for WARP’s fixed ten-minute window across restart, with expiry-only collection and one-winner concurrency
- fail authenticated serving closed when durable replay storage is unavailable
- verify signatures before advancing the per-key Lamport freshness gate, so invalid signatures cannot poison freshness state
- remove the obsolete `nonceCapacity`, `nonceEvictions`, and inert `auth.wallClockMs` compatibility knobs

## Proof

- worktree-local full unit + integration: 630 files passed, 1 skipped; 7,476 tests passed, 2 skipped
- real-Git restart and concurrent-writer integration proofs pass
- pre-push IRONCLAD gates pass: type firewalls, publication surface, ESLint, Markdown, docs topology, links, CAS ownership, and stable unit shards
- Graft committed-range review reports no breaking package-export changes

This is the first independently reviewable slice of #740. The active/saved seek-cursor migration remains in the next slice, so this PR intentionally references rather than closes the issue.

Refs #740