### PR TITLE
Retain seek cursors with git-cas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   git-cas `ExpiringSet`. Accepted nonces remain retained for WARP's fixed
   ten-minute acceptance window across process restart, cannot be evicted under
   capacity pressure, and become collectible only after expiry and sweep.
+- Changed active and named seek cursors from mutable WARP refs to immutable
+  git-cas pages retained by one cache set. Active positions have a 30-day
+  pinned lifetime; saved cursors remain pinned until explicitly dropped.
+  Reads do not extend retention, and bounded opportunistic sweeps collect
+  expired active pages.
 
 ### Removed
 
@@ -99,6 +104,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `nonceEvictions`, and the inert public `auth.wallClockMs` option. Authenticated
   serving now fails closed unless runtime storage supplies durable replay
   protection.
+- Removed the `refs/warp/<graph>/cursor/*` protocol and its public ref builders.
+  v19 intentionally does not migrate these operator-only v18 cursor refs; they
+  are ignored as inert state while authoritative graph history remains intact.
 
 ### Fixed
 

--- a/bin/cli/commands/check.ts
+++ b/bin/cli/commands/check.ts
@@ -146,8 +146,8 @@ async function getHookStatusForCheck(repoPath: string, hookPaths: HookPathPort):
 
 /** Handles the `check` command: reports graph health, GC, and hook status. */
 export async function handleCheck({ options }: { options: CliOptions }): Promise<{ payload: unknown; exitCode: number }> {
-  const { graph, graphName, persistence, hookPaths } = await openGraph(options);
-  const cursorInfo = await applyCursorCeiling(graph, persistence, graphName);
+  const { graph, graphName, persistence, cursorStore, hookPaths } = await openGraph(options);
+  const cursorInfo = await applyCursorCeiling(graph, cursorStore);
   emitCursorWarning(cursorInfo, null);
   const health = await getHealth(persistence);
   const gcMetrics = await getGcMetrics(graph);

--- a/bin/cli/commands/checkpoint.ts
+++ b/bin/cli/commands/checkpoint.ts
@@ -18,10 +18,9 @@ type CheckpointPayload =
   | { graph: string; status: 'coverage-synced' };
 
 async function assertNoActiveCursor(
-  persistence: Awaited<ReturnType<typeof openGraph>>['persistence'],
-  graphName: string,
+  cursorStore: Awaited<ReturnType<typeof openGraph>>['cursorStore'],
 ): Promise<void> {
-  const cursor = await readActiveCursor(persistence, graphName);
+  const cursor = await readActiveCursor(cursorStore);
   if (cursor !== null) {
     throw usageError('checkpoint create refuses to run while seek cursor is active; run git warp seek --latest first');
   }
@@ -38,8 +37,8 @@ async function checkpointStatus(options: CliOptions): Promise<{ payload: Checkpo
 }
 
 async function createCheckpoint(options: CliOptions): Promise<{ payload: CheckpointPayload; exitCode: number }> {
-  const { graph, graphName, persistence } = await openGraph(options);
-  await assertNoActiveCursor(persistence, graphName);
+  const { graph, graphName, cursorStore } = await openGraph(options);
+  await assertNoActiveCursor(cursorStore);
   await graph.materialize();
   const checkpoint = await graph.createCheckpoint();
   return {

--- a/bin/cli/commands/debug/shared.ts
+++ b/bin/cli/commands/debug/shared.ts
@@ -25,8 +25,8 @@ type WarpCoreRuntime = WarpCore & RuntimeHostProduct;
  * Opens a graph with debug context including cursor state for exploratory analysis.
  */
 export async function openDebugContext(options: CliOptions): Promise<{ graph: WarpGraphInstance; graphName: string; persistence: Persistence; activeCursor: CursorBlob | null }> {
-  const { graph, graphName, persistence } = await openGraph(options);
-  const activeCursor = await readActiveCursor(persistence, graphName);
+  const { graph, graphName, persistence, cursorStore } = await openGraph(options);
+  const activeCursor = await readActiveCursor(cursorStore);
   emitCursorWarning({
     active: activeCursor !== null,
     tick: activeCursor?.tick ?? null,

--- a/bin/cli/commands/gc.ts
+++ b/bin/cli/commands/gc.ts
@@ -18,10 +18,9 @@ type GcPayload =
   | { graph: string; result: ReturnType<Awaited<ReturnType<typeof openGraph>>['graph']['runGC']> };
 
 async function assertNoActiveCursor(
-  persistence: Awaited<ReturnType<typeof openGraph>>['persistence'],
-  graphName: string,
+  cursorStore: Awaited<ReturnType<typeof openGraph>>['cursorStore'],
 ): Promise<void> {
-  const cursor = await readActiveCursor(persistence, graphName);
+  const cursor = await readActiveCursor(cursorStore);
   if (cursor !== null) {
     throw usageError('gc refuses to run while seek cursor is active; run git warp seek --latest first');
   }
@@ -37,8 +36,8 @@ async function gcStatus(options: CliOptions): Promise<{ payload: GcPayload; exit
 }
 
 async function maybeRunGc(options: CliOptions): Promise<{ payload: GcPayload; exitCode: number }> {
-  const { graph, graphName, persistence } = await openGraph(options);
-  await assertNoActiveCursor(persistence, graphName);
+  const { graph, graphName, cursorStore } = await openGraph(options);
+  await assertNoActiveCursor(cursorStore);
   await graph.materialize();
   const result = graph.maybeRunGC();
   return {
@@ -48,8 +47,8 @@ async function maybeRunGc(options: CliOptions): Promise<{ payload: GcPayload; ex
 }
 
 async function runGc(options: CliOptions): Promise<{ payload: GcPayload; exitCode: number }> {
-  const { graph, graphName, persistence } = await openGraph(options);
-  await assertNoActiveCursor(persistence, graphName);
+  const { graph, graphName, cursorStore } = await openGraph(options);
+  await assertNoActiveCursor(cursorStore);
   await graph.materialize();
   const result = graph.runGC();
   return {

--- a/bin/cli/commands/history.ts
+++ b/bin/cli/commands/history.ts
@@ -61,8 +61,8 @@ function toHistoryEntry(entry: WriterPatchEntry, writer: string): HistoryEntry {
 /** Handles `git warp history`: lists a writer's patch chain. */
 export default async function handleHistory({ options, args }: { options: CliOptions; args: string[] }): Promise<{ payload: HistoryPayload; exitCode: number }> {
   const { values } = parseCommandArgs(args, HISTORY_OPTIONS, historySchema);
-  const { graph, graphName, persistence } = await openGraph(options);
-  const cursorInfo = await applyCursorCeiling(graph, persistence, graphName);
+  const { graph, graphName, cursorStore } = await openGraph(options);
+  const cursorInfo = await applyCursorCeiling(graph, cursorStore);
   emitCursorWarning(cursorInfo, null);
 
   const node = values.node ?? null;

--- a/bin/cli/commands/info.ts
+++ b/bin/cli/commands/info.ts
@@ -9,7 +9,13 @@ import {
   parseWriterIdFromRef,
 } from '../../../src/domain/utils/RefLayout.ts';
 import { notFoundError } from '../infrastructure.ts';
-import { createPersistence, listGraphNames, readActiveCursor, readCheckpointDate } from '../shared.ts';
+import {
+  createPersistence,
+  createSeekCursorStore,
+  listGraphNames,
+  readActiveCursor,
+  readCheckpointDate,
+} from '../shared.ts';
 import type { CliOptions, Persistence, GraphInfoResult } from '../types.ts';
 
 /** Collects metadata about a single graph (writer count, refs, patches, checkpoint). */
@@ -106,7 +112,8 @@ export default async function handleInfo({ options }: { options: CliOptions }): 
       includeWriterPatches: isViewMode,
       includeCheckpointDate: isViewMode,
     });
-    const activeCursor = await readActiveCursor(persistence, name);
+    const cursorStore = createSeekCursorStore(runtimeStorage, name);
+    const activeCursor = await readActiveCursor(cursorStore);
     if (activeCursor) {
       info.cursor = {
         active: true,

--- a/bin/cli/commands/materialize.ts
+++ b/bin/cli/commands/materialize.ts
@@ -3,7 +3,13 @@ import type { CorePersistence } from '../../../src/domain/types/WarpPersistence.
 import { openRuntimeHostProduct } from '../../../src/domain/warp/RuntimeHostProduct.ts';
 import type RuntimeStorageProviderPort from '../../../src/ports/RuntimeStorageProviderPort.ts';
 import { EXIT_CODES, notFoundError } from '../infrastructure.ts';
-import { createPersistence, listGraphNames, readActiveCursor, emitCursorWarning } from '../shared.ts';
+import {
+  createPersistence,
+  createSeekCursorStore,
+  listGraphNames,
+  readActiveCursor,
+  emitCursorWarning,
+} from '../shared.ts';
 import type { CliOptions, Persistence } from '../types.ts';
 
 /** Materializes a single graph, creates a checkpoint, and returns summary stats. */
@@ -67,7 +73,8 @@ export default async function handleMaterialize({ options }: { options: CliOptio
   let cursorWarningEmitted = false;
   for (const name of targets) {
     try {
-      const cursor = await readActiveCursor(persistence, name);
+      const cursorStore = createSeekCursorStore(runtimeStorage, name);
+      const cursor = await readActiveCursor(cursorStore);
       const ceiling = cursor ? cursor.tick : undefined;
       if (cursor && !cursorWarningEmitted) {
         emitCursorWarning({ active: true, tick: cursor.tick, maxTick: null }, null);

--- a/bin/cli/commands/path.ts
+++ b/bin/cli/commands/path.ts
@@ -68,8 +68,8 @@ export default async function handlePath({ options, args }: { options: CliOption
   const { values, positionals } = parseCommandArgs(args, PATH_OPTIONS, pathSchema, { allowPositionals: true });
   const from = endpointFrom(values, positionals);
   const to = endpointTo(values, positionals);
-  const { graph, graphName, persistence } = await openGraph(options);
-  const cursorInfo = await applyCursorCeiling(graph, persistence, graphName);
+  const { graph, graphName, cursorStore } = await openGraph(options);
+  const cursorInfo = await applyCursorCeiling(graph, cursorStore);
   emitCursorWarning(cursorInfo, null);
   await graph.materialize();
 

--- a/bin/cli/commands/query.ts
+++ b/bin/cli/commands/query.ts
@@ -157,8 +157,8 @@ function buildQueryBuilder(base: QueryBuilder, values: QueryValues, args: readon
 /** Handles `git warp query`: runs the public query builder from the CLI. */
 export default async function handleQuery({ options, args }: { options: CliOptions; args: string[] }): Promise<QueryCommandResult> {
   const { values } = parseCommandArgs(args, QUERY_OPTIONS, querySchema);
-  const { graph, graphName, persistence } = await openGraph(options);
-  const cursorInfo = await applyCursorCeiling(graph, persistence, graphName);
+  const { graph, graphName, cursorStore } = await openGraph(options);
+  const cursorInfo = await applyCursorCeiling(graph, cursorStore);
   emitCursorWarning(cursorInfo, null);
   await graph.materialize();
 

--- a/bin/cli/commands/reindex.ts
+++ b/bin/cli/commands/reindex.ts
@@ -10,8 +10,8 @@ import type { CliOptions } from '../types.ts';
 export default async function handleReindex({ options, args }: { options: CliOptions; args: string[] }): Promise<{ payload: unknown; exitCode: number }> {
   parseCommandArgs(args, {}, reindexSchema);
 
-  const { graph, graphName, persistence } = await openGraph(options);
-  const cursorInfo = await applyCursorCeiling(graph, persistence, graphName);
+  const { graph, graphName, cursorStore } = await openGraph(options);
+  const cursorInfo = await applyCursorCeiling(graph, cursorStore);
   emitCursorWarning(cursorInfo, null);
 
   // Clear cached index to force full rebuild

--- a/bin/cli/commands/seek.ts
+++ b/bin/cli/commands/seek.ts
@@ -16,7 +16,8 @@ import { EXIT_CODES, usageError, notFoundError, parseCommandArgs } from '../infr
 import { seekSchema } from '../schemas.ts';
 import { openGraph, readActiveCursor, writeActiveCursor } from '../shared.ts';
 import type { WarpState } from '../../../src/domain/services/JoinReducer.ts';
-import type { CliOptions, Persistence, WarpGraphInstance, WriterTickInfo, CursorBlob, SeekSpec } from '../types.ts';
+import type SeekCursorStorePort from '../../../src/ports/SeekCursorStorePort.ts';
+import type { CliOptions, WarpGraphInstance, WriterTickInfo, CursorBlob, SeekSpec } from '../types.ts';
 
 // ============================================================================
 // Seek Arg Parser
@@ -177,10 +178,10 @@ function applyDiffLimit(diff: StateDiffResult, diffBaseline: string, baselineTic
 // ============================================================================
 
 /** Handles the bare `seek` (no action flags) by returning current cursor status. */
-async function handleSeekStatus({ graph, graphName, persistence, activeCursor, ticks, maxTick, perWriter, frontierHash }: {
+async function handleSeekStatus({ graph, graphName, cursorStore, activeCursor, ticks, maxTick, perWriter, frontierHash }: {
   graph: WarpGraphInstance;
   graphName: string;
-  persistence: Persistence;
+  cursorStore: SeekCursorStorePort;
   activeCursor: CursorBlob | null;
   ticks: number[];
   maxTick: number;
@@ -194,7 +195,7 @@ async function handleSeekStatus({ graph, graphName, persistence, activeCursor, t
     const prevCounts = readSeekCounts(activeCursor);
     const prevFrontierHash = typeof activeCursor.frontierHash === 'string' ? activeCursor.frontierHash : null;
     if (prevCounts.nodes === null || prevCounts.edges === null || prevCounts.nodes !== nodes.length || prevCounts.edges !== edges.length || prevFrontierHash !== frontierHash) {
-      await writeActiveCursor(persistence, graphName, { tick: activeCursor.tick, mode: activeCursor.mode ?? 'lamport', nodes: nodes.length, edges: edges.length, frontierHash });
+      await writeActiveCursor(cursorStore, { tick: activeCursor.tick, mode: activeCursor.mode ?? 'lamport', nodes: nodes.length, edges: edges.length, frontierHash });
     }
     const diff = computeSeekStateDiff(activeCursor, { nodes: nodes.length, edges: edges.length }, frontierHash);
     const tickReceipt = await buildTickReceipt({ tick: activeCursor.tick, perWriter, graph });
@@ -246,13 +247,13 @@ async function handleSeekStatus({ graph, graphName, persistence, activeCursor, t
 /** Handles the `git warp seek` command across all sub-actions. */
 export default async function handleSeek({ options, args }: { options: CliOptions; args: string[] }): Promise<{ payload: unknown; exitCode: number }> {
   const seekSpec = parseSeekArgs(args);
-  const { graph, graphName, persistence } = await openGraph(options);
+  const { graph, graphName, cursorStore } = await openGraph(options);
 
-  const activeCursor = await readActiveCursor(persistence, graphName);
+  const activeCursor = await readActiveCursor(cursorStore);
   const { ticks, maxTick, perWriter } = await graph.discoverTicks();
   const frontierHash = await computeFrontierHash(perWriter);
   if (seekSpec.action === 'list') {
-    const saved = await listSavedCursors(persistence, graphName);
+    const saved = await listSavedCursors(cursorStore);
     return {
       payload: {
         graph: graphName,
@@ -266,11 +267,11 @@ export default async function handleSeek({ options, args }: { options: CliOption
   }
   if (seekSpec.action === 'drop') {
     const dropName = seekSpec.name as string;
-    const existing = await readSavedCursor(persistence, graphName, dropName);
+    const existing = await readSavedCursor(cursorStore, dropName);
     if (!existing) {
       throw notFoundError(`Saved cursor not found: ${dropName}`);
     }
-    await deleteSavedCursor(persistence, graphName, dropName);
+    await deleteSavedCursor(cursorStore, dropName);
     return {
       payload: {
         graph: graphName,
@@ -287,7 +288,7 @@ export default async function handleSeek({ options, args }: { options: CliOption
     if (seekSpec.diff) {
       sdResult = await computeStructuralDiff({ graph, prevTick, currentTick: maxTick, diffLimit: seekSpec.diffLimit });
     }
-    await clearActiveCursor(persistence, graphName);
+    await clearActiveCursor(cursorStore);
     // When --diff already materialized at maxTick, skip redundant re-materialize
     if (!sdResult) {
       await graph.materialize({ ceiling: maxTick });
@@ -319,7 +320,7 @@ export default async function handleSeek({ options, args }: { options: CliOption
     if (!activeCursor) {
       throw usageError('No active cursor to save. Use --tick first.');
     }
-    await writeSavedCursor(persistence, graphName, seekSpec.name as string, activeCursor);
+    await writeSavedCursor(cursorStore, seekSpec.name as string, activeCursor);
     return {
       payload: {
         graph: graphName,
@@ -332,7 +333,7 @@ export default async function handleSeek({ options, args }: { options: CliOption
   }
   if (seekSpec.action === 'load') {
     const loadName = seekSpec.name as string;
-    const saved = await readSavedCursor(persistence, graphName, loadName);
+    const saved = await readSavedCursor(cursorStore, loadName);
     if (!saved) {
       throw notFoundError(`Saved cursor not found: ${loadName}`);
     }
@@ -347,7 +348,7 @@ export default async function handleSeek({ options, args }: { options: CliOption
     }
     const nodes = await graph.getNodes();
     const edges = await graph.getEdges();
-    await writeActiveCursor(persistence, graphName, { tick: saved.tick, mode: saved.mode ?? 'lamport', nodes: nodes.length, edges: edges.length, frontierHash });
+    await writeActiveCursor(cursorStore, { tick: saved.tick, mode: saved.mode ?? 'lamport', nodes: nodes.length, edges: edges.length, frontierHash });
     const diff = computeSeekStateDiff(activeCursor, { nodes: nodes.length, edges: edges.length }, frontierHash);
     const tickReceipt = await buildTickReceipt({ tick: saved.tick, perWriter, graph });
     return {
@@ -383,7 +384,7 @@ export default async function handleSeek({ options, args }: { options: CliOption
     }
     const nodes = await graph.getNodes();
     const edges = await graph.getEdges();
-    await writeActiveCursor(persistence, graphName, { tick: resolvedTick, mode: 'lamport', nodes: nodes.length, edges: edges.length, frontierHash });
+    await writeActiveCursor(cursorStore, { tick: resolvedTick, mode: 'lamport', nodes: nodes.length, edges: edges.length, frontierHash });
     const diff = computeSeekStateDiff(activeCursor, { nodes: nodes.length, edges: edges.length }, frontierHash);
     const tickReceipt = await buildTickReceipt({ tick: resolvedTick, perWriter, graph });
     return {
@@ -407,5 +408,5 @@ export default async function handleSeek({ options, args }: { options: CliOption
   }
 
   // status (bare seek)
-  return await handleSeekStatus({ graph, graphName, persistence, activeCursor, ticks, maxTick, perWriter, frontierHash });
+  return await handleSeekStatus({ graph, graphName, cursorStore, activeCursor, ticks, maxTick, perWriter, frontierHash });
 }

--- a/bin/cli/commands/seek.ts
+++ b/bin/cli/commands/seek.ts
@@ -16,7 +16,6 @@ import { EXIT_CODES, usageError, notFoundError, parseCommandArgs } from '../infr
 import { seekSchema } from '../schemas.ts';
 import { openGraph, readActiveCursor, writeActiveCursor } from '../shared.ts';
 import type { WarpState } from '../../../src/domain/services/JoinReducer.ts';
-import type SeekCursorStorePort from '../../../src/ports/SeekCursorStorePort.ts';
 import type { CliOptions, WarpGraphInstance, WriterTickInfo, CursorBlob, SeekSpec } from '../types.ts';
 
 // ============================================================================
@@ -178,10 +177,9 @@ function applyDiffLimit(diff: StateDiffResult, diffBaseline: string, baselineTic
 // ============================================================================
 
 /** Handles the bare `seek` (no action flags) by returning current cursor status. */
-async function handleSeekStatus({ graph, graphName, cursorStore, activeCursor, ticks, maxTick, perWriter, frontierHash }: {
+async function handleSeekStatus({ graph, graphName, activeCursor, ticks, maxTick, perWriter, frontierHash }: {
   graph: WarpGraphInstance;
   graphName: string;
-  cursorStore: SeekCursorStorePort;
   activeCursor: CursorBlob | null;
   ticks: number[];
   maxTick: number;
@@ -192,11 +190,6 @@ async function handleSeekStatus({ graph, graphName, cursorStore, activeCursor, t
     await graph.materialize({ ceiling: activeCursor.tick });
     const nodes = await graph.getNodes();
     const edges = await graph.getEdges();
-    const prevCounts = readSeekCounts(activeCursor);
-    const prevFrontierHash = typeof activeCursor.frontierHash === 'string' ? activeCursor.frontierHash : null;
-    if (prevCounts.nodes === null || prevCounts.edges === null || prevCounts.nodes !== nodes.length || prevCounts.edges !== edges.length || prevFrontierHash !== frontierHash) {
-      await writeActiveCursor(cursorStore, { tick: activeCursor.tick, mode: activeCursor.mode ?? 'lamport', nodes: nodes.length, edges: edges.length, frontierHash });
-    }
     const diff = computeSeekStateDiff(activeCursor, { nodes: nodes.length, edges: edges.length }, frontierHash);
     const tickReceipt = await buildTickReceipt({ tick: activeCursor.tick, perWriter, graph });
     return {
@@ -408,5 +401,5 @@ export default async function handleSeek({ options, args }: { options: CliOption
   }
 
   // status (bare seek)
-  return await handleSeekStatus({ graph, graphName, cursorStore, activeCursor, ticks, maxTick, perWriter, frontierHash });
+  return await handleSeekStatus({ graph, graphName, activeCursor, ticks, maxTick, perWriter, frontierHash });
 }

--- a/bin/cli/commands/seekCursorHelpers.ts
+++ b/bin/cli/commands/seekCursorHelpers.ts
@@ -1,68 +1,31 @@
 /**
- * Cursor I/O helpers for the seek command.
+ * Durable cursor I/O helpers for the seek command.
  * Extracted from seek.ts to keep file size under 500 LOC.
  */
-import { textEncode } from '../../../src/domain/utils/bytes.ts';
-import {
-  buildCursorActiveRef,
-  buildCursorSavedRef,
-  buildCursorSavedPrefix,
-} from '../../../src/domain/utils/RefLayout.ts';
-import { parseCursorBlob } from '../../../src/domain/utils/parseCursorBlob.ts';
-import type { Persistence, CursorBlob } from '../types.ts';
+import type SeekCursorStorePort from '../../../src/ports/SeekCursorStorePort.ts';
+import type { CursorBlob } from '../types.ts';
 
 /** Removes the active seek cursor for a graph, returning to present state. */
-export async function clearActiveCursor(persistence: Persistence, graphName: string): Promise<void> {
-  const ref = buildCursorActiveRef(graphName);
-  const exists = await persistence.readRef(ref);
-  if (typeof exists === 'string' && exists.length > 0) {
-    await persistence.deleteRef(ref);
-  }
+export async function clearActiveCursor(cursorStore: SeekCursorStorePort): Promise<void> {
+  await cursorStore.clearActive();
 }
 
-/** Reads a named saved cursor from Git ref storage. */
-export async function readSavedCursor(persistence: Persistence, graphName: string, name: string): Promise<CursorBlob | null> {
-  const ref = buildCursorSavedRef(graphName, name);
-  const oid = await persistence.readRef(ref);
-  if (typeof oid !== 'string' || oid.length === 0) {
-    return null;
-  }
-  const buf = await persistence.readBlob(oid);
-  return parseCursorBlob(buf, `saved cursor '${name}'`);
+/** Reads a named saved cursor from git-cas retention. */
+export async function readSavedCursor(cursorStore: SeekCursorStorePort, name: string): Promise<CursorBlob | null> {
+  return await cursorStore.readSaved(name);
 }
 
-/** Persists a cursor under a named saved-cursor ref. */
-export async function writeSavedCursor(persistence: Persistence, graphName: string, name: string, cursor: CursorBlob): Promise<void> {
-  const ref = buildCursorSavedRef(graphName, name);
-  const json = JSON.stringify(cursor);
-  const oid = await persistence.writeBlob(textEncode(json));
-  await persistence.updateRef(ref, oid);
+/** Persists a cursor as a durable named bookmark. */
+export async function writeSavedCursor(cursorStore: SeekCursorStorePort, name: string, cursor: CursorBlob): Promise<void> {
+  await cursorStore.writeSaved(name, cursor);
 }
 
-/** Deletes a named saved cursor from Git ref storage. */
-export async function deleteSavedCursor(persistence: Persistence, graphName: string, name: string): Promise<void> {
-  const ref = buildCursorSavedRef(graphName, name);
-  const exists = await persistence.readRef(ref);
-  if (typeof exists === 'string' && exists.length > 0) {
-    await persistence.deleteRef(ref);
-  }
+/** Deletes a durable named cursor bookmark. */
+export async function deleteSavedCursor(cursorStore: SeekCursorStorePort, name: string): Promise<void> {
+  await cursorStore.deleteSaved(name);
 }
 
 /** Lists all saved cursors for a graph. */
-export async function listSavedCursors(persistence: Persistence, graphName: string): Promise<Array<{ name: string; tick: number; mode?: string }>> {
-  const prefix = buildCursorSavedPrefix(graphName);
-  const refs = await persistence.listRefs(prefix);
-  const cursors: Array<{ tick: number; mode?: string; name: string }> = [];
-  for (const ref of refs) {
-    const name = ref.slice(prefix.length);
-    if (typeof name === 'string' && name.length > 0) {
-      const oid = await persistence.readRef(ref);
-      if (typeof oid === 'string' && oid.length > 0) {
-        const buf = await persistence.readBlob(oid);
-        const cursor = parseCursorBlob(buf, `saved cursor '${name}'`);
-        cursors.push({ name, ...cursor });
-      }
-    }
-  }
-  return cursors;
+export async function listSavedCursors(cursorStore: SeekCursorStorePort): Promise<ReadonlyArray<{ name: string; tick: number; mode?: string }>> {
+  return await cursorStore.listSaved();
 }

--- a/bin/cli/commands/tree.ts
+++ b/bin/cli/commands/tree.ts
@@ -192,8 +192,8 @@ export default async function handleTree({ options, args }: { options: CliOption
   const { values, positionals } = parseCommandArgs(
     args, TREE_OPTIONS, treeSchema, { allowPositionals: true },
   );
-  const { graph, graphName, persistence } = await openGraph(options);
-  const cursorInfo = await applyCursorCeiling(graph, persistence, graphName);
+  const { graph, graphName, cursorStore } = await openGraph(options);
+  const cursorInfo = await applyCursorCeiling(graph, cursorStore);
   emitCursorWarning(cursorInfo, null);
 
   const queryResult = await graph.query().run();

--- a/bin/cli/commands/verify-index.ts
+++ b/bin/cli/commands/verify-index.ts
@@ -18,8 +18,8 @@ export default async function handleVerifyIndex({ options, args }: { options: Cl
     VERIFY_INDEX_OPTIONS,
     verifyIndexSchema,
   );
-  const { graph, graphName, persistence } = await openGraph(options);
-  const cursorInfo = await applyCursorCeiling(graph, persistence, graphName);
+  const { graph, graphName, cursorStore } = await openGraph(options);
+  const cursorInfo = await applyCursorCeiling(graph, cursorStore);
   emitCursorWarning(cursorInfo, null);
 
   try {

--- a/bin/cli/shared.ts
+++ b/bin/cli/shared.ts
@@ -3,16 +3,11 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import readline from 'node:readline';
-import { textEncode } from '../../src/domain/utils/bytes.ts';
 import GitTimelineHistoryAdapter from '../../src/infrastructure/adapters/GitTimelineHistoryAdapter.ts';
 import WebCryptoAdapter from '../../src/infrastructure/adapters/WebCryptoAdapter.ts';
 import { openRuntimeHostProduct } from '../../src/domain/warp/RuntimeHostProduct.ts';
-import {
-  REF_PREFIX,
-  buildCursorActiveRef,
-} from '../../src/domain/utils/RefLayout.ts';
+import { REF_PREFIX } from '../../src/domain/utils/RefLayout.ts';
 import { HookInstaller, type FsAdapter } from '../../src/domain/services/HookInstaller.ts';
-import { parseCursorBlob } from '../../src/domain/utils/parseCursorBlob.ts';
 import { usageError, notFoundError } from './infrastructure.ts';
 import { GitStorage } from '../../storage.ts';
 import { resolveWarpStorage } from '../../src/application/WarpStorageRegistry.ts';
@@ -20,6 +15,7 @@ import type RuntimeStorageProviderPort from '../../src/ports/RuntimeStorageProvi
 import type TrustChainPort from '../../src/ports/TrustChainPort.ts';
 import type CryptoPort from '../../src/ports/CryptoPort.ts';
 import type HookPathPort from '../../src/ports/HookPathPort.ts';
+import type SeekCursorStorePort from '../../src/ports/SeekCursorStorePort.ts';
 
 import type { Persistence, WarpGraphInstance, CursorBlob, CliOptions } from './types.ts';
 
@@ -122,7 +118,7 @@ export async function resolveGraphName(persistence: Persistence, explicitGraph: 
 /**
  * Opens a WarpCore for the given CLI options.
  */
-export async function openGraph(options: CliOptions): Promise<{ graph: WarpGraphInstance; graphName: string; persistence: Persistence; runtimeStorage: RuntimeStorageProviderPort; hookPaths: HookPathPort }> {
+export async function openGraph(options: CliOptions): Promise<{ graph: WarpGraphInstance; graphName: string; persistence: Persistence; runtimeStorage: RuntimeStorageProviderPort; cursorStore: SeekCursorStorePort; hookPaths: HookPathPort }> {
   const { persistence, runtimeStorage, hookPaths } = await createPersistence(options.repo);
   const graphName = await resolveGraphName(persistence, options.graph);
   if (typeof options.graph === 'string' && options.graph.length > 0) {
@@ -138,15 +134,27 @@ export async function openGraph(options: CliOptions): Promise<{ graph: WarpGraph
     writerId: options.writer,
     crypto: new WebCryptoAdapter(),
   });
-  return { graph, graphName, persistence, runtimeStorage, hookPaths };
+  const cursorStore = createSeekCursorStore(runtimeStorage, graphName);
+  return { graph, graphName, persistence, runtimeStorage, cursorStore, hookPaths };
+}
+
+/** Opens the graph-scoped durable cursor store required by v19 CLI commands. */
+export function createSeekCursorStore(
+  runtimeStorage: RuntimeStorageProviderPort,
+  graphName: string,
+): SeekCursorStorePort {
+  if (runtimeStorage.createSeekCursorStore === undefined) {
+    throw usageError('Runtime storage does not provide durable seek cursor retention');
+  }
+  return runtimeStorage.createSeekCursorStore(graphName);
 }
 
 /**
  * Reads the active cursor and sets `_seekCeiling` on the graph instance
  * so that subsequent materialize calls respect the time-travel boundary.
  */
-export async function applyCursorCeiling(graph: WarpGraphInstance, persistence: Persistence, graphName: string): Promise<{ active: boolean; tick: number | null; maxTick: number | null }> {
-  const cursor = await readActiveCursor(persistence, graphName);
+export async function applyCursorCeiling(graph: WarpGraphInstance, cursorStore: SeekCursorStorePort): Promise<{ active: boolean; tick: number | null; maxTick: number | null }> {
+  const cursor = await readActiveCursor(cursorStore);
   if (cursor) {
     graph._seekCeiling = cursor.tick;
     return { active: true, tick: cursor.tick, maxTick: null };
@@ -166,26 +174,17 @@ export function emitCursorWarning(cursorInfo: { active: boolean; tick: number | 
 }
 
 /**
- * Reads the active seek cursor for a graph from Git ref storage.
+ * Reads the active seek cursor from git-cas retention.
  */
-export async function readActiveCursor(persistence: Persistence, graphName: string): Promise<CursorBlob | null> {
-  const ref = buildCursorActiveRef(graphName);
-  const oid = await persistence.readRef(ref);
-  if (typeof oid !== 'string' || oid.length === 0) {
-    return null;
-  }
-  const buf = await persistence.readBlob(oid);
-  return parseCursorBlob(buf, 'active cursor');
+export async function readActiveCursor(cursorStore: SeekCursorStorePort): Promise<CursorBlob | null> {
+  return await cursorStore.readActive();
 }
 
 /**
- * Writes (creates or overwrites) the active seek cursor for a graph.
+ * Writes (creates or replaces) the active seek cursor in git-cas retention.
  */
-export async function writeActiveCursor(persistence: Persistence, graphName: string, cursor: CursorBlob): Promise<void> {
-  const ref = buildCursorActiveRef(graphName);
-  const json = JSON.stringify(cursor);
-  const oid = await persistence.writeBlob(textEncode(json));
-  await persistence.updateRef(ref, oid);
+export async function writeActiveCursor(cursorStore: SeekCursorStorePort, cursor: CursorBlob): Promise<void> {
+  await cursorStore.writeActive(cursor);
 }
 
 /**

--- a/bin/cli/types.ts
+++ b/bin/cli/types.ts
@@ -1,5 +1,6 @@
 import type GitTimelineHistoryAdapter from '../../src/infrastructure/adapters/GitTimelineHistoryAdapter.ts';
 import type { RuntimeHostProduct } from '../../src/domain/warp/RuntimeHostProduct.ts';
+import type { SeekCursorState } from '../../src/ports/SeekCursorStorePort.ts';
 
 export type Persistence = GitTimelineHistoryAdapter;
 export type WarpGraphInstance = RuntimeHostProduct;
@@ -10,13 +11,7 @@ export type WriterTickInfo = {
   tickShas?: Record<number, string>;
 };
 
-export type CursorBlob = {
-  tick: number;
-  mode?: string;
-  nodes?: number;
-  edges?: number;
-  frontierHash?: string;
-};
+export type CursorBlob = SeekCursorState;
 
 export type CliOptions = {
   repo: string;

--- a/docs/TECHNICAL_TEARDOWN.md
+++ b/docs/TECHNICAL_TEARDOWN.md
@@ -430,13 +430,15 @@ The source of truth is Git history under WARP refs.
 flowchart TB
     repo[".git directory"] --> branchRefs["refs/heads/*"]
     repo --> warpRefs["refs/warp/<graph>/*"]
+    repo --> casRefs["refs/cas/*"]
 
     branchRefs --> codeCommits["normal source-tree commits"]
 
     warpRefs --> writerRefs["writers/<writerId>"]
     warpRefs --> checkpointRef["checkpoint"]
     warpRefs --> stateCacheRef["state-cache"]
-    warpRefs --> cursorRef["seek cursor refs"]
+    casRefs --> cursorCacheRef["caches/git-warp.seek-cursors"]
+    cursorCacheRef --> cursorPage["immutable active and saved cursor pages"]
 
     writerRefs --> p1["patch commit 1"]
     p1 --> p2["patch commit 2"]
@@ -464,12 +466,20 @@ flowchart TB
 | Adjacency/index provider | `RuntimeHost._materializedGraph`, bitmap index tree | Derived acceleration |
 | Checkpoint | Git checkpoint commit/tree or pinned state-cache snapshot | Derived but durable folded basis |
 | State cache | CAS-backed snapshot records under state-cache refs | Derived acceleration |
-| Seek cursor | Git blob/ref storing CLI cursor position | Operator state, not graph truth |
+| Seek cursor | Immutable git-cas page retained by `git-warp.seek-cursors` | Operator state, not graph truth |
 | Query result | Object returned to API/CLI | Derived reading over a coordinate |
 | Sync request/response | JSON payload crossing HTTP or in-process peer boundary | Transport DTO |
 
 The architecture repeatedly enforces this distinction. Type annotations,
 indexes, caches, and docs do not decide truth. Runtime history does.
+
+In v19, the active seek position is pinned for 30 days and refreshed only by
+an explicit cursor write. Named cursors remain pinned bookmarks until
+`seek --drop`. Cache reads do not extend either lifetime, and opportunistic
+sweeps make expired active pages collectible. The retired
+`refs/warp/<graph>/cursor/*` layout is neither read nor migrated: those refs
+were operator-only state, never authoritative graph history, and become inert
+after upgrading to the v19 major.
 
 ## Golden Path 1: CLI Query
 

--- a/src/domain/errors/PersistenceError.ts
+++ b/src/domain/errors/PersistenceError.ts
@@ -18,6 +18,8 @@ interface PersistenceErrorOptions {
  * | `E_MISSING_OBJECT` | Stored object (commit, blob, tree) does not exist |
  * | `E_REF_NOT_FOUND` | Ref does not resolve to any object |
  * | `E_REF_IO` | Ref update/delete failed (lock contention, permission, etc.) |
+ * | `E_CURSOR_RETENTION` | git-cas declined durable cursor retention |
+ * | `E_CURSOR_CORRUPT` | Retained cursor metadata is malformed |
  */
 export default class PersistenceError extends WarpError {
   /** Stored object (commit, blob, tree) does not exist. */
@@ -28,6 +30,12 @@ export default class PersistenceError extends WarpError {
 
   /** Ref update/delete failed (lock contention, permission, etc.). */
   static E_REF_IO = 'E_REF_IO';
+
+  /** git-cas declined durable cursor retention. */
+  static E_CURSOR_RETENTION = 'E_CURSOR_RETENTION';
+
+  /** Retained cursor metadata is malformed. */
+  static E_CURSOR_CORRUPT = 'E_CURSOR_CORRUPT';
 
   declare cause: Error | undefined;
 

--- a/src/domain/utils/RefLayout.ts
+++ b/src/domain/utils/RefLayout.ts
@@ -10,8 +10,6 @@ import WarpError from '../errors/WarpError.ts';
  * - refs/warp/<graph>/writers/<writer_id>
  * - refs/warp/<graph>/checkpoints/head
  * - refs/warp/<graph>/coverage/head
- * - refs/warp/<graph>/cursor/active
- * - refs/warp/<graph>/cursor/saved/<name>
  * - refs/warp/<graph>/strands/<id>
  * - refs/warp/<graph>/strand-overlays/<id>
  * - refs/warp/<graph>/strand-braids/<id>/<support_id>
@@ -241,56 +239,6 @@ export function buildCoverageRef(graphName: string): string {
 export function buildWritersPrefix(graphName: string): string {
   validateGraphName(graphName);
   return `${REF_PREFIX}/${graphName}/writers/`;
-}
-
-/**
- * Builds the active cursor ref path for the given graph.
- *
- * The active cursor is a single ref that stores the current time-travel
- * position used by `git warp seek`. It points to a commit SHA representing
- * the materialization frontier the user has seeked to.
- *
- * @example
- * buildCursorActiveRef('events');
- * // => 'refs/warp/events/cursor/active'
- */
-export function buildCursorActiveRef(graphName: string): string {
-  validateGraphName(graphName);
-  return `${REF_PREFIX}/${graphName}/cursor/active`;
-}
-
-/**
- * Builds a saved (named) cursor ref path for the given graph and cursor name.
- *
- * Saved cursors are bookmarks created by `git warp seek --save <name>`.
- * Each saved cursor persists a time-travel position that can be restored
- * later without re-seeking.
- *
- * The cursor name is validated with the same rules as a writer ID
- * (ASCII ref-safe: `[A-Za-z0-9._-]`, 1-64 characters).
- *
- * @example
- * buildCursorSavedRef('events', 'before-tui');
- * // => 'refs/warp/events/cursor/saved/before-tui'
- */
-export function buildCursorSavedRef(graphName: string, name: string): string {
-  validateGraphName(graphName);
-  validateWriterId(name);
-  return `${REF_PREFIX}/${graphName}/cursor/saved/${name}`;
-}
-
-/**
- * Builds the saved cursor prefix path for the given graph.
- * Useful for listing all saved cursor bookmarks under a graph
- * (e.g. via `git for-each-ref`).
- *
- * @example
- * buildCursorSavedPrefix('events');
- * // => 'refs/warp/events/cursor/saved/'
- */
-export function buildCursorSavedPrefix(graphName: string): string {
-  validateGraphName(graphName);
-  return `${REF_PREFIX}/${graphName}/cursor/saved/`;
 }
 
 /**

--- a/src/domain/utils/parseCursorBlob.ts
+++ b/src/domain/utils/parseCursorBlob.ts
@@ -1,5 +1,5 @@
 /**
- * Utilities for parsing seek-cursor blobs stored as Git refs.
+ * Utilities for parsing immutable seek-cursor pages retained by git-cas.
  *
  * @module parseCursorBlob
  */

--- a/src/domain/utils/validateSavedCursorName.ts
+++ b/src/domain/utils/validateSavedCursorName.ts
@@ -1,0 +1,51 @@
+import WarpError from '../errors/WarpError.ts';
+
+const MAX_SAVED_CURSOR_NAME_LENGTH = 64;
+const SAVED_CURSOR_NAME_PATTERN = /^[A-Za-z0-9._-]+$/u;
+const PATH_TRAVERSAL_PATTERN = /\.\./u;
+const ERROR_CODE = 'E_INVALID_CURSOR_NAME';
+const ERROR_PREFIX = 'Invalid saved cursor name';
+
+/** Validates one durable seek-cursor bookmark name. */
+export function validateSavedCursorName(name: string): void {
+  if (typeof name !== 'string') {
+    throw invalidName(`expected string, got ${typeof name}`);
+  }
+  if (name.length === 0) {
+    throw invalidName('cannot be empty');
+  }
+  if (name.length > MAX_SAVED_CURSOR_NAME_LENGTH) {
+    throw invalidName(
+      `exceeds maximum length of ${MAX_SAVED_CURSOR_NAME_LENGTH} characters: ${name.length}`,
+    );
+  }
+  rejectSavedCursorPathChars(name);
+  rejectSavedCursorControlChars(name);
+}
+
+function rejectSavedCursorPathChars(name: string): void {
+  if (PATH_TRAVERSAL_PATTERN.test(name)) {
+    throw invalidName(`contains path traversal sequence '..': ${name}`);
+  }
+  if (name.includes('/')) {
+    throw invalidName(`contains forward slash: ${name}`);
+  }
+}
+
+function rejectSavedCursorControlChars(name: string): void {
+  if (name.includes('\0')) {
+    throw invalidName(`contains null byte: ${name}`);
+  }
+  if (/\s/u.test(name)) {
+    throw invalidName(`contains whitespace: ${name}`);
+  }
+  if (!SAVED_CURSOR_NAME_PATTERN.test(name)) {
+    throw invalidName(
+      `contains invalid characters (only [A-Za-z0-9._-] allowed): ${name}`,
+    );
+  }
+}
+
+function invalidName(detail: string): WarpError {
+  return new WarpError(`${ERROR_PREFIX}: ${detail}`, ERROR_CODE);
+}

--- a/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
+++ b/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
@@ -2,6 +2,7 @@ import ContentAddressableStore, {
   CborCodec,
   type AssetCapability,
   type BundleCapability,
+  type CacheCapability,
   type ExpiringSetCapability,
   type PublicationCapability,
 } from '@git-stunts/git-cas';
@@ -33,6 +34,8 @@ import LoggerObservabilityBridge from './LoggerObservabilityBridge.ts';
 import type GitTimelineHistoryAdapter from './GitTimelineHistoryAdapter.ts';
 import AdapterValidationError from '../../domain/errors/AdapterValidationError.ts';
 import GitCasSyncReplayProtectionAdapter from './GitCasSyncReplayProtectionAdapter.ts';
+import GitCasSeekCursorStoreAdapter from './GitCasSeekCursorStoreAdapter.ts';
+import type SeekCursorStorePort from '../../ports/SeekCursorStorePort.ts';
 
 type GitCasPolicy = {
   execute<T>(operation: () => Promise<T>): Promise<T>;
@@ -79,6 +82,7 @@ export default class GitCasRepositoryAdapter implements RuntimeStorageProviderPo
   private readonly _cbor: InstanceType<typeof CborCodec>;
   private readonly _contentEncryption: CasContentEncryptionPolicy | undefined;
   private readonly _materializations = new Set<GitCasMaterializationStoreAdapter>();
+  private readonly _seekCursors = new Map<string, SeekCursorStorePort>();
   private _closePromise: Promise<void> | null = null;
   private _closed = false;
 
@@ -128,6 +132,23 @@ export default class GitCasRepositoryAdapter implements RuntimeStorageProviderPo
         trie: new GitCasTrieStoreAdapter({ cas: this._cas }),
       })
     );
+  }
+
+  createSeekCursorStore(timelineName: string): SeekCursorStorePort {
+    this._assertOpen();
+    const existing = this._seekCursors.get(timelineName);
+    if (existing !== undefined) {
+      return existing;
+    }
+    const created = new GitCasSeekCursorStoreAdapter({
+      cas: {
+        caches: this._cas.caches as Pick<CacheCapability, 'open'>,
+        pages: this._cas.pages,
+      },
+      graphName: timelineName,
+    });
+    this._seekCursors.set(timelineName, created);
+    return created;
   }
 
   private _createAuditLog(content: AssetStoragePort): GitCasAuditLogAdapter {

--- a/src/infrastructure/adapters/GitCasSeekCursorStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasSeekCursorStoreAdapter.ts
@@ -1,0 +1,292 @@
+import type {
+  CacheCapability,
+  CacheSet,
+  PageCapability,
+} from '@git-stunts/git-cas';
+import PersistenceError from '../../domain/errors/PersistenceError.ts';
+import { textEncode } from '../../domain/utils/bytes.ts';
+import { validateGraphName, validateWriterId } from '../../domain/utils/RefLayout.ts';
+import { parseCursorBlob } from '../../domain/utils/parseCursorBlob.ts';
+import type SeekCursorStorePort from '../../ports/SeekCursorStorePort.ts';
+import type {
+  NamedSeekCursorState,
+  SeekCursorState,
+  SeekCursorSweepResult,
+} from '../../ports/SeekCursorStorePort.ts';
+
+type SeekCursorCache = Pick<
+  CacheSet,
+  'get' | 'put' | 'remove' | 'sweep' | 'inspect'
+>;
+
+export type GitCasSeekCursorFacade = {
+  readonly caches: {
+    open(
+      options: Parameters<CacheCapability['open']>[0],
+    ): Promise<SeekCursorCache>;
+  };
+  readonly pages: Pick<PageCapability, 'put' | 'get'>;
+};
+
+const CURSOR_NAMESPACE = 'git-warp.seek-cursors';
+const ACTIVE_CURSOR_KEY = 'active';
+const SAVED_CURSOR_KEY = 'saved';
+const CACHE_INSPECTION_PAGE_SIZE = 100;
+const MAX_CURSOR_PAGE_BYTES = 16 * 1024;
+const CURSOR_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+export const ACTIVE_SEEK_CURSOR_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * git-cas page/cache-backed seek cursor storage.
+ *
+ * Cursor bytes are immutable pages. CacheSet owns reachability, atomic
+ * replacement, expiry, and collection eligibility.
+ */
+export default class GitCasSeekCursorStoreAdapter implements SeekCursorStorePort {
+  private readonly _cache: Promise<SeekCursorCache>;
+  private readonly _cas: GitCasSeekCursorFacade;
+  private readonly _graphName: string;
+  private readonly _wallClockMs: () => number;
+  private _nextSweepAtMs = 0;
+  private _sweepInFlight: Promise<SeekCursorSweepResult> | null = null;
+
+  constructor(options: {
+    readonly cas: GitCasSeekCursorFacade;
+    readonly graphName: string;
+    readonly wallClockMs?: () => number;
+  }) {
+    validateGraphName(options.graphName);
+    const cache = options.cas.caches.open({ namespace: CURSOR_NAMESPACE });
+    // Mark an eager open failure handled until a cursor operation awaits it.
+    cache.catch(() => {});
+    this._cache = cache;
+    this._cas = options.cas;
+    this._graphName = options.graphName;
+    this._wallClockMs = options.wallClockMs ?? Date.now;
+  }
+
+  async readActive(): Promise<SeekCursorState | null> {
+    return await this._read(activeCursorIdentity(this._graphName), 'active cursor');
+  }
+
+  async writeActive(cursor: SeekCursorState): Promise<void> {
+    const nowMs = this._wallClockMs();
+    await this._maintain(nowMs);
+    await this._write(
+      activeCursorIdentity(this._graphName),
+      cursor,
+      new Date(nowMs + ACTIVE_SEEK_CURSOR_TTL_MS).toISOString(),
+    );
+  }
+
+  async clearActive(): Promise<void> {
+    await this._remove(activeCursorIdentity(this._graphName));
+  }
+
+  async readSaved(name: string): Promise<SeekCursorState | null> {
+    validateWriterId(name);
+    return await this._read(
+      savedCursorIdentity(this._graphName, name),
+      `saved cursor '${name}'`,
+    );
+  }
+
+  async writeSaved(name: string, cursor: SeekCursorState): Promise<void> {
+    validateWriterId(name);
+    await this._maintain(this._wallClockMs());
+    await this._write(savedCursorIdentity(this._graphName, name), cursor, null);
+  }
+
+  async deleteSaved(name: string): Promise<void> {
+    validateWriterId(name);
+    await this._remove(savedCursorIdentity(this._graphName, name));
+  }
+
+  async listSaved(): Promise<ReadonlyArray<NamedSeekCursorState>> {
+    const nowMs = this._wallClockMs();
+    await this._maintain(nowMs);
+    const cache = await this._cache;
+    const cursors: NamedSeekCursorState[] = [];
+    let cursor: string | null = null;
+    do {
+      const inspection = await cache.inspect({
+        limit: CACHE_INSPECTION_PAGE_SIZE,
+        cursor,
+      });
+      for (const entry of inspection.entries) {
+        const name = savedCursorName(entry.key, this._graphName);
+        if (name !== null && !expired(entry.expiresAt, nowMs)) {
+          const state = await this._readPage(entry.handle, `saved cursor '${name}'`);
+          cursors.push(Object.freeze({ name, ...state }));
+        }
+      }
+      cursor = inspection.nextCursor;
+    } while (cursor !== null);
+    cursors.sort((left, right) => left.name.localeCompare(right.name));
+    return Object.freeze(cursors);
+  }
+
+  async sweep(): Promise<SeekCursorSweepResult> {
+    if (this._sweepInFlight === null) {
+      this._sweepInFlight = this._sweepRetainedPages()
+        .finally(() => {
+          this._sweepInFlight = null;
+        });
+    }
+    return await this._sweepInFlight;
+  }
+
+  private async _read(key: string, label: string): Promise<SeekCursorState | null> {
+    await this._maintain(this._wallClockMs());
+    const cache = await this._cache;
+    const hit = await cache.get(key);
+    if (hit === null) {
+      return null;
+    }
+    return await this._readPage(hit.handle.toString(), label);
+  }
+
+  private async _readPage(handle: string, label: string): Promise<SeekCursorState> {
+    const bytes = await this._cas.pages.get({
+      handle,
+      maxBytes: MAX_CURSOR_PAGE_BYTES,
+    });
+    return normalizeCursor(parseCursorBlob(bytes, label), label);
+  }
+
+  private async _write(
+    key: string,
+    cursor: SeekCursorState,
+    expiresAt: string | null,
+  ): Promise<void> {
+    const page = await this._cas.pages.put({
+      source: textEncode(JSON.stringify(cursor)),
+      maxBytes: MAX_CURSOR_PAGE_BYTES,
+    });
+    const cache = await this._cache;
+    const stored = await cache.put(key, page.handle, {
+      retention: 'pinned',
+      expiresAt,
+    });
+    if (!stored.accepted) {
+      throw new PersistenceError(
+        'git-cas rejected seek cursor retention',
+        'E_CURSOR_RETENTION',
+      );
+    }
+  }
+
+  private async _remove(key: string): Promise<void> {
+    await this._maintain(this._wallClockMs());
+    const cache = await this._cache;
+    await cache.remove(key);
+  }
+
+  private async _maintain(nowMs: number): Promise<void> {
+    if (nowMs >= this._nextSweepAtMs) {
+      await this.sweep();
+    }
+  }
+
+  private async _sweepRetainedPages(): Promise<SeekCursorSweepResult> {
+    const cache = await this._cache;
+    const result = await cache.sweep();
+    this._nextSweepAtMs = this._wallClockMs() + CURSOR_SWEEP_INTERVAL_MS;
+    return Object.freeze({
+      removed: result.removed,
+      generation: result.generation,
+    });
+  }
+}
+
+function activeCursorIdentity(graphName: string): string {
+  return JSON.stringify([1, graphName, ACTIVE_CURSOR_KEY]);
+}
+
+function savedCursorIdentity(graphName: string, name: string): string {
+  return JSON.stringify([1, graphName, SAVED_CURSOR_KEY, name]);
+}
+
+function savedCursorName(key: string, graphName: string): string | null {
+  let identity: unknown;
+  try {
+    identity = parseJsonUnknown(key);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(identity)) {
+    return null;
+  }
+  const name: unknown = identity[3];
+  if (typeof name !== 'string') {
+    return null;
+  }
+  if (savedCursorIdentity(graphName, name) !== key) {
+    return null;
+  }
+  validateWriterId(name);
+  return name;
+}
+
+function parseJsonUnknown(source: string): unknown {
+  return JSON.parse(source) as unknown;
+}
+
+function expired(expiresAt: string | null, nowMs: number): boolean {
+  return expiresAt !== null && Date.parse(expiresAt) <= nowMs;
+}
+
+function normalizeCursor(
+  cursor: ReturnType<typeof parseCursorBlob>,
+  label: string,
+): SeekCursorState {
+  const tick = finiteNumber(cursor.tick, 'tick', label);
+  const mode = optionalString(cursor.mode, 'mode', label);
+  const nodes = optionalFiniteNumber(cursor['nodes'], 'nodes', label);
+  const edges = optionalFiniteNumber(cursor['edges'], 'edges', label);
+  const frontierHash = optionalString(
+    cursor['frontierHash'],
+    'frontierHash',
+    label,
+  );
+  return Object.freeze({
+    tick,
+    ...(mode === undefined ? {} : { mode }),
+    ...(nodes === undefined ? {} : { nodes }),
+    ...(edges === undefined ? {} : { edges }),
+    ...(frontierHash === undefined ? {} : { frontierHash }),
+  });
+}
+
+function finiteNumber(value: unknown, field: string, label: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw corruptCursor(label, field);
+  }
+  return value;
+}
+
+function optionalFiniteNumber(
+  value: unknown,
+  field: string,
+  label: string,
+): number | undefined {
+  return value === undefined ? undefined : finiteNumber(value, field, label);
+}
+
+function optionalString(
+  value: unknown,
+  field: string,
+  label: string,
+): string | undefined {
+  if (value !== undefined && typeof value !== 'string') {
+    throw corruptCursor(label, field);
+  }
+  return value;
+}
+
+function corruptCursor(label: string, field: string): PersistenceError {
+  return new PersistenceError(
+    `Corrupted ${label}: invalid ${field}`,
+    'E_CURSOR_CORRUPT',
+  );
+}

--- a/src/infrastructure/adapters/GitCasSeekCursorStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasSeekCursorStoreAdapter.ts
@@ -5,8 +5,9 @@ import type {
 } from '@git-stunts/git-cas';
 import PersistenceError from '../../domain/errors/PersistenceError.ts';
 import { textEncode } from '../../domain/utils/bytes.ts';
-import { validateGraphName, validateWriterId } from '../../domain/utils/RefLayout.ts';
+import { validateGraphName } from '../../domain/utils/RefLayout.ts';
 import { parseCursorBlob } from '../../domain/utils/parseCursorBlob.ts';
+import { validateSavedCursorName } from '../../domain/utils/validateSavedCursorName.ts';
 import type SeekCursorStorePort from '../../ports/SeekCursorStorePort.ts';
 import type {
   NamedSeekCursorState,
@@ -34,6 +35,7 @@ const SAVED_CURSOR_KEY = 'saved';
 const CACHE_INSPECTION_PAGE_SIZE = 100;
 const MAX_CURSOR_PAGE_BYTES = 16 * 1024;
 const CURSOR_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const CURSOR_SWEEP_RETRY_MS = 5 * 60 * 1000;
 export const ACTIVE_SEEK_CURSOR_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
@@ -84,7 +86,7 @@ export default class GitCasSeekCursorStoreAdapter implements SeekCursorStorePort
   }
 
   async readSaved(name: string): Promise<SeekCursorState | null> {
-    validateWriterId(name);
+    validateSavedCursorName(name);
     return await this._read(
       savedCursorIdentity(this._graphName, name),
       `saved cursor '${name}'`,
@@ -92,13 +94,13 @@ export default class GitCasSeekCursorStoreAdapter implements SeekCursorStorePort
   }
 
   async writeSaved(name: string, cursor: SeekCursorState): Promise<void> {
-    validateWriterId(name);
+    validateSavedCursorName(name);
     await this._maintain(this._wallClockMs());
     await this._write(savedCursorIdentity(this._graphName, name), cursor, null);
   }
 
   async deleteSaved(name: string): Promise<void> {
-    validateWriterId(name);
+    validateSavedCursorName(name);
     await this._remove(savedCursorIdentity(this._graphName, name));
   }
 
@@ -171,7 +173,7 @@ export default class GitCasSeekCursorStoreAdapter implements SeekCursorStorePort
     if (!stored.accepted) {
       throw new PersistenceError(
         'git-cas rejected seek cursor retention',
-        'E_CURSOR_RETENTION',
+        PersistenceError.E_CURSOR_RETENTION,
       );
     }
   }
@@ -184,7 +186,11 @@ export default class GitCasSeekCursorStoreAdapter implements SeekCursorStorePort
 
   private async _maintain(nowMs: number): Promise<void> {
     if (nowMs >= this._nextSweepAtMs) {
-      await this.sweep();
+      try {
+        await this.sweep();
+      } catch {
+        this._nextSweepAtMs = nowMs + CURSOR_SWEEP_RETRY_MS;
+      }
     }
   }
 
@@ -224,7 +230,7 @@ function savedCursorName(key: string, graphName: string): string | null {
   if (savedCursorIdentity(graphName, name) !== key) {
     return null;
   }
-  validateWriterId(name);
+  validateSavedCursorName(name);
   return name;
 }
 
@@ -287,6 +293,6 @@ function optionalString(
 function corruptCursor(label: string, field: string): PersistenceError {
   return new PersistenceError(
     `Corrupted ${label}: invalid ${field}`,
-    'E_CURSOR_CORRUPT',
+    PersistenceError.E_CURSOR_CORRUPT,
   );
 }

--- a/src/ports/RuntimeStorageProviderPort.ts
+++ b/src/ports/RuntimeStorageProviderPort.ts
@@ -14,6 +14,7 @@ import type StrandStorePort from './StrandStorePort.ts';
 import type WarpStateCachePort from './WarpStateCachePort.ts';
 import type WarpStateCacheRetentionPort from './WarpStateCacheRetentionPort.ts';
 import type SyncReplayProtectionPort from './SyncReplayProtectionPort.ts';
+import type SeekCursorStorePort from './SeekCursorStorePort.ts';
 
 export type RuntimeStorageRequest = {
   readonly timelineName: string;
@@ -42,4 +43,5 @@ export default interface RuntimeStorageProviderPort {
   createRuntimeStorageServices(
     request: RuntimeStorageRequest,
   ): Promise<RuntimeStorageServices>;
+  createSeekCursorStore?(timelineName: string): SeekCursorStorePort;
 }

--- a/src/ports/SeekCursorStorePort.ts
+++ b/src/ports/SeekCursorStorePort.ts
@@ -1,0 +1,34 @@
+export type SeekCursorState = {
+  readonly tick: number;
+  readonly mode?: string;
+  readonly nodes?: number;
+  readonly edges?: number;
+  readonly frontierHash?: string;
+};
+
+export type NamedSeekCursorState = SeekCursorState & {
+  readonly name: string;
+};
+
+export type SeekCursorSweepResult = {
+  readonly removed: number;
+  readonly generation: string | null;
+};
+
+/**
+ * Graph-scoped storage for active and named seek cursor state.
+ *
+ * Implementations retain immutable cursor bytes behind lifecycle-owned handles.
+ * Active cursor state may expire; named bookmarks remain until explicitly
+ * removed.
+ */
+export default interface SeekCursorStorePort {
+  readActive(): Promise<SeekCursorState | null>;
+  writeActive(cursor: SeekCursorState): Promise<void>;
+  clearActive(): Promise<void>;
+  readSaved(name: string): Promise<SeekCursorState | null>;
+  writeSaved(name: string, cursor: SeekCursorState): Promise<void>;
+  deleteSaved(name: string): Promise<void>;
+  listSaved(): Promise<ReadonlyArray<NamedSeekCursorState>>;
+  sweep(): Promise<SeekCursorSweepResult>;
+}

--- a/test/bats/cli-seek.bats
+++ b/test/bats/cli-seek.bats
@@ -118,6 +118,13 @@ PY
   run git warp --repo "${TEST_REPO}" --graph demo --json seek --save bp1
   assert_success
 
+  run git -C "${TEST_REPO}" for-each-ref --format='%(refname)' refs/warp/demo/cursor/
+  assert_success
+  [ -z "$output" ]
+
+  run git -C "${TEST_REPO}" show-ref --verify --hash refs/cas/caches/git-warp.seek-cursors
+  assert_success
+
   run git warp --repo "${TEST_REPO}" --graph demo --json seek --latest
   assert_success
 

--- a/test/bats/cli-seek.bats
+++ b/test/bats/cli-seek.bats
@@ -268,6 +268,32 @@ assert data["diff"] is None, f"expected diff=null due to frontier change, got {d
 PY
 }
 
+@test "seek status does not renew cursor retention after frontier changes" {
+  run git warp --repo "${TEST_REPO}" --graph demo --json seek --tick 1
+  assert_success
+  local before
+  before=$(
+    NODE_NO_WARNINGS=1 REPO_PATH="${TEST_REPO}" GRAPH_NAME=demo \
+      node --experimental-strip-types \
+      "${BATS_TEST_DIRNAME}/helpers/inspect-seek-cursor-expiry.ts"
+  )
+
+  seed_graph "append-patch.js"
+
+  run git warp --repo "${TEST_REPO}" --graph demo --json seek
+  assert_success
+  local after
+  after=$(
+    NODE_NO_WARNINGS=1 REPO_PATH="${TEST_REPO}" GRAPH_NAME=demo \
+      node --experimental-strip-types \
+      "${BATS_TEST_DIRNAME}/helpers/inspect-seek-cursor-expiry.ts"
+  )
+  if [ "$before" != "$after" ]; then
+    echo "expected active cursor expiry ${before}, got ${after}" >&2
+    return 1
+  fi
+}
+
 @test "seek --diff --json first seek shows empty baseline with all additions" {
   run git warp --repo "${TEST_REPO}" --graph demo --json seek --tick 1 --diff
   assert_success

--- a/test/bats/helpers/inspect-seek-cursor-expiry.ts
+++ b/test/bats/helpers/inspect-seek-cursor-expiry.ts
@@ -1,0 +1,32 @@
+import ContentAddressableStore from '@git-stunts/git-cas';
+import GitPlumbing from '@git-stunts/plumbing';
+
+const repoPath = requiredEnvironmentVariable('REPO_PATH');
+const graphName = requiredEnvironmentVariable('GRAPH_NAME');
+const activeKey = JSON.stringify([1, graphName, 'active']);
+const plumbing = await GitPlumbing.createDefault({ cwd: repoPath });
+const cas = ContentAddressableStore.createCbor({
+  plumbing,
+  chunking: { strategy: 'cdc' },
+  applicationRefPrefixes: ['refs/warp/'],
+});
+
+try {
+  const cache = await cas.caches.open({ namespace: 'git-warp.seek-cursors' });
+  const inspection = await cache.inspect({ limit: 100 });
+  const active = inspection.entries.find((entry) => entry.key === activeKey);
+  if (active?.expiresAt === null || active?.expiresAt === undefined) {
+    throw new Error(`active seek cursor expiry is missing for graph '${graphName}'`);
+  }
+  process.stdout.write(active.expiresAt);
+} finally {
+  await cas.close();
+}
+
+function requiredEnvironmentVariable(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${name} must be set`);
+  }
+  return value;
+}

--- a/test/integration/infrastructure/adapters/GitCasSeekCursorStoreAdapter.integration.test.ts
+++ b/test/integration/infrastructure/adapters/GitCasSeekCursorStoreAdapter.integration.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Plumbing from '@git-stunts/plumbing';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import GitCasRepositoryAdapter from '../../../../src/infrastructure/adapters/GitCasRepositoryAdapter.ts';
+import GitTimelineHistoryAdapter from '../../../../src/infrastructure/adapters/GitTimelineHistoryAdapter.ts';
+import type SeekCursorStorePort from '../../../../src/ports/SeekCursorStorePort.ts';
+
+type PlumbingInstance = Awaited<ReturnType<typeof Plumbing.createDefault>>;
+
+type OpenedStorage = {
+  readonly cursorStore: SeekCursorStorePort;
+  readonly history: GitTimelineHistoryAdapter;
+  readonly plumbing: PlumbingInstance;
+  readonly repository: GitCasRepositoryAdapter;
+  close(): Promise<void>;
+};
+
+const opened: OpenedStorage[] = [];
+const tempDirectories: string[] = [];
+
+afterEach(async () => {
+  const storages = opened.splice(0);
+  await Promise.allSettled(storages.map(async storage => await storage.close()));
+  const directories = tempDirectories.splice(0);
+  await Promise.all(directories.map(async directory => {
+    await rm(directory, { recursive: true, force: true });
+  }));
+});
+
+describe('GitCasSeekCursorStoreAdapter integration', () => {
+  it('retains active and saved cursors across restart without WARP cursor refs', async () => {
+    const repositoryPath = await createRepository();
+    const first = await openStorage(repositoryPath);
+    const active = {
+      tick: 42,
+      mode: 'all',
+      nodes: 7,
+      edges: 3,
+      frontierHash: 'frontier-active',
+    };
+    const saved = {
+      tick: 21,
+      mode: 'nodes',
+      nodes: 5,
+      frontierHash: 'frontier-saved',
+    };
+
+    await first.cursorStore.writeActive(active);
+    await first.cursorStore.writeSaved('checkpoint', saved);
+    expect(await cursorRefs(first.plumbing)).toEqual('');
+    await first.close();
+    opened.splice(opened.indexOf(first), 1);
+
+    const restarted = await openStorage(repositoryPath);
+    await expect(restarted.cursorStore.readActive()).resolves.toEqual(active);
+    await expect(restarted.cursorStore.readSaved('checkpoint')).resolves.toEqual(saved);
+    await expect(restarted.cursorStore.listSaved()).resolves.toEqual([
+      { name: 'checkpoint', ...saved },
+    ]);
+    expect(await cursorRefs(restarted.plumbing)).toEqual('');
+
+    await restarted.cursorStore.clearActive();
+    await restarted.cursorStore.deleteSaved('checkpoint');
+    await expect(restarted.cursorStore.readActive()).resolves.toBeNull();
+    await expect(restarted.cursorStore.readSaved('checkpoint')).resolves.toBeNull();
+  });
+});
+
+async function createRepository(): Promise<string> {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'git-warp-seek-cursor-'));
+  tempDirectories.push(tempDirectory);
+  const plumbing = await Plumbing.createDefault({ cwd: tempDirectory });
+  await plumbing.execute({ args: ['init', '-q'] });
+  await plumbing.execute({ args: ['config', 'user.email', 'test@test.com'] });
+  await plumbing.execute({ args: ['config', 'user.name', 'Test'] });
+  return tempDirectory;
+}
+
+async function openStorage(tempDirectory: string): Promise<OpenedStorage> {
+  const plumbing = await Plumbing.createDefault({ cwd: tempDirectory });
+  const history = new GitTimelineHistoryAdapter({ plumbing });
+  const repository = new GitCasRepositoryAdapter({ plumbing, history });
+  const result: OpenedStorage = {
+    cursorStore: repository.createSeekCursorStore('events'),
+    history,
+    plumbing,
+    repository,
+    async close(): Promise<void> {
+      await repository.close();
+      await history.close();
+    },
+  };
+  opened.push(result);
+  return result;
+}
+
+async function cursorRefs(plumbing: PlumbingInstance): Promise<string> {
+  return await plumbing.execute({
+    args: [
+      'for-each-ref',
+      '--format=%(refname)',
+      'refs/warp/events/cursor/',
+    ],
+  });
+}

--- a/test/unit/domain/utils/RefLayout.test.ts
+++ b/test/unit/domain/utils/RefLayout.test.ts
@@ -7,9 +7,6 @@ import {
   buildCheckpointRef,
   buildCoverageRef,
   buildWritersPrefix,
-  buildCursorActiveRef,
-  buildCursorSavedRef,
-  buildCursorSavedPrefix,
   parseWriterIdFromRef as _parseWriterIdFromRef,
   validateGraphName as _validateGraphName,
   validateWriterId as _validateWriterId,
@@ -401,84 +398,4 @@ describe('RefLayout', () => {
     });
   });
 
-  describe('buildCursorActiveRef', () => {
-    it('builds correct cursor active ref path', () => {
-      expect(buildCursorActiveRef('events')).toBe('refs/warp/events/cursor/active');
-    });
-
-    it('builds cursor active ref for nested graph names', () => {
-      expect(buildCursorActiveRef('team/events')).toBe(
-        'refs/warp/team/events/cursor/active'
-      );
-    });
-
-    it('throws for invalid graph name', () => {
-      expect(() => buildCursorActiveRef('')).toThrow('cannot be empty');
-      expect(() => buildCursorActiveRef('../etc')).toThrow(
-        "contains path traversal sequence '..'"
-      );
-      expect(() => buildCursorActiveRef('my graph')).toThrow('contains space');
-    });
-  });
-
-  describe('buildCursorSavedRef', () => {
-    it('builds correct cursor saved ref path', () => {
-      expect(buildCursorSavedRef('events', 'before-tui')).toBe(
-        'refs/warp/events/cursor/saved/before-tui'
-      );
-    });
-
-    it('builds saved ref for various valid inputs', () => {
-      expect(buildCursorSavedRef('my-graph', 'snap_01')).toBe(
-        'refs/warp/my-graph/cursor/saved/snap_01'
-      );
-      expect(buildCursorSavedRef('team/events', 'checkpoint.v2')).toBe(
-        'refs/warp/team/events/cursor/saved/checkpoint.v2'
-      );
-    });
-
-    it('throws for invalid graph name', () => {
-      expect(() => buildCursorSavedRef('../etc', 'name')).toThrow(
-        "contains path traversal sequence '..'"
-      );
-      expect(() => buildCursorSavedRef('', 'name')).toThrow('cannot be empty');
-    });
-
-    it('throws for invalid cursor name', () => {
-      expect(() => buildCursorSavedRef('events', '')).toThrow('cannot be empty');
-      expect(() => buildCursorSavedRef('events', 'a/b')).toThrow('contains forward slash');
-      expect(() => buildCursorSavedRef('events', 'x'.repeat(65))).toThrow(
-        'exceeds maximum length'
-      );
-      expect(() => buildCursorSavedRef('events', 'has space')).toThrow(
-        'contains whitespace'
-      );
-    });
-  });
-
-  describe('buildCursorSavedPrefix', () => {
-    it('builds correct cursor saved prefix path', () => {
-      expect(buildCursorSavedPrefix('events')).toBe('refs/warp/events/cursor/saved/');
-    });
-
-    it('builds prefix with trailing slash', () => {
-      const prefix = buildCursorSavedPrefix('my-graph');
-      expect(prefix).toBe('refs/warp/my-graph/cursor/saved/');
-      expect(prefix.endsWith('/')).toBe(true);
-    });
-
-    it('builds prefix for nested graph names', () => {
-      expect(buildCursorSavedPrefix('team/events')).toBe(
-        'refs/warp/team/events/cursor/saved/'
-      );
-    });
-
-    it('throws for invalid graph name', () => {
-      expect(() => buildCursorSavedPrefix('')).toThrow('cannot be empty');
-      expect(() => buildCursorSavedPrefix('../etc')).toThrow(
-        "contains path traversal sequence '..'"
-      );
-      expect(() => buildCursorSavedPrefix('my graph')).toThrow('contains space');
-    });
-  });
 });

--- a/test/unit/domain/utils/validateSavedCursorName.test.ts
+++ b/test/unit/domain/utils/validateSavedCursorName.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { validateSavedCursorName } from '../../../../src/domain/utils/validateSavedCursorName.ts';
+
+describe('validateSavedCursorName', () => {
+  it.each(['cursor', 'cursor_1', 'cursor-name', 'cursor.name', '.'])(
+    'accepts ref-safe cursor name %s',
+    (name) => {
+      expect(() => validateSavedCursorName(name)).not.toThrow();
+    },
+  );
+
+  it.each([
+    [42, 'expected string, got number'],
+    ['', 'cannot be empty'],
+    ['a'.repeat(65), 'exceeds maximum length of 64 characters: 65'],
+    ['parent..child', "contains path traversal sequence '..'"],
+    ['parent/child', 'contains forward slash'],
+    ['cursor\0name', 'contains null byte'],
+    ['cursor name', 'contains whitespace'],
+    ['cursor$name', 'contains invalid characters'],
+  ])('rejects %p with cursor-specific semantics', (value, detail) => {
+    const validate = (): void => {
+      Reflect.apply(validateSavedCursorName, undefined, [value]);
+    };
+
+    expect(validate).toThrow(`Invalid saved cursor name: ${detail}`);
+    expect(validate).toThrowError(
+      expect.objectContaining({
+        code: 'E_INVALID_CURSOR_NAME',
+      }),
+    );
+  });
+});

--- a/test/unit/infrastructure/adapters/GitCasSeekCursorStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasSeekCursorStoreAdapter.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import GitCasSeekCursorStoreAdapter, {
+  ACTIVE_SEEK_CURSOR_TTL_MS,
+} from '../../../../src/infrastructure/adapters/GitCasSeekCursorStoreAdapter.ts';
+import { textEncode } from '../../../../src/domain/utils/bytes.ts';
+
+const ACTIVE_KEY = JSON.stringify([1, 'events', 'active']);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('GitCasSeekCursorStoreAdapter', () => {
+  it('retains active cursor pages as pinned entries with a bounded lifetime', async () => {
+    const handle = { toString: () => 'page-1' };
+    const sweep = vi.fn(async () => ({ removed: 0, generation: 'sweep-1' }));
+    const put = vi.fn(async () => ({ accepted: true, generation: 'put-1' }));
+    const pagePut = vi.fn(async () => ({ handle }));
+    const open = vi.fn(async () => ({
+      get: vi.fn(),
+      put,
+      remove: vi.fn(),
+      sweep,
+      inspect: vi.fn(),
+    }));
+    const adapter = new GitCasSeekCursorStoreAdapter({
+      cas: {
+        caches: { open: open as any },
+        pages: {
+          put: pagePut as any,
+          get: vi.fn() as any,
+        },
+      },
+      graphName: 'events',
+      wallClockMs: () => 1_000,
+    });
+
+    await adapter.writeActive({
+      tick: 12,
+      mode: 'all',
+      nodes: 3,
+      edges: 2,
+      frontierHash: 'frontier',
+    });
+
+    expect(open).toHaveBeenCalledWith({ namespace: 'git-warp.seek-cursors' });
+    expect(sweep).toHaveBeenCalledOnce();
+    expect(pagePut).toHaveBeenCalledWith({
+      source: textEncode(JSON.stringify({
+        tick: 12,
+        mode: 'all',
+        nodes: 3,
+        edges: 2,
+        frontierHash: 'frontier',
+      })),
+      maxBytes: 16 * 1024,
+    });
+    expect(put).toHaveBeenCalledWith(ACTIVE_KEY, handle, {
+      retention: 'pinned',
+      expiresAt: new Date(1_000 + ACTIVE_SEEK_CURSOR_TTL_MS).toISOString(),
+    });
+  });
+
+  it('reads cursor pages without extending cache retention', async () => {
+    const get = vi.fn(async () => ({
+      handle: { toString: () => 'page-active' },
+    }));
+    const pageGet = vi.fn(async () => textEncode(JSON.stringify({
+      tick: 42,
+      mode: 'nodes',
+      nodes: 7,
+    })));
+    const adapter = createAdapter({
+      get,
+      pageGet,
+    });
+
+    await expect(adapter.readActive()).resolves.toEqual({
+      tick: 42,
+      mode: 'nodes',
+      nodes: 7,
+    });
+    expect(get).toHaveBeenCalledWith(ACTIVE_KEY);
+    expect(pageGet).toHaveBeenCalledWith({
+      handle: 'page-active',
+      maxBytes: 16 * 1024,
+    });
+  });
+
+  it('lists only this graph saved cursors in stable order across inspection pages', async () => {
+    const inspect = vi.fn()
+      .mockResolvedValueOnce({
+        entries: [
+          cacheEntry(JSON.stringify([1, 'events', 'saved', 'zeta']), 'page-zeta'),
+          cacheEntry(JSON.stringify([1, 'other', 'saved', 'foreign']), 'page-other'),
+          cacheEntry(ACTIVE_KEY, 'page-active'),
+        ],
+        nextCursor: 'next',
+      })
+      .mockResolvedValueOnce({
+        entries: [
+          cacheEntry(JSON.stringify([1, 'events', 'saved', 'alpha']), 'page-alpha'),
+          cacheEntry(
+            JSON.stringify([1, 'events', 'saved', 'expired']),
+            'page-expired',
+            new Date(999).toISOString(),
+          ),
+        ],
+        nextCursor: null,
+      });
+    const pageGet = vi.fn(async ({ handle }: { handle: string }) => {
+      const ticks: Readonly<Record<string, number>> = {
+        'page-alpha': 1,
+        'page-zeta': 9,
+      };
+      return textEncode(JSON.stringify({ tick: ticks[handle] }));
+    });
+    const adapter = createAdapter({
+      inspect,
+      pageGet,
+      wallClockMs: () => 1_000,
+    });
+
+    await expect(adapter.listSaved()).resolves.toEqual([
+      { name: 'alpha', tick: 1 },
+      { name: 'zeta', tick: 9 },
+    ]);
+    expect(inspect).toHaveBeenNthCalledWith(1, { limit: 100, cursor: null });
+    expect(inspect).toHaveBeenNthCalledWith(2, { limit: 100, cursor: 'next' });
+  });
+
+  it('sweeps once on first use and then at the bounded daily cadence', async () => {
+    let nowMs = 1_000;
+    const sweep = vi.fn(async () => ({ removed: 0, generation: null }));
+    const get = vi.fn(async () => null);
+    const adapter = createAdapter({
+      get,
+      sweep,
+      wallClockMs: () => nowMs,
+    });
+
+    await adapter.readActive();
+    nowMs += DAY_MS - 1;
+    await adapter.readActive();
+    expect(sweep).toHaveBeenCalledOnce();
+
+    nowMs += 1;
+    await adapter.readActive();
+    expect(sweep).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps eager cache-open rejection observable to cursor callers', async () => {
+    const openFailure = new Error('open failed');
+    const opening = Promise.reject(openFailure);
+    const catchSpy = vi.spyOn(opening, 'catch');
+    const adapter = new GitCasSeekCursorStoreAdapter({
+      cas: {
+        caches: { open: (() => opening) as any },
+        pages: {
+          put: vi.fn() as any,
+          get: vi.fn() as any,
+        },
+      },
+      graphName: 'events',
+    });
+
+    expect(catchSpy).toHaveBeenCalledOnce();
+    await expect(adapter.readActive()).rejects.toBe(openFailure);
+  });
+
+  it('fails closed when git-cas declines pinned retention', async () => {
+    const adapter = createAdapter({
+      put: vi.fn(async () => ({ accepted: false, generation: 'full' })),
+      pagePut: vi.fn(async () => ({
+        handle: { toString: () => 'page-rejected' },
+      })),
+    });
+
+    await expect(adapter.writeSaved('bookmark', { tick: 5 })).rejects.toMatchObject({
+      code: 'E_CURSOR_RETENTION',
+      message: 'git-cas rejected seek cursor retention',
+    });
+  });
+});
+
+type AdapterOverrides = {
+  readonly get?: ReturnType<typeof vi.fn>;
+  readonly inspect?: ReturnType<typeof vi.fn>;
+  readonly pageGet?: ReturnType<typeof vi.fn>;
+  readonly pagePut?: ReturnType<typeof vi.fn>;
+  readonly put?: ReturnType<typeof vi.fn>;
+  readonly sweep?: ReturnType<typeof vi.fn>;
+  readonly wallClockMs?: () => number;
+};
+
+function createAdapter(overrides: AdapterOverrides): GitCasSeekCursorStoreAdapter {
+  const cache = {
+    get: overrides.get ?? vi.fn(async () => null),
+    inspect: overrides.inspect ?? vi.fn(async () => ({ entries: [], nextCursor: null })),
+    put: overrides.put ?? vi.fn(async () => ({ accepted: true, generation: 'put' })),
+    remove: vi.fn(async () => ({ removed: true, generation: 'remove' })),
+    sweep: overrides.sweep ?? vi.fn(async () => ({ removed: 0, generation: 'sweep' })),
+  };
+  return new GitCasSeekCursorStoreAdapter({
+    cas: {
+      caches: { open: (async () => cache) as any },
+      pages: {
+        get: (overrides.pageGet ?? vi.fn()) as any,
+        put: (overrides.pagePut ?? vi.fn()) as any,
+      },
+    },
+    graphName: 'events',
+    wallClockMs: overrides.wallClockMs ?? (() => 1_000),
+  });
+}
+
+function cacheEntry(key: string, handle: string, expiresAt: string | null = null) {
+  return {
+    key,
+    handle,
+    retention: 'pinned',
+    expiresAt,
+    createdAt: '1970-01-01T00:00:00.000Z',
+    accessedAt: '1970-01-01T00:00:00.000Z',
+  };
+}

--- a/test/unit/infrastructure/adapters/GitCasSeekCursorStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/GitCasSeekCursorStoreAdapter.test.ts
@@ -147,6 +147,42 @@ describe('GitCasSeekCursorStoreAdapter', () => {
     expect(sweep).toHaveBeenCalledTimes(2);
   });
 
+  it('isolates failed opportunistic sweeps and throttles retries', async () => {
+    let nowMs = 1_000;
+    const sweepFailure = new Error('sweep failed');
+    const sweep = vi.fn(async () => {
+      throw sweepFailure;
+    });
+    const get = vi.fn(async () => null);
+    const adapter = createAdapter({
+      get,
+      sweep,
+      wallClockMs: () => nowMs,
+    });
+
+    await expect(adapter.readActive()).resolves.toBeNull();
+    expect(sweep).toHaveBeenCalledOnce();
+    expect(get).toHaveBeenCalledOnce();
+
+    nowMs += 5 * 60 * 1000 - 1;
+    await expect(adapter.readActive()).resolves.toBeNull();
+    expect(sweep).toHaveBeenCalledOnce();
+
+    nowMs += 1;
+    await expect(adapter.readActive()).resolves.toBeNull();
+    expect(sweep).toHaveBeenCalledTimes(2);
+    await expect(adapter.sweep()).rejects.toBe(sweepFailure);
+  });
+
+  it('reports saved-cursor name validation in cursor terms', async () => {
+    const adapter = createAdapter({});
+
+    await expect(adapter.readSaved('bad/name')).rejects.toMatchObject({
+      code: 'E_INVALID_CURSOR_NAME',
+      message: expect.stringContaining('Invalid saved cursor name'),
+    });
+  });
+
   it('keeps eager cache-open rejection observable to cursor callers', async () => {
     const openFailure = new Error('open failed');
     const opening = Promise.reject(openFailure);


### PR DESCRIPTION
## Summary

- add a graph-scoped seek-cursor storage port backed by immutable git-cas pages and the fixed `git-warp.seek-cursors` cache namespace
- pin active cursors for 30 days, keep named cursors pinned until explicit drop, avoid read-based lifetime extension, and sweep on first use plus a bounded daily cadence
- migrate every CLI cursor consumer to the runtime storage provider and fail closed when durable cursor retention is unavailable
- remove the mutable `refs/warp/<graph>/cursor/*` protocol and its ref builders; v19 intentionally leaves old operator-only cursor refs inert rather than migrating non-authoritative state

Issue scope: replay admission landed in #776; this PR completes the remaining active/saved cursor half of #740.

Closes #740.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run lint:md`
- `npm run lint:semgrep`
- `npm run typecheck:surface`
- `npm run typecheck:policy`
- `npx vitest run test/unit test/integration` — 632 passed files, 1 skipped; 7,475 passed tests, 2 skipped
- `PATH="$PWD/bin:$PATH" bats test/bats/` — 111/111 passed
- review repair: cursor unit/integration 9/9; seek Bats 27/27, including an expiry-preservation probe backed by `CacheSet.inspect()`
- pre-push IRONCLAD static gates and all stable unit shards passed