### PR TITLE
Prove bounded Observer under a 64 MiB heap cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   git-cas/plumbing imports at the storage composition root and rejects
   WARP-owned CAS coordination, cache implementations, reflection, and direct
   object writers through mutation-tested CI policy.
+- Added a Node subprocess gate that completes the blessed property and
+  neighborhood Observers across a Runtime reopen under a 64 MiB old-space cap,
+  while hard-failing on full materialization or whole-index scans.
 - Moved shadow-trie leaf and branch storage from unretained raw Git blobs and
   trees to bounded git-cas pages and composable bundle handles. Production
   storage now shares one git-cas facade with the trie adapter, and the storage

--- a/test/fixtures/runtime-observer-memory-child.ts
+++ b/test/fixtures/runtime-observer-memory-child.ts
@@ -1,0 +1,142 @@
+import { getHeapStatistics } from 'node:v8';
+import { clearInterval, setInterval } from 'node:timers';
+
+import { Runtime } from '../../index.ts';
+import RuntimeHost from '../../src/domain/RuntimeHost.ts';
+import LegacyReading from '../../src/domain/api/Reading.ts';
+import { createObserver } from '../../src/domain/api/ObserverRuntime.ts';
+import type { ReadingValue } from '../../src/domain/api/ObservedReading.ts';
+import { installDefaultRuntimeHostNodePorts } from '../../src/application/RuntimeHostNodeDefaults.ts';
+import { CborIndexStoreAdapter } from '../../src/infrastructure/adapters/CborIndexStoreAdapter.ts';
+import { createTestRepo } from '../integration/api/helpers/setup.ts';
+
+const LANE_NAME = 'events';
+const WRITER_ID = 'agent-1';
+const HUB_NODE_ID = 'node:hub';
+const NEIGHBOR_NODE_ID = 'node:neighbor';
+
+installDefaultRuntimeHostNodePorts();
+const configuredHeapCapMiB = readConfiguredHeapCapMiB();
+
+let peakHeapUsedBytes = 0;
+let peakRssBytes = 0;
+const sampleMemory = (): void => {
+  const memory = process.memoryUsage();
+  peakHeapUsedBytes = Math.max(peakHeapUsedBytes, memory.heapUsed);
+  peakRssBytes = Math.max(peakRssBytes, memory.rss);
+};
+const sampler = setInterval(sampleMemory, 5);
+sampler.unref();
+sampleMemory();
+
+const repository = await createTestRepo('runtime-observer-memory-cap');
+const originalMaterialize = RuntimeHost.prototype.materialize;
+const originalScanShards = CborIndexStoreAdapter.prototype.scanShards;
+let materializeCalls = 0;
+let wholeIndexScans = 0;
+
+try {
+  const seed = await repository.openGraph(LANE_NAME, WRITER_ID);
+  await seed.patch((patch) => {
+    patch
+      .addNode(HUB_NODE_ID)
+      .addNode(NEIGHBOR_NODE_ID)
+      .setProperty(HUB_NODE_ID, 'status', 'ready')
+      .addEdge(HUB_NODE_ID, NEIGHBOR_NODE_ID, 'contains');
+  });
+  await seed.materialize();
+  await seed.createCheckpoint();
+  sampleMemory();
+
+  RuntimeHost.prototype.materialize = async function prohibitedMaterialize() {
+    materializeCalls += 1;
+    throw new Error('bounded Observer called RuntimeHost.materialize()');
+  };
+  CborIndexStoreAdapter.prototype.scanShards = function prohibitedScanShards() {
+    wholeIndexScans += 1;
+    throw new Error('bounded Observer called scanShards()');
+  };
+
+  const first = await observeFromFreshRuntime(repository.tempDir);
+  sampleMemory();
+  const second = await observeFromFreshRuntime(repository.tempDir);
+  sampleMemory();
+
+  console.log(
+    JSON.stringify({
+      configuredHeapCapMiB,
+      heapLimitMiB: bytesToMiB(getHeapStatistics().heap_size_limit),
+      peakHeapUsedMiB: bytesToMiB(peakHeapUsedBytes),
+      peakRssMiB: bytesToMiB(peakRssBytes),
+      materializeCalls,
+      wholeIndexScans,
+      first,
+      second,
+    })
+  );
+} finally {
+  clearInterval(sampler);
+  RuntimeHost.prototype.materialize = originalMaterialize;
+  CborIndexStoreAdapter.prototype.scanShards = originalScanShards;
+  await repository.cleanup();
+}
+
+async function observeFromFreshRuntime(at: string) {
+  const runtime = await Runtime.open({ at, writer: WRITER_ID });
+  try {
+    const lane = await runtime.lane(LANE_NAME);
+    const propertyObservation = lane.observe(propertyObserver());
+    const property = await propertyObservation.one();
+    const propertyReceipt = await propertyObservation.receipt;
+    const neighborhoodObservation = lane.observe(neighborhoodObserver());
+    const neighborhood = await neighborhoodObservation.one();
+    const neighborhoodReceipt = await neighborhoodObservation.receipt;
+    return Object.freeze({
+      property: property.value,
+      propertyReceiptStatus: propertyReceipt.status,
+      neighborhood: neighborhood.value,
+      neighborhoodReceiptStatus: neighborhoodReceipt.status,
+    });
+  } finally {
+    await runtime.close();
+  }
+}
+
+function propertyObserver() {
+  return createObserver<string>(
+    'events.status-of',
+    LegacyReading.property({ subject: HUB_NODE_ID, key: 'status' }),
+    (value) => {
+      if (typeof value !== 'string') {
+        throw new TypeError('events.status-of expected a string');
+      }
+      return value;
+    }
+  );
+}
+
+function neighborhoodObserver() {
+  return createObserver<ReadingValue>(
+    'events.neighborhood-of',
+    LegacyReading.neighborhood({
+      subject: HUB_NODE_ID,
+      direction: 'out',
+      labels: ['contains'],
+      limit: 10,
+    }),
+    (value) => value
+  );
+}
+
+function bytesToMiB(bytes: number): number {
+  return Number((bytes / (1024 * 1024)).toFixed(2));
+}
+
+function readConfiguredHeapCapMiB(): number {
+  const argument = process.execArgv.find((value) => value.startsWith('--max-old-space-size='));
+  const value = Number(argument?.split('=', 2)[1]);
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error('bounded Observer child requires --max-old-space-size=<MiB>');
+  }
+  return value;
+}

