### PR TITLE
Unify checkpoints with retained materializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Locked the package root to the v19 facade allowlist so support ports,
   infrastructure adapters, memory helpers, cancellation utilities, sync
   internals, and canonical serialization helpers stay behind explicit subpaths.
-- Aligned `CheckpointStorePort` with the schema:5 checkpoint envelope tree. The
-  CBOR adapter now owns the named checkpoint artifact encoding for runtime
-  checkpoint creation and loading instead of exposing a stale single
-  `state.cbor` result.
+- Changed schema:5 checkpoint publication to pin the exact retained
+  materialization bundle. Checkpoints, live reads, logical/property index
+  pages, replay state, and provenance now share one git-cas representation;
+  released legacy Git-tree checkpoints remain readable behind the compatibility
+  adapter without enabling new duplicate checkpoint writes.
 - Reduced the `diagnostics` subpath to receipt-based `inspectReceipt()`;
   graph-diff and materialized-state helpers are no longer public contracts.
 - Moved receipt canonical JSON and ORSet/full-state wire encoding out of
@@ -109,6 +110,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed migration and cleanup support for unreleased materialization
   descriptor schemas v2 through v4. Schema v5 is the first release contract;
   stale derived-cache entries miss and rebuild from authoritative WARP history.
+- Removed checkpoint-schema 2 and 3 upgrade support. The offline bridge accepts
+  schema 4 and released schema-5 Git-tree checkpoints, retains their
+  authoritative state as a v19 materialization, and discards derived legacy
+  index pointers so current page indexes rebuild from authoritative history.
 - Removed the WARP-owned mutable state-snapshot index, GitCas state-cache
   adapter, graph-scoped RootSet coordinator, and retention report/repair
   protocol. The v19 CLI replaces `--repair-state-cache` with

--- a/scripts/migrations/v17.0.0/CheckpointMaterializationMigration.ts
+++ b/scripts/migrations/v17.0.0/CheckpointMaterializationMigration.ts
@@ -1,0 +1,28 @@
+import MaterializationCoordinate from '../../../src/domain/materialization/MaterializationCoordinate.ts';
+import type MaterializationHandle from '../../../src/domain/materialization/MaterializationHandle.ts';
+import { unavailableMaterializationRoots } from '../../../src/domain/materialization/UnavailableMaterializationRoots.ts';
+import type { ProvenanceIndex } from '../../../src/domain/services/provenance/ProvenanceIndex.ts';
+import type WarpState from '../../../src/domain/services/state/WarpState.ts';
+import type MaterializationStorePort from '../../../src/ports/MaterializationStorePort.ts';
+
+/** Retains authoritative migrated state without copying its derived legacy indexes. */
+export async function retainMigratedCheckpoint(options: {
+  materializations: MaterializationStorePort;
+  state: WarpState;
+  frontier: Map<string, string>;
+  stateHash: string;
+  provenanceIndex?: ProvenanceIndex;
+}): Promise<MaterializationHandle> {
+  return await options.materializations.retain({
+    coordinate: new MaterializationCoordinate({
+      frontier: options.frontier,
+      ceiling: null,
+    }),
+    roots: unavailableMaterializationRoots(),
+    stateHash: options.stateHash,
+    replayBasis: options.state,
+    ...(options.provenanceIndex === undefined
+      ? {}
+      : { provenanceSupport: options.provenanceIndex }),
+  });
+}

--- a/scripts/migrations/v17.0.0/checkpoint-schema-upgrade.ts
+++ b/scripts/migrations/v17.0.0/checkpoint-schema-upgrade.ts
@@ -4,14 +4,13 @@ import {
   CURRENT_CHECKPOINT_SCHEMA,
   isCurrentCheckpointSchema,
 } from '../../../src/domain/services/state/checkpointHelpers.ts';
-import {
-  deserializeFullState,
-} from '../../../src/domain/services/state/CheckpointSerializer.ts';
+import { deserializeFullState } from '../../../src/domain/services/state/CheckpointSerializer.ts';
 import { deserializeFrontier } from '../../../src/domain/services/Frontier.ts';
 import { DEFAULT_COMMIT_MESSAGE_CODEC } from '../../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts';
 import defaultCodec from '../../../src/infrastructure/codecs/CborCodec.ts';
 import { buildCheckpointRef } from '../../../src/domain/utils/RefLayout.ts';
 import { ProvenanceIndex } from '../../../src/domain/services/provenance/ProvenanceIndex.ts';
+import { computeStateHash } from '../../../src/domain/services/state/StateSerializer.ts';
 import type AssetStoragePort from '../../../src/ports/AssetStoragePort.ts';
 import type CodecPort from '../../../src/ports/CodecPort.ts';
 import {
@@ -20,19 +19,16 @@ import {
 } from '../../../src/ports/CommitMessageCodecPort.ts';
 import type CryptoPort from '../../../src/ports/CryptoPort.ts';
 import type CheckpointStorePort from '../../../src/ports/CheckpointStorePort.ts';
+import type MaterializationStorePort from '../../../src/ports/MaterializationStorePort.ts';
 import LegacyCheckpointStorageReader, {
   hasCurrentCheckpointStorage,
   requireMigratableLegacyStorage,
 } from './LegacyCheckpointStorageReader.ts';
 import CheckpointSchemaUpgradeError from './CheckpointSchemaUpgradeError.ts';
-
+import { retainMigratedCheckpoint } from './CheckpointMaterializationMigration.ts';
 export { default as CheckpointSchemaUpgradeError } from './CheckpointSchemaUpgradeError.ts';
-
-const RETIRED_CHECKPOINT_SCHEMAS = [2, 3, 4] as const;
-
+const RETIRED_CHECKPOINT_SCHEMAS = [4] as const;
 type UpgradeStatus = 'missing-checkpoint' | 'already-current' | 'would-upgrade' | 'upgraded';
-
-/** Legacy Git history surface required only by the retired-checkpoint migrator. */
 export interface CheckpointMigrationHistory {
   readBlob(oid: string): Promise<Uint8Array>;
   readTreeOids(treeOid: string): Promise<Record<string, string>>;
@@ -50,6 +46,7 @@ export interface CheckpointSchemaUpgradeOptions {
   readonly commitMessageCodec?: CommitMessageCodecPort;
   readonly crypto?: CryptoPort;
   readonly checkpointStore: CheckpointStorePort;
+  readonly materializationStore: MaterializationStorePort;
   readonly assetStorage: AssetStoragePort;
 }
 
@@ -152,6 +149,17 @@ export async function upgradeCheckpointSchema(
     };
   }
 
+  const crypto = requireMigrationCrypto(options.crypto);
+  const stateHash = await computeStateHash(payload.state, { codec, crypto });
+  const materialization = await retainMigratedCheckpoint({
+    materializations: options.materializationStore,
+    state: payload.state,
+    frontier: payload.frontier,
+    stateHash,
+    ...(payload.provenanceIndex === undefined
+      ? {}
+      : { provenanceIndex: payload.provenanceIndex }),
+  });
   const upgradedCheckpointSha = await createCheckpointEnvelope({
     checkpointStore,
     graphName: options.graphName,
@@ -160,8 +168,8 @@ export async function upgradeCheckpointSchema(
     parents: (await options.persistence.getNodeInfo(previousCheckpointSha)).parents,
     expectedCheckpointSha: previousCheckpointSha,
     codec,
-    ...(options.crypto === undefined ? {} : { crypto: options.crypto }),
-    ...(payload.indexTree === undefined ? {} : { indexTree: payload.indexTree }),
+    crypto,
+    materialization,
     ...(payload.provenanceIndex === undefined ? {} : { provenanceIndex: payload.provenanceIndex }),
   });
 
@@ -178,6 +186,15 @@ export async function upgradeCheckpointSchema(
     previousStorageVersion: checkpointMessage.checkpointVersion,
     currentStorageVersion: CHECKPOINT_STORAGE_FORMAT,
   };
+}
+
+function requireMigrationCrypto(crypto: CryptoPort | undefined): CryptoPort {
+  if (crypto === undefined) {
+    throw new CheckpointSchemaUpgradeError(
+      'Checkpoint migration requires the configured cryptographic hash service.',
+    );
+  }
+  return crypto;
 }
 
 function isRetiredCheckpointSchema(schema: number): schema is typeof RETIRED_CHECKPOINT_SCHEMAS[number] {

--- a/scripts/migrations/v17.0.0/openCheckpointMigrationStore.ts
+++ b/scripts/migrations/v17.0.0/openCheckpointMigrationStore.ts
@@ -3,10 +3,12 @@ import { DEFAULT_COMMIT_MESSAGE_CODEC } from '../../../src/infrastructure/adapte
 import defaultCrypto from '../../../src/infrastructure/adapters/NodeCryptoSingleton.ts';
 import type AssetStoragePort from '../../../src/ports/AssetStoragePort.ts';
 import type CheckpointStorePort from '../../../src/ports/CheckpointStorePort.ts';
+import type MaterializationStorePort from '../../../src/ports/MaterializationStorePort.ts';
 import type RuntimeStorageProviderPort from '../../../src/ports/RuntimeStorageProviderPort.ts';
 
 export interface CheckpointMigrationStorage {
   readonly checkpointStore: CheckpointStorePort;
+  readonly materializationStore: MaterializationStorePort;
   readonly assetStorage: AssetStoragePort;
 }
 
@@ -23,6 +25,7 @@ export async function openCheckpointMigrationStore(
   });
   return Object.freeze({
     checkpointStore: services.checkpoints,
+    materializationStore: services.materializations,
     assetStorage: services.content,
   });
 }

--- a/src/domain/RuntimeHost.ts
+++ b/src/domain/RuntimeHost.ts
@@ -69,6 +69,7 @@ import type CheckpointStorePort from '../ports/CheckpointStorePort.ts';
 import type IndexStorePort from '../ports/IndexStorePort.ts';
 import type IntentStorePort from '../ports/IntentStorePort.ts';
 import type MaterializationStorePort from '../ports/MaterializationStorePort.ts';
+import type MaterializationHandle from './materialization/MaterializationHandle.ts';
 import type RuntimeStorageProviderPort from '../ports/RuntimeStorageProviderPort.ts';
 import type SyncReplayProtectionPort from '../ports/SyncReplayProtectionPort.ts';
 import type { EffectPipeline } from './services/EffectPipeline.ts';
@@ -181,6 +182,10 @@ function resolveMaterializedStateCoordinate(
   return optionsOrDiff.coordinate ?? null;
 }
 
