### PR TITLE
Prove bounded oversized Observer streaming

### DIFF
--- a/benchmarks/v19/README.md
+++ b/benchmarks/v19/README.md
@@ -1,8 +1,9 @@
 # v19 Materialization Performance Contract
 
 This directory defines the versioned measurement contract for v19
-materialization work. It currently covers issue
-[#759](https://github.com/git-stunts/git-warp/issues/759):
+materialization and bounded-observation work. It covers issues
+[#759](https://github.com/git-stunts/git-warp/issues/759) and
+[#760](https://github.com/git-stunts/git-warp/issues/760):
 
 | Scenario | Fixture posture | Required storage evidence |
 |---|---|---|
@@ -43,6 +44,30 @@ compatible predecessor hit and suffix replay. Strict schema validation rejects
 unknown, missing, malformed, and semantically incomplete result records before
 any performance comparison.
 
+## Oversized streamed Observer proof
+
+`npm run performance:streaming` exercises the public many-Observer path under
+an explicit V8 old-space limit. The proof profile persists 128 deterministic
+descriptors through normal patches and the production v5 checkpoint/property
+page path. Its decoder expands one 2 MiB logical value at a time, producing a
+256 MiB result stream under a 64 MiB old-space limit: a reviewed 4× multiplier.
+
+The worker consumes the real async iterator with a 2 ms delay after every
+reading. It records exact cardinality, logical bytes, SHA-256 fingerprint,
+time-to-first-reading, throughput, peak heap, peak RSS, receipt evidence,
+property-page identities, and the maximum gap between planned and consumed
+readings. The contract requires all 128 property pages, a planning lead of at
+most one, a completed receipt, zero `RuntimeHost.materialize()` calls, and zero
+whole-index scans.
+
+Fixture generation never constructs the 256 MiB result. It persists small
+descriptors in bounded batches and expands at most one logical value while
+computing the expected fingerprint. The same bounded payload generator is used
+by the worker. A hostile control runs under the identical old-space limit and
+materializes every expanded result as heap-resident JavaScript character
+arrays; the proof fails unless that child terminates specifically from memory
+exhaustion.
+
 ## Local use
 
 Build once, then measure and evaluate:
@@ -52,13 +77,15 @@ npm run performance:measure -- --output .performance/head.json
 npm run performance:gate -- \
   --head .performance/head.json \
   --policy benchmarks/v19/policy.json
+npm run performance:streaming -- \
+  --profile proof \
+  --output .performance/streaming.json
 ```
 
 Use `GIT_WARP_PERF_RUNS`, `GIT_WARP_PERF_WARMUPS`,
 `GIT_WARP_PERF_BASE_NODES`, `GIT_WARP_PERF_INCREMENTAL_NODES`, and
 `GIT_WARP_PERF_PROPERTY_BYTES` only for local calibration. A base/head CI
 workflow and durable history are tracked separately by
-[#761](https://github.com/git-stunts/git-warp/issues/761). The oversized streamed
-Observer proof is tracked by
-[#760](https://github.com/git-stunts/git-warp/issues/760) and is intentionally
-not claimed by this materialization harness.
+[#761](https://github.com/git-stunts/git-warp/issues/761). Use
+`--profile mini` only for a fast mechanism check; it deliberately skips the
+hostile OOM control and is not release evidence.

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "benchmark:trie-geometry": "GIT_WARP_PROFILE=1 vitest run test/unit/benchmark/TrieGeometryProfile.profile.test.ts",
     "performance:measure": "npm run build --silent && node dist/scripts/performance/RunPerformance.js",
     "performance:gate": "npm run build --silent && node dist/scripts/performance/GatePerformance.js",
+    "performance:streaming": "npm run build --silent && node dist/scripts/performance/RunStreamingPerformance.js",
     "setup:hooks": "node scripts/setup-hooks.ts",
     "prepare": "patch-package && node scripts/setup-hooks.ts",
     "prepack": "npm run build && npm run lint && npm run test:local && npm run typecheck:consumer",

--- a/scripts/performance/PerformanceFixture.ts
+++ b/scripts/performance/PerformanceFixture.ts
@@ -134,20 +134,25 @@ async function appendCorpus(
   });
 }
 
-function deterministicPayload(index: number, byteLength: number, seed: number): string {
+export function deterministicPayload(
+  index: number,
+  byteLength: number,
+  seed: number,
+): string {
   const prefix = `${index.toString(16).padStart(12, '0')}:`;
   if (byteLength < prefix.length) {
     throw new Error('Performance property size is smaller than its deterministic prefix');
   }
   let state = (seed ^ index) >>> 0;
-  let payload = prefix;
-  while (payload.length < byteLength) {
+  const payload = Buffer.allocUnsafe(byteLength);
+  payload.write(prefix, 0, 'ascii');
+  for (let offset = prefix.length; offset < byteLength; offset += 1) {
     state ^= state << 13;
     state ^= state >>> 17;
     state ^= state << 5;
-    payload += String.fromCharCode(97 + ((state >>> 0) % 26));
+    payload[offset] = 97 + ((state >>> 0) % 26);
   }
-  return payload;
+  return payload.toString('ascii');
 }
 
 function fixtureManifest(
@@ -181,6 +186,6 @@ function fixtureManifest(
   });
 }
 
-function performanceNodeId(index: number): string {
+export function performanceNodeId(index: number): string {
   return `node:${index.toString().padStart(8, '0')}`;
 }

--- a/scripts/performance/RunStreamingPerformance.ts
+++ b/scripts/performance/RunStreamingPerformance.ts
@@ -1,0 +1,185 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { clearInterval, setInterval } from 'node:timers';
+import { pathToFileURL } from 'node:url';
+import {
+  prepareStreamingFixture,
+  type StreamingCorpusSpec,
+} from './StreamingFixture.ts';
+import { validateStreamingPerformanceResult }
+  from './StreamingPerformanceModel.ts';
+import {
+  assertCollectingControlExhaustsHeap,
+  runStreamingPerformanceProcess,
+  type StreamingProcessOptions,
+} from './StreamingPerformanceProcess.ts';
+
+const MEBIBYTE = 1024 * 1024;
+
+type StreamingProfile = Readonly<{
+  corpus: StreamingCorpusSpec;
+  maximumGenerationHeapBytes: number;
+  process: Omit<StreamingProcessOptions, 'mode' | 'repositoryPath'>;
+  proveHostileControl: boolean;
+}>;
+
+type RunOptions = Readonly<{
+  outputPath: string;
+  profileName: 'mini' | 'proof';
+}>;
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  const profile = streamingProfile(options.profileName);
+  const generationMemory = samplePeakMemory();
+  const fixture = await prepareStreamingFixture(profile.corpus);
+  generationMemory.stop();
+  try {
+    const generation = Object.freeze({
+      ...generationMemory.snapshot(),
+      maximumHeapUsedBytes: profile.maximumGenerationHeapBytes,
+    });
+    if (generation.peakHeapUsedBytes > generation.maximumHeapUsedBytes) {
+      throw new Error('Streaming fixture generation exceeded its heap envelope');
+    }
+    const processOptions = Object.freeze({
+      ...profile.process,
+      repositoryPath: fixture.repositoryPath,
+    });
+    const streaming = await runStreamingPerformanceProcess({
+      ...processOptions,
+      mode: 'stream',
+    });
+    validateStreamingPerformanceResult(streaming, fixture.manifest);
+    if (profile.proveHostileControl) {
+      await assertCollectingControlExhaustsHeap(processOptions);
+    }
+    const report = Object.freeze({
+      fixture: fixture.manifest,
+      generation,
+      hostileControl: profile.proveHostileControl
+        ? 'failed-with-memory-exhaustion'
+        : 'not-run-mini-profile',
+      profile: options.profileName,
+      streaming,
+    });
+    await mkdir(dirname(options.outputPath), { recursive: true });
+    await writeFile(
+      options.outputPath,
+      `${JSON.stringify(report, null, 2)}\n`,
+      'utf8',
+    );
+    printSummary(options.outputPath, report);
+  } finally {
+    await fixture.cleanup();
+  }
+}
+
+function streamingProfile(name: RunOptions['profileName']): StreamingProfile {
+  if (name === 'mini') {
+    return Object.freeze({
+      corpus: Object.freeze({
+        batchNodeCount: 2,
+        minimumLogicalToOldSpaceRatio: 0.003,
+        minimumPropertyPages: 4,
+        nodeCount: 4,
+        propertyBytesPerNode: 64 * 1024,
+      }),
+      maximumGenerationHeapBytes: 256 * MEBIBYTE,
+      process: Object.freeze({
+        consumerDelayMs: 0,
+        maxOldSpaceBytes: 64 * MEBIBYTE,
+        maximumRssBytes: 1024 * MEBIBYTE,
+      }),
+      proveHostileControl: false,
+    });
+  }
+  return Object.freeze({
+    corpus: Object.freeze({
+      batchNodeCount: 1,
+      minimumLogicalToOldSpaceRatio: 4,
+      minimumPropertyPages: 128,
+      nodeCount: 128,
+      propertyBytesPerNode: 2 * MEBIBYTE,
+    }),
+    maximumGenerationHeapBytes: 96 * MEBIBYTE,
+    process: Object.freeze({
+      consumerDelayMs: 2,
+      maxOldSpaceBytes: 64 * MEBIBYTE,
+      maximumRssBytes: 384 * MEBIBYTE,
+    }),
+    proveHostileControl: true,
+  });
+}
+
+function parseOptions(args: readonly string[]): RunOptions {
+  let outputPath = resolve('benchmarks/v19/results/streaming-latest.json');
+  let profileName: RunOptions['profileName'] = 'proof';
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const value = args[index + 1];
+    if (argument === '--output' && value !== undefined) {
+      outputPath = resolve(value);
+    } else if (argument === '--profile' && (value === 'mini' || value === 'proof')) {
+      profileName = value;
+    } else {
+      throw new Error(`Unknown streaming performance argument: ${String(argument)}`);
+    }
+    index += 1;
+  }
+  return Object.freeze({ outputPath, profileName });
+}
+
+function samplePeakMemory() {
+  let peakHeapUsedBytes = 0;
+  let peakRssBytes = 0;
+  const sample = (): void => {
+    const memory = process.memoryUsage();
+    peakHeapUsedBytes = Math.max(peakHeapUsedBytes, memory.heapUsed);
+    peakRssBytes = Math.max(peakRssBytes, memory.rss);
+  };
+  const interval = setInterval(sample, 5);
+  interval.unref();
+  sample();
+  return Object.freeze({
+    snapshot: () => Object.freeze({ peakHeapUsedBytes, peakRssBytes }),
+    stop: () => {
+      sample();
+      clearInterval(interval);
+    },
+  });
+}
+
+function printSummary(
+  outputPath: string,
+  report: Readonly<{
+    fixture: Readonly<{ logicalPropertyBytes: number; nodeCount: number }>;
+    hostileControl: string;
+    streaming: Readonly<{
+      config: Readonly<{ maxOldSpaceBytes: number }>;
+      metrics: Readonly<{ maxRssBytes: number; peakHeapUsedBytes: number }>;
+    }>;
+  }>,
+): void {
+  process.stdout.write(
+    `streamed ${String(report.fixture.nodeCount)} readings `
+    + `(${String(report.fixture.logicalPropertyBytes)} logical bytes) `
+    + `under ${String(report.streaming.config.maxOldSpaceBytes)} old-space bytes; `
+    + `peak heap ${String(report.streaming.metrics.peakHeapUsedBytes)}; `
+    + `peak RSS ${String(report.streaming.metrics.maxRssBytes)}; `
+    + `hostile control ${report.hostileControl}; ${outputPath}\n`,
+  );
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return entry !== undefined && import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isMainModule()) {
+  void main().catch((raw: unknown) => {
+    const message = raw instanceof Error ? raw.stack ?? raw.message : String(raw);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/performance/RunStreamingPerformance.ts
+++ b/scripts/performance/RunStreamingPerformance.ts
@@ -1,6 +1,5 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
-import { clearInterval, setInterval } from 'node:timers';
 import { pathToFileURL } from 'node:url';
 import {
   prepareStreamingFixture,
@@ -8,6 +7,8 @@ import {
 } from './StreamingFixture.ts';
 import { validateStreamingPerformanceResult }
   from './StreamingPerformanceModel.ts';
+import { startMemorySampler }
+  from './StreamingPerformanceInstrumentation.ts';
 import {
   assertCollectingControlExhaustsHeap,
   runStreamingPerformanceProcess,
@@ -31,7 +32,7 @@ type RunOptions = Readonly<{
 async function main(): Promise<void> {
   const options = parseOptions(process.argv.slice(2));
   const profile = streamingProfile(options.profileName);
-  const generationMemory = samplePeakMemory();
+  const generationMemory = startMemorySampler();
   const fixture = await prepareStreamingFixture(profile.corpus);
   generationMemory.stop();
   try {
@@ -128,26 +129,6 @@ function parseOptions(args: readonly string[]): RunOptions {
     index += 1;
   }
   return Object.freeze({ outputPath, profileName });
-}
-
-function samplePeakMemory() {
-  let peakHeapUsedBytes = 0;
-  let peakRssBytes = 0;
-  const sample = (): void => {
-    const memory = process.memoryUsage();
-    peakHeapUsedBytes = Math.max(peakHeapUsedBytes, memory.heapUsed);
-    peakRssBytes = Math.max(peakRssBytes, memory.rss);
-  };
-  const interval = setInterval(sample, 5);
-  interval.unref();
-  sample();
-  return Object.freeze({
-    snapshot: () => Object.freeze({ peakHeapUsedBytes, peakRssBytes }),
-    stop: () => {
-      sample();
-      clearInterval(interval);
-    },
-  });
 }
 
 function printSummary(

--- a/scripts/performance/StreamingFixture.ts
+++ b/scripts/performance/StreamingFixture.ts
@@ -1,0 +1,158 @@
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  deterministicPayload,
+  PERFORMANCE_CORPUS_SEED,
+  performanceNodeId,
+} from './PerformanceFixture.ts';
+import { openPerformanceRuntime } from './PerformanceRuntime.ts';
+import {
+  StreamingFixtureManifestSchema,
+  type StreamingFixtureManifest,
+} from './StreamingPerformanceModel.ts';
+
+const MANIFEST_NAME = 'git-warp-streaming-fixture.json';
+
+export type StreamingCorpusSpec = Readonly<{
+  batchNodeCount: number;
+  minimumLogicalToOldSpaceRatio: number;
+  minimumPropertyPages: number;
+  nodeCount: number;
+  propertyBytesPerNode: number;
+  seed?: number;
+}>;
+
+export type PreparedStreamingFixture = Readonly<{
+  cleanup: () => Promise<void>;
+  manifest: StreamingFixtureManifest;
+  repositoryPath: string;
+}>;
+
+export async function prepareStreamingFixture(
+  spec: StreamingCorpusSpec,
+): Promise<PreparedStreamingFixture> {
+  const repositoryPath = await mkdtemp(join(tmpdir(), 'git-warp-streaming-'));
+  try {
+    const seed = spec.seed ?? PERFORMANCE_CORPUS_SEED;
+    const expectedFingerprint = createHash('sha256');
+    const opened = await openPerformanceRuntime(repositoryPath);
+    try {
+      for (let start = 0; start < spec.nodeCount; start += spec.batchNodeCount) {
+        const count = Math.min(spec.batchNodeCount, spec.nodeCount - start);
+        await appendBatch(
+          opened.runtime,
+          start,
+          count,
+          spec.propertyBytesPerNode,
+          seed,
+          expectedFingerprint,
+        );
+      }
+      await opened.runtime.materialize();
+      await opened.runtime.createCheckpoint();
+      const fingerprint = expectedFingerprint.digest('hex');
+      const manifest: StreamingFixtureManifest = Object.freeze({
+        batchNodeCount: spec.batchNodeCount,
+        expectedFingerprint: fingerprint,
+        graphName: 'performance',
+        logicalPropertyBytes: spec.nodeCount * spec.propertyBytesPerNode,
+        minimumLogicalToOldSpaceRatio: spec.minimumLogicalToOldSpaceRatio,
+        minimumPropertyPages: spec.minimumPropertyPages,
+        nodeCount: spec.nodeCount,
+        persistenceMode: 'streaming-descriptor-checkpoint-v1',
+        propertyBytesPerNode: spec.propertyBytesPerNode,
+        seed,
+        writerId: 'benchmark-writer',
+      });
+      await writeFixtureManifest(repositoryPath, manifest);
+      return Object.freeze({
+        cleanup: async () => await rm(repositoryPath, { recursive: true, force: true }),
+        manifest,
+        repositoryPath,
+      });
+    } finally {
+      await opened.close();
+    }
+  } catch (raw) {
+    await rm(repositoryPath, { recursive: true, force: true });
+    throw raw;
+  }
+}
+
+export async function readStreamingFixtureManifest(
+  repositoryPath: string,
+): Promise<StreamingFixtureManifest> {
+  const parsed: unknown = JSON.parse(
+    await readFile(join(repositoryPath, MANIFEST_NAME), 'utf8'),
+  );
+  return StreamingFixtureManifestSchema.parse(parsed);
+}
+
+async function appendBatch(
+  runtime: Awaited<ReturnType<typeof openPerformanceRuntime>>['runtime'],
+  start: number,
+  count: number,
+  propertyBytesPerNode: number,
+  seed: number,
+  fingerprint: ReturnType<typeof createHash>,
+): Promise<void> {
+  const descriptors = Array.from({ length: count }, (_, offset) => (
+    streamingPayloadDescriptor(start + offset, propertyBytesPerNode, seed)
+  ));
+  for (const descriptor of descriptors) {
+    fingerprint.update(decodeStreamingPayloadDescriptor(descriptor));
+  }
+  await runtime.patch((patch) => {
+    for (const [offset, descriptor] of descriptors.entries()) {
+      const index = start + offset;
+      const nodeId = performanceNodeId(index);
+      patch.addNode(nodeId).setProperty(nodeId, 'payload', descriptor);
+      if (index > 0) {
+        patch.addEdge(performanceNodeId(index - 1), nodeId, 'next');
+      }
+    }
+  });
+}
+
+export function streamingPayloadDescriptor(
+  index: number,
+  byteLength: number,
+  seed: number,
+): string {
+  return `git-warp.streaming-payload/v1:${String(index)}:${String(byteLength)}:${String(seed)}`;
+}
+
+export function decodeStreamingPayloadDescriptor(descriptor: string): string {
+  const fields = descriptor.split(':');
+  if (
+    fields.length !== 4
+    || fields[0] !== 'git-warp.streaming-payload/v1'
+  ) {
+    throw new Error('Streaming payload descriptor is invalid');
+  }
+  const index = descriptorInteger(fields[1], 'index');
+  const byteLength = descriptorInteger(fields[2], 'byteLength');
+  const seed = descriptorInteger(fields[3], 'seed');
+  return deterministicPayload(index, byteLength, seed);
+}
+
+function descriptorInteger(value: string | undefined, field: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`Streaming payload descriptor has an invalid ${field}`);
+  }
+  return parsed;
+}
+
+async function writeFixtureManifest(
+  repositoryPath: string,
+  manifest: StreamingFixtureManifest,
+): Promise<void> {
+  await writeFile(
+    join(repositoryPath, MANIFEST_NAME),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    'utf8',
+  );
+}

--- a/scripts/performance/StreamingPerformanceInstrumentation.ts
+++ b/scripts/performance/StreamingPerformanceInstrumentation.ts
@@ -1,0 +1,87 @@
+import { clearInterval, setInterval } from 'node:timers';
+import RuntimeHost from '../../src/domain/RuntimeHost.ts';
+import { CborIndexStoreAdapter }
+  from '../../src/infrastructure/adapters/CborIndexStoreAdapter.ts';
+
+export type MemorySampler = Readonly<{
+  sample: () => void;
+  snapshot: () => Readonly<{
+    maxRssBytes: number;
+    peakHeapUsedBytes: number;
+  }>;
+  stop: () => void;
+}>;
+
+export type PathEvidence = Readonly<{
+  restore: () => void;
+  snapshot: () => Readonly<{
+    materializeCalls: number;
+    uniquePropertyPages: number;
+    wholeIndexScans: number;
+  }>;
+}>;
+
+export function installPathEvidence(): PathEvidence {
+  const propertyPages = new Set<string>();
+  let materializeCalls = 0;
+  let wholeIndexScans = 0;
+  const originalMaterialize = RuntimeHost.prototype.materialize;
+  const originalDecodeShardAt = CborIndexStoreAdapter.prototype.decodeShardAt;
+  const originalScanShards = CborIndexStoreAdapter.prototype.scanShards;
+  RuntimeHost.prototype.materialize = (async function () {
+    materializeCalls += 1;
+    await Promise.resolve();
+    throw new Error('Streaming proof prohibited RuntimeHost.materialize()');
+  }) as typeof originalMaterialize;
+  CborIndexStoreAdapter.prototype.decodeShardAt = (async function (
+    this: CborIndexStoreAdapter,
+    indexHandle,
+    path,
+    decodeOptions,
+  ) {
+    if (path.startsWith('props_')) {
+      propertyPages.add(`${indexHandle.toString()}:${path}`);
+    }
+    return await originalDecodeShardAt.call(this, indexHandle, path, decodeOptions);
+  }) as typeof originalDecodeShardAt;
+  CborIndexStoreAdapter.prototype.scanShards = (function () {
+    wholeIndexScans += 1;
+    throw new Error('Streaming proof prohibited whole-index shard scanning');
+  }) as typeof originalScanShards;
+  return Object.freeze({
+    restore: () => {
+      RuntimeHost.prototype.materialize = originalMaterialize;
+      CborIndexStoreAdapter.prototype.decodeShardAt = originalDecodeShardAt;
+      CborIndexStoreAdapter.prototype.scanShards = originalScanShards;
+    },
+    snapshot: () => Object.freeze({
+      materializeCalls,
+      uniquePropertyPages: propertyPages.size,
+      wholeIndexScans,
+    }),
+  });
+}
+
+export function startMemorySampler(): MemorySampler {
+  let peakHeapUsedBytes = 0;
+  let peakRssBytes = 0;
+  const sampleMemory = (): void => {
+    const memory = process.memoryUsage();
+    peakHeapUsedBytes = Math.max(peakHeapUsedBytes, memory.heapUsed);
+    peakRssBytes = Math.max(peakRssBytes, memory.rss);
+  };
+  const sampler = setInterval(sampleMemory, 5);
+  sampler.unref();
+  sampleMemory();
+  return Object.freeze({
+    sample: sampleMemory,
+    snapshot: () => Object.freeze({
+      maxRssBytes: Math.max(
+        peakRssBytes,
+        process.resourceUsage().maxRSS * 1024,
+      ),
+      peakHeapUsedBytes,
+    }),
+    stop: () => { clearInterval(sampler); },
+  });
+}

--- a/scripts/performance/StreamingPerformanceModel.ts
+++ b/scripts/performance/StreamingPerformanceModel.ts
@@ -1,0 +1,151 @@
+import z from 'zod';
+
+export const STREAMING_SCHEMA_VERSION = 1;
+
+const positiveFinite = z.number().finite().positive();
+const nonNegativeFinite = z.number().finite().nonnegative();
+const positiveInteger = z.number().int().positive();
+const nonNegativeInteger = z.number().int().nonnegative();
+
+export const StreamingFixtureManifestSchema = z.object({
+  batchNodeCount: positiveInteger,
+  expectedFingerprint: z.string().regex(/^[0-9a-f]{64}$/u),
+  graphName: z.literal('performance'),
+  logicalPropertyBytes: positiveInteger,
+  minimumLogicalToOldSpaceRatio: positiveFinite,
+  minimumPropertyPages: positiveInteger,
+  nodeCount: positiveInteger,
+  persistenceMode: z.literal('streaming-descriptor-checkpoint-v1'),
+  propertyBytesPerNode: positiveInteger,
+  seed: nonNegativeInteger,
+  writerId: z.literal('benchmark-writer'),
+}).strict();
+
+export type StreamingFixtureManifest = Readonly<
+  z.infer<typeof StreamingFixtureManifestSchema>
+>;
+
+export const StreamingPerformanceResultSchema = z.object({
+  config: z.object({
+    consumerDelayMs: nonNegativeInteger,
+    expectedReadingCount: positiveInteger,
+    logicalPropertyBytes: positiveInteger,
+    logicalToOldSpaceRatio: positiveFinite,
+    maxOldSpaceBytes: positiveInteger,
+    maximumRssBytes: positiveInteger,
+    minimumPropertyPages: positiveInteger,
+    observedHeapLimitBytes: positiveInteger,
+  }).strict(),
+  evidence: z.object({
+    decodedReadings: positiveInteger,
+    materializeCalls: nonNegativeInteger,
+    maximumPlanningLead: nonNegativeInteger,
+    plannedReadings: positiveInteger,
+    uniquePropertyPages: positiveInteger,
+    wholeIndexScans: nonNegativeInteger,
+  }).strict(),
+  metrics: z.object({
+    maxRssBytes: positiveInteger,
+    peakHeapUsedBytes: positiveInteger,
+    throughputPerSecond: positiveFinite,
+    timeToFirstReadingMs: nonNegativeFinite,
+    wallMs: positiveFinite,
+  }).strict(),
+  receipt: z.object({
+    basisId: z.string().min(1),
+    status: z.literal('completed'),
+    tickId: z.string().min(1).nullable(),
+  }).strict(),
+  schemaVersion: z.literal(STREAMING_SCHEMA_VERSION),
+  semantic: z.object({
+    fingerprint: z.string().regex(/^[0-9a-f]{64}$/u),
+    readingCount: positiveInteger,
+    resultBytes: positiveInteger,
+  }).strict(),
+}).strict();
+
+export type StreamingPerformanceResult = Readonly<
+  z.infer<typeof StreamingPerformanceResultSchema>
+>;
+
+export function parseStreamingPerformanceResult(
+  value: unknown,
+): StreamingPerformanceResult {
+  return StreamingPerformanceResultSchema.parse(value);
+}
+
+export function validateStreamingPerformanceResult(
+  result: StreamingPerformanceResult,
+  manifest: StreamingFixtureManifest,
+): void {
+  validateCardinality(result, manifest);
+  validateSemanticBytes(result, manifest);
+  validateStreamingPath(result, manifest);
+  validateMemoryEnvelope(result);
+}
+
+function validateCardinality(
+  result: StreamingPerformanceResult,
+  manifest: StreamingFixtureManifest,
+): void {
+  if (
+    result.config.expectedReadingCount !== manifest.nodeCount
+    || result.semantic.readingCount !== manifest.nodeCount
+    || result.evidence.plannedReadings !== manifest.nodeCount
+    || result.evidence.decodedReadings !== manifest.nodeCount
+  ) {
+    throw new Error('Streaming performance result has incomplete cardinality');
+  }
+}
+
+function validateSemanticBytes(
+  result: StreamingPerformanceResult,
+  manifest: StreamingFixtureManifest,
+): void {
+  if (
+    result.config.logicalPropertyBytes !== manifest.logicalPropertyBytes
+    || result.semantic.resultBytes !== manifest.logicalPropertyBytes
+  ) {
+    throw new Error('Streaming performance result has incomplete logical bytes');
+  }
+  if (result.semantic.fingerprint !== manifest.expectedFingerprint) {
+    throw new Error('Streaming performance result changed semantic bytes');
+  }
+  const actualRatio = manifest.logicalPropertyBytes / result.config.maxOldSpaceBytes;
+  if (
+    Math.abs(result.config.logicalToOldSpaceRatio - actualRatio) > Number.EPSILON
+    || result.config.logicalToOldSpaceRatio < manifest.minimumLogicalToOldSpaceRatio
+  ) {
+    throw new Error('Streaming performance result did not satisfy its size multiplier');
+  }
+}
+
+function validateStreamingPath(
+  result: StreamingPerformanceResult,
+  manifest: StreamingFixtureManifest,
+): void {
+  if (
+    result.evidence.materializeCalls !== 0
+    || result.evidence.wholeIndexScans !== 0
+  ) {
+    throw new Error('Streaming performance result used a prohibited whole-state path');
+  }
+  if (result.evidence.uniquePropertyPages < manifest.minimumPropertyPages) {
+    throw new Error('Streaming performance result did not exercise enough property pages');
+  }
+  if (result.config.minimumPropertyPages !== manifest.minimumPropertyPages) {
+    throw new Error('Streaming performance result changed its property-page contract');
+  }
+  if (result.evidence.maximumPlanningLead > 1) {
+    throw new Error('Streaming performance result violated consumer backpressure');
+  }
+}
+
+function validateMemoryEnvelope(result: StreamingPerformanceResult): void {
+  if (result.metrics.peakHeapUsedBytes >= result.config.observedHeapLimitBytes) {
+    throw new Error('Streaming performance result exceeded its heap cap');
+  }
+  if (result.metrics.maxRssBytes > result.config.maximumRssBytes) {
+    throw new Error('Streaming performance result exceeded its RSS envelope');
+  }
+}

--- a/scripts/performance/StreamingPerformanceProcess.ts
+++ b/scripts/performance/StreamingPerformanceProcess.ts
@@ -1,0 +1,82 @@
+import { fileURLToPath } from 'node:url';
+import { spawnAndCollect } from './PerformanceProcess.ts';
+import {
+  parseStreamingPerformanceResult,
+  type StreamingPerformanceResult,
+} from './StreamingPerformanceModel.ts';
+
+const RESULT_PREFIX = 'GIT_WARP_STREAMING_PERFORMANCE_RESULT=';
+const WORKER_TIMEOUT_MS = 10 * 60 * 1000;
+
+export type StreamingProcessOptions = Readonly<{
+  consumerDelayMs: number;
+  maxOldSpaceBytes: number;
+  maximumRssBytes: number;
+  mode: 'collect' | 'stream';
+  repositoryPath: string;
+}>;
+
+export async function runStreamingPerformanceProcess(
+  options: StreamingProcessOptions,
+): Promise<StreamingPerformanceResult> {
+  const maxOldSpaceMib = exactMib(options.maxOldSpaceBytes);
+  const workerPath = fileURLToPath(
+    new URL('./StreamingPerformanceWorker.js', import.meta.url),
+  );
+  const completed = await spawnAndCollect(
+    process.execPath,
+    [
+      `--max-old-space-size=${String(maxOldSpaceMib)}`,
+      workerPath,
+      '--repo',
+      options.repositoryPath,
+      '--consumer-delay-ms',
+      String(options.consumerDelayMs),
+      '--max-old-space-bytes',
+      String(options.maxOldSpaceBytes),
+      '--maximum-rss-bytes',
+      String(options.maximumRssBytes),
+      '--mode',
+      options.mode,
+    ],
+    process.env,
+    WORKER_TIMEOUT_MS,
+  );
+  return parseWorkerResult(completed.stdout);
+}
+
+export async function assertCollectingControlExhaustsHeap(
+  options: Omit<StreamingProcessOptions, 'mode'>,
+): Promise<void> {
+  try {
+    await runStreamingPerformanceProcess({ ...options, mode: 'collect' });
+  } catch (raw) {
+    const message = raw instanceof Error ? raw.message : String(raw);
+    if (isHeapExhaustionFailure(message)) {
+      return;
+    }
+    throw new Error(`Collecting control failed for an unexpected reason: ${message}`);
+  }
+  throw new Error('Collecting control unexpectedly completed within the heap cap');
+}
+
+export function isHeapExhaustionFailure(message: string): boolean {
+  return /heap out of memory|allocation failed|SIGABRT/iu.test(message);
+}
+
+function exactMib(bytes: number): number {
+  const mebibyte = 1024 * 1024;
+  if (!Number.isSafeInteger(bytes) || bytes <= 0 || bytes % mebibyte !== 0) {
+    throw new Error('maxOldSpaceBytes must be a positive whole number of MiB');
+  }
+  return bytes / mebibyte;
+}
+
+function parseWorkerResult(stdout: string): StreamingPerformanceResult {
+  const line = stdout.split('\n').find((entry) => entry.startsWith(RESULT_PREFIX));
+  if (line === undefined) {
+    throw new Error(`Streaming worker emitted no result: ${stdout}`);
+  }
+  const parsed: unknown = JSON.parse(line.slice(RESULT_PREFIX.length));
+  return parseStreamingPerformanceResult(parsed);
+}

--- a/scripts/performance/StreamingPerformanceWorker.ts
+++ b/scripts/performance/StreamingPerformanceWorker.ts
@@ -1,0 +1,257 @@
+import { createHash } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import { setTimeout } from 'node:timers';
+import { pathToFileURL } from 'node:url';
+import { getHeapStatistics } from 'node:v8';
+import { Runtime } from '../../index.ts';
+import { installDefaultRuntimeHostNodePorts }
+  from '../../src/application/RuntimeHostNodeDefaults.ts';
+import {
+  createManyObserver,
+} from '../../src/domain/api/ObserverRuntime.ts';
+import LegacyReading from '../../src/domain/api/Reading.ts';
+import { performanceNodeId } from './PerformanceFixture.ts';
+import {
+  decodeStreamingPayloadDescriptor,
+  readStreamingFixtureManifest,
+} from './StreamingFixture.ts';
+import {
+  STREAMING_SCHEMA_VERSION,
+  type StreamingPerformanceResult,
+} from './StreamingPerformanceModel.ts';
+import {
+  installPathEvidence,
+  startMemorySampler,
+} from './StreamingPerformanceInstrumentation.ts';
+
+const GRAPH_NAME = 'performance';
+const RESULT_PREFIX = 'GIT_WARP_STREAMING_PERFORMANCE_RESULT=';
+const WRITER_ID = 'benchmark-writer';
+
+export type StreamingWorkerOptions = Readonly<{
+  consumerDelayMs: number;
+  maxOldSpaceBytes: number;
+  maximumRssBytes: number;
+  mode: 'collect' | 'stream';
+  repositoryPath: string;
+}>;
+
+async function main(): Promise<void> {
+  const options = parseWorkerOptions(process.argv.slice(2));
+  const result = await runStreamingPerformanceWorker(options);
+  process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(result)}\n`);
+}
+
+export async function runStreamingPerformanceWorker(
+  options: StreamingWorkerOptions,
+): Promise<StreamingPerformanceResult> {
+  installDefaultRuntimeHostNodePorts();
+  const manifest = await readStreamingFixtureManifest(options.repositoryPath);
+  const pathEvidence = installPathEvidence();
+  const memory = startMemorySampler();
+  let runtime: Runtime | undefined;
+  try {
+    runtime = await Runtime.open({
+      at: options.repositoryPath,
+      writer: WRITER_ID,
+    });
+    const lane = await runtime.lane(GRAPH_NAME);
+    const observation = await consumeObservation(
+      lane,
+      manifest,
+      options,
+      memory.sample,
+    );
+    return Object.freeze({
+      config: Object.freeze({
+        consumerDelayMs: options.consumerDelayMs,
+        expectedReadingCount: manifest.nodeCount,
+        logicalPropertyBytes: manifest.logicalPropertyBytes,
+        logicalToOldSpaceRatio:
+          manifest.logicalPropertyBytes / options.maxOldSpaceBytes,
+        maxOldSpaceBytes: options.maxOldSpaceBytes,
+        maximumRssBytes: options.maximumRssBytes,
+        minimumPropertyPages: manifest.minimumPropertyPages,
+        observedHeapLimitBytes: getHeapStatistics().heap_size_limit,
+      }),
+      evidence: Object.freeze({
+        ...observation.evidence,
+        ...pathEvidence.snapshot(),
+      }),
+      metrics: Object.freeze({
+        ...observation.metrics,
+        ...memory.snapshot(),
+      }),
+      receipt: observation.receipt,
+      schemaVersion: STREAMING_SCHEMA_VERSION,
+      semantic: observation.semantic,
+    });
+  } finally {
+    memory.stop();
+    pathEvidence.restore();
+    await runtime?.close();
+  }
+}
+
+async function consumeObservation(
+  lane: Awaited<ReturnType<Runtime['lane']>>,
+  manifest: Awaited<ReturnType<typeof readStreamingFixtureManifest>>,
+  options: StreamingWorkerOptions,
+  sampleMemory: () => void,
+) {
+  let plannedReadings = 0;
+  let decodedReadings = 0;
+  let maximumPlanningLead = 0;
+  const observer = createManyObserver<string>(
+    'performance.streamed-properties',
+    () => (function* () {
+      for (let index = 0; index < manifest.nodeCount; index += 1) {
+        plannedReadings += 1;
+        maximumPlanningLead = Math.max(
+          maximumPlanningLead,
+          plannedReadings - decodedReadings,
+        );
+        yield LegacyReading.property({
+          key: 'payload',
+          subject: performanceNodeId(index),
+        });
+      }
+    })(),
+    decodePayload,
+  );
+  const observation = lane.observe(observer);
+  const fingerprint = createHash('sha256');
+  const collected = options.mode === 'collect' ? [] as string[][] : undefined;
+  let resultBytes = 0;
+  let readingCount = 0;
+  let timeToFirstReadingMs: number | undefined;
+  const wallStart = performance.now();
+  for await (const reading of observation) {
+    decodedReadings += 1;
+    timeToFirstReadingMs ??= performance.now() - wallStart;
+    fingerprint.update(reading.value);
+    resultBytes += reading.value.length;
+    readingCount += 1;
+    collected?.push([...reading.value]);
+    if (options.consumerDelayMs > 0) {
+      await delay(options.consumerDelayMs);
+    }
+    sampleMemory();
+  }
+  const receipt = await observation.receipt;
+  const wallMs = performance.now() - wallStart;
+  sampleMemory();
+  if (receipt.status !== 'completed') {
+    throw new Error(`Streaming observation ended with ${receipt.status}`);
+  }
+  const receiptEvidence = receipt.evidence;
+  if (receiptEvidence === undefined) {
+    throw new Error('Streaming observation receipt has no accepted evidence');
+  }
+  return Object.freeze({
+    evidence: Object.freeze({
+      decodedReadings,
+      maximumPlanningLead,
+      plannedReadings,
+    }),
+    metrics: Object.freeze({
+      throughputPerSecond: readingCount / (wallMs / 1000),
+      timeToFirstReadingMs: timeToFirstReadingMs ?? 0,
+      wallMs,
+    }),
+    receipt: Object.freeze({
+      basisId: receiptEvidence.basis.id,
+      status: receipt.status,
+      tickId: receiptEvidence.tick?.id ?? null,
+    }),
+    semantic: Object.freeze({
+      fingerprint: fingerprint.digest('hex'),
+      readingCount,
+      resultBytes,
+    }),
+  });
+}
+
+function decodePayload(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new TypeError('performance.streamed-properties expected a descriptor string');
+  }
+  return decodeStreamingPayloadDescriptor(value);
+}
+
+function parseWorkerOptions(args: readonly string[]): StreamingWorkerOptions {
+  let consumerDelayMs: number | undefined;
+  let maxOldSpaceBytes: number | undefined;
+  let maximumRssBytes: number | undefined;
+  let mode: StreamingWorkerOptions['mode'] | undefined;
+  let repositoryPath: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const value = args[index + 1];
+    if (argument === '--consumer-delay-ms') {
+      consumerDelayMs = nonNegativeInteger(value, argument);
+    } else if (argument === '--max-old-space-bytes') {
+      maxOldSpaceBytes = positiveInteger(value, argument);
+    } else if (argument === '--maximum-rss-bytes') {
+      maximumRssBytes = positiveInteger(value, argument);
+    } else if (argument === '--mode' && (value === 'stream' || value === 'collect')) {
+      mode = value;
+    } else if (argument === '--repo' && value !== undefined) {
+      repositoryPath = value;
+    } else {
+      throw new Error(`Unknown streaming worker argument: ${String(argument)}`);
+    }
+    index += 1;
+  }
+  if (
+    consumerDelayMs === undefined
+    || maxOldSpaceBytes === undefined
+    || maximumRssBytes === undefined
+    || mode === undefined
+    || repositoryPath === undefined
+  ) {
+    throw new Error('Streaming worker requires delay, memory, mode, and repo options');
+  }
+  return Object.freeze({
+    consumerDelayMs,
+    maxOldSpaceBytes,
+    maximumRssBytes,
+    mode,
+    repositoryPath,
+  });
+}
+
+function positiveInteger(value: string | undefined, option: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${option} requires a positive integer`);
+  }
+  return parsed;
+}
+
+function nonNegativeInteger(value: string | undefined, option: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${option} requires a non-negative integer`);
+  }
+  return parsed;
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise<void>((resolvePromise) => {
+    setTimeout(resolvePromise, milliseconds);
+  });
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return entry !== undefined && import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isMainModule()) {
+  void main().catch((raw: unknown) => {
+    const message = raw instanceof Error ? raw.stack ?? raw.message : String(raw);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/integration/scripts/StreamingPerformanceHarness.test.ts
+++ b/test/integration/scripts/StreamingPerformanceHarness.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  prepareStreamingFixture,
+} from '../../../scripts/performance/StreamingFixture.ts';
+import { validateStreamingPerformanceResult }
+  from '../../../scripts/performance/StreamingPerformanceModel.ts';
+import { runStreamingPerformanceWorker }
+  from '../../../scripts/performance/StreamingPerformanceWorker.ts';
+
+const MEBIBYTE = 1024 * 1024;
+
+describe('v19 streamed observation performance harness', () => {
+  it('persists descriptors and decodes logical payloads lazily from retained pages', async () => {
+    const fixture = await prepareStreamingFixture({
+      batchNodeCount: 2,
+      minimumLogicalToOldSpaceRatio: 0.003,
+      minimumPropertyPages: 4,
+      nodeCount: 4,
+      propertyBytesPerNode: 64 * 1024,
+    });
+    try {
+      const result = await runStreamingPerformanceWorker({
+        consumerDelayMs: 1,
+        maxOldSpaceBytes: 64 * MEBIBYTE,
+        maximumRssBytes: 1024 * MEBIBYTE,
+        mode: 'stream',
+        repositoryPath: fixture.repositoryPath,
+      });
+      expect(() => validateStreamingPerformanceResult(result, fixture.manifest))
+        .not.toThrow();
+      expect(result.evidence).toMatchObject({
+        decodedReadings: 4,
+        materializeCalls: 0,
+        maximumPlanningLead: 1,
+        plannedReadings: 4,
+        uniquePropertyPages: 4,
+        wholeIndexScans: 0,
+      });
+      expect(result.receipt.status).toBe('completed');
+      expect(result.semantic).toMatchObject({
+        fingerprint: fixture.manifest.expectedFingerprint,
+        readingCount: 4,
+        resultBytes: 4 * 64 * 1024,
+      });
+    } finally {
+      await fixture.cleanup();
+    }
+  }, 120_000);
+});

--- a/test/unit/scripts/StreamingPerformanceModel.test.ts
+++ b/test/unit/scripts/StreamingPerformanceModel.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  StreamingFixtureManifestSchema,
+  StreamingPerformanceResultSchema,
+  validateStreamingPerformanceResult,
+} from '../../../scripts/performance/StreamingPerformanceModel.ts';
+import { deterministicPayload }
+  from '../../../scripts/performance/PerformanceFixture.ts';
+import { isHeapExhaustionFailure }
+  from '../../../scripts/performance/StreamingPerformanceProcess.ts';
+
+const MEBIBYTE = 1024 * 1024;
+
+describe('StreamingPerformanceModel', () => {
+  it('keeps the deterministic corpus bytes stable with bounded allocation', () => {
+    expect(deterministicPayload(0, 32, 0x19c0ffee))
+      .toBe('000000000000:aenzxgfmspmgujsusno');
+    expect(deterministicPayload(7, 32, 0x19c0ffee))
+      .toBe('000000000007:dlqkmypdbrhognjltnw');
+  });
+
+  it('classifies only expected collecting-control heap failures', () => {
+    expect(isHeapExhaustionFailure(
+      'FATAL ERROR: Allocation failed - JavaScript heap out of memory (SIGABRT)',
+    )).toBe(true);
+    expect(isHeapExhaustionFailure('worker timed out after 600000 ms')).toBe(false);
+  });
+
+  it('accepts exact bounded streaming evidence', () => {
+    expect(() => validateStreamingPerformanceResult(result(), manifest())).not.toThrow();
+  });
+
+  it.each([
+    ['whole-state path', { evidence: { materializeCalls: 1 } }],
+    ['planning lead', { evidence: { maximumPlanningLead: 2 } }],
+    ['property pages', { evidence: { uniquePropertyPages: 3 } }],
+    ['RSS envelope', { metrics: { maxRssBytes: 257 * MEBIBYTE } }],
+  ])('rejects a violated %s contract', (_name, override) => {
+    const candidate = result(override);
+    expect(() => validateStreamingPerformanceResult(candidate, manifest())).toThrow();
+  });
+});
+
+function manifest() {
+  return StreamingFixtureManifestSchema.parse({
+    batchNodeCount: 1,
+    expectedFingerprint: 'a'.repeat(64),
+    graphName: 'performance',
+    logicalPropertyBytes: 128 * MEBIBYTE,
+    minimumLogicalToOldSpaceRatio: 4,
+    minimumPropertyPages: 4,
+    nodeCount: 4,
+    persistenceMode: 'streaming-descriptor-checkpoint-v1',
+    propertyBytesPerNode: 32 * MEBIBYTE,
+    seed: 1,
+    writerId: 'benchmark-writer',
+  });
+}
+
+function result(
+  override: Readonly<{
+    evidence?: Readonly<{
+      materializeCalls?: number;
+      maximumPlanningLead?: number;
+      uniquePropertyPages?: number;
+    }>;
+    metrics?: Readonly<{ maxRssBytes?: number }>;
+  }> = {},
+) {
+  return StreamingPerformanceResultSchema.parse({
+    config: {
+      consumerDelayMs: 2,
+      expectedReadingCount: 4,
+      logicalPropertyBytes: 128 * MEBIBYTE,
+      logicalToOldSpaceRatio: 4,
+      maxOldSpaceBytes: 32 * MEBIBYTE,
+      maximumRssBytes: 256 * MEBIBYTE,
+      minimumPropertyPages: 4,
+      observedHeapLimitBytes: 80 * MEBIBYTE,
+    },
+    evidence: {
+      decodedReadings: 4,
+      materializeCalls: override.evidence?.materializeCalls ?? 0,
+      maximumPlanningLead: override.evidence?.maximumPlanningLead ?? 1,
+      plannedReadings: 4,
+      uniquePropertyPages: override.evidence?.uniquePropertyPages ?? 4,
+      wholeIndexScans: 0,
+    },
+    metrics: {
+      maxRssBytes: override.metrics?.maxRssBytes ?? 200 * MEBIBYTE,
+      peakHeapUsedBytes: 40 * MEBIBYTE,
+      throughputPerSecond: 10,
+      timeToFirstReadingMs: 5,
+      wallMs: 400,
+    },
+    receipt: {
+      basisId: 'basis',
+      status: 'completed',
+      tickId: 'tick',
+    },
+    schemaVersion: 1,
+    semantic: {
+      fingerprint: 'a'.repeat(64),
+      readingCount: 4,
+      resultBytes: 128 * MEBIBYTE,
+    },
+  });
+}


### PR DESCRIPTION
Streams a deterministic 256 MiB logical result through the public many-Observer under a 64 MiB old-space limit, with 2 ms consumer backpressure and 128 production v5 property pages. The worker fails closed on materialization or whole-index scans; the same-cap heap-resident collector must OOM.

Measured locally: 38.3 MiB peak heap, 144.5 MiB peak RSS (384 MiB envelope), planning lead 1, 128/128 readings and pages, completed basis/tick receipt, exact bytes/fingerprint. Fixture generation peaked at 63.8 MiB under its 96 MiB envelope.

Validation: full IRONCLAD pre-push gate; 595 files, 7,151 tests passed, 2 skipped; compiled proof profile passed.

Closes #760