--- a/test/integration/application/Runtime.observerMemoryCap.test.ts
+++ b/test/integration/application/Runtime.observerMemoryCap.test.ts
@@ -1,0 +1,61 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const HEAP_CAP_MIB = 64;
+const CHILD_PATH = new URL('../../fixtures/runtime-observer-memory-child.ts', import.meta.url)
+  .pathname;
+
+describe('Runtime Observer memory cap', () => {
+  it('completes a warm-reopen bounded observation under an explicit old-space cap', async () => {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [`--max-old-space-size=${HEAP_CAP_MIB}`, CHILD_PATH],
+      {
+        maxBuffer: 1024 * 1024,
+        timeout: 120_000,
+      }
+    );
+    const result = JSON.parse(stdout.trim()) as MemoryCapResult;
+
+    expect(result.configuredHeapCapMiB).toBe(HEAP_CAP_MIB);
+    expect(result.peakHeapUsedMiB).toBeLessThan(HEAP_CAP_MIB);
+    expect(result.materializeCalls).toBe(0);
+    expect(result.wholeIndexScans).toBe(0);
+    expect(result.first).toEqual(expectedObservation());
+    expect(result.second).toEqual(result.first);
+  }, 130_000);
+});
+
+function expectedObservation() {
+  return {
+    property: 'ready',
+    propertyReceiptStatus: 'completed',
+    neighborhood: {
+      subject: 'node:hub',
+      direction: 'out',
+      edges: [
+        {
+          direction: 'out',
+          neighborId: 'node:neighbor',
+          label: 'contains',
+        },
+      ],
+      completeness: 'complete',
+      cursor: null,
+    },
+    neighborhoodReceiptStatus: 'completed',
+  };
+}
+
+type MemoryCapResult = Readonly<{
+  configuredHeapCapMiB: number;
+  heapLimitMiB: number;
+  peakHeapUsedMiB: number;
+  peakRssMiB: number;
+  materializeCalls: number;
+  wholeIndexScans: number;
+  first: unknown;
+  second: unknown;
+}>;


### PR DESCRIPTION
Runs the blessed property and neighborhood Observers twice across fresh Runtime reopen cycles in a real Git repository under Node --max-old-space-size=64. The child hard-fails if the read falls back to full materialization or a whole-index scan.

Local Node 26 proof: 40.88 MiB peak heap; identical completed observations; zero forbidden-path calls.

Relates to #742 and #760.

Validation: four focused evidence files, 14 tests passed; mandatory pre-push firewall, 592 files, 7,139 passed, 2 skipped.