+function retainedMaterializationFrom(result: MaterializeResult): MaterializationHandle | null {
+  return result.materialization === undefined ? null : result.materialization;
+}
+
 type Subscriber = {
   onChange: (diff: StateDiffResult) => void;
   onError?: (error: Error) => void;
@@ -259,6 +264,7 @@ export default class RuntimeHost {
   _stateHashService: StateHashService | null;
   _auditService: AuditReceiptService | null;
   _materializations: MaterializationStorePort;
+  _retainedMaterialization: MaterializationHandle | null;
   _syncReplayProtection: SyncReplayProtectionPort | null;
   _closePromise: Promise<void> | null;
 
@@ -432,6 +438,7 @@ export default class RuntimeHost {
     this._indexStore = indexStore;
     this._auditService = auditService || null;
     this._materializations = materializations;
+    this._retainedMaterialization = null;
     this._closePromise = null;
   }
 
@@ -555,6 +562,7 @@ export default class RuntimeHost {
     this._stateDirty = false;
     this._versionVector = state.observedFrontier.clone();
     this._materializedGraph = { state, stateHash, adjacency };
+    this._retainedMaterialization = null;
     this._cachedCeiling = coordinate?.ceiling ?? null;
     this._cachedFrontier = coordinate === null ? null : new Map(coordinate.frontier);
     this._buildViewFromResult({ state, stateHash, diff });
@@ -900,6 +908,7 @@ export default class RuntimeHost {
     this._provenanceDegraded = provenance.degraded;
     this._cachedCeiling = result.ceiling;
     this._cachedFrontier = result.frontier ? new Map(result.frontier) : null;
+    this._retainedMaterialization = retainedMaterializationFrom(result);
 
     // 2. Build view (index)
     this._buildViewFromResult(result);

--- a/src/domain/materialization/MaterializationIndexProfile.ts
+++ b/src/domain/materialization/MaterializationIndexProfile.ts
@@ -1,0 +1,36 @@
+import WarpError from '../errors/WarpError.ts';
+
+export const MAX_MATERIALIZATION_INDEX_SHARD_BYTES = 16 * 1024 * 1024;
+export const MAX_MATERIALIZATION_INDEX_SHARDS = 100_000;
+
+export const MATERIALIZATION_INDEX_SHARD_LIMITS = Object.freeze({
+  maxBytes: MAX_MATERIALIZATION_INDEX_SHARD_BYTES,
+  structureLimits: Object.freeze({
+    maxContainerEntries: 1_000_000,
+    maxDepth: 32,
+    maxItems: 2_000_000,
+  }),
+});
+
+export function requireMaterializationIndexShardCount(count: number): number {
+  if (!Number.isSafeInteger(count) || count < 1) {
+    throw shardCountError(count, 'must be a positive safe integer');
+  }
+  if (count > MAX_MATERIALIZATION_INDEX_SHARDS) {
+    throw shardCountError(count, 'exceeds the retained materialization limit');
+  }
+  return count;
+}
+
+function shardCountError(actual: number, reason: string): WarpError {
+  return new WarpError(
+    `Materialization index shard count ${String(actual)} ${reason}`,
+    'E_MATERIALIZATION_INDEX_LIMIT',
+    {
+      context: {
+        actual,
+        maximum: MAX_MATERIALIZATION_INDEX_SHARDS,
+      },
+    },
+  );
+}

--- a/src/domain/materialization/MaterializationRoots.ts
+++ b/src/domain/materialization/MaterializationRoots.ts
@@ -27,9 +27,21 @@ export type MaterializationRootsOptions = Readonly<{
   roaringIndexes: MaterializationRoot;
 }>;
 
+type MaterializationRootsByName = Readonly<{
+  adjacency: MaterializationRoot;
+  'edge-alive': MaterializationRoot;
+  'edge-births': MaterializationRoot;
+  frontier: MaterializationRoot;
+  'node-alive': MaterializationRoot;
+  properties: MaterializationRoot;
+  'provenance-support': MaterializationRoot;
+  'replay-basis': MaterializationRoot;
+  'roaring-indexes': MaterializationRoot;
+}>;
+
 /** Independently addressable retained roots for one materialized causal chart. */
 export default class MaterializationRoots {
-  private readonly roots: Readonly<Record<MaterializationRootName, MaterializationRoot>>;
+  private readonly roots: MaterializationRootsByName;
   readonly adjacency: MaterializationRoot;
   readonly edgeAlive: MaterializationRoot;
   readonly edgeBirths: MaterializationRoot;
@@ -52,7 +64,7 @@ export default class MaterializationRoots {
       'provenance-support': requireRoot(options.provenanceSupport, 'provenanceSupport'),
       'replay-basis': requireRoot(options.replayBasis, 'replayBasis'),
       'roaring-indexes': requireRoot(options.roaringIndexes, 'roaringIndexes'),
-    } satisfies Record<MaterializationRootName, MaterializationRoot>);
+    } satisfies MaterializationRootsByName);
     this.adjacency = this.roots.adjacency;
     this.edgeAlive = this.roots['edge-alive'];
     this.edgeBirths = this.roots['edge-births'];
@@ -71,10 +83,36 @@ export default class MaterializationRoots {
     );
   }
 
+  withRoot(name: MaterializationRootName, root: MaterializationRoot): MaterializationRoots {
+    const rootName = requireRootName(name);
+    const replacement = {
+      ...this.roots,
+      [rootName]: requireRoot(root, rootName),
+    };
+    return new MaterializationRoots({
+      adjacency: replacement.adjacency,
+      edgeAlive: replacement['edge-alive'],
+      edgeBirths: replacement['edge-births'],
+      frontier: replacement.frontier,
+      nodeAlive: replacement['node-alive'],
+      properties: replacement.properties,
+      provenanceSupport: replacement['provenance-support'],
+      replayBasis: replacement['replay-basis'],
+      roaringIndexes: replacement['roaring-indexes'],
+    });
+  }
+
   equals(other: MaterializationRoots): boolean {
     return other instanceof MaterializationRoots
       && MATERIALIZATION_ROOT_NAMES.every((name) => this.roots[name].equals(other.roots[name]));
   }
+}
+
+function requireRootName(name: MaterializationRootName): MaterializationRootName {
+  if (!MATERIALIZATION_ROOT_NAMES.includes(name)) {
+    throw rootsError(`unknown root name: ${String(name)}`);
+  }
+  return name;
 }
 
 function rootEntry(

--- a/src/domain/materialization/MaterializationRoots.ts
+++ b/src/domain/materialization/MaterializationRoots.ts
@@ -110,7 +110,7 @@ export default class MaterializationRoots {
 
 function requireRootName(name: MaterializationRootName): MaterializationRootName {
   if (!MATERIALIZATION_ROOT_NAMES.includes(name)) {
-    throw rootsError(`unknown root name: ${String(name)}`);
+    throw rootsError(`unsupported root name: ${String(name)}`);
   }
   return name;
 }

--- a/src/domain/materialization/MaterializationRoots.ts
+++ b/src/domain/materialization/MaterializationRoots.ts
@@ -1,7 +1,17 @@
 import WarpError from '../errors/WarpError.ts';
 import MaterializationRoot from './MaterializationRoot.ts';
 
-export const MATERIALIZATION_ROOT_NAMES = defineRootNames(
+export const MATERIALIZATION_ROOT_NAMES: readonly [
+  'adjacency',
+  'edge-alive',
+  'edge-births',
+  'frontier',
+  'node-alive',
+  'properties',
+  'provenance-support',
+  'replay-basis',
+  'roaring-indexes',
+] = defineRootNames(
   'adjacency',
   'edge-alive',
   'edge-births',

--- a/src/domain/materialization/UnavailableMaterializationRoots.ts
+++ b/src/domain/materialization/UnavailableMaterializationRoots.ts
@@ -1,0 +1,18 @@
+import MaterializationRoot from './MaterializationRoot.ts';
+import MaterializationRoots from './MaterializationRoots.ts';
+
+/** Whole materialization descriptor with no derived roots retained yet. */
+export function unavailableMaterializationRoots(): MaterializationRoots {
+  const unavailable = () => MaterializationRoot.unavailable();
+  return new MaterializationRoots({
+    adjacency: unavailable(),
+    edgeAlive: unavailable(),
+    edgeBirths: unavailable(),
+    frontier: unavailable(),
+    nodeAlive: unavailable(),
+    properties: unavailable(),
+    provenanceSupport: unavailable(),
+    replayBasis: unavailable(),
+    roaringIndexes: unavailable(),
+  });
+}

--- a/src/domain/services/controllers/CheckpointController.ts
+++ b/src/domain/services/controllers/CheckpointController.ts
@@ -216,13 +216,14 @@ export default class CheckpointController {
     }
     if (h._indexStore !== undefined) {
       const workspace = await h._materializations.openWorkspace(coordinate);
+      let promoted: MaterializationHandle;
       try {
         const prepared = await prepareMaterializationIndexRoots({
           state,
           store: h._indexStore,
           workspace,
         });
-        return await workspace.promote({
+        promoted = await workspace.promote({
           coordinate,
           roots: materializationRootsWithIndexes(prepared),
           stateHash,
@@ -235,6 +236,8 @@ export default class CheckpointController {
         await releaseWorkspaceAfterFailure(workspace, h._logger ?? undefined);
         throw raw;
       }
+      await workspace.release();
+      return promoted;
     }
     return await h._materializations.retain({
       coordinate,

--- a/src/domain/services/controllers/CheckpointController.ts
+++ b/src/domain/services/controllers/CheckpointController.ts
@@ -35,10 +35,20 @@ import type CommitMessageCodecPort from '../../../ports/CommitMessageCodecPort.t
 import type CryptoPort from '../../../ports/CryptoPort.ts';
 import type LoggerPort from '../../../ports/LoggerPort.ts';
 import type CheckpointStorePort from '../../../ports/CheckpointStorePort.ts';
+import type IndexStorePort from '../../../ports/IndexStorePort.ts';
 import type StateHashService from '../state/StateHashService.ts';
-import type MaterializedViewService from '../MaterializedViewService.ts';
 import type GCPolicy from '../GCPolicy.ts';
 import { E_NO_STATE_MSG } from './QueryStateMessages.ts';
+import MaterializationCoordinate from '../../materialization/MaterializationCoordinate.ts';
+import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
+import { unavailableMaterializationRoots } from '../../materialization/UnavailableMaterializationRoots.ts';
+import { computeStateHash } from '../state/StateSerializer.ts';
+import type MaterializationStorePort from '../../../ports/MaterializationStorePort.ts';
+import {
+  materializationRootsWithIndexes,
+  prepareMaterializationIndexRoots,
+} from './MaterializationIndexRoots.ts';
+import { releaseWorkspaceAfterFailure } from './MaterializationWorkspaceCleanup.ts';
 
 type CheckpointFrontier = Pick<LoadedCheckpoint, 'schema' | 'frontier'>;
 
@@ -51,8 +61,8 @@ type CheckpointHost = {
   _cachedState: WarpState | null;
   _stateDirty: boolean;
   _checkpointing: boolean;
-  _viewService: MaterializedViewService | null;
   _checkpointStore: CheckpointStorePort;
+  _indexStore?: IndexStorePort;
   _stateHashService: StateHashService | null;
   _provenanceIndex: ProvenanceIndex | null;
   _materializedGraph?: object | null;
@@ -70,6 +80,8 @@ type CheckpointHost = {
   _lastFrontier: Map<string, string> | null;
   _cachedViewHash: string | null;
   _stateCache: WarpStateCachePort | null;
+  _materializations?: MaterializationStorePort;
+  _retainedMaterialization?: MaterializationHandle | null;
   _readPatch(patchMeta: ReturnType<CommitMessageCodecPort['decodePatch']>): Promise<Patch>;
   discoverWriters(): Promise<string[]>;
 };
@@ -143,19 +155,7 @@ export default class CheckpointController {
       return pinned.snapshotId;
     }
 
-    let indexTree = h._cachedIndexTree;
-    if ((indexTree === null || indexTree === undefined) && h._viewService !== null && h._viewService !== undefined) {
-      try {
-        const { tree } = h._viewService.build(state);
-        indexTree = tree;
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        h._logger?.warn('[warp] checkpoint index build failed; saving checkpoint without index', {
-          error: message,
-        });
-        indexTree = null;
-      }
-    }
+    const materialization = await this._retainCheckpointMaterialization(state, frontier);
 
     const stateHashService = h._stateHashService ?? null;
     const checkpointSha = await createCheckpointCommit({
@@ -167,7 +167,7 @@ export default class CheckpointController {
       ...(h._provenanceIndex ? { provenanceIndex: h._provenanceIndex } : {}),
       crypto: h._crypto,
       codec: h._codec,
-      ...(indexTree ? { indexTree } : {}),
+      ...(materialization === null ? {} : { materialization }),
       ...(stateHashService ? { stateHashService } : {}),
     });
     return checkpointSha;
@@ -190,6 +190,61 @@ export default class CheckpointController {
       frontier,
       ceiling: null,
     };
+  }
+
+  private async _retainCheckpointMaterialization(
+    state: WarpState,
+    frontier: Map<string, string>,
+  ): Promise<MaterializationHandle | null> {
+    const h = this._host;
+    if (h._materializations === undefined) {
+      return null;
+    }
+    const coordinate = new MaterializationCoordinate({ frontier, ceiling: null });
+    const stateHash = h._stateHashService === null
+      ? await computeStateHash(state, { codec: h._codec, crypto: h._crypto })
+      : await h._stateHashService.compute(state);
+    const retained = h._retainedMaterialization ?? null;
+    if (
+      retained !== null
+      && retained.stateHash === stateHash
+      && retained.coordinate.equals(coordinate)
+      && retained.roots.properties.status !== 'unavailable'
+      && retained.roots.roaringIndexes.status !== 'unavailable'
+    ) {
+      return retained;
+    }
+    if (h._indexStore !== undefined) {
+      const workspace = await h._materializations.openWorkspace(coordinate);
+      try {
+        const prepared = await prepareMaterializationIndexRoots({
+          state,
+          store: h._indexStore,
+          workspace,
+        });
+        return await workspace.promote({
+          coordinate,
+          roots: materializationRootsWithIndexes(prepared),
+          stateHash,
+          replayBasis: state,
+          ...(h._provenanceIndex === null
+            ? {}
+            : { provenanceSupport: h._provenanceIndex }),
+        });
+      } catch (raw) {
+        await releaseWorkspaceAfterFailure(workspace, h._logger ?? undefined);
+        throw raw;
+      }
+    }
+    return await h._materializations.retain({
+      coordinate,
+      roots: unavailableMaterializationRoots(),
+      stateHash,
+      replayBasis: state,
+      ...(h._provenanceIndex === null
+        ? {}
+        : { provenanceSupport: h._provenanceIndex }),
+    });
   }
 
   private async _buildSnapshotRecord(params: {
@@ -250,6 +305,8 @@ export default class CheckpointController {
           schema: CURRENT_CHECKPOINT_SCHEMA,
           appliedVV: null,
           indexShardHandles: null,
+          indexRoot: null,
+          propertyRoot: null,
         };
       }
     }

--- a/src/domain/services/controllers/MaterializationIndexRoots.ts
+++ b/src/domain/services/controllers/MaterializationIndexRoots.ts
@@ -1,0 +1,160 @@
+import type IndexStorePort from '../../../ports/IndexStorePort.ts';
+import type MaterializationWorkspacePort from '../../../ports/MaterializationWorkspacePort.ts';
+import type { IndexShard } from '../../artifacts/IndexShard.ts';
+import { PropertyShard } from '../../artifacts/PropertyShard.ts';
+import MaterializationRoot from '../../materialization/MaterializationRoot.ts';
+import MaterializationRoots from '../../materialization/MaterializationRoots.ts';
+import {
+  MATERIALIZATION_INDEX_SHARD_LIMITS,
+  MAX_MATERIALIZATION_INDEX_SHARDS,
+  requireMaterializationIndexShardCount,
+} from '../../materialization/MaterializationIndexProfile.ts';
+import {
+  materializationPropertyShardKey,
+  MATERIALIZATION_PROPERTY_SHARD_LIMITS,
+  MAX_MATERIALIZATION_PROPERTY_SHARDS,
+  requireMaterializationPropertyShardCount,
+} from '../../materialization/MaterializationPropertyProfile.ts';
+import WarpStream from '../../stream/WarpStream.ts';
+import LogicalIndexBuildService from '../index/LogicalIndexBuildService.ts';
+import PropertyIndexBuilder from '../index/PropertyIndexBuilder.ts';
+import type WarpState from '../state/WarpState.ts';
+
+export type PreparedMaterializationIndexRoots = Readonly<{
+  properties: MaterializationRoot;
+  roaringIndexes: MaterializationRoot;
+}>;
+
+/** Stages bounded page-backed logical and property roots in one materialization workspace. */
+export async function prepareMaterializationIndexRoots(args: {
+  readonly state: WarpState;
+  readonly store: IndexStorePort | undefined;
+  readonly workspace: MaterializationWorkspacePort;
+  readonly existingPropertyRoot?: MaterializationRoot;
+  readonly existingIndexRoot?: MaterializationRoot;
+}): Promise<PreparedMaterializationIndexRoots> {
+  return Object.freeze({
+    properties: await resolvePropertyRoot({
+      state: args.state,
+      store: args.store,
+      workspace: args.workspace,
+      existing: args.existingPropertyRoot,
+    }),
+    roaringIndexes: await resolveIndexRoot({
+      state: args.state,
+      store: args.store,
+      workspace: args.workspace,
+      existing: args.existingIndexRoot,
+    }),
+  });
+}
+
+/** Builds a whole-state descriptor whose retained derived roots are the bounded indexes. */
+export function materializationRootsWithIndexes(
+  prepared: PreparedMaterializationIndexRoots,
+): MaterializationRoots {
+  const unavailable = () => MaterializationRoot.unavailable();
+  return new MaterializationRoots({
+    adjacency: unavailable(),
+    edgeAlive: unavailable(),
+    edgeBirths: unavailable(),
+    frontier: unavailable(),
+    nodeAlive: unavailable(),
+    properties: prepared.properties,
+    provenanceSupport: unavailable(),
+    replayBasis: unavailable(),
+    roaringIndexes: prepared.roaringIndexes,
+  });
+}
+
+async function materializeIndexRoot(
+  state: WarpState,
+  store: IndexStorePort | undefined,
+  workspace: MaterializationWorkspacePort,
+): Promise<MaterializationRoot> {
+  if (store === undefined) {
+    return MaterializationRoot.unavailable();
+  }
+  const shards = new LogicalIndexBuildService()
+    .buildShards(state)
+    .shards
+    .filter((shard) => !(shard instanceof PropertyShard));
+  const shardCount = requireMaterializationIndexShardCount(shards.length);
+  const handle = await store.writeShards(
+    WarpStream.from<IndexShard>(shards),
+    {
+      expectedShardCount: shardCount,
+      memberStorage: 'page',
+      maxShardCount: MAX_MATERIALIZATION_INDEX_SHARDS,
+      maxShardBytes: MATERIALIZATION_INDEX_SHARD_LIMITS.maxBytes,
+      structureLimits: MATERIALIZATION_INDEX_SHARD_LIMITS.structureLimits,
+      staging: workspace,
+    },
+  );
+  return MaterializationRoot.retained(handle);
+}
+
+async function resolveIndexRoot(args: {
+  readonly state: WarpState;
+  readonly store: IndexStorePort | undefined;
+  readonly workspace: MaterializationWorkspacePort;
+  readonly existing: MaterializationRoot | undefined;
+}): Promise<MaterializationRoot> {
+  if (args.existing !== undefined && args.existing.status !== 'unavailable') {
+    return args.existing;
+  }
+  return await materializeIndexRoot(args.state, args.store, args.workspace);
+}
+
+async function materializePropertyRoot(
+  state: WarpState,
+  store: IndexStorePort | undefined,
+  workspace: MaterializationWorkspacePort,
+): Promise<MaterializationRoot> {
+  if (store === undefined) {
+    return MaterializationRoot.unavailable();
+  }
+  const builder = buildMaterializationPropertyIndex(state);
+  const shardCount = builder.shardCount();
+  if (shardCount === 0) {
+    return MaterializationRoot.empty();
+  }
+  requireMaterializationPropertyShardCount(shardCount);
+  const handle = await store.writeShards(
+    WarpStream.from<IndexShard>(builder.yieldShards()),
+    {
+      expectedShardCount: shardCount,
+      memberStorage: 'page',
+      maxShardCount: MAX_MATERIALIZATION_PROPERTY_SHARDS,
+      maxShardBytes: MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxBytes,
+      structureLimits: MATERIALIZATION_PROPERTY_SHARD_LIMITS.structureLimits,
+      staging: workspace,
+    },
+  );
+  return MaterializationRoot.retained(handle);
+}
+
+function buildMaterializationPropertyIndex(state: WarpState): PropertyIndexBuilder {
+  const builder = new PropertyIndexBuilder({
+    schemaVersion: 2,
+    shardKey: materializationPropertyShardKey,
+  });
+  for (const entry of state.nodeProperties()) {
+    if (state.nodeAlive.contains(entry.nodeId)) {
+      builder.addProperty(entry.nodeId, entry.key, entry.register.value);
+    }
+  }
+  return builder;
+}
+
+async function resolvePropertyRoot(args: {
+  readonly state: WarpState;
+  readonly store: IndexStorePort | undefined;
+  readonly workspace: MaterializationWorkspacePort;
+  readonly existing: MaterializationRoot | undefined;
+}): Promise<MaterializationRoot> {
+  if (args.existing !== undefined && args.existing.status !== 'unavailable') {
+    return args.existing;
+  }
+  return await materializePropertyRoot(args.state, args.store, args.workspace);
+}

--- a/src/domain/services/controllers/MaterializationRetention.ts
+++ b/src/domain/services/controllers/MaterializationRetention.ts
@@ -1,5 +1,6 @@
 import MaterializationCoordinate from '../../materialization/MaterializationCoordinate.ts';
 import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
+import { unavailableMaterializationRoots } from '../../materialization/UnavailableMaterializationRoots.ts';
 import WarpError from '../../errors/WarpError.ts';
 import {
   materializationSessionOpen,
@@ -67,18 +68,20 @@ async function publishMaterialization(input: {
   readonly stateHash: string;
 }): Promise<MaterializationHandle | undefined> {
   const { params } = input;
-  if (params.reduced.roots === undefined || params.frontier === null) {
+  if (params.frontier === null) {
     await acceptSessionWithoutMaterialization(params.reduced);
     return undefined;
   }
+  const roots = params.reduced.roots ?? unavailableMaterializationRoots();
   const request = {
     coordinate: new MaterializationCoordinate({
       frontier: params.frontier,
       ceiling: params.ceiling,
     }),
-    roots: params.reduced.roots,
+    roots,
     stateHash: input.stateHash,
     replayBasis: params.reduced.state,
+    provenanceSupport: params.summary.provenance,
   };
   const materialization = params.reduced.workspace === undefined
     ? await input.deps.materializations.retain(request)

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -317,7 +317,10 @@ export default class MaterializeController {
         ...(retainedRoots === null ? {} : { roots: retainedRoots }),
         ...(retainedRoots === null || retained === null
           ? {}
-          : { propertyRoot: retained.roots.properties }),
+          : {
+            propertyRoot: retained.roots.properties,
+            indexRoot: retained.roots.roaringIndexes,
+          }),
         ...(retainedRoots === null || retained === null
           ? {}
           : { replayBasisRoot: retained.roots.replayBasis }),
@@ -412,6 +415,7 @@ export default class MaterializeController {
         ? {}
         : {
           propertyRoot: resumeFrom.roots.properties,
+          indexRoot: resumeFrom.roots.roaringIndexes,
           replayBasisRoot: resumeFrom.roots.replayBasis,
         }),
     });

--- a/src/domain/services/controllers/MaterializeController.ts
+++ b/src/domain/services/controllers/MaterializeController.ts
@@ -320,6 +320,7 @@ export default class MaterializeController {
           : {
             propertyRoot: retained.roots.properties,
             indexRoot: retained.roots.roaringIndexes,
+            provenanceSupportRoot: retained.roots.provenanceSupport,
           }),
         ...(retainedRoots === null || retained === null
           ? {}
@@ -416,6 +417,7 @@ export default class MaterializeController {
         : {
           propertyRoot: resumeFrom.roots.properties,
           indexRoot: resumeFrom.roots.roaringIndexes,
+          provenanceSupportRoot: resumeFrom.roots.provenanceSupport,
           replayBasisRoot: resumeFrom.roots.replayBasis,
         }),
     });

--- a/src/domain/services/controllers/MaterializeSessionBridge.ts
+++ b/src/domain/services/controllers/MaterializeSessionBridge.ts
@@ -47,6 +47,7 @@ export async function reduceSessionBackedState(args: {
   readonly propertyStore?: IndexStorePort;
   readonly propertyRoot?: MaterializationRoot;
   readonly indexRoot?: MaterializationRoot;
+  readonly provenanceSupportRoot?: MaterializationRoot;
   readonly replayBasisRoot?: MaterializationRoot;
   readonly coordinate: MaterializationCoordinate;
   readonly patches: MaterializeSessionPatchSource;
@@ -134,10 +135,17 @@ export async function reduceSessionBackedState(args: {
     const replayBasis = reducedPatchCount === 0 && args.replayBasisRoot !== undefined
       ? args.replayBasisRoot
       : MaterializationRoot.unavailable();
+    const provenanceSupport = (
+      reducedPatchCount === 0
+      && args.provenanceSupportRoot !== undefined
+    )
+      ? args.provenanceSupportRoot
+      : MaterializationRoot.unavailable();
     const roots = materializationRootsFromSession(
       close.roots,
       properties,
       roaringIndexes,
+      provenanceSupport,
       replayBasis,
     );
     return {
@@ -202,6 +210,7 @@ function materializationRootsFromSession(
   roots: MaterializeSessionOpen,
   properties: MaterializationRoot,
   roaringIndexes: MaterializationRoot,
+  provenanceSupport: MaterializationRoot,
   replayBasis: MaterializationRoot,
 ): MaterializationRoots {
   return new MaterializationRoots({
@@ -211,7 +220,7 @@ function materializationRootsFromSession(
     frontier: MaterializationRoot.unavailable(),
     nodeAlive: sessionMaterializationRoot(roots.nodeAliveRootOid),
     properties,
-    provenanceSupport: MaterializationRoot.unavailable(),
+    provenanceSupport,
     replayBasis,
     roaringIndexes,
   });

--- a/src/domain/services/controllers/MaterializeSessionBridge.ts
+++ b/src/domain/services/controllers/MaterializeSessionBridge.ts
@@ -11,6 +11,11 @@ import type MaterializationCoordinate from "../../materialization/Materializatio
 import type StorageRetentionWitness from "../../storage/StorageRetentionWitness.ts";
 import MaterializationRoot from "../../materialization/MaterializationRoot.ts";
 import MaterializationRoots from "../../materialization/MaterializationRoots.ts";
+import {
+  MATERIALIZATION_INDEX_SHARD_LIMITS,
+  MAX_MATERIALIZATION_INDEX_SHARDS,
+  requireMaterializationIndexShardCount,
+} from "../../materialization/MaterializationIndexProfile.ts";
 import BundleHandle from "../../storage/BundleHandle.ts";
 import type { PatchDiff } from "../../types/PatchDiff.ts";
 import type { TickReceipt } from "../../types/TickReceipt.ts";
@@ -25,8 +30,10 @@ import {
 } from "./MaterializeHelpers.ts";
 import { releaseWorkspaceAfterFailure } from "./MaterializationWorkspaceCleanup.ts";
 import PropertyIndexBuilder from "../index/PropertyIndexBuilder.ts";
+import LogicalIndexBuildService from "../index/LogicalIndexBuildService.ts";
 import WarpStream from "../../stream/WarpStream.ts";
 import type { IndexShard } from "../../artifacts/IndexShard.ts";
+import { PropertyShard } from "../../artifacts/PropertyShard.ts";
 import {
   materializationPropertyShardKey,
   MATERIALIZATION_PROPERTY_SHARD_LIMITS,
@@ -54,6 +61,7 @@ export async function reduceSessionBackedState(args: {
   readonly logger?: LoggerPort;
   readonly propertyStore?: IndexStorePort;
   readonly propertyRoot?: MaterializationRoot;
+  readonly indexRoot?: MaterializationRoot;
   readonly replayBasisRoot?: MaterializationRoot;
   readonly coordinate: MaterializationCoordinate;
   readonly patches: MaterializeSessionPatchSource;
@@ -127,11 +135,27 @@ export async function reduceSessionBackedState(args: {
       workspace,
       reducedPatchCount === 0 ? args.propertyRoot : undefined,
     );
-    await retainPreparedPropertyRoot(workspace, close.roots, properties);
+    const roaringIndexes = await resolveIndexRoot(
+      reduced.state,
+      args.propertyStore,
+      workspace,
+      reducedPatchCount === 0 ? args.indexRoot : undefined,
+    );
+    await retainPreparedIndexRoots(
+      workspace,
+      close.roots,
+      properties,
+      roaringIndexes,
+    );
     const replayBasis = reducedPatchCount === 0 && args.replayBasisRoot !== undefined
       ? args.replayBasisRoot
       : MaterializationRoot.unavailable();
-    const roots = materializationRootsFromSession(close.roots, properties, replayBasis);
+    const roots = materializationRootsFromSession(
+      close.roots,
+      properties,
+      roaringIndexes,
+      replayBasis,
+    );
     return {
       ...reduced,
       roots,
@@ -193,6 +217,7 @@ export function materializationSessionOpen(
 function materializationRootsFromSession(
   roots: MaterializeSessionOpen,
   properties: MaterializationRoot,
+  roaringIndexes: MaterializationRoot,
   replayBasis: MaterializationRoot,
 ): MaterializationRoots {
   return new MaterializationRoots({
@@ -204,8 +229,47 @@ function materializationRootsFromSession(
     properties,
     provenanceSupport: MaterializationRoot.unavailable(),
     replayBasis,
-    roaringIndexes: MaterializationRoot.unavailable(),
+    roaringIndexes,
   });
+}
+
+async function materializeIndexRoot(
+  state: WarpStateClass,
+  store: IndexStorePort | undefined,
+  workspace: MaterializationWorkspacePort,
+): Promise<MaterializationRoot> {
+  if (store === undefined) {
+    return MaterializationRoot.unavailable();
+  }
+  const shards = new LogicalIndexBuildService()
+    .buildShards(state)
+    .shards
+    .filter((shard) => !(shard instanceof PropertyShard));
+  const shardCount = requireMaterializationIndexShardCount(shards.length);
+  const handle = await store.writeShards(
+    WarpStream.from<IndexShard>(shards),
+    {
+      expectedShardCount: shardCount,
+      memberStorage: 'page',
+      maxShardCount: MAX_MATERIALIZATION_INDEX_SHARDS,
+      maxShardBytes: MATERIALIZATION_INDEX_SHARD_LIMITS.maxBytes,
+      structureLimits: MATERIALIZATION_INDEX_SHARD_LIMITS.structureLimits,
+      staging: workspace,
+    },
+  );
+  return MaterializationRoot.retained(handle);
+}
+
+async function resolveIndexRoot(
+  state: WarpStateClass,
+  store: IndexStorePort | undefined,
+  workspace: MaterializationWorkspacePort,
+  existing: MaterializationRoot | undefined,
+): Promise<MaterializationRoot> {
+  if (existing !== undefined && existing.status !== 'unavailable') {
+    return existing;
+  }
+  return await materializeIndexRoot(state, store, workspace);
 }
 
 async function materializePropertyRoot(
@@ -258,18 +322,26 @@ async function resolvePropertyRoot(
   return await materializePropertyRoot(state, store, workspace);
 }
 
-async function retainPreparedPropertyRoot(
+async function retainPreparedIndexRoots(
   workspace: MaterializationWorkspacePort,
   roots: MaterializeSessionOpen,
   properties: MaterializationRoot,
+  roaringIndexes: MaterializationRoot,
 ): Promise<void> {
-  if (properties.status !== 'retained' || properties.handle === null) {
+  const propertiesRoot = properties.status === 'retained'
+    ? properties.handle?.toString()
+    : undefined;
+  const roaringIndexesRoot = roaringIndexes.status === 'retained'
+    ? roaringIndexes.handle?.toString()
+    : undefined;
+  if (propertiesRoot === undefined && roaringIndexesRoot === undefined) {
     return;
   }
   await workspace.checkpoint({
     nodeAliveRoot: roots.nodeAliveRootOid,
     edgeAliveRoot: roots.edgeAliveRootOid,
-    propertiesRoot: properties.handle.toString(),
+    ...(propertiesRoot === undefined ? {} : { propertiesRoot }),
+    ...(roaringIndexesRoot === undefined ? {} : { roaringIndexesRoot }),
   });
 }
 

--- a/src/domain/services/controllers/MaterializeSessionBridge.ts
+++ b/src/domain/services/controllers/MaterializeSessionBridge.ts
@@ -11,11 +11,6 @@ import type MaterializationCoordinate from "../../materialization/Materializatio
 import type StorageRetentionWitness from "../../storage/StorageRetentionWitness.ts";
 import MaterializationRoot from "../../materialization/MaterializationRoot.ts";
 import MaterializationRoots from "../../materialization/MaterializationRoots.ts";
-import {
-  MATERIALIZATION_INDEX_SHARD_LIMITS,
-  MAX_MATERIALIZATION_INDEX_SHARDS,
-  requireMaterializationIndexShardCount,
-} from "../../materialization/MaterializationIndexProfile.ts";
 import BundleHandle from "../../storage/BundleHandle.ts";
 import type { PatchDiff } from "../../types/PatchDiff.ts";
 import type { TickReceipt } from "../../types/TickReceipt.ts";
@@ -29,17 +24,7 @@ import {
   type MaterializeAdjacency,
 } from "./MaterializeHelpers.ts";
 import { releaseWorkspaceAfterFailure } from "./MaterializationWorkspaceCleanup.ts";
-import PropertyIndexBuilder from "../index/PropertyIndexBuilder.ts";
-import LogicalIndexBuildService from "../index/LogicalIndexBuildService.ts";
-import WarpStream from "../../stream/WarpStream.ts";
-import type { IndexShard } from "../../artifacts/IndexShard.ts";
-import { PropertyShard } from "../../artifacts/PropertyShard.ts";
-import {
-  materializationPropertyShardKey,
-  MATERIALIZATION_PROPERTY_SHARD_LIMITS,
-  MAX_MATERIALIZATION_PROPERTY_SHARDS,
-  requireMaterializationPropertyShardCount,
-} from "../../materialization/MaterializationPropertyProfile.ts";
+import { prepareMaterializationIndexRoots } from "./MaterializationIndexRoots.ts";
 
 export type MaterializeSessionOpen = {
   readonly nodeAliveRootOid: string | null;
@@ -129,18 +114,17 @@ export async function reduceSessionBackedState(args: {
     }
 
     const close = await frame.session.prepareClose();
-    const properties = await resolvePropertyRoot(
-      reduced.state,
-      args.propertyStore,
+    const { properties, roaringIndexes } = await prepareMaterializationIndexRoots({
+      state: reduced.state,
+      store: args.propertyStore,
       workspace,
-      reducedPatchCount === 0 ? args.propertyRoot : undefined,
-    );
-    const roaringIndexes = await resolveIndexRoot(
-      reduced.state,
-      args.propertyStore,
-      workspace,
-      reducedPatchCount === 0 ? args.indexRoot : undefined,
-    );
+      ...(reducedPatchCount === 0 && args.propertyRoot !== undefined
+        ? { existingPropertyRoot: args.propertyRoot }
+        : {}),
+      ...(reducedPatchCount === 0 && args.indexRoot !== undefined
+        ? { existingIndexRoot: args.indexRoot }
+        : {}),
+    });
     await retainPreparedIndexRoots(
       workspace,
       close.roots,
@@ -231,95 +215,6 @@ function materializationRootsFromSession(
     replayBasis,
     roaringIndexes,
   });
-}
-
-async function materializeIndexRoot(
-  state: WarpStateClass,
-  store: IndexStorePort | undefined,
-  workspace: MaterializationWorkspacePort,
-): Promise<MaterializationRoot> {
-  if (store === undefined) {
-    return MaterializationRoot.unavailable();
-  }
-  const shards = new LogicalIndexBuildService()
-    .buildShards(state)
-    .shards
-    .filter((shard) => !(shard instanceof PropertyShard));
-  const shardCount = requireMaterializationIndexShardCount(shards.length);
-  const handle = await store.writeShards(
-    WarpStream.from<IndexShard>(shards),
-    {
-      expectedShardCount: shardCount,
-      memberStorage: 'page',
-      maxShardCount: MAX_MATERIALIZATION_INDEX_SHARDS,
-      maxShardBytes: MATERIALIZATION_INDEX_SHARD_LIMITS.maxBytes,
-      structureLimits: MATERIALIZATION_INDEX_SHARD_LIMITS.structureLimits,
-      staging: workspace,
-    },
-  );
-  return MaterializationRoot.retained(handle);
-}
-
-async function resolveIndexRoot(
-  state: WarpStateClass,
-  store: IndexStorePort | undefined,
-  workspace: MaterializationWorkspacePort,
-  existing: MaterializationRoot | undefined,
-): Promise<MaterializationRoot> {
-  if (existing !== undefined && existing.status !== 'unavailable') {
-    return existing;
-  }
-  return await materializeIndexRoot(state, store, workspace);
-}
-
-async function materializePropertyRoot(
-  state: WarpStateClass,
-  store: IndexStorePort | undefined,
-  workspace: MaterializationWorkspacePort,
-): Promise<MaterializationRoot> {
-  if (store === undefined) {
-    return MaterializationRoot.unavailable();
-  }
-  const builder = new PropertyIndexBuilder({
-    schemaVersion: 2,
-    shardKey: materializationPropertyShardKey,
-  });
-  let propertyCount = 0;
-  for (const entry of state.nodeProperties()) {
-    if (state.nodeAlive.contains(entry.nodeId)) {
-      builder.addProperty(entry.nodeId, entry.key, entry.register.value);
-      propertyCount += 1;
-    }
-  }
-  if (propertyCount === 0) {
-    return MaterializationRoot.empty();
-  }
-  const shardCount = builder.shardCount();
-  requireMaterializationPropertyShardCount(shardCount);
-  const handle = await store.writeShards(
-    WarpStream.from<IndexShard>(builder.yieldShards()),
-    {
-      expectedShardCount: shardCount,
-      memberStorage: 'page',
-      maxShardCount: MAX_MATERIALIZATION_PROPERTY_SHARDS,
-      maxShardBytes: MATERIALIZATION_PROPERTY_SHARD_LIMITS.maxBytes,
-      structureLimits: MATERIALIZATION_PROPERTY_SHARD_LIMITS.structureLimits,
-      staging: workspace,
-    },
-  );
-  return MaterializationRoot.retained(handle);
-}
-
-async function resolvePropertyRoot(
-  state: WarpStateClass,
-  store: IndexStorePort | undefined,
-  workspace: MaterializationWorkspacePort,
-  existing: MaterializationRoot | undefined,
-): Promise<MaterializationRoot> {
-  if (existing !== undefined && existing.status !== "unavailable") {
-    return existing;
-  }
-  return await materializePropertyRoot(state, store, workspace);
 }
 
 async function retainPreparedIndexRoots(

--- a/src/domain/services/index/LogicalIndexReader.ts
+++ b/src/domain/services/index/LogicalIndexReader.ts
@@ -19,6 +19,7 @@ import type CodecPort from '../../../ports/CodecPort.ts';
 import type IndexStorePort from '../../../ports/IndexStorePort.ts';
 import type AssetHandle from '../../storage/AssetHandle.ts';
 import type BundleHandle from '../../storage/BundleHandle.ts';
+import { MATERIALIZATION_INDEX_SHARD_LIMITS } from '../../materialization/MaterializationIndexProfile.ts';
 import type { IndexShard } from '../../artifacts/IndexShard.ts';
 import type CodecValue from '../../types/codec/CodecValue.ts';
 import {
@@ -100,6 +101,37 @@ export default class LogicalIndexReader {
     const Ctor = getRoaringBitmap32();
     for (const [path, handle] of Object.entries(shardHandles)) {
       replacement._loadDecodedItem(path, await indexStore.decodeShard(handle), Ctor);
+    }
+    this._replaceState(replacement);
+    return this;
+  }
+
+  /** Loads only the named members from a retained page/asset-backed index bundle. */
+  async loadFromStorePaths(
+    indexHandle: BundleHandle,
+    paths: readonly string[],
+  ): Promise<this> {
+    if (this._indexStore === null) {
+      throw new IndexError(
+        'LogicalIndexReader: loadFromStorePaths() requires an indexStore',
+        { code: 'E_INDEX_NO_STORE' },
+      );
+    }
+    const replacement = new LogicalIndexReader({ indexStore: this._indexStore });
+    const Ctor = getRoaringBitmap32();
+    for (const path of paths) {
+      const decoded = await this._indexStore.decodeShardAt(
+        indexHandle,
+        path,
+        MATERIALIZATION_INDEX_SHARD_LIMITS,
+      );
+      if (decoded === null) {
+        throw new IndexError(`Index shard is missing: ${path}`, {
+          code: 'E_INDEX_SHARD_MISSING',
+          context: { path },
+        });
+      }
+      replacement._loadDecodedItem(path, decoded, Ctor);
     }
     this._replaceState(replacement);
     return this;

--- a/src/domain/services/index/PropertyIndexReader.ts
+++ b/src/domain/services/index/PropertyIndexReader.ts
@@ -13,6 +13,12 @@ import { requireCodec } from '../codec/CodecRequirement.ts';
 import type CodecPort from '../../../ports/CodecPort.ts';
 import type IndexStorePort from '../../../ports/IndexStorePort.ts';
 import type AssetHandle from '../../storage/AssetHandle.ts';
+import type BundleHandle from '../../storage/BundleHandle.ts';
+import {
+  MATERIALIZATION_PROPERTY_SHARD_LIMITS,
+  materializationPropertyShardKey,
+  materializationPropertyShardPath,
+} from '../../materialization/MaterializationPropertyProfile.ts';
 import { isPropValue, type PropValue } from '../../types/PropValue.ts';
 import type CodecValue from '../../types/codec/CodecValue.ts';
 
@@ -271,6 +277,7 @@ export default class PropertyIndexReader {
   private readonly _indexStore: IndexStorePort | null;
   private _shardHandles: Map<string, AssetHandle>;
   private _inMemoryShards: Map<string, Uint8Array>;
+  private _indexRoot: BundleHandle | null;
 
   constructor(options?: {
     codec?: CodecPort;
@@ -281,17 +288,27 @@ export default class PropertyIndexReader {
     this._indexStore = indexStore ?? null;
     this._shardHandles = new Map();
     this._inMemoryShards = new Map();
+    this._indexRoot = null;
   }
 
   /** Configures opaque shard handles for lazy loading. */
   setupHandles(shardHandles: Readonly<Record<string, AssetHandle>>): void {
     this._shardHandles = new Map(Object.entries(shardHandles));
     this._inMemoryShards.clear();
+    this._indexRoot = null;
+  }
+
+  /** Configures a retained page/asset-backed bundle for exact member reads. */
+  setupRoot(indexRoot: BundleHandle): void {
+    this._shardHandles.clear();
+    this._inMemoryShards.clear();
+    this._indexRoot = indexRoot;
   }
 
   /** Configures encoded in-memory shards for a freshly built view. */
   setupTree(tree: Readonly<Record<string, Uint8Array>>): void {
     this._shardHandles.clear();
+    this._indexRoot = null;
     this._inMemoryShards = new Map(
       Object.entries(tree).filter(([path]) => path.startsWith('props_')),
     );
@@ -320,15 +337,39 @@ export default class PropertyIndexReader {
   }
 
   private async _loadShard(nodeId: string): Promise<PropertyShard | null> {
-    const shardKey = computeShardKey(nodeId);
-    const path = `props_${shardKey}.cbor`;
-
+    if (this._indexRoot !== null) {
+      return await this._fetchAndDecodeRoot(
+        this._indexRoot,
+        materializationPropertyShardPath(nodeId),
+      );
+    }
+    const path = `props_${computeShardKey(nodeId)}.cbor`;
     const handle = this._shardHandles.get(path);
     const inMemory = this._inMemoryShards.get(path);
-    if (handle === undefined && inMemory === undefined) {
-      return null;
+    if (handle !== undefined || inMemory !== undefined) {
+      return await this._fetchAndDecode({ path, handle, inMemory });
     }
-    return await this._fetchAndDecode({ path, handle, inMemory });
+    return null;
+  }
+
+  private async _fetchAndDecodeRoot(
+    root: BundleHandle,
+    path: string,
+  ): Promise<PropertyShard | null> {
+    if (this._indexStore === null) {
+      throw new IndexError(`PropertyIndexReader: no index store for '${path}'`, {
+        code: 'E_INDEX_NO_STORE',
+        context: { path },
+      });
+    }
+    const decoded = await this._indexStore.decodeShardAt(
+      root,
+      path,
+      MATERIALIZATION_PROPERTY_SHARD_LIMITS,
+    );
+    return decoded === null
+      ? null
+      : decodePropertyShard(decoded, path, materializationPropertyShardKey);
   }
 
   private async _fetchAndDecode(options: {

--- a/src/domain/services/optic/CheckpointShardFactReader.ts
+++ b/src/domain/services/optic/CheckpointShardFactReader.ts
@@ -13,7 +13,10 @@ import type { CheckpointTailIndexBasis } from './CheckpointTailBasisLoader.ts';
 import type CheckpointTailOpticSource from './CheckpointTailOpticSource.ts';
 import type { ReadIdentityIndexShard } from './ReadIdentity.ts';
 import type AssetHandle from '../../storage/AssetHandle.ts';
+import type BundleHandle from '../../storage/BundleHandle.ts';
 import { collectAsyncIterable } from '../../utils/streamUtils.ts';
+import { MAX_MATERIALIZATION_INDEX_SHARD_BYTES } from '../../materialization/MaterializationIndexProfile.ts';
+import { materializationPropertyShardPath } from '../../materialization/MaterializationPropertyProfile.ts';
 
 export type {
   CheckpointShardNeighborhoodPage,
@@ -36,6 +39,10 @@ type CheckpointShardReadFailureContext = {
   readonly oid: string;
 };
 
+type BoundCheckpointShard =
+  | Readonly<{ kind: 'asset'; handle: AssetHandle }>
+  | Readonly<{ kind: 'bundle'; root: BundleHandle }>;
+
 export default class CheckpointShardFactReader {
   private readonly _source: CheckpointTailOpticSource;
 
@@ -53,10 +60,14 @@ export default class CheckpointShardFactReader {
     if (token === undefined) {
       return false;
     }
-    const handle = requireBoundShardHandle(basis, path, token);
+    const shard = requireBoundShard(basis, path, token);
     try {
-      const reader = await new LogicalIndexReader({ indexStore: this._source._indexStore })
-        .loadFromHandles({ [path]: handle });
+      const reader = new LogicalIndexReader({ indexStore: this._source._indexStore });
+      if (shard.kind === 'asset') {
+        await reader.loadFromHandles({ [path]: shard.handle });
+      } else {
+        await reader.loadFromStorePaths(shard.root, [path]);
+      }
       return reader.toLogicalIndex().isAlive(nodeId);
     } catch (error) {
       if (!(error instanceof Error)) {
@@ -72,14 +83,18 @@ export default class CheckpointShardFactReader {
     nodeId: string,
     propertyKey: string,
   ): Promise<PropValue | undefined> {
-    const path = this._propertyPath(nodeId);
+    const path = this._propertyPath(basis, nodeId);
     const token = basis.manifest.propertyRoots.get(path);
     if (token === undefined) {
       return undefined;
     }
-    const handle = requireBoundShardHandle(basis, path, token);
+    const shard = requireBoundShard(basis, path, token);
     const reader = new PropertyIndexReader({ indexStore: this._source._indexStore });
-    reader.setupHandles({ [path]: handle });
+    if (shard.kind === 'asset') {
+      reader.setupHandles({ [path]: shard.handle });
+    } else {
+      reader.setupRoot(shard.root);
+    }
     try {
       return await reader.getProperty(nodeId, propertyKey);
     } catch (error) {
@@ -97,11 +112,11 @@ export default class CheckpointShardFactReader {
   ): Promise<CheckpointShardNeighborhoodPage> {
     const neighborhoodReader = new CheckpointNeighborhoodPageReader({
       source: this._source,
-      readShard: async (path, token) => await readShardAsset({
+      readShard: async (path, token) => await readBoundShard({
         graphName: this._source.graphName,
         indexStore: this._source._indexStore,
         path,
-        handle: requireBoundShardHandle(basis, path, token),
+        shard: requireBoundShard(basis, path, token),
       }),
     });
     try {
@@ -127,7 +142,7 @@ export default class CheckpointShardFactReader {
     basis: CheckpointTailIndexBasis,
     nodeId: string,
   ): readonly ReadIdentityIndexShard[] {
-    const path = this._propertyPath(nodeId);
+    const path = this._propertyPath(basis, nodeId);
     return shardIdentities([{ path, oid: basis.manifest.propertyRoots.get(path) }]);
   }
 
@@ -135,8 +150,10 @@ export default class CheckpointShardFactReader {
     return `meta_${computeShardKey(nodeId)}.cbor`;
   }
 
-  private _propertyPath(nodeId: string): string {
-    return `props_${computeShardKey(nodeId)}.cbor`;
+  private _propertyPath(basis: CheckpointTailIndexBasis, nodeId: string): string {
+    return basis.propertyRoot === null
+      ? `props_${computeShardKey(nodeId)}.cbor`
+      : materializationPropertyShardPath(nodeId);
   }
 
 }
@@ -163,19 +180,59 @@ function rethrowPropertyShardReadFailure(
   throw error;
 }
 
-function requireBoundShardHandle(
+function requireBoundShard(
   basis: CheckpointTailIndexBasis,
   path: string,
   manifestToken: string,
-): AssetHandle {
+): BoundCheckpointShard {
   const handle = basis.indexHandles[path] ?? basis.propHandles[path];
-  if (handle === undefined) {
-    throwShardIdentityMismatch(path, manifestToken, null);
+  if (handle !== undefined) {
+    return requireAssetBinding(path, manifestToken, handle);
   }
+  return requireBundleBinding(basis, path, manifestToken);
+}
+
+function requireAssetBinding(
+  path: string,
+  manifestToken: string,
+  handle: AssetHandle,
+): BoundCheckpointShard {
   if (handle.toString() !== manifestToken) {
     throwShardIdentityMismatch(path, manifestToken, handle.toString());
   }
-  return handle;
+  return Object.freeze({ kind: 'asset', handle });
+}
+
+function requireBundleBinding(
+  basis: CheckpointTailIndexBasis,
+  path: string,
+  manifestToken: string,
+): BoundCheckpointShard {
+  const reference = basis.indexReferences[path] ?? basis.propReferences[path];
+  if (reference === undefined) {
+    throwShardIdentityMismatch(path, manifestToken, null);
+  }
+  if (reference.token !== manifestToken) {
+    throwShardIdentityMismatch(path, manifestToken, reference.token);
+  }
+  return Object.freeze({
+    kind: 'bundle',
+    root: requireBundleRoot(basis, path, manifestToken),
+  });
+}
+
+function requireBundleRoot(
+  basis: CheckpointTailIndexBasis,
+  path: string,
+  manifestToken: string,
+): BundleHandle {
+  const root = basis.indexReferences[path] === undefined
+    ? basis.propertyRoot
+    : basis.indexRoot;
+  if (root === null) {
+    throwShardIdentityMismatch(path, manifestToken, null);
+  }
+  return root;
 }
 
 function throwShardIdentityMismatch(
@@ -194,20 +251,20 @@ function throwShardIdentityMismatch(
   });
 }
 
-async function readShardAsset(options: {
+async function readBoundShard(options: {
   readonly graphName: string;
   readonly indexStore: CheckpointTailOpticSource['_indexStore'];
   readonly path: string;
-  readonly handle: AssetHandle;
+  readonly shard: BoundCheckpointShard;
 }): Promise<Uint8Array> {
   try {
-    return await collectAsyncIterable(options.indexStore.openShard(options.handle));
+    return await collectAsyncIterable(openBoundShard(options));
   } catch (error) {
     const failure = error instanceof Error
       ? checkpointLogicalShardReadFailure(error, {
         graphName: options.graphName,
         path: options.path,
-        oid: options.handle.toString(),
+        oid: boundShardToken(options.shard),
       })
       : null;
     if (failure !== null) {
@@ -215,6 +272,22 @@ async function readShardAsset(options: {
     }
     throw error;
   }
+}
+
+function openBoundShard(options: {
+  readonly indexStore: CheckpointTailOpticSource['_indexStore'];
+  readonly path: string;
+  readonly shard: BoundCheckpointShard;
+}): AsyncIterable<Uint8Array> {
+  return options.shard.kind === 'asset'
+    ? options.indexStore.openShard(options.shard.handle)
+    : options.indexStore.openShardAt(options.shard.root, options.path, {
+      maxBytes: MAX_MATERIALIZATION_INDEX_SHARD_BYTES,
+    });
+}
+
+function boundShardToken(shard: BoundCheckpointShard): string {
+  return shard.kind === 'asset' ? shard.handle.toString() : shard.root.toString();
 }
 
 function firstShardFailureContext(

--- a/src/domain/services/optic/CheckpointTailBasisLoader.ts
+++ b/src/domain/services/optic/CheckpointTailBasisLoader.ts
@@ -1,5 +1,8 @@
 import QueryError from '../../errors/QueryError.ts';
 import type AssetHandle from '../../storage/AssetHandle.ts';
+import type BundleHandle from '../../storage/BundleHandle.ts';
+import type { IndexShardReference } from '../../../ports/IndexStorePort.ts';
+import type { CheckpointBasis } from '../../../ports/CheckpointStorePort.ts';
 import { partitionShardHandles } from '../MaterializedViewHelpers.ts';
 import { isCurrentCheckpointSchema } from '../state/checkpointHelpers.ts';
 import CheckpointBasisManifest, {
@@ -22,6 +25,10 @@ export type CheckpointTailIndexBasis = {
   readonly manifest: CheckpointBasisManifest;
   readonly indexHandles: Readonly<Record<string, AssetHandle>>;
   readonly propHandles: Readonly<Record<string, AssetHandle>>;
+  readonly indexRoot: BundleHandle | null;
+  readonly propertyRoot: BundleHandle | null;
+  readonly indexReferences: Readonly<Record<string, IndexShardReference>>;
+  readonly propReferences: Readonly<Record<string, IndexShardReference>>;
 };
 
 type CheckpointTailManifestRoots = {
@@ -46,27 +53,16 @@ export default class CheckpointTailBasisLoader {
     if (!isCurrentCheckpointSchema(basis.schema)) {
       throwNoBoundedBasis(this._source.graphName, 'checkpoint-without-index-tree');
     }
-    const { indexHandles, propHandles } = partitionShardHandles(basis.indexShardHandles);
-    if (Object.keys(indexHandles).length === 0 && Object.keys(propHandles).length === 0) {
+    const shards = await loadBasisShards(this._source, basis);
+    if (shardReferenceCount(shards) === 0) {
       throwNoBoundedBasis(this._source.graphName, 'checkpoint-missing-index-shards');
     }
-    const indexIdentities = handleIdentities(indexHandles);
-    const propIdentities = handleIdentities(propHandles);
-    return {
+    return createIndexBasis({
+      source: this._source,
       checkpointSha,
-      schema: basis.schema,
-      frontier: basis.frontier,
-      manifest: createManifest({
-        graphName: this._source.graphName,
-        checkpointSha,
-        frontier: basis.frontier,
-        schema: basis.schema,
-        indexOids: indexIdentities,
-        propOids: propIdentities,
-      }),
-      indexHandles,
-      propHandles,
-    };
+      basis,
+      shards,
+    });
   }
 
   private async _readCheckpointSha(): Promise<string> {
@@ -77,6 +73,58 @@ export default class CheckpointTailBasisLoader {
     return checkpointSha;
   }
 
+}
+
+type LoadedBasisShards = Pick<
+  CheckpointTailIndexBasis,
+  'indexHandles' | 'propHandles' | 'indexReferences' | 'propReferences'
+>;
+
+function createIndexBasis(options: {
+  source: CheckpointTailOpticSource;
+  checkpointSha: string;
+  basis: CheckpointBasis;
+  shards: LoadedBasisShards;
+}): CheckpointTailIndexBasis {
+  const { source, checkpointSha, basis, shards } = options;
+  return {
+    checkpointSha,
+    schema: basis.schema,
+    frontier: basis.frontier,
+    manifest: createManifest({
+      graphName: source.graphName,
+      checkpointSha,
+      frontier: basis.frontier,
+      schema: basis.schema,
+      indexOids: referenceIdentities(shards.indexReferences),
+      propOids: referenceIdentities(shards.propReferences),
+    }),
+    ...shards,
+    indexRoot: basis.indexRoot,
+    propertyRoot: basis.propertyRoot,
+  };
+}
+
+async function loadBasisShards(
+  source: CheckpointTailOpticSource,
+  basis: CheckpointBasis,
+): Promise<LoadedBasisShards> {
+  const { indexHandles, propHandles } = partitionShardHandles(basis.indexShardHandles);
+  return {
+    indexHandles,
+    propHandles,
+    indexReferences: basis.indexRoot === null
+      ? handleReferences(indexHandles)
+      : await source._indexStore.readShardReferences(basis.indexRoot),
+    propReferences: basis.propertyRoot === null
+      ? handleReferences(propHandles)
+      : await source._indexStore.readShardReferences(basis.propertyRoot),
+  };
+}
+
+function shardReferenceCount(shards: LoadedBasisShards): number {
+  return Object.keys(shards.indexReferences).length
+    + Object.keys(shards.propReferences).length;
 }
 
 function createManifest(options: {
@@ -182,11 +230,22 @@ function appliedVersionVectorFromFrontier(frontier: Map<string, string>): Map<st
   return versionVector;
 }
 
-function handleIdentities(
+function handleReferences(
   handles: Readonly<Record<string, AssetHandle>>,
+): Readonly<Record<string, IndexShardReference>> {
+  return Object.freeze(Object.fromEntries(
+    Object.entries(handles).map(([path, handle]) => [
+      path,
+      Object.freeze({ kind: 'asset' as const, token: handle.toString() }),
+    ]),
+  ));
+}
+
+function referenceIdentities(
+  references: Readonly<Record<string, IndexShardReference>>,
 ): CheckpointTailShardIdentityMap {
   return Object.freeze(Object.fromEntries(
-    Object.entries(handles).map(([path, handle]) => [path, handle.toString()]),
+    Object.entries(references).map(([path, reference]) => [path, reference.token]),
   ));
 }
 

--- a/src/domain/services/optic/CheckpointTailBasisVerifier.ts
+++ b/src/domain/services/optic/CheckpointTailBasisVerifier.ts
@@ -40,7 +40,7 @@ async function verifyCheckpointBasis(
   try {
     const basis = await source._checkpointStore.loadBasis(checkpointSha, source.graphName);
     requireCurrentSchema(source.graphName, basis.schema);
-    requireIndexShards(source.graphName, basis.indexShardHandles);
+    requireIndexShards(source.graphName, basis);
   } catch (error) {
     if (error instanceof QueryError && error.code === 'E_OPTIC_NO_BOUNDED_BASIS') {
       throw error;
@@ -57,9 +57,9 @@ function requireCurrentSchema(graphName: string, schema: number): void {
 
 function requireIndexShards(
   graphName: string,
-  handles: CheckpointBasis['indexShardHandles'],
+  basis: CheckpointBasis,
 ): void {
-  if (Object.keys(handles).length === 0) {
+  if (Object.keys(basis.indexShardHandles).length === 0 && basis.indexRoot === null) {
     throwNoBoundedBasis(graphName, 'checkpoint-missing-index-shards');
   }
 }

--- a/src/domain/services/state/checkpointCreate.ts
+++ b/src/domain/services/state/checkpointCreate.ts
@@ -10,6 +10,7 @@ import type CryptoPort from '../../../ports/CryptoPort.ts';
 import type CheckpointStorePort from '../../../ports/CheckpointStorePort.ts';
 import type StateHashService from './StateHashService.ts';
 import type { ProvenanceIndex } from '../provenance/ProvenanceIndex.ts';
+import type MaterializationHandle from '../../materialization/MaterializationHandle.ts';
 
 export interface CreateCheckpointOptions {
   checkpointStore: CheckpointStorePort;
@@ -20,6 +21,7 @@ export interface CreateCheckpointOptions {
   expectedCheckpointSha?: string | null;
   compact?: boolean;
   provenanceIndex?: ProvenanceIndex;
+  materialization?: MaterializationHandle;
   codec?: CodecPort;
   crypto?: CryptoPort;
   indexTree?: Readonly<Record<string, Uint8Array>>;
@@ -44,6 +46,7 @@ export async function createCheckpointEnvelope({
   expectedCheckpointSha,
   compact = true,
   provenanceIndex,
+  materialization,
   codec,
   crypto,
   indexTree,
@@ -51,7 +54,7 @@ export async function createCheckpointEnvelope({
 }: CreateCheckpointOptions): Promise<string> {
   const appliedVV = computeAppliedVV(state);
   let checkpointState = state;
-  if (compact) {
+  if (compact && materialization === undefined) {
     checkpointState = cloneState(state);
     checkpointState.nodeAlive.compact(appliedVV);
     checkpointState.edgeAlive.compact(appliedVV);
@@ -71,6 +74,7 @@ export async function createCheckpointEnvelope({
     appliedVV,
     stateHash,
     parents,
+    ...(materialization === undefined ? {} : { materialization }),
     ...(expectedCheckpointSha === undefined ? {} : { expectedCheckpointSha }),
     ...(provenanceIndex === undefined ? {} : { provenanceIndex }),
     ...(indexTree === undefined ? {} : { indexShards: indexTree }),

--- a/src/domain/services/state/checkpointLoad.ts
+++ b/src/domain/services/state/checkpointLoad.ts
@@ -19,6 +19,7 @@ import { encodeEdgeKey, encodePropKey } from '../KeyCodec.ts';
 import type { PropValue } from '../../types/PropValue.ts';
 import type CheckpointStorePort from '../../../ports/CheckpointStorePort.ts';
 import type AssetHandle from '../../storage/AssetHandle.ts';
+import type BundleHandle from '../../storage/BundleHandle.ts';
 import type Patch from '../../types/Patch.ts';
 import type { ProvenanceIndex } from '../provenance/ProvenanceIndex.ts';
 
@@ -31,6 +32,8 @@ export interface LoadedCheckpoint {
   appliedVV: VersionVector | null;
   provenanceIndex?: ProvenanceIndex;
   indexShardHandles: Readonly<Record<string, AssetHandle>> | null;
+  indexRoot: BundleHandle | null;
+  propertyRoot: BundleHandle | null;
 }
 
 /**
@@ -59,6 +62,8 @@ export async function loadCheckpoint(
     schema: checkpoint.schema,
     appliedVV: checkpoint.appliedVV,
     indexShardHandles: checkpoint.indexShardHandles,
+    indexRoot: checkpoint.indexRoot,
+    propertyRoot: checkpoint.propertyRoot,
   };
   if (checkpoint.provenanceIndex !== null && checkpoint.provenanceIndex !== undefined) {
     result.provenanceIndex = checkpoint.provenanceIndex;

--- a/src/infrastructure/adapters/CborCheckpointStoreAdapter.ts
+++ b/src/infrastructure/adapters/CborCheckpointStoreAdapter.ts
@@ -1,6 +1,9 @@
-import type {
-  BundleCapability,
-  PublicationCapability,
+import {
+  BundleHandle as GitCasBundleHandle,
+  type AssetCapability,
+  type BundleCapability,
+  type PageCapability,
+  type PublicationCapability,
 } from '@git-stunts/git-cas';
 import CheckpointStorePort, {
   type CheckpointBasis,
@@ -11,18 +14,20 @@ import CheckpointStorePort, {
 } from '../../ports/CheckpointStorePort.ts';
 import type AssetStoragePort from '../../ports/AssetStoragePort.ts';
 import type CodecPort from '../../ports/CodecPort.ts';
+import type CryptoPort from '../../ports/CryptoPort.ts';
 import {
   CHECKPOINT_STORAGE_FORMAT,
   type default as CommitMessageCodecPort,
 } from '../../ports/CommitMessageCodecPort.ts';
 import AssetHandle from '../../domain/storage/AssetHandle.ts';
-import BundleHandle from '../../domain/storage/BundleHandle.ts';
+import type BundleHandle from '../../domain/storage/BundleHandle.ts';
 import PersistenceError from '../../domain/errors/PersistenceError.ts';
 import VersionVector from '../../domain/crdt/VersionVector.ts';
 import { ProvenanceIndex } from '../../domain/services/provenance/ProvenanceIndex.ts';
+import type MaterializationRoot from '../../domain/materialization/MaterializationRoot.ts';
 import {
+  computeAppliedVV,
   deserializeCheckpointStateEnvelope,
-  serializeCheckpointStateEnvelope,
   type CheckpointStateEnvelopeBuffers,
 } from '../../domain/services/state/CheckpointSerializer.ts';
 import {
@@ -32,10 +37,17 @@ import {
 import { buildCheckpointRef, buildCoverageRef } from '../../domain/utils/RefLayout.ts';
 import { collectAsyncIterable } from '../../domain/utils/streamUtils.ts';
 import { adaptGitCasRetentionWitness } from './GitCasRetentionWitnessAdapter.ts';
-import { stageCheckpointBundleArtifacts } from './CheckpointBundleArtifactStager.ts';
 import LegacyCheckpointArtifactAdapter from './LegacyCheckpointArtifactAdapter.ts';
 import { classifyCheckpointStorage } from './CheckpointStorageFormatClassifier.ts';
 import { requireAdapterDependency } from './AdapterDependencyGuard.ts';
+import GitCasMaterializationSnapshotReader, {
+  type MaterializationSnapshot,
+} from './GitCasMaterializationSnapshotReader.ts';
+import {
+  requireCheckpointMaterialization,
+  requirePublishedBundle,
+  requireRetainedBundle,
+} from './CheckpointMaterializationPublication.ts';
 
 interface CheckpointHistory {
   readBlob(oid: string): Promise<Uint8Array>;
@@ -48,7 +60,12 @@ interface CheckpointHistory {
 }
 
 export type GitCasCheckpointFacade = {
-  readonly bundles: Pick<BundleCapability, 'putOrdered' | 'iterateMemberReferences'>;
+  readonly assets: Pick<AssetCapability, 'open'>;
+  readonly pages: Pick<PageCapability, 'get'>;
+  readonly bundles: Pick<
+    BundleCapability,
+    'getMemberReference' | 'iterateMemberReferences' | 'putOrdered'
+  >;
   readonly publications: Pick<PublicationCapability, 'commit'>;
 };
 
@@ -60,6 +77,9 @@ type CheckpointLayout = {
   readonly metadata: ReturnType<CommitMessageCodecPort['decodeCheckpoint']>;
   readonly artifacts: Readonly<Record<string, CheckpointArtifact>>;
   readonly indexShardHandles: Readonly<Record<string, AssetHandle>>;
+  readonly materialization: MaterializationSnapshot | null;
+  readonly indexRoot: BundleHandle | null;
+  readonly propertyRoot: BundleHandle | null;
 };
 
 /**
@@ -73,9 +93,11 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
   private readonly _assets: AssetStoragePort;
   private readonly _cas: GitCasCheckpointFacade;
   private readonly _legacyArtifacts: LegacyCheckpointArtifactAdapter;
+  private readonly _materializationSnapshots: GitCasMaterializationSnapshotReader;
 
   constructor(options: {
     codec: CodecPort;
+    crypto: CryptoPort;
     commitMessageCodec: CommitMessageCodecPort;
     history: CheckpointHistory;
     assetStorage: AssetStoragePort;
@@ -83,6 +105,7 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
   }) {
     super();
     requireAdapterDependency(options.codec, 'codec');
+    requireAdapterDependency(options.crypto, 'crypto');
     requireAdapterDependency(options.commitMessageCodec, 'commitMessageCodec');
     requireAdapterDependency(options.history, 'history');
     requireAdapterDependency(options.assetStorage, 'assetStorage');
@@ -96,6 +119,11 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
       history: options.history,
       assets: options.assetStorage,
     });
+    this._materializationSnapshots = new GitCasMaterializationSnapshotReader({
+      cas: options.cas,
+      codec: options.codec,
+      crypto: options.crypto,
+    });
   }
 
   override async publishCheckpoint(record: CheckpointRecord): Promise<PublishedCheckpoint> {
@@ -103,16 +131,9 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
     const expectedHead = record.expectedCheckpointSha === undefined
       ? await this._history.readRef(checkpointRef)
       : record.expectedCheckpointSha;
-    const stateEnvelope = serializeCheckpointStateEnvelope(record.state, { codec: this._codec });
-    const bundle = await this._cas.bundles.putOrdered({
-      members: stageCheckpointBundleArtifacts({
-        assets: this._assets,
-        codec: this._codec,
-        envelope: stateEnvelope,
-        record,
-      }),
-    });
-    const bundleHandle = new BundleHandle(bundle.handle.toString());
+    const materialization = requireCheckpointMaterialization(record);
+    const bundleHandle = materialization.bundle;
+    const root = GitCasBundleHandle.parse(bundleHandle.toString());
     const message = this._messageCodec.encodeCheckpoint({
       kind: 'checkpoint',
       graph: record.graphName,
@@ -122,7 +143,7 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
       bundleHandle,
     });
     const publication = await this._cas.publications.commit({
-      root: bundle.handle,
+      root,
       commit: { parents: record.parents, message },
       ref: { name: checkpointRef, expected: expectedHead },
     });
@@ -145,13 +166,18 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
     expectedGraphName?: string,
   ): Promise<CheckpointData> {
     const layout = await this._readLayout(checkpointSha, expectedGraphName);
-    const state = deserializeCheckpointStateEnvelope(
+    const state = layout.materialization?.state ?? deserializeCheckpointStateEnvelope(
       await this._readStateEnvelope(checkpointSha, layout.artifacts),
       { codec: this._codec },
     );
-    const frontier = await this._readFrontier(checkpointSha, layout.artifacts);
-    const appliedVV = await this._readAppliedVV(layout.artifacts);
-    const provenanceIndex = await this._readProvenanceIndex(layout.artifacts);
+    const frontier = layout.materialization?.coordinate.frontier()
+      ?? await this._readFrontier(checkpointSha, layout.artifacts);
+    const appliedVV = layout.materialization === null
+      ? await this._readAppliedVV(layout.artifacts)
+      : computeAppliedVV(state);
+    const provenanceIndex = layout.materialization === null
+      ? await this._readProvenanceIndex(layout.artifacts)
+      : layout.materialization.provenanceIndex;
     const result: CheckpointData = {
       state,
       frontier,
@@ -161,6 +187,8 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
       indexShardHandles: hasEntries(layout.indexShardHandles)
         ? layout.indexShardHandles
         : null,
+      indexRoot: layout.indexRoot,
+      propertyRoot: layout.propertyRoot,
     };
     if (provenanceIndex !== null) {
       result.provenanceIndex = provenanceIndex;
@@ -192,7 +220,11 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
     expectedGraphName?: string,
   ): Promise<CheckpointBasis> {
     const layout = await this._readLayout(checkpointSha, expectedGraphName);
-    if (!hasEntries(layout.indexShardHandles)) {
+    if (
+      !hasEntries(layout.indexShardHandles)
+      && layout.indexRoot === null
+      && layout.propertyRoot === null
+    ) {
       throw new PersistenceError(
         `Checkpoint ${checkpointSha} has no bounded index basis`,
         'E_CHECKPOINT_MISSING_INDEX',
@@ -203,8 +235,11 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
       checkpointSha,
       stateHash: layout.metadata.stateHash,
       schema: layout.metadata.schema,
-      frontier: await this._readFrontier(checkpointSha, layout.artifacts),
+      frontier: layout.materialization?.coordinate.frontier()
+        ?? await this._readFrontier(checkpointSha, layout.artifacts),
       indexShardHandles: layout.indexShardHandles,
+      indexRoot: layout.indexRoot,
+      propertyRoot: layout.propertyRoot,
     });
   }
 
@@ -256,6 +291,9 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
       indexShardHandles: Object.freeze(Object.fromEntries(
         Object.entries(indexOids).map(([path, oid]) => [path, new AssetHandle(oid)]),
       )),
+      materialization: null,
+      indexRoot: null,
+      propertyRoot: null,
     };
   }
 
@@ -263,43 +301,26 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
     metadata: CheckpointLayout['metadata'],
     bundleHandle: BundleHandle,
   ): Promise<CheckpointLayout> {
-    const artifacts = new Map<string, CheckpointArtifact>();
-    const indexShardHandles = new Map<string, AssetHandle>();
-    for await (const member of this._cas.bundles.iterateMemberReferences({
-      handle: bundleHandle.toString(),
-    })) {
-      if (member.handle.kind !== 'asset') {
-        throw new PersistenceError(
-          `Checkpoint bundle member is not an asset: ${member.path}`,
-          'E_CHECKPOINT_INVALID_BUNDLE_MEMBER',
-          { context: { path: member.path, kind: member.handle.kind } },
-        );
-      }
-      if (artifacts.has(member.path)) {
-        throw new PersistenceError(
-          `Checkpoint bundle contains a duplicate member: ${member.path}`,
-          'E_CHECKPOINT_DUPLICATE_BUNDLE_MEMBER',
-          { context: { path: member.path } },
-        );
-      }
-      const handle = new AssetHandle(member.handle.toString());
-      artifacts.set(member.path, Object.freeze({ kind: 'asset', handle }));
-      if (member.path.startsWith('index/')) {
-        const indexPath = member.path.slice('index/'.length);
-        if (indexPath.length === 0) {
-          throw new PersistenceError(
-            'Checkpoint bundle contains an empty index member path',
-            'E_CHECKPOINT_INVALID_BUNDLE_MEMBER',
-            { context: { path: member.path } },
-          );
-        }
-        indexShardHandles.set(indexPath, handle);
-      }
+    const materialization = await this._materializationSnapshots.read(bundleHandle);
+    if (materialization.stateHash !== metadata.stateHash) {
+      throw new PersistenceError(
+        'Checkpoint metadata does not match its materialization state hash',
+        'E_CHECKPOINT_MATERIALIZATION_MISMATCH',
+      );
+    }
+    if (materialization.coordinate.ceiling !== null) {
+      throw new PersistenceError(
+        'Checkpoint materialization does not represent a live coordinate',
+        'E_CHECKPOINT_MATERIALIZATION_MISMATCH',
+      );
     }
     return {
       metadata,
-      artifacts: Object.freeze(Object.fromEntries(artifacts)),
-      indexShardHandles: Object.freeze(Object.fromEntries(indexShardHandles)),
+      artifacts: Object.freeze({}),
+      indexShardHandles: Object.freeze({}),
+      materialization,
+      indexRoot: retainedRootHandle(materialization.roots.roaringIndexes),
+      propertyRoot: retainedRootHandle(materialization.roots.properties),
     };
   }
 
@@ -395,6 +416,10 @@ function legacyCheckpointArtifact(oid: string): CheckpointArtifact {
   return Object.freeze({ kind: 'legacy-object', oid });
 }
 
+function retainedRootHandle(root: MaterializationRoot): BundleHandle | null {
+  return root.status === 'retained' ? root.handle : null;
+}
+
 function requireArtifact(
   checkpointSha: string,
   artifacts: Readonly<Record<string, CheckpointArtifact>>,
@@ -409,26 +434,6 @@ function requireArtifact(
     'E_CHECKPOINT_MISSING_ARTIFACT',
     { context: { checkpointSha, path } },
   );
-}
-
-function requirePublishedBundle(publishedToken: string, expected: BundleHandle): void {
-  if (publishedToken !== expected.toString()) {
-    throw new PersistenceError(
-      'Checkpoint publication returned a different bundle handle',
-      'E_CHECKPOINT_PUBLICATION_MISMATCH',
-      { context: { expected: expected.toString(), actual: publishedToken } },
-    );
-  }
-}
-
-function requireRetainedBundle(retainedToken: string, expected: BundleHandle): void {
-  if (retainedToken !== expected.toString()) {
-    throw new PersistenceError(
-      'Checkpoint retention evidence names a different bundle handle',
-      'E_CHECKPOINT_RETENTION_MISMATCH',
-      { context: { expected: expected.toString(), actual: retainedToken } },
-    );
-  }
 }
 
 function unsupportedCheckpointSchema(checkpointSha: string, schema: number): PersistenceError {

--- a/src/infrastructure/adapters/CborCheckpointStoreAdapter.ts
+++ b/src/infrastructure/adapters/CborCheckpointStoreAdapter.ts
@@ -44,6 +44,7 @@ import GitCasMaterializationSnapshotReader, {
   type MaterializationSnapshot,
 } from './GitCasMaterializationSnapshotReader.ts';
 import {
+  checkpointMaterializationMismatch,
   requireCheckpointMaterialization,
   requirePublishedBundle,
   requireRetainedBundle,
@@ -303,15 +304,13 @@ export class CborCheckpointStoreAdapter extends CheckpointStorePort {
   ): Promise<CheckpointLayout> {
     const materialization = await this._materializationSnapshots.read(bundleHandle);
     if (materialization.stateHash !== metadata.stateHash) {
-      throw new PersistenceError(
+      throw checkpointMaterializationMismatch(
         'Checkpoint metadata does not match its materialization state hash',
-        'E_CHECKPOINT_MATERIALIZATION_MISMATCH',
       );
     }
     if (materialization.coordinate.ceiling !== null) {
-      throw new PersistenceError(
+      throw checkpointMaterializationMismatch(
         'Checkpoint materialization does not represent a live coordinate',
-        'E_CHECKPOINT_MATERIALIZATION_MISMATCH',
       );
     }
     return {

--- a/src/infrastructure/adapters/CborIndexStoreAdapter.ts
+++ b/src/infrastructure/adapters/CborIndexStoreAdapter.ts
@@ -5,6 +5,7 @@ import type {
 } from '@git-stunts/git-cas';
 import IndexStorePort, {
   type IndexShardDecodeOptions,
+  type IndexShardReference,
   type IndexShardWriteOptions,
 } from '../../ports/IndexStorePort.ts';
 import type AssetStoragePort from '../../ports/AssetStoragePort.ts';
@@ -190,6 +191,26 @@ export class CborIndexStoreAdapter extends IndexStorePort {
     return Object.freeze(Object.fromEntries(entries));
   }
 
+  override async readShardReferences(
+    indexHandle: BundleHandle,
+  ): Promise<Readonly<Record<string, IndexShardReference>>> {
+    const entries: Array<[string, IndexShardReference]> = [];
+    const seenPaths = new Set<string>();
+    for await (const member of this._cas.bundles.iterateMemberReferences({
+      handle: indexHandle.toString(),
+    })) {
+      requireUniqueBundleMember(seenPaths, member.path);
+      entries.push([
+        member.path,
+        Object.freeze({
+          kind: requireShardMemberKind(member.path, member.handle.kind),
+          token: member.handle.toString(),
+        }),
+      ]);
+    }
+    return Object.freeze(Object.fromEntries(entries));
+  }
+
   override async readShardHandle(
     indexHandle: BundleHandle,
     path: string,
@@ -205,6 +226,20 @@ export class CborIndexStoreAdapter extends IndexStorePort {
 
   override openShard(shardHandle: AssetHandle): AsyncIterable<Uint8Array> {
     return this._assets.open(shardHandle);
+  }
+
+  override openShardAt(
+    indexHandle: BundleHandle,
+    path: string,
+    options: Readonly<{ maxBytes?: number }> = {},
+  ): AsyncIterable<Uint8Array> {
+    return streamShardAt({
+      cas: this._cas,
+      assets: this._assets,
+      indexHandle,
+      path,
+      maxBytes: optionalPositiveInteger(options.maxBytes, 'maxBytes'),
+    });
   }
 
   override async decodeShard<TDecoded extends CodecValue = CodecValue>(
@@ -241,6 +276,52 @@ export class CborIndexStoreAdapter extends IndexStorePort {
     });
     validateRequestedStructure(bytes, options);
     return this._codec.decode<TDecoded>(bytes);
+  }
+}
+
+async function* streamShardAt(args: {
+  cas: GitCasIndexFacade;
+  assets: AssetStoragePort;
+  indexHandle: BundleHandle;
+  path: string;
+  maxBytes: number | undefined;
+}): AsyncIterable<Uint8Array> {
+  const member = await args.cas.bundles.getMemberReference({
+    handle: args.indexHandle.toString(),
+    path: args.path,
+  });
+  if (member === null) {
+    throw missingBundleMember(args.path);
+  }
+  if (member.handle.kind === 'page') {
+    yield await args.cas.pages.get({
+      handle: member.handle.toString(),
+      ...(args.maxBytes === undefined ? {} : { maxBytes: args.maxBytes }),
+    });
+    return;
+  }
+  yield* streamAssetShard({
+    assets: args.assets,
+    handle: requireAssetMember(args.path, member.handle.kind, member.handle.toString()),
+    maxBytes: args.maxBytes,
+  });
+}
+
+async function* streamAssetShard(args: {
+  assets: AssetStoragePort;
+  handle: AssetHandle;
+  maxBytes: number | undefined;
+}): AsyncIterable<Uint8Array> {
+  let chunkCount = 0;
+  let total = 0;
+  for await (const chunk of args.assets.open(args.handle)) {
+    chunkCount += 1;
+    requireShardChunkCount(chunkCount);
+    if (args.maxBytes !== undefined && chunk.byteLength > args.maxBytes - total) {
+      throw shardTooLarge(total + chunk.byteLength, args.maxBytes);
+    }
+    total += chunk.byteLength;
+    yield chunk;
   }
 }
 
@@ -341,6 +422,20 @@ function requireAssetMember(path: string, kind: string, token: string): AssetHan
     throw invalidBundleMember(path, kind);
   }
   return new AssetHandle(token);
+}
+
+function requireShardMemberKind(path: string, kind: string): 'asset' | 'page' {
+  if (kind !== 'asset' && kind !== 'page') {
+    throw invalidBundleMember(path, kind);
+  }
+  return kind;
+}
+
+function missingBundleMember(path: string): IndexError {
+  return new IndexError(`Index bundle has no shard member: ${path}`, {
+    code: 'E_INDEX_SHARD_MISSING',
+    context: { path },
+  });
 }
 
 function invalidBundleMember(path: string, kind: string): IndexError {

--- a/src/infrastructure/adapters/CheckpointMaterializationPublication.ts
+++ b/src/infrastructure/adapters/CheckpointMaterializationPublication.ts
@@ -1,0 +1,57 @@
+import type MaterializationHandle from '../../domain/materialization/MaterializationHandle.ts';
+import PersistenceError from '../../domain/errors/PersistenceError.ts';
+import type BundleHandle from '../../domain/storage/BundleHandle.ts';
+import type { CheckpointRecord } from '../../ports/CheckpointStorePort.ts';
+
+export function requireCheckpointMaterialization(
+  record: CheckpointRecord,
+): MaterializationHandle {
+  const { materialization } = record;
+  if (materialization === undefined) {
+    throw new PersistenceError(
+      'Current checkpoint publication requires a retained materialization',
+      'E_CHECKPOINT_MISSING_MATERIALIZATION',
+    );
+  }
+  if (materialization.stateHash !== record.stateHash) {
+    throw materializationMismatch(
+      'Checkpoint state hash does not match its retained materialization',
+    );
+  }
+  if (materialization.coordinate.ceiling !== null) {
+    throw materializationMismatch(
+      'Checkpoint materialization must represent the live coordinate',
+    );
+  }
+  return materialization;
+}
+
+export function requirePublishedBundle(
+  publishedToken: string,
+  expected: BundleHandle,
+): void {
+  if (publishedToken !== expected.toString()) {
+    throw new PersistenceError(
+      'Checkpoint publication returned a different bundle handle',
+      'E_CHECKPOINT_PUBLICATION_MISMATCH',
+      { context: { expected: expected.toString(), actual: publishedToken } },
+    );
+  }
+}
+
+export function requireRetainedBundle(
+  retainedToken: string,
+  expected: BundleHandle,
+): void {
+  if (retainedToken !== expected.toString()) {
+    throw new PersistenceError(
+      'Checkpoint retention evidence names a different bundle handle',
+      'E_CHECKPOINT_RETENTION_MISMATCH',
+      { context: { expected: expected.toString(), actual: retainedToken } },
+    );
+  }
+}
+
+function materializationMismatch(message: string): PersistenceError {
+  return new PersistenceError(message, 'E_CHECKPOINT_MATERIALIZATION_MISMATCH');
+}

--- a/src/infrastructure/adapters/CheckpointMaterializationPublication.ts
+++ b/src/infrastructure/adapters/CheckpointMaterializationPublication.ts
@@ -14,13 +14,18 @@ export function requireCheckpointMaterialization(
     );
   }
   if (materialization.stateHash !== record.stateHash) {
-    throw materializationMismatch(
+    throw checkpointMaterializationMismatch(
       'Checkpoint state hash does not match its retained materialization',
     );
   }
   if (materialization.coordinate.ceiling !== null) {
-    throw materializationMismatch(
+    throw checkpointMaterializationMismatch(
       'Checkpoint materialization must represent the live coordinate',
+    );
+  }
+  if (!frontiersEqual(materialization.coordinate.frontier(), record.frontier)) {
+    throw checkpointMaterializationMismatch(
+      'Checkpoint frontier does not match its retained materialization',
     );
   }
   return materialization;
@@ -52,6 +57,14 @@ export function requireRetainedBundle(
   }
 }
 
-function materializationMismatch(message: string): PersistenceError {
+export function checkpointMaterializationMismatch(message: string): PersistenceError {
   return new PersistenceError(message, 'E_CHECKPOINT_MATERIALIZATION_MISMATCH');
+}
+
+function frontiersEqual(
+  left: ReadonlyMap<string, string>,
+  right: ReadonlyMap<string, string>,
+): boolean {
+  return left.size === right.size
+    && [...left].every(([writerId, patchSha]) => right.get(writerId) === patchSha);
 }

--- a/src/infrastructure/adapters/GitCasMaterializationCacheDiagnosticsAdapter.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationCacheDiagnosticsAdapter.ts
@@ -25,6 +25,7 @@ import {
 } from './GitCasMaterializationBundle.ts';
 import {
   decodeMaterializationDescriptor,
+  MATERIALIZATION_DESCRIPTOR_MAX_BYTES,
 } from './GitCasMaterializationDescriptor.ts';
 import {
   requireDependency,
@@ -33,7 +34,6 @@ import {
 
 const CACHE_NAMESPACE = 'git-warp/materializations';
 const CACHE_INSPECTION_PAGE_SIZE = 100;
-const MAX_DESCRIPTOR_BYTES = 1024 * 1024;
 const MISSING_ERROR_CODES = new Set([
   'BUNDLE_MEMBER_NOT_FOUND',
   'GIT_OBJECT_NOT_FOUND',
@@ -164,7 +164,7 @@ implements MaterializationCacheDiagnosticsPort {
     const descriptor = decodeMaterializationDescriptor(
       this.#codec.decode(await this.#cas.pages.get({
         handle: members.descriptor,
-        maxBytes: MAX_DESCRIPTOR_BYTES,
+        maxBytes: MATERIALIZATION_DESCRIPTOR_MAX_BYTES,
       })),
     );
     const expectedKey = await this.#cacheKeys.forCoordinate(descriptor.coordinate);

--- a/src/infrastructure/adapters/GitCasMaterializationDescriptor.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationDescriptor.ts
@@ -10,6 +10,7 @@ import type BundleHandle from '../../domain/storage/BundleHandle.ts';
 import WarpError from '../../domain/errors/WarpError.ts';
 
 export const MATERIALIZATION_DESCRIPTOR_SCHEMA_VERSION = 5;
+export const MATERIALIZATION_DESCRIPTOR_MAX_BYTES = 1024 * 1024;
 
 export type DecodedMaterializationDescriptor = Readonly<{
   coordinate: MaterializationCoordinate;

--- a/src/infrastructure/adapters/GitCasMaterializationProvenanceSupport.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationProvenanceSupport.ts
@@ -1,0 +1,85 @@
+import type {
+  AssetCapability,
+  AssetHandle,
+  BundleCapability,
+  BundleMemberReference,
+} from '@git-stunts/git-cas';
+import MaterializationRoot from '../../domain/materialization/MaterializationRoot.ts';
+import MaterializationRoots from '../../domain/materialization/MaterializationRoots.ts';
+import { ProvenanceIndex } from '../../domain/services/provenance/ProvenanceIndex.ts';
+import BundleHandle from '../../domain/storage/BundleHandle.ts';
+import WarpStream from '../../domain/stream/WarpStream.ts';
+import { collectAsyncIterable } from '../../domain/utils/streamUtils.ts';
+import type CodecPort from '../../ports/CodecPort.ts';
+import type { GitCasStagingWorkspace } from './GitCasMaterializationWorkspace.ts';
+import { storageError } from './GitCasMaterializationStoreValidation.ts';
+
+const PROVENANCE_PATH = 'provenance.cbor';
+
+type ProvenanceSupportFacade = Readonly<{
+  assets: Pick<AssetCapability, 'open'>;
+  bundles: Pick<BundleCapability, 'getMemberReference'>;
+}>;
+
+/** Stages and opens the complete provenance index retained with a materialization. */
+export default class GitCasMaterializationProvenanceSupport {
+  readonly #cas: ProvenanceSupportFacade;
+  readonly #codec: CodecPort;
+
+  constructor(options: { cas: ProvenanceSupportFacade; codec: CodecPort }) {
+    this.#cas = options.cas;
+    this.#codec = options.codec;
+  }
+
+  async stage(
+    workspace: GitCasStagingWorkspace,
+    provenance: ProvenanceIndex,
+  ): Promise<MaterializationRoot> {
+    const asset = await workspace.assets.put({
+      source: WarpStream.from([provenance.serialize({ codec: this.#codec })]),
+      slug: 'git-warp-materialization-provenance',
+      filename: PROVENANCE_PATH,
+    });
+    const bundle = await workspace.bundles.putOrdered({
+      members: [[PROVENANCE_PATH, asset.handle]],
+      limits: { maxMembers: 1 },
+    });
+    return MaterializationRoot.retained(new BundleHandle(bundle.handle.toString()));
+  }
+
+  async loadRoot(root: BundleHandle): Promise<ProvenanceIndex> {
+    const member = await this.#cas.bundles.getMemberReference({
+      handle: root.toString(),
+      path: PROVENANCE_PATH,
+    });
+    const asset = requireProvenanceAsset(member);
+    return ProvenanceIndex.deserialize(
+      await collectAsyncIterable(this.#cas.assets.open({ handle: asset })),
+      { codec: this.#codec },
+    );
+  }
+}
+
+export function replaceProvenanceSupportRoot(
+  roots: MaterializationRoots,
+  provenanceSupport: MaterializationRoot,
+): MaterializationRoots {
+  return new MaterializationRoots({
+    adjacency: roots.adjacency,
+    edgeAlive: roots.edgeAlive,
+    edgeBirths: roots.edgeBirths,
+    frontier: roots.frontier,
+    nodeAlive: roots.nodeAlive,
+    properties: roots.properties,
+    provenanceSupport,
+    replayBasis: roots.replayBasis,
+    roaringIndexes: roots.roaringIndexes,
+  });
+}
+
+function requireProvenanceAsset(member: BundleMemberReference | null): AssetHandle {
+  if (member === null || member.handle.kind !== 'asset') {
+    throw storageError('provenance support root has no provenance asset');
+  }
+  return member.handle;
+}

--- a/src/infrastructure/adapters/GitCasMaterializationProvenanceSupport.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationProvenanceSupport.ts
@@ -5,7 +5,7 @@ import type {
   BundleMemberReference,
 } from '@git-stunts/git-cas';
 import MaterializationRoot from '../../domain/materialization/MaterializationRoot.ts';
-import MaterializationRoots from '../../domain/materialization/MaterializationRoots.ts';
+import type MaterializationRoots from '../../domain/materialization/MaterializationRoots.ts';
 import { ProvenanceIndex } from '../../domain/services/provenance/ProvenanceIndex.ts';
 import BundleHandle from '../../domain/storage/BundleHandle.ts';
 import WarpStream from '../../domain/stream/WarpStream.ts';
@@ -64,17 +64,7 @@ export function replaceProvenanceSupportRoot(
   roots: MaterializationRoots,
   provenanceSupport: MaterializationRoot,
 ): MaterializationRoots {
-  return new MaterializationRoots({
-    adjacency: roots.adjacency,
-    edgeAlive: roots.edgeAlive,
-    edgeBirths: roots.edgeBirths,
-    frontier: roots.frontier,
-    nodeAlive: roots.nodeAlive,
-    properties: roots.properties,
-    provenanceSupport,
-    replayBasis: roots.replayBasis,
-    roaringIndexes: roots.roaringIndexes,
-  });
+  return roots.withRoot('provenance-support', provenanceSupport);
 }
 
 function requireProvenanceAsset(member: BundleMemberReference | null): AssetHandle {

--- a/src/infrastructure/adapters/GitCasMaterializationReplayBasis.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationReplayBasis.ts
@@ -6,7 +6,7 @@ import type {
 } from '@git-stunts/git-cas';
 import MaterializationHandle from '../../domain/materialization/MaterializationHandle.ts';
 import MaterializationRoot from '../../domain/materialization/MaterializationRoot.ts';
-import MaterializationRoots from '../../domain/materialization/MaterializationRoots.ts';
+import type MaterializationRoots from '../../domain/materialization/MaterializationRoots.ts';
 import type WarpState from '../../domain/services/state/WarpState.ts';
 import { computeStateHash } from '../../domain/services/state/StateSerializer.ts';
 import WarpStream from '../../domain/stream/WarpStream.ts';
@@ -104,17 +104,7 @@ export function replaceReplayBasisRoot(
   roots: MaterializationRoots,
   replayBasis: MaterializationRoot,
 ): MaterializationRoots {
-  return new MaterializationRoots({
-    adjacency: roots.adjacency,
-    edgeAlive: roots.edgeAlive,
-    edgeBirths: roots.edgeBirths,
-    frontier: roots.frontier,
-    nodeAlive: roots.nodeAlive,
-    properties: roots.properties,
-    provenanceSupport: roots.provenanceSupport,
-    replayBasis,
-    roaringIndexes: roots.roaringIndexes,
-  });
+  return roots.withRoot('replay-basis', replayBasis);
 }
 
 function requireReplayAsset(member: BundleMemberReference | null): AssetHandle {

--- a/src/infrastructure/adapters/GitCasMaterializationReplayBasis.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationReplayBasis.ts
@@ -74,14 +74,18 @@ export default class GitCasMaterializationReplayBasis {
     if (materialization.stateHash === null) {
       throw storageError('partial materialization cannot contain a replay basis');
     }
+    return await this.loadRoot(root.handle, materialization.stateHash);
+  }
+
+  async loadRoot(root: BundleHandle, expectedStateHash: string): Promise<WarpState> {
     const member = await this.#cas.bundles.getMemberReference({
-      handle: root.handle.toString(),
+      handle: root.toString(),
       path: REPLAY_BASIS_PATH,
     });
     const asset = requireReplayAsset(member);
     const bytes = await collectAsyncIterable(this.#cas.assets.open({ handle: asset }));
     const state = decodeCanonicalWarpFullState(bytes, this.#codec);
-    await this.#requireMatchingHash(state, materialization.stateHash);
+    await this.#requireMatchingHash(state, expectedStateHash);
     return state;
   }
 

--- a/src/infrastructure/adapters/GitCasMaterializationSnapshotReader.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationSnapshotReader.ts
@@ -1,0 +1,113 @@
+import type {
+  AssetCapability,
+  BundleCapability,
+  PageCapability,
+} from '@git-stunts/git-cas';
+import type MaterializationCoordinate from '../../domain/materialization/MaterializationCoordinate.ts';
+import type MaterializationRoot from '../../domain/materialization/MaterializationRoot.ts';
+import type MaterializationRoots from '../../domain/materialization/MaterializationRoots.ts';
+import type WarpState from '../../domain/services/state/WarpState.ts';
+import type { ProvenanceIndex } from '../../domain/services/provenance/ProvenanceIndex.ts';
+import type BundleHandle from '../../domain/storage/BundleHandle.ts';
+import type CodecPort from '../../ports/CodecPort.ts';
+import type CryptoPort from '../../ports/CryptoPort.ts';
+import {
+  decodeMaterializationDescriptor,
+  materializationRootsFromDescriptor,
+  type DecodedMaterializationDescriptor,
+} from './GitCasMaterializationDescriptor.ts';
+import {
+  decodeMaterializationMembers,
+} from './GitCasMaterializationBundle.ts';
+import GitCasMaterializationReplayBasis from './GitCasMaterializationReplayBasis.ts';
+import { storageError } from './GitCasMaterializationStoreValidation.ts';
+import GitCasMaterializationProvenanceSupport from './GitCasMaterializationProvenanceSupport.ts';
+
+const MAX_DESCRIPTOR_BYTES = 1024 * 1024;
+
+export type GitCasMaterializationSnapshotFacade = Readonly<{
+  assets: Pick<AssetCapability, 'open'>;
+  pages: Pick<PageCapability, 'get'>;
+  bundles: Pick<
+    BundleCapability,
+    'getMemberReference' | 'iterateMemberReferences'
+  >;
+}>;
+
+export type MaterializationSnapshot = Readonly<{
+  coordinate: MaterializationCoordinate;
+  roots: MaterializationRoots;
+  state: WarpState;
+  stateHash: string;
+  provenanceIndex: ProvenanceIndex | null;
+}>;
+
+/** Opens the canonical whole-state snapshot already retained by a materialization bundle. */
+export default class GitCasMaterializationSnapshotReader {
+  readonly #cas: GitCasMaterializationSnapshotFacade;
+  readonly #codec: CodecPort;
+  readonly #replayBasis: GitCasMaterializationReplayBasis;
+  readonly #provenanceSupport: GitCasMaterializationProvenanceSupport;
+
+  constructor(options: {
+    cas: GitCasMaterializationSnapshotFacade;
+    codec: CodecPort;
+    crypto: CryptoPort;
+  }) {
+    this.#cas = options.cas;
+    this.#codec = options.codec;
+    this.#replayBasis = new GitCasMaterializationReplayBasis(options);
+    this.#provenanceSupport = new GitCasMaterializationProvenanceSupport(options);
+  }
+
+  async read(bundle: BundleHandle): Promise<MaterializationSnapshot> {
+    const members = await decodeMaterializationMembers(
+      this.#cas.bundles.iterateMemberReferences({ handle: bundle.toString() }),
+    );
+    const descriptor = requireWholeStateDescriptor(
+      decodeMaterializationDescriptor(this.#codec.decode(
+        await this.#cas.pages.get({
+          handle: members.descriptor,
+          maxBytes: MAX_DESCRIPTOR_BYTES,
+        }),
+      )),
+    );
+    const roots = materializationRootsFromDescriptor(descriptor, members.retainedRoots);
+    const state = await this.#replayBasis.loadRoot(
+      requireRetainedRoot(roots.replayBasis, 'replay basis'),
+      descriptor.stateHash,
+    );
+    const provenanceRoot = optionalRetainedRoot(roots.provenanceSupport);
+    const provenanceIndex = provenanceRoot === null
+      ? null
+      : await this.#provenanceSupport.loadRoot(provenanceRoot);
+    return Object.freeze({
+      coordinate: descriptor.coordinate,
+      roots,
+      state,
+      stateHash: descriptor.stateHash,
+      provenanceIndex,
+    });
+  }
+}
+
+function requireWholeStateDescriptor(
+  descriptor: DecodedMaterializationDescriptor,
+): DecodedMaterializationDescriptor & { readonly stateHash: string } {
+  if (descriptor.stateHash === null) {
+    throw storageError('checkpoint materialization is partial');
+  }
+  return descriptor as DecodedMaterializationDescriptor & { readonly stateHash: string };
+}
+
+function requireRetainedRoot(root: MaterializationRoot, name: string): BundleHandle {
+  const retained = optionalRetainedRoot(root);
+  if (retained === null) {
+    throw storageError(`checkpoint materialization has no ${name}`);
+  }
+  return retained;
+}
+
+function optionalRetainedRoot(root: MaterializationRoot): BundleHandle | null {
+  return root.status === 'retained' ? root.handle : null;
+}

--- a/src/infrastructure/adapters/GitCasMaterializationSnapshotReader.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationSnapshotReader.ts
@@ -13,6 +13,7 @@ import type CodecPort from '../../ports/CodecPort.ts';
 import type CryptoPort from '../../ports/CryptoPort.ts';
 import {
   decodeMaterializationDescriptor,
+  MATERIALIZATION_DESCRIPTOR_MAX_BYTES,
   materializationRootsFromDescriptor,
   type DecodedMaterializationDescriptor,
 } from './GitCasMaterializationDescriptor.ts';
@@ -22,8 +23,6 @@ import {
 import GitCasMaterializationReplayBasis from './GitCasMaterializationReplayBasis.ts';
 import { storageError } from './GitCasMaterializationStoreValidation.ts';
 import GitCasMaterializationProvenanceSupport from './GitCasMaterializationProvenanceSupport.ts';
-
-const MAX_DESCRIPTOR_BYTES = 1024 * 1024;
 
 export type GitCasMaterializationSnapshotFacade = Readonly<{
   assets: Pick<AssetCapability, 'open'>;
@@ -68,7 +67,7 @@ export default class GitCasMaterializationSnapshotReader {
       decodeMaterializationDescriptor(this.#codec.decode(
         await this.#cas.pages.get({
           handle: members.descriptor,
-          maxBytes: MAX_DESCRIPTOR_BYTES,
+          maxBytes: MATERIALIZATION_DESCRIPTOR_MAX_BYTES,
         }),
       )),
     );

--- a/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
@@ -46,6 +46,7 @@ import {
 import { completeWithCleanup } from './OperationCleanup.ts';
 import {
   decodeMaterializationDescriptor,
+  MATERIALIZATION_DESCRIPTOR_MAX_BYTES,
   materializationDescriptorData,
   materializationRootsFromDescriptor,
   type DecodedMaterializationDescriptor,
@@ -62,7 +63,6 @@ import GitCasMaterializationProvenanceSupport, {
 const CACHE_NAMESPACE = 'git-warp/materializations';
 const WORKSPACE_NAMESPACE = 'git-warp/materializations';
 const WORKSPACE_TTL_MS = 2 * 60 * 60 * 1000;
-const MAX_DESCRIPTOR_BYTES = 1024 * 1024;
 
 export type { GitCasMaterializationFacade } from './GitCasMaterializationStoreTypes.ts';
 
@@ -221,7 +221,7 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
 
     const descriptorPage = await workspace.pages.put({
       source: descriptorBytes,
-      maxBytes: MAX_DESCRIPTOR_BYTES,
+      maxBytes: MATERIALIZATION_DESCRIPTOR_MAX_BYTES,
     });
     requireWorkspaceStage(descriptorPage);
     const bundle = await workspace.bundles.putOrdered({
@@ -449,7 +449,7 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
   async #readDescriptor(handle: PageHandle): Promise<DecodedMaterializationDescriptor> {
     const bytes = await this.#cas.pages.get({
       handle,
-      maxBytes: MAX_DESCRIPTOR_BYTES,
+      maxBytes: MATERIALIZATION_DESCRIPTOR_MAX_BYTES,
     });
     return decodeMaterializationDescriptor(this.#codec.decode(bytes));
   }

--- a/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts
@@ -55,6 +55,9 @@ import {
   materializationMembers,
   type DecodedMaterializationMembers,
 } from './GitCasMaterializationBundle.ts';
+import GitCasMaterializationProvenanceSupport, {
+  replaceProvenanceSupportRoot,
+} from './GitCasMaterializationProvenanceSupport.ts';
 
 const CACHE_NAMESPACE = 'git-warp/materializations';
 const WORKSPACE_NAMESPACE = 'git-warp/materializations';
@@ -62,6 +65,14 @@ const WORKSPACE_TTL_MS = 2 * 60 * 60 * 1000;
 const MAX_DESCRIPTOR_BYTES = 1024 * 1024;
 
 export type { GitCasMaterializationFacade } from './GitCasMaterializationStoreTypes.ts';
+
+type MaterializationStoreOptions = {
+  readonly cas: GitCasMaterializationFacade;
+  readonly codec: CodecPort;
+  readonly crypto: CryptoPort;
+  readonly laneName: string;
+  readonly onClose?: () => void;
+};
 
 /** git-cas-backed retained materialization lifecycle. */
 export default class GitCasMaterializationStoreAdapter extends MaterializationStorePort {
@@ -73,6 +84,7 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
   readonly #onClose: () => void;
   readonly #predecessorResolver: GitCasMaterializationPredecessorResolver;
   readonly #replayBasis: GitCasMaterializationReplayBasis;
+  readonly #provenanceSupport: GitCasMaterializationProvenanceSupport;
   #currentLease: GitCasMaterializationLease | null = null;
   #leaseMutation: Promise<void> = Promise.resolve();
   readonly #retirements = new Set<Promise<void>>();
@@ -83,13 +95,7 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
   #closed = false;
   #closePromise: Promise<void> | null = null;
 
-  constructor(options: {
-    readonly cas: GitCasMaterializationFacade;
-    readonly codec: CodecPort;
-    readonly crypto: CryptoPort;
-    readonly laneName: string;
-    readonly onClose?: () => void;
-  }) {
+  constructor(options: MaterializationStoreOptions) {
     super();
     requireAdapterOptions(options);
     requireDependency(options.cas, 'cas');
@@ -105,11 +111,9 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
       laneName: this.#laneName,
     });
     this.#onClose = options.onClose ?? (() => undefined);
-    this.#replayBasis = new GitCasMaterializationReplayBasis({
-      cas: this.#cas,
-      codec: this.#codec,
-      crypto: this.#crypto,
-    });
+    const support = materializationSupport(options);
+    this.#replayBasis = support.replayBasis;
+    this.#provenanceSupport = support.provenance;
     this.#predecessorResolver = this.#createPredecessorResolver();
   }
 
@@ -166,12 +170,7 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
   ): Promise<MaterializationHandle> {
     requireRetainRequest(request);
     const { stateHash } = request;
-    const roots = request.replayBasis === undefined
-      ? request.roots
-      : replaceReplayBasisRoot(
-        request.roots,
-        await this.#replayBasis.stage(workspace, request.replayBasis),
-      );
+    const roots = await this.#prepareRetainedRoots(workspace, request);
     const retainedRequest = { ...request, roots };
     const bundle = await this.#stageWorkspaceBundle(workspace, retainedRequest, stateHash);
     const retention = await this.#promoteWorkspaceBundle(
@@ -187,6 +186,24 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
       stateHash,
       retention,
     });
+  }
+
+  async #prepareRetainedRoots(
+    workspace: GitCasStagingWorkspace,
+    request: RetainMaterializationRequest,
+  ) {
+    const replayRoots = request.replayBasis === undefined
+      ? request.roots
+      : replaceReplayBasisRoot(
+        request.roots,
+        await this.#replayBasis.stage(workspace, request.replayBasis),
+      );
+    return request.provenanceSupport === undefined
+      ? replayRoots
+      : replaceProvenanceSupportRoot(
+        replayRoots,
+        await this.#provenanceSupport.stage(workspace, request.provenanceSupport),
+      );
   }
 
   async #stageWorkspaceBundle(
@@ -442,4 +459,18 @@ export default class GitCasMaterializationStoreAdapter extends MaterializationSt
       handle: bundle.toString(),
     }));
   }
+}
+
+function materializationSupport(options: MaterializationStoreOptions) {
+  return {
+    replayBasis: new GitCasMaterializationReplayBasis({
+      cas: options.cas,
+      codec: options.codec,
+      crypto: options.crypto,
+    }),
+    provenance: new GitCasMaterializationProvenanceSupport({
+      cas: options.cas,
+      codec: options.codec,
+    }),
+  };
 }

--- a/src/infrastructure/adapters/GitCasMaterializationStoreValidation.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationStoreValidation.ts
@@ -8,15 +8,19 @@ export function requireRetainRequest(request: RetainMaterializationRequest): voi
     throw storageError('retain request must be an object');
   }
   requireCoordinate(request.coordinate);
-  requireRetainRoots(request.roots);
+  requireRetainRoots(request);
   requireRetainStateHash(request);
 }
 
-function requireRetainRoots(roots: MaterializationRoots): void {
+function requireRetainRoots(request: RetainMaterializationRequest): void {
+  const { roots } = request;
   if (!(roots instanceof MaterializationRoots)) {
     throw storageError('retain request roots have an invalid runtime identity');
   }
-  if (roots.entries().every(([, root]) => root.status === 'unavailable')) {
+  if (
+    request.replayBasis === undefined
+    && roots.entries().every(([, root]) => root.status === 'unavailable')
+  ) {
     throw storageError('retain request must provide at least one materialization root');
   }
 }

--- a/src/infrastructure/adapters/GitCasMaterializationWorkspace.ts
+++ b/src/infrastructure/adapters/GitCasMaterializationWorkspace.ts
@@ -163,16 +163,21 @@ function workspaceMembers(
 ): Array<[string, string]> {
   requireRoots(roots);
   const members: Array<[string, string]> = [];
-  if (roots.edgeAliveRoot !== null) {
-    members.push(['roots/edge-alive', parseRoot(roots.edgeAliveRoot)]);
-  }
-  if (roots.nodeAliveRoot !== null) {
-    members.push(['roots/node-alive', parseRoot(roots.nodeAliveRoot)]);
-  }
-  if (roots.propertiesRoot !== undefined && roots.propertiesRoot !== null) {
-    members.push(['roots/properties', parseRoot(roots.propertiesRoot)]);
-  }
+  appendWorkspaceRoot(members, 'roots/edge-alive', roots.edgeAliveRoot);
+  appendWorkspaceRoot(members, 'roots/node-alive', roots.nodeAliveRoot);
+  appendWorkspaceRoot(members, 'roots/properties', roots.propertiesRoot);
+  appendWorkspaceRoot(members, 'roots/roaring-indexes', roots.roaringIndexesRoot);
   return members;
+}
+
+function appendWorkspaceRoot(
+  members: Array<[string, string]>,
+  path: string,
+  root: string | null | undefined,
+): void {
+  if (root !== undefined && root !== null) {
+    members.push([path, parseRoot(root)]);
+  }
 }
 
 function parseRoot(token: string): string {

--- a/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
+++ b/src/infrastructure/adapters/GitCasRepositoryAdapter.ts
@@ -189,6 +189,7 @@ export default class GitCasRepositoryAdapter implements RuntimeStorageProviderPo
   ): CborCheckpointStoreAdapter {
     return new CborCheckpointStoreAdapter({
       codec: request.codec,
+      crypto: request.crypto,
       commitMessageCodec: request.commitMessageCodec,
       history: this._history,
       assetStorage: content,

--- a/src/ports/CheckpointStorePort.ts
+++ b/src/ports/CheckpointStorePort.ts
@@ -4,6 +4,7 @@ import type { ProvenanceIndex } from '../domain/services/provenance/ProvenanceIn
 import type AssetHandle from '../domain/storage/AssetHandle.ts';
 import type BundleHandle from '../domain/storage/BundleHandle.ts';
 import type StorageRetentionWitness from '../domain/storage/StorageRetentionWitness.ts';
+import type MaterializationHandle from '../domain/materialization/MaterializationHandle.ts';
 
 /** Immutable checkpoint state and optional bounded-read index payloads. */
 export interface CheckpointRecord {
@@ -14,6 +15,7 @@ export interface CheckpointRecord {
   stateHash: string;
   parents: string[];
   expectedCheckpointSha?: string | null;
+  materialization?: MaterializationHandle;
   provenanceIndex?: ProvenanceIndex | null;
   indexShards?: Readonly<Record<string, Uint8Array>> | null;
 }
@@ -34,6 +36,8 @@ export interface CheckpointData {
   appliedVV: VersionVector | null;
   provenanceIndex?: ProvenanceIndex | null;
   indexShardHandles: Readonly<Record<string, AssetHandle>> | null;
+  indexRoot: BundleHandle | null;
+  propertyRoot: BundleHandle | null;
 }
 
 /** Bounded checkpoint support needed to prepare an optic basis. */
@@ -43,6 +47,8 @@ export interface CheckpointBasis {
   schema: number;
   frontier: Map<string, string>;
   indexShardHandles: Readonly<Record<string, AssetHandle>>;
+  indexRoot: BundleHandle | null;
+  propertyRoot: BundleHandle | null;
 }
 
 /** Metadata readable without opening checkpoint state or index payloads. */

--- a/src/ports/IndexStorePort.ts
+++ b/src/ports/IndexStorePort.ts
@@ -41,6 +41,11 @@ export type IndexShardDecodeOptions = Readonly<{
   structureLimits?: IndexShardStructureLimits;
 }>;
 
+export type IndexShardReference = Readonly<{
+  kind: 'asset' | 'page';
+  token: string;
+}>;
+
 /**
  * IndexStorePort — domain-facing port for index shard persistence.
  *
@@ -98,6 +103,11 @@ export default abstract class IndexStorePort {
     _indexHandle: BundleHandle,
   ): Promise<Readonly<Record<string, AssetHandle>>>;
 
+  /** Lists opaque asset/page member identities without opening shard bytes. */
+  abstract readShardReferences(
+    _indexHandle: BundleHandle,
+  ): Promise<Readonly<Record<string, IndexShardReference>>>;
+
   /** Resolves one shard handle by path without enumerating or decoding siblings. */
   abstract readShardHandle(
     _indexHandle: BundleHandle,
@@ -106,6 +116,13 @@ export default abstract class IndexStorePort {
 
   /** Streams one encoded shard without opening unrelated index members. */
   abstract openShard(_shardHandle: AssetHandle): AsyncIterable<Uint8Array>;
+
+  /** Streams one exact asset- or page-backed bundle member by path. */
+  abstract openShardAt(
+    _indexHandle: BundleHandle,
+    _path: string,
+    _options?: Readonly<{ maxBytes?: number }>,
+  ): AsyncIterable<Uint8Array>;
 
   /**
    * Reads and decodes a single shard asset by opaque handle.

--- a/src/ports/MaterializationWorkspacePort.ts
+++ b/src/ports/MaterializationWorkspacePort.ts
@@ -3,6 +3,7 @@ import type MaterializationHandle from '../domain/materialization/Materializatio
 import type MaterializationRoots from '../domain/materialization/MaterializationRoots.ts';
 import type StorageRetentionWitness from '../domain/storage/StorageRetentionWitness.ts';
 import type WarpState from '../domain/services/state/WarpState.ts';
+import type { ProvenanceIndex } from '../domain/services/provenance/ProvenanceIndex.ts';
 import ArtifactStagingPort from './ArtifactStagingPort.ts';
 
 export type MaterializationWorkspaceRoots = Readonly<{
@@ -17,6 +18,7 @@ export type PromoteMaterializationRequest = Readonly<{
   roots: MaterializationRoots;
   stateHash: string | null;
   replayBasis?: WarpState;
+  provenanceSupport?: ProvenanceIndex;
 }>;
 
 /**

--- a/src/ports/MaterializationWorkspacePort.ts
+++ b/src/ports/MaterializationWorkspacePort.ts
@@ -9,6 +9,7 @@ export type MaterializationWorkspaceRoots = Readonly<{
   nodeAliveRoot: string | null;
   edgeAliveRoot: string | null;
   propertiesRoot?: string | null;
+  roaringIndexesRoot?: string | null;
 }>;
 
 export type PromoteMaterializationRequest = Readonly<{

--- a/test/helpers/InMemoryCheckpointStore.ts
+++ b/test/helpers/InMemoryCheckpointStore.ts
@@ -45,6 +45,8 @@ export default class InMemoryCheckpointStore extends CheckpointStorePort {
       schema: 5,
       appliedVV: record.appliedVV,
       indexShardHandles,
+      indexRoot: null,
+      propertyRoot: null,
       ...(record.provenanceIndex === undefined || record.provenanceIndex === null
         ? {}
         : { provenanceIndex: record.provenanceIndex }),
@@ -119,6 +121,8 @@ export default class InMemoryCheckpointStore extends CheckpointStorePort {
       schema: checkpoint.schema,
       frontier: new Map(checkpoint.frontier),
       indexShardHandles: checkpoint.indexShardHandles,
+      indexRoot: null,
+      propertyRoot: null,
     });
   }
 

--- a/test/helpers/MemoryRuntimeStorageAdapter.ts
+++ b/test/helpers/MemoryRuntimeStorageAdapter.ts
@@ -141,14 +141,16 @@ const TEST_COMPATIBILITY_POLICY = new SubstrateCompatibilityPolicy({
   legacyTrustRecordBlobReads: true,
 });
 
-function withFixtureObjectTypeProbe(history: InMemoryGraphAdapter): InMemoryGraphAdapter {
+export function withFixtureObjectTypeProbe(history: InMemoryGraphAdapter): InMemoryGraphAdapter {
   if (typeof history.readObjectType === 'function') {
     return history;
   }
   const fallbackObjects = new InMemoryGraphAdapter();
-  const publicationCommits = new Set<string>();
+  const objectTypes = new Map<string, 'blob' | 'tree' | 'commit'>([
+    [history.emptyTree, 'tree'],
+  ]);
   const readObjectType = (oid: string): Promise<string> => Promise.resolve(
-    publicationCommits.has(oid) ? 'commit' : 'blob',
+    objectTypes.get(oid) ?? 'blob',
   );
   const commitNodeWithTree = async (
     options: Parameters<InMemoryGraphAdapter['commitNodeWithTree']>[0],
@@ -157,21 +159,29 @@ function withFixtureObjectTypeProbe(history: InMemoryGraphAdapter): InMemoryGrap
       await history.commitNodeWithTree(options),
       async () => await fallbackObjects.writeBlob(JSON.stringify(options)),
     );
-    publicationCommits.add(oid);
+    objectTypes.set(oid, 'commit');
     return oid;
   };
   const writeBlob = async (
     content: Parameters<InMemoryGraphAdapter['writeBlob']>[0],
-  ): Promise<string> => await normalizeToGitObjectId(
-    await history.writeBlob(content),
-    async () => await fallbackObjects.writeBlob(content),
-  );
+  ): Promise<string> => {
+    const oid = await normalizeToGitObjectId(
+      await history.writeBlob(content),
+      async () => await fallbackObjects.writeBlob(content),
+    );
+    objectTypes.set(oid, 'blob');
+    return oid;
+  };
   const writeTree = async (
     entries: Parameters<InMemoryGraphAdapter['writeTree']>[0],
-  ): Promise<string> => await normalizeToGitObjectId(
-    await history.writeTree(entries),
-    async () => await fallbackObjects.writeTree(entries),
-  );
+  ): Promise<string> => {
+    const oid = await normalizeToGitObjectId(
+      await history.writeTree(entries),
+      async () => await fallbackObjects.writeTree(entries),
+    );
+    objectTypes.set(oid, 'tree');
+    return oid;
+  };
   return new Proxy(history, {
     get(target, property): unknown {
       if (property === 'readObjectType') {

--- a/test/helpers/MemoryRuntimeStorageAdapter.ts
+++ b/test/helpers/MemoryRuntimeStorageAdapter.ts
@@ -16,7 +16,7 @@ import SubstrateCompatibilityPolicy from '../../src/infrastructure/adapters/Subs
 import type AssetStoragePort from '../../src/ports/AssetStoragePort.ts';
 import InMemoryBlobStorageAdapter from './InMemoryBlobStorageAdapter.ts';
 import InMemoryGitCasFacade from './InMemoryGitCasFacade.ts';
-import type InMemoryGraphAdapter from './InMemoryGraphAdapter.ts';
+import InMemoryGraphAdapter from './InMemoryGraphAdapter.ts';
 import InMemorySyncReplayProtection from './InMemorySyncReplayProtection.ts';
 
 export type MemoryRuntimeStorageAdapterOptions = {
@@ -84,6 +84,7 @@ export default class MemoryRuntimeStorageAdapter implements RuntimeStorageProvid
       }),
       checkpoints: new CborCheckpointStoreAdapter({
         codec: request.codec,
+        crypto: request.crypto,
         commitMessageCodec: request.commitMessageCodec,
         history: this.#history,
         assetStorage: this.#content,
@@ -144,6 +145,7 @@ function withFixtureObjectTypeProbe(history: InMemoryGraphAdapter): InMemoryGrap
   if (typeof history.readObjectType === 'function') {
     return history;
   }
+  const fallbackObjects = new InMemoryGraphAdapter();
   const publicationCommits = new Set<string>();
   const readObjectType = (oid: string): Promise<string> => Promise.resolve(
     publicationCommits.has(oid) ? 'commit' : 'blob',
@@ -151,9 +153,28 @@ function withFixtureObjectTypeProbe(history: InMemoryGraphAdapter): InMemoryGrap
   const commitNodeWithTree = async (
     options: Parameters<InMemoryGraphAdapter['commitNodeWithTree']>[0],
   ): Promise<string> => {
-    const oid = await history.commitNodeWithTree(options);
+    const candidate = await history.commitNodeWithTree(options);
+    const oid = isGitObjectId(candidate)
+      ? candidate
+      : await fallbackObjects.writeBlob(JSON.stringify(options));
     publicationCommits.add(oid);
     return oid;
+  };
+  const writeBlob = async (
+    content: Parameters<InMemoryGraphAdapter['writeBlob']>[0],
+  ): Promise<string> => {
+    const candidate = await history.writeBlob(content);
+    return isGitObjectId(candidate)
+      ? candidate
+      : await fallbackObjects.writeBlob(content);
+  };
+  const writeTree = async (
+    entries: Parameters<InMemoryGraphAdapter['writeTree']>[0],
+  ): Promise<string> => {
+    const candidate = await history.writeTree(entries);
+    return isGitObjectId(candidate)
+      ? candidate
+      : await fallbackObjects.writeTree(entries);
   };
   return new Proxy(history, {
     get(target, property): unknown {
@@ -163,8 +184,18 @@ function withFixtureObjectTypeProbe(history: InMemoryGraphAdapter): InMemoryGrap
       if (property === 'commitNodeWithTree') {
         return commitNodeWithTree;
       }
+      if (property === 'writeBlob') {
+        return writeBlob;
+      }
+      if (property === 'writeTree') {
+        return writeTree;
+      }
       const value: unknown = Reflect.get(target, property, target);
       return typeof value === 'function' ? value.bind(target) : value;
     },
   });
+}
+
+function isGitObjectId(value: unknown): value is string {
+  return typeof value === 'string' && /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/u.test(value);
 }

--- a/test/helpers/MemoryRuntimeStorageAdapter.ts
+++ b/test/helpers/MemoryRuntimeStorageAdapter.ts
@@ -153,29 +153,25 @@ function withFixtureObjectTypeProbe(history: InMemoryGraphAdapter): InMemoryGrap
   const commitNodeWithTree = async (
     options: Parameters<InMemoryGraphAdapter['commitNodeWithTree']>[0],
   ): Promise<string> => {
-    const candidate = await history.commitNodeWithTree(options);
-    const oid = isGitObjectId(candidate)
-      ? candidate
-      : await fallbackObjects.writeBlob(JSON.stringify(options));
+    const oid = await normalizeToGitObjectId(
+      await history.commitNodeWithTree(options),
+      async () => await fallbackObjects.writeBlob(JSON.stringify(options)),
+    );
     publicationCommits.add(oid);
     return oid;
   };
   const writeBlob = async (
     content: Parameters<InMemoryGraphAdapter['writeBlob']>[0],
-  ): Promise<string> => {
-    const candidate = await history.writeBlob(content);
-    return isGitObjectId(candidate)
-      ? candidate
-      : await fallbackObjects.writeBlob(content);
-  };
+  ): Promise<string> => await normalizeToGitObjectId(
+    await history.writeBlob(content),
+    async () => await fallbackObjects.writeBlob(content),
+  );
   const writeTree = async (
     entries: Parameters<InMemoryGraphAdapter['writeTree']>[0],
-  ): Promise<string> => {
-    const candidate = await history.writeTree(entries);
-    return isGitObjectId(candidate)
-      ? candidate
-      : await fallbackObjects.writeTree(entries);
-  };
+  ): Promise<string> => await normalizeToGitObjectId(
+    await history.writeTree(entries),
+    async () => await fallbackObjects.writeTree(entries),
+  );
   return new Proxy(history, {
     get(target, property): unknown {
       if (property === 'readObjectType') {
@@ -194,6 +190,13 @@ function withFixtureObjectTypeProbe(history: InMemoryGraphAdapter): InMemoryGrap
       return typeof value === 'function' ? value.bind(target) : value;
     },
   });
+}
+
+async function normalizeToGitObjectId(
+  candidate: string,
+  fallback: () => Promise<string>,
+): Promise<string> {
+  return isGitObjectId(candidate) ? candidate : await fallback();
 }
 
 function isGitObjectId(value: unknown): value is string {

--- a/test/helpers/MockIndexStorage.ts
+++ b/test/helpers/MockIndexStorage.ts
@@ -7,6 +7,7 @@ import WarpStream from '../../src/domain/stream/WarpStream.ts';
 import type CodecValue from '../../src/domain/types/codec/CodecValue.ts';
 import defaultCodec from '../../src/infrastructure/codecs/CborCodec.ts';
 import IndexStorePort from '../../src/ports/IndexStorePort.ts';
+import type { IndexShardReference } from '../../src/ports/IndexStorePort.ts';
 import { IndexShardEncodeTransform } from '../../src/infrastructure/adapters/IndexShardEncodeTransform.ts';
 
 /** Test-only semantic index store with directly writable encoded shards. */
@@ -45,6 +46,20 @@ export default class MockIndexStorage extends IndexStorePort {
     return this.#indexes.get(indexHandle.toString()) ?? Object.freeze({});
   }
 
+  override async readShardReferences(
+    indexHandle: BundleHandle,
+  ): Promise<Readonly<Record<string, IndexShardReference>>> {
+    const handles: Readonly<Record<string, AssetHandle>> = (
+      this.#indexes.get(indexHandle.toString()) ?? Object.freeze({})
+    );
+    return Object.freeze(Object.fromEntries(
+      Object.entries(handles).map(([path, handle]) => [
+        path,
+        Object.freeze({ kind: 'asset' as const, token: handle.toString() }),
+      ]),
+    ));
+  }
+
   override async readShardHandle(
     indexHandle: BundleHandle,
     path: string,
@@ -65,6 +80,20 @@ export default class MockIndexStorage extends IndexStorePort {
       });
     }
     yield bytes.slice();
+  }
+
+  override async *openShardAt(
+    indexHandle: BundleHandle,
+    path: string,
+  ): AsyncIterable<Uint8Array> {
+    const handle = await this.readShardHandle(indexHandle, path);
+    if (handle === null) {
+      throw new IndexError(`Shard not found: ${path}`, {
+        code: 'E_INDEX_SHARD_MISSING',
+        context: { path },
+      });
+    }
+    yield* this.openShard(handle);
   }
 
   override async decodeShard<TDecoded extends CodecValue = CodecValue>(

--- a/test/helpers/WarpGraphMockPersistence.ts
+++ b/test/helpers/WarpGraphMockPersistence.ts
@@ -8,6 +8,7 @@ import PatchJournalPort, {
 } from '../../src/ports/PatchJournalPort.ts';
 import type Patch from '../../src/domain/types/Patch.ts';
 import type { PatchCommitMessage } from '../../src/ports/CommitMessageCodecPort.ts';
+import InMemoryGraphAdapter from './InMemoryGraphAdapter.ts';
 import { generateOidFromNumber } from './WarpGraphObjectIds.ts';
 
 type PopulatedCommit = {
@@ -36,11 +37,16 @@ class MockPersistenceFixtureError extends Error {
 
 class WarpGraphMockPersistence {
   readonly #refs = new Map<string, string>();
+  readonly #objects = new InMemoryGraphAdapter();
 
   readonly readRef = vi.fn(async (ref: string) => this.#refs.get(ref) ?? null);
   readonly showNode = vi.fn();
-  readonly writeBlob = vi.fn();
-  readonly writeTree = vi.fn();
+  readonly writeBlob = vi.fn(async (content: Uint8Array | string) => {
+    return await this.#objects.writeBlob(content);
+  });
+  readonly writeTree = vi.fn(async (entries: string[]) => {
+    return await this.#objects.writeTree(entries);
+  });
   readonly readBlob = vi.fn();
   readonly readTreeOids = vi.fn(async (_treeOid: string): Promise<Record<string, string>> => ({}));
   readonly commitNode = vi.fn();

--- a/test/helpers/retainUnavailableMaterialization.ts
+++ b/test/helpers/retainUnavailableMaterialization.ts
@@ -1,0 +1,29 @@
+import MaterializationCoordinate from '../../src/domain/materialization/MaterializationCoordinate.ts';
+import type MaterializationHandle from '../../src/domain/materialization/MaterializationHandle.ts';
+import { unavailableMaterializationRoots } from '../../src/domain/materialization/UnavailableMaterializationRoots.ts';
+import { computeStateHash } from '../../src/domain/services/state/StateSerializer.ts';
+import type WarpState from '../../src/domain/services/state/WarpState.ts';
+import type CodecPort from '../../src/ports/CodecPort.ts';
+import type CryptoPort from '../../src/ports/CryptoPort.ts';
+import type MaterializationStorePort from '../../src/ports/MaterializationStorePort.ts';
+
+export default async function retainUnavailableMaterialization(options: {
+  materializations: Pick<MaterializationStorePort, 'retain'>;
+  frontier: Map<string, string>;
+  state: WarpState;
+  codec: CodecPort;
+  crypto: CryptoPort;
+}): Promise<MaterializationHandle> {
+  return await options.materializations.retain({
+    coordinate: new MaterializationCoordinate({
+      frontier: options.frontier,
+      ceiling: null,
+    }),
+    roots: unavailableMaterializationRoots(),
+    stateHash: await computeStateHash(options.state, {
+      codec: options.codec,
+      crypto: options.crypto,
+    }),
+    replayBasis: options.state,
+  });
+}

--- a/test/integration/api/checkpoint.test.ts
+++ b/test/integration/api/checkpoint.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'node:child_process';
 import ContentAddressableStore, {
-  AssetHandle as GitCasAssetHandle,
   BundleHandle as GitCasBundleHandle,
   type BundleMember,
 } from '@git-stunts/git-cas';
@@ -30,10 +29,39 @@ async function readCheckpointArtifacts(repo, checkpointSha) {
     const memberHandles = Object.fromEntries(
       members.map((member) => [member.path, member.handle.toString()]),
     );
-    return { decoded, members, memberHandles };
-  } finally {
+    const memberKinds = Object.fromEntries(
+      members.map((member) => [member.path, member.handle.kind]),
+    );
+    return { cas, decoded, members, memberHandles, memberKinds };
+  } catch (error) {
     await cas.close();
+    throw error;
   }
+}
+
+async function closeCheckpointArtifacts(checkpoint) {
+  await checkpoint.cas.close();
+}
+
+async function collectRetainedOids(cas, rootHandle) {
+  const retainedOids = new Set();
+  const pendingBundles = [rootHandle];
+  const visitedBundles = new Set();
+  while (pendingBundles.length > 0) {
+    const bundle = pendingBundles.pop();
+    if (bundle === undefined || visitedBundles.has(bundle)) {
+      continue;
+    }
+    visitedBundles.add(bundle);
+    retainedOids.add(GitCasBundleHandle.parse(bundle).oid);
+    for await (const member of cas.bundles.iterateMembers({ handle: bundle })) {
+      retainedOids.add(member.handle.oid);
+      if (member.handle.kind === 'bundle') {
+        pendingBundles.push(member.handle.toString());
+      }
+    }
+  }
+  return retainedOids;
 }
 
 describe('API: Checkpoint', () => {
@@ -57,12 +85,19 @@ describe('API: Checkpoint', () => {
     const sha = await graph.createCheckpoint();
     expect(sha).toMatch(/^[0-9a-f]{40}$/);
 
-    const { decoded, memberHandles } = await readCheckpointArtifacts(repo, sha);
-    expect(decoded.schema).toBe(5);
-    expect(decoded.bundleHandle).not.toBeNull();
-    expect(memberHandles['state/nodeAlive']).toBeDefined();
-    expect(memberHandles['state/edgeAlive']).toBeDefined();
-    expect(memberHandles['state.cbor']).toBeUndefined();
+    const checkpoint = await readCheckpointArtifacts(repo, sha);
+    try {
+      expect(checkpoint.decoded.schema).toBe(5);
+      expect(checkpoint.decoded.bundleHandle).not.toBeNull();
+      expect(checkpoint.memberKinds['meta/descriptor']).toBe('page');
+      expect(checkpoint.memberKinds['roots/node-alive']).toBe('bundle');
+      expect(checkpoint.memberKinds['roots/replay-basis']).toBe('bundle');
+      expect(checkpoint.memberKinds['roots/provenance-support']).toBe('bundle');
+      expect(checkpoint.memberHandles['state/nodeAlive']).toBeUndefined();
+      expect(checkpoint.memberHandles['state.cbor']).toBeUndefined();
+    } finally {
+      await closeCheckpointArtifacts(checkpoint);
+    }
   });
 
   it('materializeAt rejects session-backed runtime checkpoints', async () => {
@@ -73,16 +108,20 @@ describe('API: Checkpoint', () => {
     await graph.materialize();
 
     const sha = await graph.createCheckpoint();
-    const { decoded, memberHandles } = await readCheckpointArtifacts(repo, sha);
-    expect(decoded.schema).toBe(5);
-    expect(memberHandles['state/nodeAlive']).toBeDefined();
-    expect(memberHandles['state/edgeAlive']).toBeDefined();
-    expect(memberHandles['state.cbor']).toBeUndefined();
+    const checkpoint = await readCheckpointArtifacts(repo, sha);
+    try {
+      expect(checkpoint.decoded.schema).toBe(5);
+      expect(checkpoint.memberKinds['meta/descriptor']).toBe('page');
+      expect(checkpoint.memberKinds['roots/node-alive']).toBe('bundle');
+      expect(checkpoint.memberHandles['state/nodeAlive']).toBeUndefined();
 
-    await expect(graph.materializeAt(sha)).rejects.toBeInstanceOf(SchemaUnsupportedError);
-    await expect(graph.materializeAt(sha)).rejects.toMatchObject({
-      code: 'E_SCHEMA_UNSUPPORTED',
-    });
+      await expect(graph.materializeAt(sha)).rejects.toBeInstanceOf(SchemaUnsupportedError);
+      await expect(graph.materializeAt(sha)).rejects.toMatchObject({
+        code: 'E_SCHEMA_UNSUPPORTED',
+      });
+    } finally {
+      await closeCheckpointArtifacts(checkpoint);
+    }
   });
 
   it('incremental checkpoint after additional patches', async () => {
@@ -100,41 +139,49 @@ describe('API: Checkpoint', () => {
 
     expect(sha1).not.toBe(sha2);
     expect(sha2).toMatch(/^[0-9a-f]{40}$/);
-    expect(checkpoint1.decoded.schema).toBe(5);
-    expect(checkpoint2.decoded.schema).toBe(5);
-    expect(checkpoint1.memberHandles['state/nodeAlive']).toBeDefined();
-    expect(checkpoint2.memberHandles['state/nodeAlive']).toBeDefined();
-    expect(checkpoint1.memberHandles['state.cbor']).toBeUndefined();
-    expect(checkpoint2.memberHandles['state.cbor']).toBeUndefined();
+    try {
+      expect(checkpoint1.decoded.schema).toBe(5);
+      expect(checkpoint2.decoded.schema).toBe(5);
+      expect(checkpoint1.memberKinds['roots/node-alive']).toBe('bundle');
+      expect(checkpoint2.memberKinds['roots/node-alive']).toBe('bundle');
+      expect(checkpoint1.memberHandles['state/nodeAlive']).toBeUndefined();
+      expect(checkpoint2.memberHandles['state/nodeAlive']).toBeUndefined();
+      expect(checkpoint1.decoded.bundleHandle?.equals(checkpoint2.decoded.bundleHandle))
+        .toBe(false);
+    } finally {
+      await Promise.all([
+        closeCheckpointArtifacts(checkpoint1),
+        closeCheckpointArtifacts(checkpoint2),
+      ]);
+    }
   });
 
-  it('keeps the checkpoint bundle and every asset out of immediate-prune output', async () => {
+  it('keeps the checkpoint bundle graph out of immediate-prune output', async () => {
     const graph = await repo.openGraph('test', 'writer1', { stateCache: null });
     await (await graph.createPatch()).addNode('n1').commit();
     await graph.materialize();
 
     const sha = await graph.createCheckpoint();
-    const { decoded, members } = await readCheckpointArtifacts(repo, sha);
-    if (decoded.bundleHandle === null) {
-      throw new Error('expected current checkpoint bundle handle');
-    }
-    const retainedOids = [
-      GitCasBundleHandle.parse(decoded.bundleHandle.toString()).oid,
-      ...members.map((member) => {
-        if (member.handle.kind !== 'asset') {
-          throw new Error(`expected checkpoint asset member: ${member.path}`);
-        }
-        return GitCasAssetHandle.from(member.handle).oid;
-      }),
-    ];
-    const prunable = execSync('git prune -n --expire=now', {
-      cwd: repo.tempDir,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    const checkpoint = await readCheckpointArtifacts(repo, sha);
+    try {
+      if (checkpoint.decoded.bundleHandle === null) {
+        throw new Error('expected current checkpoint bundle handle');
+      }
+      const retainedOids = await collectRetainedOids(
+        checkpoint.cas,
+        checkpoint.decoded.bundleHandle.toString(),
+      );
+      const prunable = execSync('git prune -n --expire=now', {
+        cwd: repo.tempDir,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
 
-    for (const oid of retainedOids) {
-      expect(prunable).not.toContain(oid);
+      for (const oid of retainedOids) {
+        expect(prunable).not.toContain(oid);
+      }
+    } finally {
+      await closeCheckpointArtifacts(checkpoint);
     }
   });
 });

--- a/test/unit/domain/RuntimeHost.snapshotCache.test.ts
+++ b/test/unit/domain/RuntimeHost.snapshotCache.test.ts
@@ -62,7 +62,7 @@ class RecordingStateCache extends WarpStateCachePort {
 }
 
 describe('RuntimeHost snapshot cache', () => {
-  it('uses the exact retained snapshot on an unchanged second materialization', async () => {
+  it('uses the exact retained materialization ahead of the snapshot cache on an unchanged read', async () => {
     const persistence = new InMemoryGraphAdapter();
     const stateCache = new RecordingStateCache();
     const runtime = await openMemoryRuntimeHostProduct({
@@ -88,8 +88,9 @@ describe('RuntimeHost snapshot cache', () => {
 
     const second = await runtime.materialize();
 
-    expect(stateCache.exactLookups).toHaveLength(2);
+    expect(stateCache.exactLookups).toHaveLength(1);
     expect(stateCache.publications).toHaveLength(1);
+    expect(Reflect.get(runtime, '_retainedMaterialization')).not.toBeNull();
     expect(runtime.provenanceIndex?.patchesFor('node:one')).toEqual([patchId]);
     expect(Reflect.get(runtime, '_provenanceDegraded')).toBe(false);
     expect(buildView).toHaveBeenCalledTimes(viewBuildsAfterFirstRead);

--- a/test/unit/domain/WarpGraph.checkpoint.test.ts
+++ b/test/unit/domain/WarpGraph.checkpoint.test.ts
@@ -363,7 +363,7 @@ describe('WarpCore', () => {
       );
     });
 
-    it('falls back to checkpoint without index when index build fails', async () => {
+    it('does not rebuild the removed legacy checkpoint index tree', async () => {
       const persistence = createMockPersistence();
       const graph = await openRuntimeHostProduct({
         persistence,
@@ -398,10 +398,7 @@ describe('WarpCore', () => {
       const sha = await graph.createCheckpoint();
 
       expect(sha).toBe(checkpointSha);
-      expect(warn).toHaveBeenCalledWith(
-        '[warp] checkpoint index build failed; saving checkpoint without index',
-        expect.objectContaining({ error: 'roaring unavailable' }),
-      );
+      expect(warn).not.toHaveBeenCalled();
       expect(persistence.commitNodeWithTree).toHaveBeenCalled();
     });
   });

--- a/test/unit/domain/materialization/MaterializationIdentity.test.ts
+++ b/test/unit/domain/materialization/MaterializationIdentity.test.ts
@@ -145,7 +145,7 @@ describe('MaterializationRoots', () => {
     expect(() => Reflect.apply(materializationRoots().withRoot, materializationRoots(), [
       'future-root',
       retainedRoot('future-root'),
-    ])).toThrowError(/unknown root name/u);
+    ])).toThrowError(/unsupported root name/u);
   });
 
   it.each([

--- a/test/unit/domain/materialization/MaterializationIdentity.test.ts
+++ b/test/unit/domain/materialization/MaterializationIdentity.test.ts
@@ -128,6 +128,26 @@ describe('MaterializationRoots', () => {
     expect(roots.equals(new MaterializationRoots(changedOptions))).toBe(false);
   });
 
+  it('replaces exactly one named root', () => {
+    const roots = materializationRoots();
+    const original = new Map(roots.entries());
+    const replacement = retainedRoot('replacement-replay-basis');
+    const changed = roots.withRoot('replay-basis', replacement);
+
+    expect(changed.replayBasis).toBe(replacement);
+    expect(changed.entries().filter(([name, root]) => {
+      const previous = original.get(name);
+      return previous === undefined || !root.equals(previous);
+    }).map(([name]) => name)).toEqual(['replay-basis']);
+  });
+
+  it('rejects an unknown replacement root name', () => {
+    expect(() => Reflect.apply(materializationRoots().withRoot, materializationRoots(), [
+      'future-root',
+      retainedRoot('future-root'),
+    ])).toThrowError(/unknown root name/u);
+  });
+
   it.each([
     'adjacency',
     'edgeAlive',

--- a/test/unit/domain/materialization/MaterializationIndexProfile.test.ts
+++ b/test/unit/domain/materialization/MaterializationIndexProfile.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_MATERIALIZATION_INDEX_SHARDS,
+  requireMaterializationIndexShardCount,
+} from '../../../../src/domain/materialization/MaterializationIndexProfile.ts';
+
+describe('MaterializationIndexProfile', () => {
+  it('accepts positive shard counts through the retained index ceiling', () => {
+    expect(requireMaterializationIndexShardCount(1)).toBe(1);
+    expect(requireMaterializationIndexShardCount(MAX_MATERIALIZATION_INDEX_SHARDS))
+      .toBe(MAX_MATERIALIZATION_INDEX_SHARDS);
+  });
+
+  it.each([0, -1, 1.5, Number.NaN, MAX_MATERIALIZATION_INDEX_SHARDS + 1])(
+    'rejects invalid or unbounded shard count %s',
+    (count) => {
+      expect(() => requireMaterializationIndexShardCount(count))
+        .toThrowError(expect.objectContaining({ code: 'E_MATERIALIZATION_INDEX_LIMIT' }));
+    },
+  );
+});

--- a/test/unit/domain/services/LogicalIndexReader.test.ts
+++ b/test/unit/domain/services/LogicalIndexReader.test.ts
@@ -157,6 +157,11 @@ describe('LogicalIndexReader', () => {
   });
 
   describe('loadFromHandles', () => {
+    it('requires an index store', async () => {
+      await expect(new LogicalIndexReader().loadFromHandles({}))
+        .rejects.toMatchObject({ code: 'E_INDEX_NO_STORE' });
+    });
+
     it('loads shards through the semantic index store', async () => {
       const state = fixtureToState(F7_MULTILABEL_SAME_NEIGHBOR);
       const service = new MaterializedViewService({ codec: defaultCodec });
@@ -400,6 +405,23 @@ describe('LogicalIndexReader', () => {
       const reader = new LogicalIndexReader({ codec: defaultCodec });
       await expect(reader.loadFromStore(new BundleHandle('any-index')))
         .rejects.toThrow(/indexStore/i);
+    });
+
+    it('fails closed for missing retained bundle members', async () => {
+      const storage = new MockIndexStorage();
+      vi.spyOn(storage, 'decodeShardAt').mockResolvedValue(null);
+      const reader = new LogicalIndexReader({ indexStore: storage });
+      const indexHandle = new BundleHandle('retained-index');
+
+      await expect(reader.loadFromStorePaths(indexHandle, ['meta_ff.cbor']))
+        .rejects.toMatchObject({ code: 'E_INDEX_SHARD_MISSING' });
+    });
+
+    it('requires an index store for retained bundle members', async () => {
+      await expect(new LogicalIndexReader().loadFromStorePaths(
+        new BundleHandle('retained-index'),
+        [],
+      )).rejects.toMatchObject({ code: 'E_INDEX_NO_STORE' });
     });
   });
 

--- a/test/unit/domain/services/PropertyIndex.test.ts
+++ b/test/unit/domain/services/PropertyIndex.test.ts
@@ -8,6 +8,7 @@ import {
   requireMaterializationPropertyShardCount,
 } from '../../../../src/domain/materialization/MaterializationPropertyProfile.ts';
 import computeShardKey from '../../../../src/domain/utils/shardKey.ts';
+import BundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
 import defaultCodec from '../../../../src/infrastructure/codecs/CborCodec.ts';
 import { F10_PROTO_POLLUTION } from '../../../helpers/fixtureDsl.ts';
 import MockIndexStorage from '../../../helpers/MockIndexStorage.ts';
@@ -96,6 +97,14 @@ describe('PropertyIndex handle-backed reads', () => {
     reader.setupHandles({ [`props_${computeShardKey('node:1')}.cbor`]: handle });
 
     await expect(reader.getNodeProps('node:1')).rejects.toMatchObject({ code: 'E_INDEX_NO_STORE' });
+  });
+
+  it('fails when retained-root reads have no index store', async () => {
+    const reader = new PropertyIndexReader();
+    reader.setupRoot(new BundleHandle('retained-properties'));
+
+    await expect(reader.getNodeProps('node:1'))
+      .rejects.toMatchObject({ code: 'E_INDEX_NO_STORE' });
   });
 
   it('rejects malformed decoded shard payloads', async () => {

--- a/test/unit/domain/services/controllers/CheckpointController.test.ts
+++ b/test/unit/domain/services/controllers/CheckpointController.test.ts
@@ -244,6 +244,37 @@ describe('CheckpointController', () => {
       );
     });
 
+    it('publishes the exact retained materialization without rebuilding an index tree', async () => {
+      const state = stubState();
+      const retained = { bundle: 'retained-materialization' };
+      const retain = vi.fn().mockResolvedValue(retained);
+      const build = vi.fn(() => {
+        throw new Error('checkpoint must not rebuild the retained index');
+      });
+      host['_cachedState'] = state;
+      host['_stateDirty'] = false;
+      host['_materializations'] = { retain };
+      host['_stateHashService'] = { compute: vi.fn().mockResolvedValue('state-hash') };
+      host['_viewService'] = { build };
+      host['discoverWriters'] = vi.fn().mockResolvedValue([]);
+      createCheckpointCommitMock.mockResolvedValue('cp-sha');
+
+      await expect(ctrl.createCheckpoint()).resolves.toBe('cp-sha');
+
+      expect(retain).toHaveBeenCalledWith(expect.objectContaining({
+        stateHash: 'state-hash',
+        replayBasis: state,
+      }));
+      expect(build).not.toHaveBeenCalled();
+      expect(createCheckpointCommitMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state,
+          materialization: retained,
+        }),
+      );
+      expect(createCheckpointCommitMock.mock.calls[0]?.[0]).not.toHaveProperty('indexTree');
+    });
+
     it('fails closed when cached state is dirty', async () => {
       host['_stateDirty'] = true;
       host['_cachedState'] = stubState();
@@ -284,12 +315,11 @@ describe('CheckpointController', () => {
       expect(materializeGraphTrap).not.toHaveBeenCalled();
     });
 
-    it('logs warning when index build fails and still creates checkpoint', async () => {
+    it('does not rebuild the removed legacy checkpoint index tree', async () => {
       const warnFn = vi.fn();
+      const build = vi.fn(() => { throw new Error('legacy build must not run'); });
       host['_logger'] = { warn: warnFn, info: vi.fn() };
-      host['_viewService'] = {
-        build: vi.fn(() => { throw new Error('boom'); }),
-      };
+      host['_viewService'] = { build };
       host['_cachedIndexTree'] = null;
       host['_cachedState'] = stubState();
       host['discoverWriters'] = vi.fn().mockResolvedValue([]);
@@ -298,10 +328,8 @@ describe('CheckpointController', () => {
       const result = await ctrl.createCheckpoint();
 
       expect(result).toBe('cp-sha');
-      expect(warnFn).toHaveBeenCalledWith(
-        expect.stringContaining('index build failed'),
-        expect.objectContaining({ error: 'boom' }),
-      );
+      expect(build).not.toHaveBeenCalled();
+      expect(warnFn).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/domain/services/controllers/CheckpointController.test.ts
+++ b/test/unit/domain/services/controllers/CheckpointController.test.ts
@@ -50,6 +50,8 @@ const {
   createFrontierMock,
   updateFrontierMock,
   frontierFingerprintMock,
+  materializationRootsWithIndexesMock,
+  prepareMaterializationIndexRootsMock,
 } = vi.hoisted(() => ({
   loadCheckpointMock: vi.fn(),
   createCheckpointCommitMock: vi.fn(),
@@ -63,6 +65,8 @@ const {
   createFrontierMock: vi.fn(),
   updateFrontierMock: vi.fn(),
   frontierFingerprintMock: vi.fn(),
+  materializationRootsWithIndexesMock: vi.fn(),
+  prepareMaterializationIndexRootsMock: vi.fn(),
 }));
 
 vi.mock('../../../../../src/domain/services/state/checkpointLoad.ts', () => ({
@@ -103,6 +107,11 @@ vi.mock('../../../../../src/domain/services/Frontier.ts', () => ({
   createFrontier: createFrontierMock,
   updateFrontier: updateFrontierMock,
   frontierFingerprint: frontierFingerprintMock,
+}));
+
+vi.mock('../../../../../src/domain/services/controllers/MaterializationIndexRoots.ts', () => ({
+  materializationRootsWithIndexes: materializationRootsWithIndexesMock,
+  prepareMaterializationIndexRoots: prepareMaterializationIndexRootsMock,
 }));
 
 /* ------------------------------------------------------------------ */
@@ -201,6 +210,8 @@ describe('CheckpointController', () => {
     createFrontierMock.mockReturnValue(new Map());
     updateFrontierMock.mockReturnValue(undefined);
     frontierFingerprintMock.mockReturnValue('fp-stable');
+    materializationRootsWithIndexesMock.mockReturnValue({});
+    prepareMaterializationIndexRootsMock.mockResolvedValue({});
     collectGCMetricsMock.mockReturnValue({
       nodeLiveDots: 10,
       edgeLiveDots: 5,
@@ -273,6 +284,44 @@ describe('CheckpointController', () => {
         }),
       );
       expect(createCheckpointCommitMock.mock.calls[0]?.[0]).not.toHaveProperty('indexTree');
+    });
+
+    it('releases the workspace after retaining checkpoint index roots', async () => {
+      const state = stubState();
+      const retained = { bundle: 'indexed-materialization' };
+      const promote = vi.fn().mockResolvedValue(retained);
+      const release = vi.fn().mockResolvedValue(undefined);
+      const workspace = { promote, release };
+      const openWorkspace = vi.fn().mockResolvedValue(workspace);
+      const prepared = { properties: 'properties', roaringIndexes: 'indexes' };
+      const roots = { properties: 'properties', roaringIndexes: 'indexes' };
+      prepareMaterializationIndexRootsMock.mockResolvedValue(prepared);
+      materializationRootsWithIndexesMock.mockReturnValue(roots);
+      host['_cachedState'] = state;
+      host['_stateDirty'] = false;
+      host['_materializations'] = { openWorkspace };
+      host['_indexStore'] = {};
+      host['_stateHashService'] = { compute: vi.fn().mockResolvedValue('state-hash') };
+      host['discoverWriters'] = vi.fn().mockResolvedValue([]);
+      createCheckpointCommitMock.mockResolvedValue('cp-sha');
+
+      await expect(ctrl.createCheckpoint()).resolves.toBe('cp-sha');
+
+      expect(openWorkspace).toHaveBeenCalledOnce();
+      expect(prepareMaterializationIndexRootsMock).toHaveBeenCalledWith({
+        state,
+        store: host['_indexStore'],
+        workspace,
+      });
+      expect(promote).toHaveBeenCalledWith(expect.objectContaining({
+        roots,
+        stateHash: 'state-hash',
+        replayBasis: state,
+      }));
+      expect(release).toHaveBeenCalledOnce();
+      expect(createCheckpointCommitMock).toHaveBeenCalledWith(
+        expect.objectContaining({ materialization: retained }),
+      );
     });
 
     it('fails closed when cached state is dirty', async () => {

--- a/test/unit/domain/services/controllers/MaterializeController.propertyRootRetention.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.propertyRootRetention.test.ts
@@ -110,6 +110,7 @@ describe("MaterializeController property-root retention", () => {
   it("rebuilds a supplied property root when the reduction observes a patch", async () => {
     const materializations = new InMemoryMaterializationStore();
     const propertyStore = new MockIndexStorage();
+    const writeShards = vi.spyOn(propertyStore, "writeShards");
     const stale = MaterializationRoot.retained(new BundleHandle("test:stale-properties"));
 
     const reduced = await reduceSessionBackedState({
@@ -128,7 +129,13 @@ describe("MaterializeController property-root retention", () => {
 
     expect(reduced.roots.properties.status).toBe("retained");
     expect(reduced.roots.properties.equals(stale)).toBe(false);
-    expect(propertyStore.writeBlob).toHaveBeenCalledOnce();
+    expect(reduced.roots.roaringIndexes.status).toBe("retained");
+    expect(writeShards).toHaveBeenCalledTimes(2);
+    expect(materializations.workspaces[0]?.checkpoints.at(-1))
+      .toEqual(expect.objectContaining({
+        propertiesRoot: reduced.roots.properties.handle?.toString(),
+        roaringIndexesRoot: reduced.roots.roaringIndexes.handle?.toString(),
+      }));
     await reduced.workspace.release();
   });
 });

--- a/test/unit/domain/services/controllers/MaterializeController.stateSession.fixtures.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.stateSession.fixtures.ts
@@ -1,0 +1,141 @@
+import { vi } from "vitest";
+
+import { Dot } from "../../../../../src/domain/crdt/Dot.ts";
+import MaterializeController from "../../../../../src/domain/services/controllers/MaterializeController.ts";
+import StateSession from "../../../../../src/domain/orset/session/StateSession.ts";
+import TrieGeometry from "../../../../../src/domain/orset/trie/TrieGeometry.ts";
+import cborCodec from "../../../../../src/infrastructure/codecs/CborCodec.ts";
+import { DEFAULT_COMMIT_MESSAGE_CODEC } from "../../../../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts";
+import { createEmptyState } from "../../../../../src/domain/services/JoinReducer.ts";
+import type { CheckpointData, PatchWithSha } from "../../../../../src/domain/capabilities/PatchCollector.ts";
+import InMemoryCheckpointStore from "../../../../helpers/InMemoryCheckpointStore.ts";
+import InMemoryMaterializationStore from "../../../../helpers/InMemoryMaterializationStore.ts";
+import type MaterializationWorkspacePort from "../../../../../src/ports/MaterializationWorkspacePort.ts";
+
+import { InMemoryTrieStore } from "../../../../helpers/trieHelpers.ts";
+
+const GEOMETRY = TrieGeometry.default16way();
+
+export type Coordinate = {
+  frontier: Map<string, string>;
+  ceiling: number | null;
+};
+
+export function snapshotRecord(coordinate: Coordinate) {
+  const state = createEmptyState();
+  state.nodeAlive.add("node:base", Dot.create("seed", 1));
+  const removedNodeDot = Dot.create("seed", 2);
+  state.nodeAlive.add("node:removed", removedNodeDot);
+  state.nodeAlive.remove(new Set([Dot.encode(removedNodeDot)]));
+  const removedEdgeDot = Dot.create("seed", 3);
+  state.edgeAlive.add("node:base\0node:removed\0related", removedEdgeDot);
+  state.edgeAlive.remove(new Set([Dot.encode(removedEdgeDot)]));
+  return {
+    snapshotId: "snapshot-base",
+    coordinate,
+    state,
+    retention: "evictable" as const,
+    provenancePosture: "full" as const,
+    stateHash: "snapshot-base-hash",
+    payloadRef: "snapshot-base-payload",
+    createdAt: "snapshot-base-created-at",
+  };
+}
+
+async function* streamFromPromise<T>(items: Promise<T[]>): AsyncIterable<T> {
+  for (const item of await items) {
+    yield item;
+  }
+}
+
+export function createControllerFixtures() {
+  const stateCache = {
+    getExact: vi.fn(),
+    getBestCompatiblePredecessor: vi.fn(),
+    put: vi.fn(),
+    pin: vi.fn(),
+    publishCheckpointHead: vi.fn(),
+    resolveCheckpointHead: vi.fn(),
+    pruneEvictable: vi.fn(),
+  };
+  const patches = {
+    discoverWriters: vi.fn().mockResolvedValue([]),
+    loadWriterPatches: vi.fn<(_writerId: string) => Promise<PatchWithSha[]>>().mockResolvedValue([]),
+    collectForFrontier:
+      vi.fn<(_frontier: Map<string, string>, _ceiling: number | null) => Promise<PatchWithSha[]>>().mockResolvedValue([]),
+    collectForFrontierSinceCoordinate:
+      vi.fn<(_frontier: Map<string, string>, _ceiling: number | null, _coordinate: Coordinate) => Promise<PatchWithSha[]>>()
+        .mockResolvedValue([]),
+    loadCheckpoint: vi.fn().mockResolvedValue(null),
+    loadPatchesSince: vi.fn<(_checkpoint: CheckpointData) => Promise<PatchWithSha[]>>().mockResolvedValue([]),
+    loadPatchChain: vi.fn<(_toSha: string, _fromSha?: string | null) => Promise<PatchWithSha[]>>().mockResolvedValue([]),
+    isAncestor: vi.fn().mockResolvedValue(false),
+    getFrontier: vi.fn().mockResolvedValue(new Map([["writer-1", "tip-1"]])),
+    streamWriterPatches: vi.fn((writerId: string) => streamFromPromise(patches.loadWriterPatches(writerId))),
+    streamForFrontier: vi.fn((frontier: Map<string, string>, ceiling: number | null) =>
+      streamFromPromise(patches.collectForFrontier(frontier, ceiling))),
+    streamForFrontierSinceCoordinate: vi.fn((
+      frontier: Map<string, string>,
+      ceiling: number | null,
+      coordinate: Coordinate,
+    ) => streamFromPromise(patches.collectForFrontierSinceCoordinate(frontier, ceiling, coordinate))),
+    streamPatchesSince: vi.fn((checkpoint: Parameters<typeof patches.loadPatchesSince>[0]) =>
+      streamFromPromise(patches.loadPatchesSince(checkpoint))),
+  };
+  const store = new InMemoryTrieStore();
+  const materializations = new InMemoryMaterializationStore();
+  const openStateSession = vi.fn(
+    async (roots: {
+      readonly nodeAliveRootOid: string | null;
+      readonly edgeAliveRootOid: string | null;
+    }, options: { readonly workspace: MaterializationWorkspacePort }): Promise<StateSession> =>
+      await StateSession.open({
+        nodeAliveRootOid: roots.nodeAliveRootOid,
+        edgeAliveRootOid: roots.edgeAliveRootOid,
+        store,
+        codec: cborCodec,
+        geometry: GEOMETRY,
+        maxDirtyPages: 1,
+        workspace: options.workspace,
+      }),
+  );
+
+  const deps = {
+    logger: {
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    },
+    codec: cborCodec,
+    crypto: {
+      hash: vi.fn().mockResolvedValue("state-hash-1"),
+      hmac: vi.fn().mockResolvedValue(new Uint8Array([1])),
+      timingSafeEqual: vi.fn().mockReturnValue(false),
+    },
+    persistence: {
+      readRef: vi.fn().mockResolvedValue(null),
+      readTreeOids: vi.fn().mockResolvedValue({}),
+      showNode: vi.fn().mockResolvedValue(""),
+      readBlob: vi.fn().mockResolvedValue(new Uint8Array([1])),
+    },
+    checkpointStore: new InMemoryCheckpointStore(),
+    materializations,
+    commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC,
+    getStateCache: () => stateCache,
+    patches,
+    graphCloner: { openReadOnly: vi.fn() },
+    graphName: "test-graph",
+    openStateSession,
+  };
+
+  return {
+    controller: new MaterializeController(deps),
+    patches,
+    stateCache,
+    openStateSession,
+    materializations,
+    deps,
+  };
+}

--- a/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
@@ -550,6 +550,7 @@ describe("MaterializeController — state session integration", () => {
 
     fixtures.stateCache.getExact.mockResolvedValue(published);
     const propertyStore = new MockIndexStorage();
+    const writeShards = vi.spyOn(propertyStore, "writeShards");
     const upgradedController = new MaterializeController({
       ...fixtures.deps,
       propertyStore,
@@ -559,11 +560,15 @@ describe("MaterializeController — state session integration", () => {
 
     expect(fixtures.materializations.retainedRequests).toHaveLength(2);
     expect(upgraded.materialization?.roots.properties.status).toBe("retained");
+    expect(upgraded.materialization?.roots.roaringIndexes.status).toBe("retained");
     expect(upgraded.materialization?.bundle.equals(cold.materialization.bundle)).toBe(false);
     expect(reused.materialization?.bundle.equals(upgraded.materialization?.bundle)).toBe(true);
-    expect(propertyStore.writeBlob).toHaveBeenCalledOnce();
-    expect(fixtures.materializations.workspaces[1]?.checkpoints.at(-1)?.propertiesRoot)
-      .toBe(upgraded.materialization?.roots.properties.handle?.toString());
+    expect(writeShards).toHaveBeenCalledTimes(2);
+    expect(fixtures.materializations.workspaces[1]?.checkpoints.at(-1))
+      .toEqual(expect.objectContaining({
+        propertiesRoot: upgraded.materialization?.roots.properties.handle?.toString(),
+        roaringIndexesRoot: upgraded.materialization?.roots.roaringIndexes.handle?.toString(),
+      }));
   });
 
   it("does not retry an exact acquisition release failure", async () => {

--- a/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
@@ -8,31 +8,22 @@ import NodeAdd from "../../../../../src/domain/types/ops/NodeAdd.ts";
 import NodePropSet from "../../../../../src/domain/types/ops/NodePropSet.ts";
 import EdgeAdd from "../../../../../src/domain/types/ops/EdgeAdd.ts";
 import StateSession from "../../../../../src/domain/orset/session/StateSession.ts";
-import TrieGeometry from "../../../../../src/domain/orset/trie/TrieGeometry.ts";
-import cborCodec from "../../../../../src/infrastructure/codecs/CborCodec.ts";
-import { DEFAULT_COMMIT_MESSAGE_CODEC } from "../../../../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts";
 import SchemaUnsupportedError from "../../../../../src/domain/errors/SchemaUnsupportedError.ts";
-import { InMemoryTrieStore } from "../../../../helpers/trieHelpers.ts";
-import { createEmptyState } from "../../../../../src/domain/services/JoinReducer.ts";
 import Patch from "../../../../../src/domain/types/Patch.ts";
-import type { CheckpointData, PatchWithSha } from "../../../../../src/domain/capabilities/PatchCollector.ts";
-import InMemoryCheckpointStore from "../../../../helpers/InMemoryCheckpointStore.ts";
+import type { PatchWithSha } from "../../../../../src/domain/capabilities/PatchCollector.ts";
 import InMemoryMaterializationStore, {
   InMemoryMaterializationAcquisition,
   InMemoryMaterializationWorkspace,
 } from "../../../../helpers/InMemoryMaterializationStore.ts";
-import type MaterializationWorkspacePort from "../../../../../src/ports/MaterializationWorkspacePort.ts";
 import MaterializationCoordinate from "../../../../../src/domain/materialization/MaterializationCoordinate.ts";
 import MaterializationHandle from "../../../../../src/domain/materialization/MaterializationHandle.ts";
 import type { RetainMaterializationRequest } from "../../../../../src/ports/MaterializationStorePort.ts";
 import MockIndexStorage from "../../../../helpers/MockIndexStorage.ts";
-
-const GEOMETRY = TrieGeometry.default16way();
-
-type Coordinate = {
-  frontier: Map<string, string>;
-  ceiling: number | null;
-};
+import {
+  createControllerFixtures,
+  snapshotRecord,
+  type Coordinate,
+} from "./MaterializeController.stateSession.fixtures.ts";
 
 type PatchRecord = PatchWithSha;
 
@@ -104,125 +95,6 @@ function edgeAddPatchRecord(args: {
       writes: [`${args.from}\0${args.to}\0${args.label}`],
     }),
     sha: args.sha,
-  };
-}
-
-function snapshotRecord(coordinate: Coordinate) {
-  const state = createEmptyState();
-  state.nodeAlive.add("node:base", Dot.create("seed", 1));
-  const removedNodeDot = Dot.create("seed", 2);
-  state.nodeAlive.add("node:removed", removedNodeDot);
-  state.nodeAlive.remove(new Set([Dot.encode(removedNodeDot)]));
-  const removedEdgeDot = Dot.create("seed", 3);
-  state.edgeAlive.add("node:base\0node:removed\0related", removedEdgeDot);
-  state.edgeAlive.remove(new Set([Dot.encode(removedEdgeDot)]));
-  return {
-    snapshotId: "snapshot-base",
-    coordinate,
-    state,
-    retention: "evictable" as const,
-    provenancePosture: "full" as const,
-    stateHash: "snapshot-base-hash",
-    payloadRef: "snapshot-base-payload",
-    createdAt: "snapshot-base-created-at",
-  };
-}
-
-async function* streamFromPromise<T>(items: Promise<T[]>): AsyncIterable<T> {
-  for (const item of await items) {
-    yield item;
-  }
-}
-
-function createControllerFixtures() {
-  const stateCache = {
-    getExact: vi.fn(),
-    getBestCompatiblePredecessor: vi.fn(),
-    put: vi.fn(),
-    pin: vi.fn(),
-    publishCheckpointHead: vi.fn(),
-    resolveCheckpointHead: vi.fn(),
-    pruneEvictable: vi.fn(),
-  };
-  const patches = {
-    discoverWriters: vi.fn().mockResolvedValue([]),
-    loadWriterPatches: vi.fn<(_writerId: string) => Promise<PatchWithSha[]>>().mockResolvedValue([]),
-    collectForFrontier:
-      vi.fn<(_frontier: Map<string, string>, _ceiling: number | null) => Promise<PatchWithSha[]>>().mockResolvedValue([]),
-    collectForFrontierSinceCoordinate:
-      vi.fn<(_frontier: Map<string, string>, _ceiling: number | null, _coordinate: Coordinate) => Promise<PatchWithSha[]>>()
-        .mockResolvedValue([]),
-    loadCheckpoint: vi.fn().mockResolvedValue(null),
-    loadPatchesSince: vi.fn<(_checkpoint: CheckpointData) => Promise<PatchWithSha[]>>().mockResolvedValue([]),
-    loadPatchChain: vi.fn<(_toSha: string, _fromSha?: string | null) => Promise<PatchWithSha[]>>().mockResolvedValue([]),
-    isAncestor: vi.fn().mockResolvedValue(false),
-    getFrontier: vi.fn().mockResolvedValue(new Map([["writer-1", "tip-1"]])),
-    streamWriterPatches: vi.fn((writerId: string) => streamFromPromise(patches.loadWriterPatches(writerId))),
-    streamForFrontier: vi.fn((frontier: Map<string, string>, ceiling: number | null) =>
-      streamFromPromise(patches.collectForFrontier(frontier, ceiling))),
-    streamForFrontierSinceCoordinate: vi.fn((
-      frontier: Map<string, string>,
-      ceiling: number | null,
-      coordinate: Coordinate,
-    ) => streamFromPromise(patches.collectForFrontierSinceCoordinate(frontier, ceiling, coordinate))),
-    streamPatchesSince: vi.fn((checkpoint: Parameters<typeof patches.loadPatchesSince>[0]) =>
-      streamFromPromise(patches.loadPatchesSince(checkpoint))),
-  };
-  const store = new InMemoryTrieStore();
-  const materializations = new InMemoryMaterializationStore();
-  const openStateSession = vi.fn(
-    async (roots: {
-      readonly nodeAliveRootOid: string | null;
-      readonly edgeAliveRootOid: string | null;
-    }, options: { readonly workspace: MaterializationWorkspacePort }): Promise<StateSession> =>
-      await StateSession.open({
-        nodeAliveRootOid: roots.nodeAliveRootOid,
-        edgeAliveRootOid: roots.edgeAliveRootOid,
-        store,
-        codec: cborCodec,
-        geometry: GEOMETRY,
-        maxDirtyPages: 1,
-        workspace: options.workspace,
-      }),
-  );
-
-  const deps = {
-    logger: {
-      warn: vi.fn(),
-      info: vi.fn(),
-      debug: vi.fn(),
-      error: vi.fn(),
-      child: vi.fn(),
-    },
-    codec: cborCodec,
-    crypto: {
-      hash: vi.fn().mockResolvedValue("state-hash-1"),
-      hmac: vi.fn().mockResolvedValue(new Uint8Array([1])),
-      timingSafeEqual: vi.fn().mockReturnValue(false),
-    },
-    persistence: {
-      readRef: vi.fn().mockResolvedValue(null),
-      readTreeOids: vi.fn().mockResolvedValue({}),
-      showNode: vi.fn().mockResolvedValue(""),
-      readBlob: vi.fn().mockResolvedValue(new Uint8Array([1])),
-    },
-    checkpointStore: new InMemoryCheckpointStore(),
-    materializations,
-    commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC,
-    getStateCache: () => stateCache,
-    patches,
-    graphCloner: { openReadOnly: vi.fn() },
-    graphName: "test-graph",
-    openStateSession,
-  };
-
-  return {
-    controller: new MaterializeController(deps),
-    patches,
-    stateCache,
-    openStateSession,
-    materializations,
-    deps,
   };
 }
 
@@ -527,6 +399,30 @@ describe("MaterializeController — state session integration", () => {
     expect(reopened.state.nodeAlive.contains("node:retained")).toBe(true);
     expect(warm.materialization?.bundle.equals(cold.materialization?.bundle)).toBe(true);
     expect(reopened.materialization?.bundle.equals(cold.materialization?.bundle)).toBe(true);
+  });
+
+  it("rebuilds an exact cached snapshot when retained roots are absent", async () => {
+    const fixtures = createControllerFixtures();
+    const snapshot = snapshotRecord({
+      frontier: new Map([["writer-1", "tip-1"]]),
+      ceiling: null,
+    });
+    fixtures.stateCache.getExact.mockResolvedValue(snapshot);
+
+    const result = await new MaterializeController(fixtures.deps).materialize();
+
+    expect(result.patchCount).toBe(0);
+    expect(result.state.nodeAlive.contains("node:base")).toBe(true);
+    expect(result.state.nodeAlive.contains("node:removed")).toBe(false);
+    expect(result.materialization).toBeDefined();
+    expect(fixtures.patches.collectForFrontier).not.toHaveBeenCalled();
+    expect(fixtures.openStateSession).toHaveBeenCalledWith({
+      nodeAliveRootOid: null,
+      edgeAliveRootOid: null,
+    }, expect.objectContaining({ workspace: expect.anything() }));
+    expect(fixtures.materializations.retainedRequests).toHaveLength(1);
+    expect(fixtures.materializations.exactLookups).toHaveLength(2);
+    expect(fixtures.stateCache.put).not.toHaveBeenCalled();
   });
 
   it("promotes a newly available property root instead of reusing an incomplete handle", async () => {

--- a/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.stateSession.test.ts
@@ -793,9 +793,7 @@ describe("MaterializeController — state session integration", () => {
 
   it("fails fast on materializeAt when the controller is on the session-backed runtime line", async () => {
     const { controller } = createControllerFixtures();
-
-    await expect(controller.materializeAt("a".repeat(40))).rejects.toBeInstanceOf(
-      SchemaUnsupportedError,
-    );
+    await expect(controller.materializeAt("a".repeat(40)))
+      .rejects.toBeInstanceOf(SchemaUnsupportedError);
   });
 });

--- a/test/unit/domain/services/controllers/MaterializeController.test.ts
+++ b/test/unit/domain/services/controllers/MaterializeController.test.ts
@@ -6,6 +6,7 @@ import { encodeEdgeKey } from '../../../../../src/domain/services/KeyCodec.ts';
 import QueryError from '../../../../../src/domain/errors/QueryError.ts';
 import AdjacencyMap from '../../../../../src/domain/capabilities/AdjacencyMap.ts';
 import type PatchType from '../../../../../src/domain/types/Patch.ts';
+import InMemoryMaterializationStore from '../../../../helpers/InMemoryMaterializationStore.ts';
 
 /** @typedef {import('../../../../../src/domain/services/state/WarpState.ts').default} WarpState */
 /** @typedef {import('../../../../../src/domain/types/TickReceipt.ts').TickReceipt} TickReceipt */
@@ -162,10 +163,7 @@ function makeDeps({ patchesOverrides = {}, persistenceOverrides = {}, depsOverri
       hmac: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
     },
     persistence,
-    materializations: {
-      acquireExact: vi.fn().mockResolvedValue(null),
-      acquireBestCompatiblePredecessor: vi.fn().mockResolvedValue(null),
-    },
+    materializations: new InMemoryMaterializationStore(),
     patches,
     graphCloner: { openReadOnly: vi.fn() },
     graphName: 'test',

--- a/test/unit/domain/services/optic/CheckpointShardFactReader.manifest.test.ts
+++ b/test/unit/domain/services/optic/CheckpointShardFactReader.manifest.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { EdgeShard } from '../../../../../src/domain/artifacts/EdgeShard.ts';
 import { MetaShard } from '../../../../../src/domain/artifacts/MetaShard.ts';
+import { PropertyShard } from '../../../../../src/domain/artifacts/PropertyShard.ts';
 import { shardToEntry } from '../../../../../src/domain/services/MaterializedViewHelpers.ts';
 import LogicalBitmapIndexBuilder from '../../../../../src/domain/services/index/LogicalBitmapIndexBuilder.ts';
 import CheckpointBasisManifest, {
@@ -19,8 +20,13 @@ import CheckpointTailOpticSource, {
 } from '../../../../../src/domain/services/optic/CheckpointTailOpticSource.ts';
 import { CURRENT_CHECKPOINT_SCHEMA } from '../../../../../src/domain/services/state/checkpointHelpers.ts';
 import AssetHandle from '../../../../../src/domain/storage/AssetHandle.ts';
+import WarpStream from '../../../../../src/domain/stream/WarpStream.ts';
 import type CodecValue from '../../../../../src/domain/types/codec/CodecValue.ts';
 import computeShardKey from '../../../../../src/domain/utils/shardKey.ts';
+import {
+  materializationPropertyShardKey,
+  materializationPropertyShardPath,
+} from '../../../../../src/domain/materialization/MaterializationPropertyProfile.ts';
 import defaultCodec from '../../../../../src/infrastructure/codecs/CborCodec.ts';
 import type CodecPort from '../../../../../src/ports/CodecPort.ts';
 import InMemoryCheckpointStore from '../../../../helpers/InMemoryCheckpointStore.ts';
@@ -34,6 +40,53 @@ const NEIGHBOR_ID = 'node:manifest-neighbor';
 const EDGE_LABEL = 'owns';
 
 describe('CheckpointShardFactReader manifest-backed routing', () => {
+  it('reads exact bundle members without converting current roots to legacy handles', async () => {
+    const indexStore = new MockIndexStorage();
+    const metaShardKey = computeShardKey(NODE_ID);
+    const propertyShardKey = materializationPropertyShardKey(NODE_ID);
+    const metaPath = `meta_${metaShardKey}.cbor`;
+    const propPath = materializationPropertyShardPath(NODE_ID);
+    const builder = new LogicalBitmapIndexBuilder();
+    builder.registerNode(NODE_ID);
+    builder.markAlive(NODE_ID);
+    const indexRoot = await indexStore.writeShards(WarpStream.from(builder.yieldShards()));
+    const propertyRoot = await indexStore.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey: propertyShardKey,
+        schemaVersion: 2,
+        entries: [[NODE_ID, { [PROPERTY_KEY]: PROPERTY_VALUE }]],
+      }),
+    ]));
+    const indexReferences = await indexStore.readShardReferences(indexRoot);
+    const propReferences = await indexStore.readShardReferences(propertyRoot);
+    const metaToken = indexReferences[metaPath]?.token;
+    const propToken = propReferences[propPath]?.token;
+    if (metaToken === undefined || propToken === undefined) {
+      throw new Error('expected retained shard references');
+    }
+    const legacyShape = manifestBasis({
+      livenessRoots: new Map([[metaPath, new AssetHandle(metaToken)]]),
+      propertyRoots: new Map([[propPath, new AssetHandle(propToken)]]),
+    });
+    const basis: CheckpointTailIndexBasis = {
+      ...legacyShape,
+      indexHandles: Object.freeze({}),
+      propHandles: Object.freeze({}),
+      indexRoot,
+      propertyRoot,
+      indexReferences,
+      propReferences,
+    };
+    const reader = new CheckpointShardFactReader({
+      source: new ManifestShardSource(indexStore),
+    });
+
+    await expect(reader.readNodeAlive(basis, NODE_ID)).resolves.toBe(true);
+    await expect(reader.readProperty(basis, NODE_ID, PROPERTY_KEY))
+      .resolves.toBe(PROPERTY_VALUE);
+    expect(indexStore.decodedShardPaths).toEqual([metaPath, propPath]);
+  });
+
   it('reads liveness and properties through their manifest-selected asset handles', async () => {
     const indexStore = new MockIndexStorage();
     const metaPath = `meta_${computeShardKey(NODE_ID)}.cbor`;
@@ -357,6 +410,10 @@ function manifestBasis(options: {
       edgeFactRoots,
     ),
     propHandles: handleRecord(options.propertyRoots),
+    indexRoot: null,
+    propertyRoot: null,
+    indexReferences: Object.freeze({}),
+    propReferences: Object.freeze({}),
   };
 }
 

--- a/test/unit/domain/services/optic/CheckpointTailBasisVerifier.test.ts
+++ b/test/unit/domain/services/optic/CheckpointTailBasisVerifier.test.ts
@@ -7,6 +7,7 @@ import CheckpointTailOpticSource, {
 } from '../../../../../src/domain/services/optic/CheckpointTailOpticSource.ts';
 import { CURRENT_CHECKPOINT_SCHEMA } from '../../../../../src/domain/services/state/checkpointHelpers.ts';
 import AssetHandle from '../../../../../src/domain/storage/AssetHandle.ts';
+import BundleHandle from '../../../../../src/domain/storage/BundleHandle.ts';
 import defaultCodec from '../../../../../src/infrastructure/codecs/CborCodec.ts';
 import type {
   CheckpointBasis,
@@ -133,6 +134,19 @@ describe('CheckpointTailBasisVerifier', () => {
     });
   });
 
+  it('accepts a retained current index root without legacy shard handles', async () => {
+    const source = new TestCheckpointTailOpticSource({
+      result: validBasis({
+        indexShardHandles: Object.freeze({}),
+        indexRoot: new BundleHandle('retained-current-index-root'),
+      }),
+    });
+
+    await expect(new CheckpointTailBasisVerifier({ source }).verify()).resolves.toEqual({
+      checkpointSha: CHECKPOINT_SHA,
+    });
+  });
+
   it('maps checkpoint-store failures to unavailable bounded support', async () => {
     const source = new TestCheckpointTailOpticSource({
       result: new Error('checkpoint publication is unavailable'),
@@ -154,6 +168,8 @@ function validBasis(overrides: Partial<CheckpointBasis> = {}): CheckpointBasis {
     indexShardHandles: Object.freeze({
       'meta_00.cbor': new AssetHandle('checkpoint-index:meta-00'),
     }),
+    indexRoot: null,
+    propertyRoot: null,
     ...overrides,
   };
 }

--- a/test/unit/domain/services/optic/CheckpointTailReadIdentityBuilder.test.ts
+++ b/test/unit/domain/services/optic/CheckpointTailReadIdentityBuilder.test.ts
@@ -64,6 +64,10 @@ function indexBasis(): CheckpointTailIndexBasis {
     manifest: manifest(),
     indexHandles: {},
     propHandles: {},
+    indexRoot: null,
+    propertyRoot: null,
+    indexReferences: {},
+    propReferences: {},
   };
 }
 

--- a/test/unit/domain/warp/hydrateCheckpointIndex.regression.test.ts
+++ b/test/unit/domain/warp/hydrateCheckpointIndex.regression.test.ts
@@ -6,6 +6,7 @@ import { EventId } from '../../../../src/domain/utils/EventId.ts';
 import MaterializedViewService from '../../../../src/domain/services/MaterializedViewService.ts';
 import defaultCrypto from '../../../../src/infrastructure/adapters/NodeCryptoSingleton.ts';
 import defaultCodec from '../../../../src/infrastructure/codecs/CborCodec.ts';
+import InMemoryMaterializationStore from '../../../helpers/InMemoryMaterializationStore.ts';
 
 /**
  * @param {string[]} nodes
@@ -54,10 +55,7 @@ describe('materialize stale-checkpoint regression', () => {
       persistence: {},
       graphName: 'test',
       graphCloner: {},
-      materializations: {
-        acquireExact: async () => null,
-        acquireBestCompatiblePredecessor: async () => null,
-      },
+      materializations: new InMemoryMaterializationStore(),
       patches: {
         loadCheckpoint: async () => ({
           schema: 5,

--- a/test/unit/helpers/MemoryRuntimeStorageAdapter.test.ts
+++ b/test/unit/helpers/MemoryRuntimeStorageAdapter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import InMemoryGraphAdapter from '../../helpers/InMemoryGraphAdapter.ts';
+import { withFixtureObjectTypeProbe } from '../../helpers/MemoryRuntimeStorageAdapter.ts';
+
+describe('MemoryRuntimeStorageAdapter object type probe', () => {
+  it('preserves normalized blob, tree, and commit object kinds', async () => {
+    const history = new InMemoryGraphAdapter();
+    Object.defineProperty(history, 'readObjectType', {
+      configurable: true,
+      value: undefined,
+    });
+    const probed = withFixtureObjectTypeProbe(history);
+    const blobOid = await probed.writeBlob('content');
+    const treeOid = await probed.writeTree([
+      `100644 blob ${blobOid}\tcontent`,
+    ]);
+    const commitOid = await probed.commitNodeWithTree({
+      treeOid,
+      message: 'publish content',
+    });
+
+    await expect(probed.readObjectType(blobOid)).resolves.toBe('blob');
+    await expect(probed.readObjectType(treeOid)).resolves.toBe('tree');
+    await expect(probed.readObjectType(probed.emptyTree)).resolves.toBe('tree');
+    await expect(probed.readObjectType(commitOid)).resolves.toBe('commit');
+  });
+});

--- a/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
+++ b/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
@@ -120,8 +120,18 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
   it('writes and scans every supported shard class through one index handle', async () => {
     const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
     const recovered = await indexes.scanShards(indexHandle).collect();
+    const streamed = await collectAsyncIterable(
+      indexes.openShardAt(indexHandle, 'meta_a0.cbor'),
+    );
 
     expect(indexHandle).toBeInstanceOf(BundleHandle);
+    expect(defaultCodec.decode(streamed)).toMatchObject({
+      nextLocalId: 2,
+      nodeToGlobal: [['node:1', 0], ['node:2', 1]],
+    });
+    await expect(collectAsyncIterable(indexes.openShardAt(indexHandle, 'meta_a0.cbor', {
+      maxBytes: 1,
+    }))).rejects.toMatchObject({ code: 'E_INDEX_SHARD_TOO_LARGE' });
     expect(recovered).toHaveLength(6);
     expect(recovered.some((shard) => shard instanceof MetaShard)).toBe(true);
     expect(recovered.some((shard) => shard instanceof EdgeShard && shard.direction === 'fwd')).toBe(true);
@@ -405,11 +415,14 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     const bundle = await cas.bundles.putOrdered({
       members: [['nested.cbor', nested.handle.toString()]],
     });
+    const indexHandle = new BundleHandle(bundle.handle.toString());
 
     await expect(indexes.decodeShardAt(
-      new BundleHandle(bundle.handle.toString()),
+      indexHandle,
       'nested.cbor',
     )).rejects.toMatchObject({ code: 'E_INDEX_INVALID_BUNDLE_MEMBER' });
+    await expect(indexes.readShardReferences(indexHandle))
+      .rejects.toMatchObject({ code: 'E_INDEX_INVALID_BUNDLE_MEMBER' });
   });
 
   it('rejects oversized shards on write and exact read', async () => {

--- a/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
+++ b/test/unit/infrastructure/CborIndexStoreAdapter.test.ts
@@ -191,6 +191,7 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
     const indexHandle = await indexes.writeShards(WarpStream.from(shards()));
     const open = vi.spyOn(assets, 'open');
     const handles = await indexes.readShardHandles(indexHandle);
+    const references = await indexes.readShardReferences(indexHandle);
 
     expect(Object.keys(handles).sort()).toEqual([
       'fwd_a0.cbor',
@@ -201,6 +202,12 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
       'rev_a0.cbor',
     ]);
     expect(Object.values(handles).every((handle) => handle instanceof AssetHandle)).toBe(true);
+    expect(Object.entries(references)).toEqual(
+      Object.entries(handles).map(([path, handle]) => [
+        path,
+        { kind: 'asset', token: handle.toString() },
+      ]),
+    );
     expect(open).not.toHaveBeenCalled();
   });
 
@@ -258,6 +265,18 @@ describe('CborIndexStoreAdapter opaque shard boundary', () => {
 
     expect(GitCasPageHandle.from(token)).toBeInstanceOf(GitCasPageHandle);
     expect(stage).not.toHaveBeenCalled();
+    await expect(indexes.readShardReferences(indexHandle)).resolves.toEqual({
+      [path]: { kind: 'page', token },
+    });
+    const opened = await collectAsyncIterable(indexes.openShardAt(indexHandle, path, {
+      maxBytes: 1024,
+    }));
+    expect(defaultCodec.decode(opened)).toEqual({
+      schemaVersion: 2,
+      entries: [[nodeId, [['status', 'ready']]]],
+    });
+    await expect(collectAsyncIterable(indexes.openShardAt(indexHandle, 'missing.cbor')))
+      .rejects.toMatchObject({ code: 'E_INDEX_SHARD_MISSING' });
     await expect(indexes.decodeShardAt(indexHandle, path, {
       maxBytes: 1024,
       structureLimits: {

--- a/test/unit/infrastructure/adapters/CborCheckpointStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/CborCheckpointStoreAdapter.test.ts
@@ -103,10 +103,14 @@ function createFixture() {
 
 async function record(
   fixture: ReturnType<typeof createFixture>,
-  options: { indexes?: boolean; parents?: string[] } = {},
+  options: {
+    indexes?: boolean;
+    parents?: string[];
+    frontier?: Map<string, string>;
+  } = {},
 ): Promise<CheckpointRecord> {
   const state = createState();
-  const frontier = new Map([['w1', 'a'.repeat(40)]]);
+  const frontier = options.frontier ?? new Map([['w1', 'a'.repeat(40)]]);
   const coordinate = new MaterializationCoordinate({ frontier, ceiling: null });
   const adjacency = await fixture.cas.bundles.putOrdered({ members: [] });
   const unavailable = () => MaterializationRoot.unavailable();
@@ -313,13 +317,14 @@ describe('CborCheckpointStoreAdapter materialization lifecycle', () => {
 
   it('exposes retained logical and property roots as the bounded basis', async () => {
     const fixture = createFixture();
-    const published = await fixture.checkpoints.publishCheckpoint(
-      await record(fixture, { indexes: true }),
-    );
+    const input = await record(fixture, { indexes: true });
+    const published = await fixture.checkpoints.publishCheckpoint(input);
     const basis = await fixture.checkpoints.loadBasis(published.checkpointSha);
 
-    expect(basis.indexRoot).not.toBeNull();
-    expect(basis.propertyRoot).not.toBeNull();
+    expect(basis.indexRoot?.toString())
+      .toBe(input.materialization?.roots.roaringIndexes.handle?.toString());
+    expect(basis.propertyRoot?.toString())
+      .toBe(input.materialization?.roots.properties.handle?.toString());
     expect(basis.indexShardHandles).toEqual({});
     expect(basis.frontier).toEqual(new Map([['w1', 'a'.repeat(40)]]));
   });
@@ -382,6 +387,28 @@ describe('CborCheckpointStoreAdapter materialization lifecycle', () => {
       ...input,
       materialization: ceiling,
     })).rejects.toMatchObject({ code: 'E_CHECKPOINT_MATERIALIZATION_MISMATCH' });
+
+    await expect(fixture.checkpoints.publishCheckpoint({
+      ...input,
+      frontier: new Map([['w1', 'b'.repeat(40)]]),
+    })).rejects.toMatchObject({ code: 'E_CHECKPOINT_MATERIALIZATION_MISMATCH' });
+  });
+
+  it('compares checkpoint frontiers independent of map insertion order', async () => {
+    const fixture = createFixture();
+    const input = await record(fixture, {
+      frontier: new Map([
+        ['w1', 'a'.repeat(40)],
+        ['w2', 'b'.repeat(40)],
+      ]),
+    });
+
+    await expect(fixture.checkpoints.publishCheckpoint({
+      ...input,
+      frontier: new Map([...input.frontier].reverse()),
+    })).resolves.toMatchObject({
+      bundleHandle: input.materialization?.bundle,
+    });
   });
 
   it('rejects loaded materialization state-hash and coordinate mismatches', async () => {

--- a/test/unit/infrastructure/adapters/CborCheckpointStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/CborCheckpointStoreAdapter.test.ts
@@ -13,6 +13,9 @@ import { MetaShard } from '../../../../src/domain/artifacts/MetaShard.ts';
 import { PropertyShard } from '../../../../src/domain/artifacts/PropertyShard.ts';
 import WarpState from '../../../../src/domain/services/state/WarpState.ts';
 import { ProvenanceIndex } from '../../../../src/domain/services/provenance/ProvenanceIndex.ts';
+import {
+  serializeCheckpointStateEnvelope,
+} from '../../../../src/domain/services/state/CheckpointSerializer.ts';
 import { computeStateHash } from '../../../../src/domain/services/state/StateSerializer.ts';
 import type { PropValue } from '../../../../src/domain/types/PropValue.ts';
 import { EventId } from '../../../../src/domain/utils/EventId.ts';
@@ -23,6 +26,13 @@ import {
 import { CborIndexStoreAdapter } from '../../../../src/infrastructure/adapters/CborIndexStoreAdapter.ts';
 import GitCasAssetStorageAdapter from '../../../../src/infrastructure/adapters/GitCasAssetStorageAdapter.ts';
 import GitCasMaterializationStoreAdapter from '../../../../src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts';
+import GitCasMaterializationSnapshotReader from '../../../../src/infrastructure/adapters/GitCasMaterializationSnapshotReader.ts';
+import {
+  materializationDescriptorData,
+} from '../../../../src/infrastructure/adapters/GitCasMaterializationDescriptor.ts';
+import {
+  materializationMembers,
+} from '../../../../src/infrastructure/adapters/GitCasMaterializationBundle.ts';
 import NodeCryptoAdapter from '../../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
 import {
   DEFAULT_COMMIT_MESSAGE_CODEC,
@@ -158,6 +168,91 @@ async function record(
   };
 }
 
+function requireMaterialization(record: CheckpointRecord): MaterializationHandle {
+  if (record.materialization === undefined) {
+    throw new Error('expected retained materialization');
+  }
+  return record.materialization;
+}
+
+async function commitBundleCheckpoint(
+  fixture: ReturnType<typeof createFixture>,
+  bundleHandle: BundleHandle,
+  stateHash: string,
+): Promise<string> {
+  return await fixture.history.commitNode({
+    parents: [],
+    message: DEFAULT_COMMIT_MESSAGE_CODEC.encodeCheckpoint({
+      kind: 'checkpoint',
+      graph: 'test',
+      stateHash,
+      schema: 5,
+      checkpointVersion: CHECKPOINT_STORAGE_FORMAT,
+      bundleHandle,
+    }),
+  });
+}
+
+async function commitLegacyCheckpoint(
+  fixture: ReturnType<typeof createFixture>,
+  options: {
+    frontier: unknown;
+    nested?: boolean;
+    flattenedIndex?: boolean;
+    provenance?: boolean;
+  },
+): Promise<string> {
+  const state = createState();
+  const stateHash = await computeStateHash(state, {
+    codec: fixture.codec,
+    crypto: fixture.crypto,
+  });
+  const envelope = serializeCheckpointStateEnvelope(state, { codec: fixture.codec });
+  const statePayloads = Object.entries({
+    nodeAlive: envelope.nodeAlive,
+    edgeAlive: envelope.edgeAlive,
+    'prop.cbor': envelope.prop,
+    'observedFrontier.cbor': envelope.observedFrontier,
+    'edgeBirthEvent.cbor': envelope.edgeBirthEvent,
+  });
+  const stateEntries = await Promise.all(statePayloads.map(async ([path, bytes]) => (
+    `100644 blob ${await fixture.history.writeBlob(bytes)}\t${path}`
+  )));
+  const frontierOid = await fixture.history.writeBlob(fixture.codec.encode(options.frontier));
+  const rootEntries: string[] = options.nested === true
+    ? [
+      `040000 tree ${await fixture.history.writeTree(stateEntries)}\tstate`,
+      `040000 tree ${await fixture.history.writeTree([])}\tindex`,
+      `100644 blob ${frontierOid}\tfrontier.cbor`,
+    ]
+    : [
+      ...stateEntries.map((entry) => entry.replace('\t', '\tstate/')),
+      `100644 blob ${frontierOid}\tfrontier.cbor`,
+    ];
+  if (options.flattenedIndex === true) {
+    rootEntries.push(
+      `100644 blob ${await fixture.history.writeBlob(new Uint8Array([1]))}\tindex/meta_ff.cbor`,
+    );
+  }
+  if (options.provenance === true) {
+    rootEntries.push(
+      `100644 blob ${await fixture.history.writeBlob(
+        ProvenanceIndex.empty().serialize({ codec: fixture.codec }),
+      )}\tprovenanceIndex.cbor`,
+    );
+  }
+  const treeOid = await fixture.history.writeTree(rootEntries);
+  const message = DEFAULT_COMMIT_MESSAGE_CODEC.encodeCheckpoint({
+    kind: 'checkpoint',
+    graph: 'test',
+    stateHash,
+    schema: 5,
+    checkpointVersion: LEGACY_CHECKPOINT_STORAGE_FORMAT,
+    bundleHandle: null,
+  });
+  return await fixture.history.commitNodeWithTree({ treeOid, parents: [], message });
+}
+
 describe('CborCheckpointStoreAdapter materialization lifecycle', () => {
   it('is a CheckpointStorePort and requires every semantic dependency', () => {
     const { codec, crypto, history, assets, cas, checkpoints } = createFixture();
@@ -287,6 +382,189 @@ describe('CborCheckpointStoreAdapter materialization lifecycle', () => {
       ...input,
       materialization: ceiling,
     })).rejects.toMatchObject({ code: 'E_CHECKPOINT_MATERIALIZATION_MISMATCH' });
+  });
+
+  it('rejects loaded materialization state-hash and coordinate mismatches', async () => {
+    const fixture = createFixture();
+    const input = await record(fixture);
+    const retained = requireMaterialization(input);
+    const wrongHashCheckpoint = await commitBundleCheckpoint(
+      fixture,
+      retained.bundle,
+      'f'.repeat(64),
+    );
+    await expect(fixture.checkpoints.loadCheckpoint(wrongHashCheckpoint))
+      .rejects.toMatchObject({ code: 'E_CHECKPOINT_MATERIALIZATION_MISMATCH' });
+
+    const ceilingMaterialization = await fixture.materializations.retain({
+      coordinate: new MaterializationCoordinate({
+        frontier: input.frontier,
+        ceiling: 1,
+      }),
+      roots: retained.roots,
+      stateHash: input.stateHash,
+      replayBasis: input.state,
+      provenanceSupport: ProvenanceIndex.empty(),
+    });
+    const ceilingCheckpoint = await commitBundleCheckpoint(
+      fixture,
+      ceilingMaterialization.bundle,
+      input.stateHash,
+    );
+    await expect(fixture.checkpoints.loadCheckpoint(ceilingCheckpoint))
+      .rejects.toMatchObject({ code: 'E_CHECKPOINT_MATERIALIZATION_MISMATCH' });
+  });
+
+  it('rejects a malformed retained provenance support root', async () => {
+    const fixture = createFixture();
+    const input = await record(fixture);
+    const retained = requireMaterialization(input);
+    const provenanceRoot = retained.roots.provenanceSupport;
+    const provenanceHandle = provenanceRoot.handle;
+    if (provenanceRoot.status !== 'retained' || provenanceHandle === null) {
+      throw new Error('expected retained provenance support');
+    }
+    const wrongMember = await fixture.cas.bundles.putOrdered({ members: [] });
+    fixture.cas.replaceBundleMembers(provenanceHandle.toString(), [
+      ['provenance.cbor', wrongMember.handle.toString()],
+    ]);
+    const checkpoint = await commitBundleCheckpoint(
+      fixture,
+      retained.bundle,
+      input.stateHash,
+    );
+
+    await expect(fixture.checkpoints.loadCheckpoint(checkpoint))
+      .rejects.toMatchObject({ code: 'E_MATERIALIZATION_STORAGE' });
+  });
+
+  it('rejects a replay basis whose state hash disagrees with its descriptor', async () => {
+    const fixture = createFixture();
+    const input = await record(fixture);
+    const retained = requireMaterialization(input);
+    const descriptorToken = fixture.cas.readBundleMembers(retained.bundle.toString())
+      .find(([path]) => path === 'meta/descriptor')?.[1];
+    if (descriptorToken === undefined) {
+      throw new Error('expected materialization descriptor page');
+    }
+    const descriptor = fixture.codec.decode<Record<string, unknown>>(
+      await fixture.cas.pages.get({ handle: descriptorToken }),
+    );
+    const wrongStateHash = 'f'.repeat(64);
+    fixture.cas.replaceStoredPage(
+      descriptorToken,
+      fixture.codec.encode({ ...descriptor, stateHash: wrongStateHash }),
+    );
+    const checkpoint = await commitBundleCheckpoint(
+      fixture,
+      retained.bundle,
+      wrongStateHash,
+    );
+
+    await expect(fixture.checkpoints.loadCheckpoint(checkpoint))
+      .rejects.toMatchObject({ code: 'E_MATERIALIZATION_STORAGE' });
+  });
+
+  it.each([
+    [null, 'checkpoint materialization is partial'],
+    ['d'.repeat(64), 'checkpoint materialization has no replay basis'],
+  ])('rejects incomplete materialization snapshots (stateHash=%s)', async (
+    stateHash,
+    message,
+  ) => {
+    const fixture = createFixture();
+    const adjacency = await fixture.cas.bundles.putOrdered({ members: [] });
+    const unavailable = () => MaterializationRoot.unavailable();
+    const roots = new MaterializationRoots({
+      adjacency: MaterializationRoot.retained(new BundleHandle(adjacency.handle.toString())),
+      edgeAlive: unavailable(),
+      edgeBirths: unavailable(),
+      frontier: unavailable(),
+      nodeAlive: unavailable(),
+      properties: unavailable(),
+      provenanceSupport: unavailable(),
+      replayBasis: unavailable(),
+      roaringIndexes: unavailable(),
+    });
+    const descriptor = await fixture.cas.pages.put({
+      source: fixture.codec.encode(materializationDescriptorData({
+        coordinate: new MaterializationCoordinate({ frontier: new Map(), ceiling: null }),
+        laneName: 'test',
+        roots,
+        stateHash,
+      })),
+    });
+    const bundle = await fixture.cas.bundles.putOrdered({
+      members: materializationMembers(descriptor.handle.toString(), roots),
+    });
+    const reader = new GitCasMaterializationSnapshotReader({
+      cas: fixture.cas,
+      codec: fixture.codec,
+      crypto: fixture.crypto,
+    });
+
+    await expect(reader.read(new BundleHandle(bundle.handle.toString())))
+      .rejects.toThrow(message);
+  });
+
+  it.each([false, true])(
+    'loads the released flat/nested schema-5 tree layout (nested=%s)',
+    async (nested) => {
+      const fixture = createFixture();
+      const checkpoint = await commitLegacyCheckpoint(fixture, {
+        frontier: { w1: 'a'.repeat(40) },
+        nested,
+      });
+
+      const loaded = await fixture.checkpoints.loadCheckpoint(checkpoint);
+      expect(loaded.state.nodeAlive.contains('user:alice')).toBe(true);
+      expect(loaded.frontier).toEqual(new Map([['w1', 'a'.repeat(40)]]));
+      expect(loaded.appliedVV).toBeNull();
+      expect(loaded.provenanceIndex).toBeUndefined();
+    },
+  );
+
+  it('loads flattened legacy indexes and serialized provenance', async () => {
+    const fixture = createFixture();
+    const checkpoint = await commitLegacyCheckpoint(fixture, {
+      frontier: { w1: 'a'.repeat(40) },
+      flattenedIndex: true,
+      provenance: true,
+    });
+
+    const loaded = await fixture.checkpoints.loadCheckpoint(checkpoint);
+    expect(loaded.indexShardHandles).toHaveProperty('meta_ff.cbor');
+    expect(loaded.provenanceIndex?.toJSON()).toEqual(ProvenanceIndex.empty().toJSON());
+  });
+
+  it('rejects missing legacy artifacts and invalid legacy frontiers', async () => {
+    const fixture = createFixture();
+    const emptyTreeCheckpoint = await fixture.history.commitNodeWithTree({
+      treeOid: fixture.history.emptyTree,
+      parents: [],
+      message: DEFAULT_COMMIT_MESSAGE_CODEC.encodeCheckpoint({
+        kind: 'checkpoint',
+        graph: 'test',
+        stateHash: 'd'.repeat(64),
+        schema: 5,
+        checkpointVersion: LEGACY_CHECKPOINT_STORAGE_FORMAT,
+        bundleHandle: null,
+      }),
+    });
+    await expect(fixture.checkpoints.loadCheckpoint(emptyTreeCheckpoint))
+      .rejects.toMatchObject({ code: 'E_CHECKPOINT_MISSING_ARTIFACT' });
+
+    const invalidFrontierCheckpoint = await commitLegacyCheckpoint(fixture, {
+      frontier: [],
+    });
+    await expect(fixture.checkpoints.loadCheckpoint(invalidFrontierCheckpoint))
+      .rejects.toMatchObject({ code: 'E_CHECKPOINT_INVALID_FRONTIER' });
+
+    const emptyWriterTipCheckpoint = await commitLegacyCheckpoint(fixture, {
+      frontier: { w1: '' },
+    });
+    await expect(fixture.checkpoints.loadCheckpoint(emptyWriterTipCheckpoint))
+      .rejects.toMatchObject({ code: 'E_CHECKPOINT_INVALID_FRONTIER' });
   });
 
   it('rejects publication and retention witnesses for another bundle', async () => {

--- a/test/unit/infrastructure/adapters/CborCheckpointStoreAdapter.test.ts
+++ b/test/unit/infrastructure/adapters/CborCheckpointStoreAdapter.test.ts
@@ -1,32 +1,41 @@
 import { describe, expect, it, vi } from 'vitest';
-import {
-  BundleHandle as GitCasBundleHandle,
-  RetentionWitness,
-} from '@git-stunts/git-cas';
+import { RetentionWitness } from '@git-stunts/git-cas';
 import { Dot } from '../../../../src/domain/crdt/Dot.ts';
 import type { LWWRegister } from '../../../../src/domain/crdt/LWW.ts';
 import ORSet from '../../../../src/domain/crdt/ORSet.ts';
 import VersionVector from '../../../../src/domain/crdt/VersionVector.ts';
-import { ProvenanceIndex } from '../../../../src/domain/services/provenance/ProvenanceIndex.ts';
+import MaterializationCoordinate from '../../../../src/domain/materialization/MaterializationCoordinate.ts';
+import MaterializationHandle from '../../../../src/domain/materialization/MaterializationHandle.ts';
+import MaterializationRoot from '../../../../src/domain/materialization/MaterializationRoot.ts';
+import MaterializationRoots from '../../../../src/domain/materialization/MaterializationRoots.ts';
+import BundleHandle from '../../../../src/domain/storage/BundleHandle.ts';
+import { MetaShard } from '../../../../src/domain/artifacts/MetaShard.ts';
+import { PropertyShard } from '../../../../src/domain/artifacts/PropertyShard.ts';
 import WarpState from '../../../../src/domain/services/state/WarpState.ts';
+import { ProvenanceIndex } from '../../../../src/domain/services/provenance/ProvenanceIndex.ts';
+import { computeStateHash } from '../../../../src/domain/services/state/StateSerializer.ts';
 import type { PropValue } from '../../../../src/domain/types/PropValue.ts';
 import { EventId } from '../../../../src/domain/utils/EventId.ts';
-import { collectAsyncIterable } from '../../../../src/domain/utils/streamUtils.ts';
 import {
   CborCheckpointStoreAdapter,
   type GitCasCheckpointFacade,
 } from '../../../../src/infrastructure/adapters/CborCheckpointStoreAdapter.ts';
 import { CborIndexStoreAdapter } from '../../../../src/infrastructure/adapters/CborIndexStoreAdapter.ts';
 import GitCasAssetStorageAdapter from '../../../../src/infrastructure/adapters/GitCasAssetStorageAdapter.ts';
+import GitCasMaterializationStoreAdapter from '../../../../src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts';
+import NodeCryptoAdapter from '../../../../src/infrastructure/adapters/NodeCryptoAdapter.ts';
 import {
   DEFAULT_COMMIT_MESSAGE_CODEC,
 } from '../../../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts';
 import { CborCodec } from '../../../../src/infrastructure/codecs/CborCodec.ts';
-import CheckpointStorePort from '../../../../src/ports/CheckpointStorePort.ts';
+import CheckpointStorePort, {
+  type CheckpointRecord,
+} from '../../../../src/ports/CheckpointStorePort.ts';
 import {
   CHECKPOINT_STORAGE_FORMAT,
   LEGACY_CHECKPOINT_STORAGE_FORMAT,
 } from '../../../../src/ports/CommitMessageCodecPort.ts';
+import WarpStream from '../../../../src/domain/stream/WarpStream.ts';
 import InMemoryBlobStorageAdapter from '../../../helpers/InMemoryBlobStorageAdapter.ts';
 import InMemoryGraphAdapter from '../../../helpers/InMemoryGraphAdapter.ts';
 import InMemoryGitCasFacade from '../../../helpers/InMemoryGitCasFacade.ts';
@@ -49,360 +58,309 @@ function createState(): WarpState {
 
 function createFixture() {
   const codec = new CborCodec();
+  const crypto = new NodeCryptoAdapter();
   const history = new InMemoryGraphAdapter();
   const backing = new InMemoryBlobStorageAdapter();
   const cas = new InMemoryGitCasFacade({ history, storage: backing });
   const assets = new GitCasAssetStorageAdapter({ cas, legacyReader: history });
+  const indexes = new CborIndexStoreAdapter({ codec, assetStorage: assets, cas });
+  const materializations = new GitCasMaterializationStoreAdapter({
+    cas,
+    codec,
+    crypto,
+    laneName: 'test',
+  });
   const checkpoints = new CborCheckpointStoreAdapter({
     codec,
+    crypto,
     commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC,
     history,
     assetStorage: assets,
     cas,
   });
-  return { codec, history, backing, cas, assets, checkpoints };
-}
-
-function record(options: {
-  index?: boolean;
-  parents?: string[];
-  provenance?: boolean;
-} = {}) {
-  const appliedVV = VersionVector.empty();
-  appliedVV.set('w1', 3);
   return {
-    graphName: 'test',
-    state: createState(),
-    frontier: new Map([['w1', 'a'.repeat(40)]]),
-    appliedVV,
-    stateHash: 'd'.repeat(64),
-    parents: options.parents ?? [],
-    ...(options.provenance === true ? { provenanceIndex: ProvenanceIndex.empty() } : {}),
-    ...(options.index === true
-      ? { indexShards: { 'meta_aa.cbor': new CborCodec().encode({ node: 1 }) } }
-      : {}),
+    codec,
+    crypto,
+    history,
+    backing,
+    cas,
+    assets,
+    indexes,
+    materializations,
+    checkpoints,
   };
 }
 
-describe('CborCheckpointStoreAdapter semantic lifecycle', () => {
+async function record(
+  fixture: ReturnType<typeof createFixture>,
+  options: { indexes?: boolean; parents?: string[] } = {},
+): Promise<CheckpointRecord> {
+  const state = createState();
+  const frontier = new Map([['w1', 'a'.repeat(40)]]);
+  const coordinate = new MaterializationCoordinate({ frontier, ceiling: null });
+  const adjacency = await fixture.cas.bundles.putOrdered({ members: [] });
+  const unavailable = () => MaterializationRoot.unavailable();
+  const indexRoot = options.indexes === true
+    ? await fixture.indexes.writeShards(WarpStream.from([
+      new MetaShard({
+        shardKey: 'aa',
+        nodeToGlobal: [['user:alice', 0]],
+        nextLocalId: 1,
+        alive: new Uint8Array([1]),
+      }),
+    ]), { memberStorage: 'page', expectedShardCount: 1, maxShardBytes: 1024 })
+    : null;
+  const propertyRoot = options.indexes === true
+    ? await fixture.indexes.writeShards(WarpStream.from([
+      new PropertyShard({
+        shardKey: 'aa',
+        schemaVersion: 2,
+        entries: [['user:alice', { name: 'Alice' }]],
+      }),
+    ]), { memberStorage: 'page', expectedShardCount: 1, maxShardBytes: 1024 })
+    : null;
+  const roots = new MaterializationRoots({
+    adjacency: MaterializationRoot.retained(
+      new BundleHandle(adjacency.handle.toString()),
+    ),
+    edgeAlive: unavailable(),
+    edgeBirths: unavailable(),
+    frontier: unavailable(),
+    nodeAlive: unavailable(),
+    properties: propertyRoot === null
+      ? unavailable()
+      : MaterializationRoot.retained(propertyRoot),
+    provenanceSupport: unavailable(),
+    replayBasis: unavailable(),
+    roaringIndexes: indexRoot === null
+      ? unavailable()
+      : MaterializationRoot.retained(indexRoot),
+  });
+  const stateHash = await computeStateHash(state, {
+    codec: fixture.codec,
+    crypto: fixture.crypto,
+  });
+  const materialization = await fixture.materializations.retain({
+    coordinate,
+    roots,
+    stateHash,
+    replayBasis: state,
+    provenanceSupport: ProvenanceIndex.empty(),
+  });
+  return {
+    graphName: 'test',
+    state,
+    frontier,
+    appliedVV: state.observedFrontier,
+    stateHash,
+    parents: options.parents ?? [],
+    materialization,
+  };
+}
+
+describe('CborCheckpointStoreAdapter materialization lifecycle', () => {
   it('is a CheckpointStorePort and requires every semantic dependency', () => {
-    const { codec, history, assets, cas, checkpoints } = createFixture();
+    const { codec, crypto, history, assets, cas, checkpoints } = createFixture();
     expect(checkpoints).toBeInstanceOf(CheckpointStorePort);
 
     // @ts-expect-error Runtime dependency guard for JavaScript callers.
-    expect(() => new CborCheckpointStoreAdapter({ commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC, history, assetStorage: assets, cas }))
+    expect(() => new CborCheckpointStoreAdapter({ crypto, commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC, history, assetStorage: assets, cas }))
       .toThrow(/codec/);
     // @ts-expect-error Runtime dependency guard for JavaScript callers.
-    expect(() => new CborCheckpointStoreAdapter({ codec, history, assetStorage: assets, cas }))
-      .toThrow(/commitMessageCodec/);
+    expect(() => new CborCheckpointStoreAdapter({ codec, commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC, history, assetStorage: assets, cas }))
+      .toThrow(/crypto/);
     // @ts-expect-error Runtime dependency guard for JavaScript callers.
-    expect(() => new CborCheckpointStoreAdapter({ codec, commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC, assetStorage: assets, cas }))
-      .toThrow(/history/);
-    expect(() => new CborCheckpointStoreAdapter({
-      codec,
-      commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC,
-      history,
-      assetStorage: assets,
-      // @ts-expect-error Runtime dependency guard for JavaScript callers.
-      cas: null,
-    })).toThrow(/cas/);
+    expect(() => new CborCheckpointStoreAdapter({ codec, crypto, history, assetStorage: assets, cas }))
+      .toThrow(/commitMessageCodec/);
   });
 
-  it('publishes, resolves, and round-trips checkpoint state', async () => {
-    const { checkpoints } = createFixture();
-    const published = await checkpoints.publishCheckpoint(record());
-    const loaded = await checkpoints.loadCheckpoint(published.checkpointSha);
+  it('publishes the exact retained materialization and round-trips state', async () => {
+    const fixture = createFixture();
+    const input = await record(fixture);
+    const published = await fixture.checkpoints.publishCheckpoint(input);
+    const loaded = await fixture.checkpoints.loadCheckpoint(published.checkpointSha);
 
-    expect(await checkpoints.resolveHead('test')).toBe(published.checkpointSha);
-    expect(loaded.stateHash).toBe('d'.repeat(64));
-    expect(loaded.schema).toBe(5);
+    expect(published.bundleHandle.toString()).toBe(input.materialization?.bundle.toString());
+    expect(await fixture.checkpoints.resolveHead('test')).toBe(published.checkpointSha);
+    expect(loaded.stateHash).toBe(input.stateHash);
     expect(loaded.state.nodeAlive.contains('user:alice')).toBe(true);
     expect(loaded.state.edgeAlive.contains('user:alice\0user:bob\0knows')).toBe(true);
-    expect(loaded.state.getNodeProp('user:alice', 'name')?.value).toBe('Alice');
-    expect(loaded.frontier).toEqual(new Map([['w1', 'a'.repeat(40)]]));
+    expect(loaded.frontier).toEqual(input.frontier);
     expect(loaded.appliedVV?.get('w1')).toBe(3);
     expect(loaded.indexShardHandles).toBeNull();
+    expect(loaded.indexRoot).toBeNull();
+    expect(loaded.propertyRoot).toBeNull();
+    expect(loaded.provenanceIndex?.toJSON()).toEqual(ProvenanceIndex.empty().toJSON());
     expect(published.retention.reachability).toBe('anchored');
-    expect(published.retention.handle.equals(published.bundleHandle)).toBe(true);
   });
 
-  it('rejects a checkpoint bound to a different graph before opening assets', async () => {
-    const { assets, checkpoints } = createFixture();
-    const published = await checkpoints.publishCheckpoint(record());
-    const open = vi.spyOn(assets, 'open');
+  it('reads metadata without opening materialization payloads', async () => {
+    const fixture = createFixture();
+    const input = await record(fixture);
+    const published = await fixture.checkpoints.publishCheckpoint(input);
+    const open = vi.fn(fixture.cas.assets.open);
+    const getPage = vi.fn(fixture.cas.pages.get);
+    const metadataReader = checkpointAdapter(fixture, {
+      assets: { open },
+      pages: { get: getPage },
+      bundles: fixture.cas.bundles,
+      publications: fixture.cas.publications,
+    });
 
-    await expect(checkpoints.loadCheckpoint(published.checkpointSha, 'other'))
-      .rejects.toMatchObject({
-        code: 'E_CHECKPOINT_GRAPH_MISMATCH',
-        context: {
-          actualGraphName: 'test',
-          expectedGraphName: 'other',
-        },
-      });
-    await expect(checkpoints.readMetadata(published.checkpointSha, 'other'))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_GRAPH_MISMATCH' });
-    await expect(checkpoints.loadBasis(published.checkpointSha, 'other'))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_GRAPH_MISMATCH' });
-    expect(open).not.toHaveBeenCalled();
-  });
-
-  it('reads metadata without opening checkpoint payloads', async () => {
-    const { assets, checkpoints } = createFixture();
-    const published = await checkpoints.publishCheckpoint(record());
-    const open = vi.spyOn(assets, 'open');
-
-    await expect(checkpoints.readMetadata(published.checkpointSha)).resolves.toEqual({
+    await expect(metadataReader.readMetadata(published.checkpointSha)).resolves.toEqual({
       checkpointSha: published.checkpointSha,
-      stateHash: 'd'.repeat(64),
+      stateHash: input.stateHash,
       schema: 5,
     });
     expect(open).not.toHaveBeenCalled();
+    expect(getPage).not.toHaveBeenCalled();
   });
 
-  it('loads a bounded basis and opens one shard through an opaque handle', async () => {
-    const { codec, assets, checkpoints } = createFixture();
-    const published = await checkpoints.publishCheckpoint(record({ index: true }));
-    const basis = await checkpoints.loadBasis(published.checkpointSha);
-    const shardHandle = basis.indexShardHandles['meta_aa.cbor'];
-    if (shardHandle === undefined) {
-      throw new Error('expected checkpoint index shard handle');
-    }
-    const bytes = await collectAsyncIterable(assets.open(shardHandle));
+  it('exposes retained logical and property roots as the bounded basis', async () => {
+    const fixture = createFixture();
+    const published = await fixture.checkpoints.publishCheckpoint(
+      await record(fixture, { indexes: true }),
+    );
+    const basis = await fixture.checkpoints.loadBasis(published.checkpointSha);
 
-    expect(codec.decode(bytes)).toEqual({ node: 1 });
+    expect(basis.indexRoot).not.toBeNull();
+    expect(basis.propertyRoot).not.toBeNull();
+    expect(basis.indexShardHandles).toEqual({});
     expect(basis.frontier).toEqual(new Map([['w1', 'a'.repeat(40)]]));
-    expect(Object.isFrozen(basis.indexShardHandles)).toBe(true);
   });
 
-  it('round-trips an optional provenance index through the checkpoint bundle', async () => {
-    const { checkpoints } = createFixture();
-    const published = await checkpoints.publishCheckpoint(record({ provenance: true }));
-    const loaded = await checkpoints.loadCheckpoint(published.checkpointSha);
-
-    expect(loaded.provenanceIndex?.toJSON()).toEqual(ProvenanceIndex.empty().toJSON());
-  });
-
-  it('rejects an index member whose bytes are missing at publication time', async () => {
-    const { checkpoints } = createFixture();
-    const indexShards: Record<string, Uint8Array> = {};
-    Object.defineProperty(indexShards, 'missing.cbor', {
-      enumerable: true,
-      value: undefined,
-    });
-
-    await expect(checkpoints.publishCheckpoint({ ...record(), indexShards }))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_MISSING_INDEX_SHARD' });
-  });
-
-  it('fails closed when a checkpoint has no bounded index basis', async () => {
-    const { checkpoints } = createFixture();
-    const published = await checkpoints.publishCheckpoint(record());
-
-    await expect(checkpoints.loadBasis(published.checkpointSha))
+  it('fails closed when a retained materialization has no bounded indexes', async () => {
+    const fixture = createFixture();
+    const published = await fixture.checkpoints.publishCheckpoint(await record(fixture));
+    await expect(fixture.checkpoints.loadBasis(published.checkpointSha))
       .rejects.toMatchObject({ code: 'E_CHECKPOINT_MISSING_INDEX' });
   });
 
-  it('rejects a publication result that names a different bundle', async () => {
+  it('rejects graph mismatches before opening materialization payloads', async () => {
     const fixture = createFixture();
-    const otherBundle = await fixture.cas.bundles.putOrdered({ members: [] });
-    const cas: GitCasCheckpointFacade = {
+    const published = await fixture.checkpoints.publishCheckpoint(await record(fixture));
+    const open = vi.fn(fixture.cas.assets.open);
+    const guardedReader = checkpointAdapter(fixture, {
+      assets: { open },
+      pages: fixture.cas.pages,
       bundles: fixture.cas.bundles,
-      publications: {
-        commit: async (request) => {
-          const publication = await fixture.cas.publications.commit(request);
-          return Object.freeze({ ...publication, root: otherBundle.handle });
-        },
-      },
-    };
+      publications: fixture.cas.publications,
+    });
 
-    await expect(checkpointAdapter(fixture, cas).publishCheckpoint(record()))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_PUBLICATION_MISMATCH' });
+    await expect(guardedReader.loadCheckpoint(published.checkpointSha, 'other'))
+      .rejects.toMatchObject({ code: 'E_CHECKPOINT_GRAPH_MISMATCH' });
+    expect(open).not.toHaveBeenCalled();
   });
 
-  it('rejects retention evidence that names a different bundle', async () => {
+  it('rejects publication without a retained materialization', async () => {
     const fixture = createFixture();
-    const otherBundle = await fixture.cas.bundles.putOrdered({ members: [] });
-    const cas: GitCasCheckpointFacade = {
+    const input = await record(fixture);
+    const { materialization: _materialization, ...missing } = input;
+    await expect(fixture.checkpoints.publishCheckpoint(missing))
+      .rejects.toMatchObject({ code: 'E_CHECKPOINT_MISSING_MATERIALIZATION' });
+  });
+
+  it('rejects materialization state-hash and coordinate mismatches', async () => {
+    const fixture = createFixture();
+    const input = await record(fixture);
+    await expect(fixture.checkpoints.publishCheckpoint({
+      ...input,
+      stateHash: 'f'.repeat(64),
+    })).rejects.toMatchObject({ code: 'E_CHECKPOINT_MATERIALIZATION_MISMATCH' });
+
+    const retained = input.materialization;
+    if (retained === undefined) {
+      throw new Error('expected retained materialization');
+    }
+    const ceiling = new MaterializationHandle({
+      laneName: retained.laneName,
+      bundle: retained.bundle,
+      coordinate: new MaterializationCoordinate({
+        frontier: retained.coordinate.frontier(),
+        ceiling: 1,
+      }),
+      roots: retained.roots,
+      stateHash: retained.stateHash,
+      retention: retained.retention,
+    });
+    await expect(fixture.checkpoints.publishCheckpoint({
+      ...input,
+      materialization: ceiling,
+    })).rejects.toMatchObject({ code: 'E_CHECKPOINT_MATERIALIZATION_MISMATCH' });
+  });
+
+  it('rejects publication and retention witnesses for another bundle', async () => {
+    const fixture = createFixture();
+    const input = await record(fixture);
+    const other = await fixture.cas.bundles.putOrdered({ members: [] });
+    const publicationMismatch: GitCasCheckpointFacade = {
+      assets: fixture.cas.assets,
+      pages: fixture.cas.pages,
       bundles: fixture.cas.bundles,
       publications: {
         commit: async (request) => {
           const publication = await fixture.cas.publications.commit(request);
-          const witness = new RetentionWitness({
-            handle: otherBundle.handle,
-            policy: 'pinned',
-            reachability: 'anchored',
-            root: {
-              kind: 'publication',
-              namespace: publication.ref,
-              ref: publication.ref,
-              generation: publication.commitId,
-              path: '/',
-            },
-            observedAt: new Date(0).toISOString(),
-          });
-          return Object.freeze({ ...publication, witness });
+          return Object.freeze({ ...publication, root: other.handle });
         },
       },
     };
+    await expect(checkpointAdapter(fixture, publicationMismatch).publishCheckpoint(input))
+      .rejects.toMatchObject({ code: 'E_CHECKPOINT_PUBLICATION_MISMATCH' });
 
-    await expect(checkpointAdapter(fixture, cas).publishCheckpoint(record()))
+    const retentionMismatch: GitCasCheckpointFacade = {
+      assets: fixture.cas.assets,
+      pages: fixture.cas.pages,
+      bundles: fixture.cas.bundles,
+      publications: {
+        commit: async (request) => {
+          const publication = await fixture.cas.publications.commit(request);
+          return Object.freeze({
+            ...publication,
+            witness: new RetentionWitness({
+              handle: other.handle,
+              policy: 'pinned',
+              reachability: 'anchored',
+              root: {
+                kind: 'publication',
+                namespace: publication.ref,
+                ref: publication.ref,
+                generation: publication.commitId,
+                path: '/',
+              },
+              observedAt: new Date(0).toISOString(),
+            }),
+          });
+        },
+      },
+    };
+    await expect(checkpointAdapter(fixture, retentionMismatch).publishCheckpoint(input))
       .rejects.toMatchObject({ code: 'E_CHECKPOINT_RETENTION_MISMATCH' });
   });
 
-  it('rejects non-asset checkpoint bundle members', async () => {
-    const fixture = createFixture();
-    const published = await fixture.checkpoints.publishCheckpoint(record());
-    const cas: GitCasCheckpointFacade = {
-      bundles: {
-        putOrdered: fixture.cas.bundles.putOrdered,
-        iterateMemberReferences: async function* (request) {
-          for await (const member of fixture.cas.bundles.iterateMemberReferences(request)) {
-            yield Object.freeze({
-              ...member,
-              handle: GitCasBundleHandle.parse(published.bundleHandle.toString()),
-            });
-          }
-        },
-      },
-      publications: fixture.cas.publications,
-    };
-
-    await expect(checkpointAdapter(fixture, cas).loadCheckpoint(published.checkpointSha))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_INVALID_BUNDLE_MEMBER' });
-  });
-
-  it('rejects duplicate checkpoint bundle member paths', async () => {
-    const fixture = createFixture();
-    const published = await fixture.checkpoints.publishCheckpoint(record());
-    const cas: GitCasCheckpointFacade = {
-      bundles: {
-        putOrdered: fixture.cas.bundles.putOrdered,
-        iterateMemberReferences: async function* (request) {
-          let duplicated = false;
-          for await (const member of fixture.cas.bundles.iterateMemberReferences(request)) {
-            yield member;
-            if (!duplicated) {
-              yield member;
-              duplicated = true;
-            }
-          }
-        },
-      },
-      publications: fixture.cas.publications,
-    };
-
-    await expect(checkpointAdapter(fixture, cas).loadCheckpoint(published.checkpointSha))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_DUPLICATE_BUNDLE_MEMBER' });
-  });
-
-  it('rejects an empty index member path in a checkpoint bundle', async () => {
-    const fixture = createFixture();
-    const published = await fixture.checkpoints.publishCheckpoint(record());
-    const cas: GitCasCheckpointFacade = {
-      bundles: {
-        putOrdered: fixture.cas.bundles.putOrdered,
-        iterateMemberReferences: async function* (request) {
-          let replaced = false;
-          for await (const member of fixture.cas.bundles.iterateMemberReferences(request)) {
-            yield replaced ? member : Object.freeze({ ...member, path: 'index/' });
-            replaced = true;
-          }
-        },
-      },
-      publications: fixture.cas.publications,
-    };
-
-    await expect(checkpointAdapter(fixture, cas).loadCheckpoint(published.checkpointSha))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_INVALID_BUNDLE_MEMBER' });
-  });
-
-  it('rejects current checkpoint metadata without a bundle handle', async () => {
-    const { history, checkpoints } = createFixture();
-    const checkpointSha = await history.commitNode({
-      message: malformedCheckpointMessage(CHECKPOINT_STORAGE_FORMAT),
-      parents: [],
-    });
-
-    await expect(checkpoints.loadCheckpoint(checkpointSha))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_MISSING_BUNDLE_HANDLE' });
-    await expect(checkpoints.readMetadata(checkpointSha))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_MISSING_BUNDLE_HANDLE' });
-  });
-
-  it('rejects bundle handles attached to legacy checkpoint storage metadata', async () => {
-    const { history, checkpoints } = createFixture();
-    const published = await checkpoints.publishCheckpoint(record());
-    const currentMessage = DEFAULT_COMMIT_MESSAGE_CODEC.encodeCheckpoint({
-      kind: 'checkpoint',
-      graph: 'test',
-      stateHash: 'd'.repeat(64),
-      schema: 5,
-      checkpointVersion: CHECKPOINT_STORAGE_FORMAT,
-      bundleHandle: published.bundleHandle,
-    });
-    const checkpointSha = await history.commitNode({
-      message: currentMessage.replace(
-        `eg-checkpoint: ${CHECKPOINT_STORAGE_FORMAT}`,
-        `eg-checkpoint: ${LEGACY_CHECKPOINT_STORAGE_FORMAT}`,
-      ),
-      parents: [],
-    });
-
-    await expect(checkpoints.readMetadata(checkpointSha))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_UNSUPPORTED_STORAGE' });
-  });
-
-  it('rejects unknown checkpoint storage versions', async () => {
-    const { history, checkpoints } = createFixture();
-    const checkpointSha = await history.commitNode({
-      message: malformedCheckpointMessage('v999'),
-      parents: [],
-    });
-
-    await expect(checkpoints.readMetadata(checkpointSha))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_UNSUPPORTED_STORAGE' });
-  });
-
   it.each([
-    null,
-    [],
-    { w1: 1 },
-    { '': 'a'.repeat(40) },
-    { w1: '' },
-  ])('rejects malformed decoded frontier entries: %j', async (frontier) => {
+    [CHECKPOINT_STORAGE_FORMAT, 'E_CHECKPOINT_MISSING_BUNDLE_HANDLE'],
+    ['future-checkpoint-layout', 'E_CHECKPOINT_UNSUPPORTED_STORAGE'],
+  ])('rejects unsupported storage metadata %s', async (storageVersion, code) => {
     const fixture = createFixture();
-    const checkpointSha = await checkpointWithFrontier(fixture, frontier);
-
-    await expect(fixture.checkpoints.loadCheckpoint(checkpointSha))
-      .rejects.toMatchObject({ code: 'E_CHECKPOINT_INVALID_FRONTIER' });
+    const sha = await fixture.history.commitNode({
+      parents: [],
+      message: malformedCheckpointMessage(storageVersion),
+    });
+    await expect(fixture.checkpoints.readMetadata(sha)).rejects.toMatchObject({ code });
   });
 
   it('publishes coverage as a causal anchor of checkpoint parents', async () => {
-    const { history, checkpoints } = createFixture();
-    const published = await checkpoints.publishCheckpoint(record());
-    const coverageSha = await checkpoints.publishCoverage({
+    const fixture = createFixture();
+    const published = await fixture.checkpoints.publishCheckpoint(await record(fixture));
+    const anchor = await fixture.checkpoints.publishCoverage({
       graphName: 'test',
       parents: [published.checkpointSha],
     });
-
-    expect((await history.getNodeInfo(coverageSha)).parents).toEqual([published.checkpointSha]);
-    expect(DEFAULT_COMMIT_MESSAGE_CODEC.detectKind(await history.showNode(coverageSha))).toBe('anchor');
+    expect(DEFAULT_COMMIT_MESSAGE_CODEC.detectKind(
+      (await fixture.history.getNodeInfo(anchor)).message,
+    )).toBe('anchor');
   });
 });
-
-async function checkpointWithFrontier(
-  fixture: ReturnType<typeof createFixture>,
-  frontier: unknown,
-): Promise<string> {
-  const published = await fixture.checkpoints.publishCheckpoint(record());
-  const frontierMember = fixture.cas.readBundleMembers(published.bundleHandle.toString())
-    .find(([path]) => path === 'frontier.cbor');
-  if (frontierMember === undefined) {
-    throw new Error('expected frontier bundle member');
-  }
-  fixture.backing.replace(frontierMember[1], fixture.codec.encode(frontier));
-  return published.checkpointSha;
-}
 
 function checkpointAdapter(
   fixture: ReturnType<typeof createFixture>,
@@ -410,6 +368,7 @@ function checkpointAdapter(
 ): CborCheckpointStoreAdapter {
   return new CborCheckpointStoreAdapter({
     codec: fixture.codec,
+    crypto: fixture.crypto,
     commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC,
     history: fixture.history,
     assetStorage: fixture.assets,

--- a/test/unit/ports/CheckpointStorePort.test.ts
+++ b/test/unit/ports/CheckpointStorePort.test.ts
@@ -28,8 +28,10 @@ describe('CheckpointStorePort', () => {
       frontier: new Map(),
       stateHash: 'state-hash',
       schema: 5,
-      appliedVV: VersionVector.empty(),
-      indexShardHandles: null,
+        appliedVV: VersionVector.empty(),
+        indexShardHandles: null,
+        indexRoot: null,
+        propertyRoot: null,
     };
     const bundleHandle = new BundleHandle('checkpoint-bundle');
     const retention = new StorageRetentionWitness({
@@ -59,8 +61,10 @@ describe('CheckpointStorePort', () => {
           checkpointSha: 'checkpoint-sha',
           stateHash: 'state-hash',
           schema: 5,
-          frontier: new Map(),
-          indexShardHandles: {},
+        frontier: new Map(),
+        indexShardHandles: {},
+        indexRoot: null,
+        propertyRoot: null,
         };
       }
       async publishCoverage() { return 'coverage-sha'; }

--- a/test/unit/ports/IndexStorePort.test.ts
+++ b/test/unit/ports/IndexStorePort.test.ts
@@ -14,8 +14,10 @@ describe('IndexStorePort', () => {
     expect(IndexStorePort.prototype.writeShards).toBeUndefined();
     expect(IndexStorePort.prototype.scanShards).toBeUndefined();
     expect(IndexStorePort.prototype.readShardHandles).toBeUndefined();
+    expect(IndexStorePort.prototype.readShardReferences).toBeUndefined();
     expect(IndexStorePort.prototype.readShardHandle).toBeUndefined();
     expect(IndexStorePort.prototype.openShard).toBeUndefined();
+    expect(IndexStorePort.prototype.openShardAt).toBeUndefined();
     expect(IndexStorePort.prototype.decodeShard).toBeUndefined();
     expect(IndexStorePort.prototype.decodeShardAt).toBeUndefined();
   });
@@ -54,10 +56,23 @@ describe('IndexStorePort', () => {
       async readShardHandles(_handle: BundleHandle) {
         return { 'shard.cbor': this.shardHandle };
       }
+      async readShardReferences(_handle: BundleHandle) {
+        return {
+          'shard.cbor': {
+            kind: 'asset' as const,
+            token: this.shardHandle.toString(),
+          },
+        };
+      }
       async readShardHandle(_handle: BundleHandle, path: string) {
         return path === 'shard.cbor' ? this.shardHandle : null;
       }
       async *openShard(_handle: AssetHandle) { yield new Uint8Array([1]); }
+      async *openShardAt(_handle: BundleHandle, path: string) {
+        if (path === 'shard.cbor') {
+          yield new Uint8Array([1]);
+        }
+      }
       async decodeShard<TDecoded extends CodecValue = CodecValue>(
         _handle: AssetHandle,
       ): Promise<TDecoded> {

--- a/test/unit/scripts/checkpoint-schema-upgrade.test.ts
+++ b/test/unit/scripts/checkpoint-schema-upgrade.test.ts
@@ -4,9 +4,6 @@ import NodeCryptoAdapter from '../../../src/infrastructure/adapters/NodeCryptoAd
 import { Dot } from '../../../src/domain/crdt/Dot.ts';
 import VersionVector from '../../../src/domain/crdt/VersionVector.ts';
 import { createEmptyState } from '../../../src/domain/services/JoinReducer.ts';
-import MaterializationCoordinate from '../../../src/domain/materialization/MaterializationCoordinate.ts';
-import MaterializationRoot from '../../../src/domain/materialization/MaterializationRoot.ts';
-import MaterializationRoots from '../../../src/domain/materialization/MaterializationRoots.ts';
 import { createFrontier, serializeFrontier, updateFrontier } from '../../../src/domain/services/Frontier.ts';
 import {
   computeAppliedVV,
@@ -32,6 +29,7 @@ import {
 import type AssetStoragePort from '../../../src/ports/AssetStoragePort.ts';
 import InMemoryBlobStorageAdapter from '../../helpers/InMemoryBlobStorageAdapter.ts';
 import InMemoryGitCasFacade from '../../helpers/InMemoryGitCasFacade.ts';
+import retainUnavailableMaterialization from '../../helpers/retainUnavailableMaterialization.ts';
 import {
   CheckpointSchemaUpgradeError,
   upgradeCheckpointSchema,
@@ -404,26 +402,12 @@ async function createCurrentCheckpoint(options: {
   state: ReturnType<typeof buildState>;
   frontier: Map<string, string>;
 }): Promise<string> {
-  const unavailable = () => MaterializationRoot.unavailable();
-  const stateHash = await computeStateHash(options.state, { crypto, codec: defaultCodec });
-  const materialization = await options.storage.materializationStore.retain({
-    coordinate: new MaterializationCoordinate({
-      frontier: options.frontier,
-      ceiling: null,
-    }),
-    roots: new MaterializationRoots({
-      adjacency: unavailable(),
-      edgeAlive: unavailable(),
-      edgeBirths: unavailable(),
-      frontier: unavailable(),
-      nodeAlive: unavailable(),
-      properties: unavailable(),
-      provenanceSupport: unavailable(),
-      replayBasis: unavailable(),
-      roaringIndexes: unavailable(),
-    }),
-    stateHash,
-    replayBasis: options.state,
+  const materialization = await retainUnavailableMaterialization({
+    materializations: options.storage.materializationStore,
+    frontier: options.frontier,
+    state: options.state,
+    crypto,
+    codec: defaultCodec,
   });
   return await createCheckpointEnvelope({
     checkpointStore: options.storage.checkpointStore,

--- a/test/unit/scripts/checkpoint-schema-upgrade.test.ts
+++ b/test/unit/scripts/checkpoint-schema-upgrade.test.ts
@@ -4,6 +4,9 @@ import NodeCryptoAdapter from '../../../src/infrastructure/adapters/NodeCryptoAd
 import { Dot } from '../../../src/domain/crdt/Dot.ts';
 import VersionVector from '../../../src/domain/crdt/VersionVector.ts';
 import { createEmptyState } from '../../../src/domain/services/JoinReducer.ts';
+import MaterializationCoordinate from '../../../src/domain/materialization/MaterializationCoordinate.ts';
+import MaterializationRoot from '../../../src/domain/materialization/MaterializationRoot.ts';
+import MaterializationRoots from '../../../src/domain/materialization/MaterializationRoots.ts';
 import { createFrontier, serializeFrontier, updateFrontier } from '../../../src/domain/services/Frontier.ts';
 import {
   computeAppliedVV,
@@ -19,8 +22,8 @@ import { DEFAULT_COMMIT_MESSAGE_CODEC } from '../../../src/infrastructure/adapte
 import defaultCodec from '../../../src/infrastructure/codecs/CborCodec.ts';
 import { CborCheckpointStoreAdapter } from '../../../src/infrastructure/adapters/CborCheckpointStoreAdapter.ts';
 import GitCasAssetStorageAdapter from '../../../src/infrastructure/adapters/GitCasAssetStorageAdapter.ts';
+import GitCasMaterializationStoreAdapter from '../../../src/infrastructure/adapters/GitCasMaterializationStoreAdapter.ts';
 import { buildCheckpointRef } from '../../../src/domain/utils/RefLayout.ts';
-import { collectAsyncIterable } from '../../../src/domain/utils/streamUtils.ts';
 import { textEncode } from '../../../src/domain/utils/bytes.ts';
 import {
   CHECKPOINT_STORAGE_FORMAT,
@@ -151,7 +154,8 @@ describe('checkpoint schema upgrade script boundary', () => {
     const loaded = await loadCheckpoint(migrationStorage.checkpointStore, upgradedSha);
     expect(loaded.schema).toBe(CURRENT_CHECKPOINT_SCHEMA);
     expect(loaded.state.nodeAlive.contains('node:a')).toBe(true);
-    expect(Object.keys(loaded.indexShardHandles ?? {})).toEqual(['nodes/shard.cbor']);
+    expect(loaded.indexShardHandles).toBeNull();
+    expect(loaded.indexRoot).toBeNull();
   });
 
   it('does not move the checkpoint ref when the retired payload is incomplete', async () => {
@@ -172,7 +176,7 @@ describe('checkpoint schema upgrade script boundary', () => {
     expect(await persistence.readRef(checkpointRef)).toBe(retiredCheckpointSha);
   });
 
-  it('republishes a schema-5 checkpoint and its pointer-backed index as a v19 bundle', async () => {
+  it('republishes schema-5 state without copying its derived pointer-backed index', async () => {
     const persistence = new InMemoryGraphAdapter();
     const migrationStorage = createCheckpointMigrationStorage(persistence);
     const indexBytes = new Uint8Array([9, 8, 7, 6]);
@@ -214,12 +218,10 @@ describe('checkpoint schema upgrade script boundary', () => {
 
     const loaded = await migrationStorage.checkpointStore.loadCheckpoint(upgradedSha);
     expect(loaded.state.nodeAlive.contains('node:a')).toBe(true);
-    const indexHandle = loaded.indexShardHandles?.['nodes/shard.cbor'];
-    if (indexHandle === undefined) {
-      throw new Error('Expected migrated index shard handle');
-    }
-    expect(await collectAsyncIterable(migrationStorage.assetStorage.open(indexHandle)))
-      .toEqual(indexBytes);
+    expect(loaded.state.nodeAlive.contains('node:a')).toBe(true);
+    expect(loaded.indexShardHandles).toBeNull();
+    expect(loaded.indexRoot).toBeNull();
+    expect(loaded.propertyRoot).toBeNull();
   });
 
   it('dry-runs schema-5 storage migration without moving the checkpoint ref', async () => {
@@ -326,13 +328,11 @@ describe('checkpoint schema upgrade script boundary', () => {
     const state = buildState();
     const frontier = createFrontier();
     updateFrontier(frontier, 'writer-a', makeOid('patch-a'));
-    const currentCheckpointSha = await createCheckpointEnvelope({
-      checkpointStore: migrationStorage.checkpointStore,
+    const currentCheckpointSha = await createCurrentCheckpoint({
+      storage: migrationStorage,
       graphName,
       state,
       frontier,
-      crypto,
-      codec: defaultCodec,
     });
 
     const result = await upgradeCheckpointSchema({
@@ -350,13 +350,11 @@ describe('checkpoint schema upgrade script boundary', () => {
   it('rejects a checkpoint ref that names another graph', async () => {
     const persistence = new InMemoryGraphAdapter();
     const migrationStorage = createCheckpointMigrationStorage(persistence);
-    const foreignCheckpointSha = await createCheckpointEnvelope({
-      checkpointStore: migrationStorage.checkpointStore,
+    const foreignCheckpointSha = await createCurrentCheckpoint({
+      storage: migrationStorage,
       graphName: 'other-graph',
       state: buildState(),
       frontier: createFrontier(),
-      crypto,
-      codec: defaultCodec,
     });
     await persistence.updateRef(checkpointRef, foreignCheckpointSha);
 
@@ -375,20 +373,67 @@ function createCheckpointMigrationStorage(
 ): {
   readonly checkpointStore: CborCheckpointStoreAdapter;
   readonly assetStorage: GitCasAssetStorageAdapter;
+  readonly materializationStore: GitCasMaterializationStoreAdapter;
 } {
   const backing = new InMemoryBlobStorageAdapter();
   const cas = new InMemoryGitCasFacade({ history: persistence, storage: backing });
   const assetStorage = new GitCasAssetStorageAdapter({ cas, legacyReader: persistence });
+  const materializationStore = new GitCasMaterializationStoreAdapter({
+    cas,
+    codec: defaultCodec,
+    crypto: new NodeCryptoAdapter(),
+    laneName: 'test-graph',
+  });
   return {
     checkpointStore: new CborCheckpointStoreAdapter({
       codec: defaultCodec,
+      crypto: new NodeCryptoAdapter(),
       commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC,
       history: persistence,
       assetStorage,
       cas,
     }),
     assetStorage,
+    materializationStore,
   };
+}
+
+async function createCurrentCheckpoint(options: {
+  storage: ReturnType<typeof createCheckpointMigrationStorage>;
+  graphName: string;
+  state: ReturnType<typeof buildState>;
+  frontier: Map<string, string>;
+}): Promise<string> {
+  const unavailable = () => MaterializationRoot.unavailable();
+  const stateHash = await computeStateHash(options.state, { crypto, codec: defaultCodec });
+  const materialization = await options.storage.materializationStore.retain({
+    coordinate: new MaterializationCoordinate({
+      frontier: options.frontier,
+      ceiling: null,
+    }),
+    roots: new MaterializationRoots({
+      adjacency: unavailable(),
+      edgeAlive: unavailable(),
+      edgeBirths: unavailable(),
+      frontier: unavailable(),
+      nodeAlive: unavailable(),
+      properties: unavailable(),
+      provenanceSupport: unavailable(),
+      replayBasis: unavailable(),
+      roaringIndexes: unavailable(),
+    }),
+    stateHash,
+    replayBasis: options.state,
+  });
+  return await createCheckpointEnvelope({
+    checkpointStore: options.storage.checkpointStore,
+    graphName: options.graphName,
+    state: options.state,
+    frontier: options.frontier,
+    crypto,
+    codec: defaultCodec,
+    materialization,
+  });
 }
 
 async function writeLegacyCurrentCheckpoint(options: {

--- a/test/unit/scripts/v16-to-v17-upgrade.test.ts
+++ b/test/unit/scripts/v16-to-v17-upgrade.test.ts
@@ -9,6 +9,10 @@ import NodeCryptoAdapter from '../../../src/infrastructure/adapters/NodeCryptoAd
 import { createEmptyState } from '../../../src/domain/services/JoinReducer.ts';
 import { createFrontier } from '../../../src/domain/services/Frontier.ts';
 import { createCheckpointEnvelope } from '../../../src/domain/services/state/checkpointCreate.ts';
+import { computeStateHash } from '../../../src/domain/services/state/StateSerializer.ts';
+import MaterializationCoordinate from '../../../src/domain/materialization/MaterializationCoordinate.ts';
+import MaterializationRoot from '../../../src/domain/materialization/MaterializationRoot.ts';
+import MaterializationRoots from '../../../src/domain/materialization/MaterializationRoots.ts';
 import {
   formatHumanResult,
   parseArgs,
@@ -75,13 +79,34 @@ describe('v16 to v17 top-level upgrade utility', () => {
       crypto: new NodeCryptoAdapter(),
       commitMessageCodec: DEFAULT_COMMIT_MESSAGE_CODEC,
     });
+    const state = createEmptyState();
+    const frontier = createFrontier();
+    const crypto = new NodeCryptoAdapter();
+    const unavailable = () => MaterializationRoot.unavailable();
+    const materialization = await services.materializations.retain({
+      coordinate: new MaterializationCoordinate({ frontier, ceiling: null }),
+      roots: new MaterializationRoots({
+        adjacency: unavailable(),
+        edgeAlive: unavailable(),
+        edgeBirths: unavailable(),
+        frontier: unavailable(),
+        nodeAlive: unavailable(),
+        properties: unavailable(),
+        provenanceSupport: unavailable(),
+        replayBasis: unavailable(),
+        roaringIndexes: unavailable(),
+      }),
+      stateHash: await computeStateHash(state, { codec: defaultCodec, crypto }),
+      replayBasis: state,
+    });
     const checkpointSha = await createCheckpointEnvelope({
       checkpointStore: services.checkpoints,
       graphName: 'alpha',
-      state: createEmptyState(),
-      frontier: createFrontier(),
+      state,
+      frontier,
       codec: defaultCodec,
-      crypto: new NodeCryptoAdapter(),
+      crypto,
+      materialization,
     });
     await persistence.updateRef('refs/warp/alpha/coverage/head', oid('a'));
     await persistence.updateRef('refs/warp/alpha/seek-cache', oid('b'));

--- a/test/unit/scripts/v16-to-v17-upgrade.test.ts
+++ b/test/unit/scripts/v16-to-v17-upgrade.test.ts
@@ -9,16 +9,13 @@ import NodeCryptoAdapter from '../../../src/infrastructure/adapters/NodeCryptoAd
 import { createEmptyState } from '../../../src/domain/services/JoinReducer.ts';
 import { createFrontier } from '../../../src/domain/services/Frontier.ts';
 import { createCheckpointEnvelope } from '../../../src/domain/services/state/checkpointCreate.ts';
-import { computeStateHash } from '../../../src/domain/services/state/StateSerializer.ts';
-import MaterializationCoordinate from '../../../src/domain/materialization/MaterializationCoordinate.ts';
-import MaterializationRoot from '../../../src/domain/materialization/MaterializationRoot.ts';
-import MaterializationRoots from '../../../src/domain/materialization/MaterializationRoots.ts';
 import {
   formatHumanResult,
   parseArgs,
   upgradeV16ToV17,
 } from '../../../scripts/upgrade-v16-to-v17.ts';
 import { parseUpgradeCommandEntrypoint } from '../../helpers/parseUpgradeCommandEntrypoint.ts';
+import retainUnavailableMaterialization from '../../helpers/retainUnavailableMaterialization.ts';
 
 function oid(hex: string): string {
   return hex.repeat(40).slice(0, 40);
@@ -82,22 +79,12 @@ describe('v16 to v17 top-level upgrade utility', () => {
     const state = createEmptyState();
     const frontier = createFrontier();
     const crypto = new NodeCryptoAdapter();
-    const unavailable = () => MaterializationRoot.unavailable();
-    const materialization = await services.materializations.retain({
-      coordinate: new MaterializationCoordinate({ frontier, ceiling: null }),
-      roots: new MaterializationRoots({
-        adjacency: unavailable(),
-        edgeAlive: unavailable(),
-        edgeBirths: unavailable(),
-        frontier: unavailable(),
-        nodeAlive: unavailable(),
-        properties: unavailable(),
-        provenanceSupport: unavailable(),
-        replayBasis: unavailable(),
-        roaringIndexes: unavailable(),
-      }),
-      stateHash: await computeStateHash(state, { codec: defaultCodec, crypto }),
-      replayBasis: state,
+    const materialization = await retainUnavailableMaterialization({
+      materializations: services.materializations,
+      frontier,
+      state,
+      codec: defaultCodec,
+      crypto,
     });
     const checkpointSha = await createCheckpointEnvelope({
       checkpointStore: services.checkpoints,


### PR DESCRIPTION
## Summary

- retain bounded page-backed logical and property indexes as exact git-cas roots on materializations
- publish current schema-5 checkpoint commits directly from the already-retained materialization bundle instead of constructing a duplicate checkpoint artifact tree
- load checkpoint state, provenance, and bounded index roots from that canonical materialization while preserving the released legacy Git-tree reader
- remove upgrade support for checkpoint schemas 2 and 3; keep the schema-4 and released schema-5 compatibility bridge and rebuild derived indexes from authoritative state

## Why

Checkpoint creation still duplicated whole-state and index assembly after materialization. That increased CPU, memory residency, object writes, and the number of storage representations that had to remain mutually consistent. The v19 path now gives runtime reads, checkpoint recovery, provenance, and bounded logical/property reads one retained git-cas representation with explicit integrity checks.

## User impact

Current checkpoints are cheaper to create and reopen, and their bounded-read roots are exact page-backed references rather than copied checkpoint assets. Old released Git-tree checkpoints remain readable. Very old schema-2/schema-3 checkpoint migration is intentionally no longer supported in v19.

## Validation

- repository pre-push firewall: all static, documentation, publication-surface, TypeScript, consumer, and CAS-ownership gates passed
- stable suite: 592 files, 7,140 tests total (7,138 passed, 2 skipped)
- coverage suite: 614 files, 7,318 tests total (7,316 passed, 2 skipped), 92.95% line coverage
- GitHub Node, Bun, Deno, release preflight, Semgrep, quarantine, and coverage checks passed
- CodeRabbit approved with zero unresolved review threads
- git diff --check

Part of #739.