### PR TITLE
Gate v19 performance regressions in CI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -99,11 +99,15 @@ jobs:
       - name: Gate performance evidence
         shell: bash
         run: |
+          gate_status=0
           node head/dist/scripts/performance/GatePerformance.js \
             --comparison performance-results/comparison.json \
             --policy head/benchmarks/v19/policy.json \
-            --summary performance-results/summary.md
-          cat performance-results/summary.md >> "$GITHUB_STEP_SUMMARY"
+            --summary performance-results/summary.md || gate_status=$?
+          if [[ -f performance-results/summary.md ]]; then
+            cat performance-results/summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$gate_status"
 
       - name: Retain raw samples and environment evidence
         if: ${{ always() }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,115 @@
+name: Performance
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      base:
+        description: Base ref to compare
+        required: true
+        default: main^
+        type: string
+      head:
+        description: Head ref to compare
+        required: true
+        default: main
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: performance-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: v19 base/head performance
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      RUNNER_ENVIRONMENT: github-actions-ubuntu-24.04
+    steps:
+      - name: Resolve exact comparison refs
+        id: refs
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || inputs.base }}
+          HEAD_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event_name == 'push' && github.sha || inputs.head }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$BASE_REF" || "$BASE_REF" =~ ^0+$ ]]; then
+            echo "Performance comparison requires a concrete base ref"
+            exit 1
+          fi
+          test -n "$HEAD_REF"
+          echo "base=$BASE_REF" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD_REF" >> "$GITHUB_OUTPUT"
+
+      - name: Check out base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ steps.refs.outputs.base }}
+          path: base
+          persist-credentials: false
+
+      - name: Check out head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ steps.refs.outputs.head }}
+          path: head
+          persist-credentials: false
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: |
+            base/package-lock.json
+            head/package-lock.json
+
+      - name: Install base
+        working-directory: base
+        run: npm ci
+
+      - name: Install head
+        working-directory: head
+        run: npm ci
+
+      - name: Build base and head
+        shell: bash
+        run: |
+          npm --prefix base run build --silent
+          npm --prefix head run build --silent
+
+      - name: Measure counterbalanced base and head
+        shell: bash
+        run: |
+          node head/dist/scripts/performance/RunPerformanceComparison.js \
+            --base-directory base \
+            --head-directory head \
+            --output-directory performance-results \
+            --order-seed "${{ github.event.pull_request.number || github.run_number }}"
+
+      - name: Gate performance evidence
+        shell: bash
+        run: |
+          node head/dist/scripts/performance/GatePerformance.js \
+            --comparison performance-results/comparison.json \
+            --policy head/benchmarks/v19/policy.json \
+            --summary performance-results/summary.md
+          cat performance-results/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Retain raw samples and environment evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: v19-performance-${{ github.sha }}
+          path: performance-results
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
         type: string
 
 permissions:
+  actions: read
   contents: read
   issues: read
 
@@ -103,6 +104,34 @@ jobs:
             STAGE="tag-workflow"
           fi
           npm run release:guard -- --stage "$STAGE" --tag "${{ steps.meta.outputs.tag }}"
+
+      - name: Verify current v19 performance evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${{ steps.meta.outputs.tag_version }}"
+          MAJOR="${TAG_VERSION%%.*}"
+          if (( MAJOR < 19 )); then
+            echo "Performance evidence gate begins with v19"
+            exit 0
+          fi
+          HEAD_SHA="$(git rev-parse HEAD)"
+          RUN_COUNT="$(
+            gh api \
+              -X GET \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/performance.yml/runs" \
+              -f head_sha="$HEAD_SHA" \
+              -f event=push \
+              -f status=success \
+              --jq '.total_count'
+          )"
+          if [[ "$RUN_COUNT" -lt 1 ]]; then
+            echo "No successful main Performance workflow found for $HEAD_SHA"
+            exit 1
+          fi
+          echo "Found current green performance evidence for $HEAD_SHA"
 
       - name: Lychee link check
         uses: lycheeverse/lychee-action@v2

--- a/benchmarks/v19/README.md
+++ b/benchmarks/v19/README.md
@@ -34,14 +34,15 @@ CPU is the blocking regression metric. Wall time remains diagnostic because
 hosted-runner scheduling and filesystem noise are not stable enough for a
 trustworthy wall-time gate. Peak RSS and heap have blocking absolute envelopes.
 The checked-in policy combines a relative CPU ratio with an absolute noise
-floor and reviewed CPU/memory ceilings.
+floor and reviewed materialization and streaming CPU/memory ceilings.
 
 The reviewed CI corpus contains 25 base nodes, a five-node suffix, and 256
 property bytes per node. The earlier 1,500-node bootstrap profile was rejected
 after one worker exceeded the ten-minute timeout. The checked-in
 [`calibration.json`](./calibration.json) records the replacement profile,
-observed medians and dispersion, the exact environment, and the policy
-rationale.
+observed medians and dispersion, the exact GitHub-hosted Ubuntu 24.04/Node 22
+gating environment, and the policy rationale. A local Apple Silicon calibration
+is retained as secondary evidence, not as the source of CI ceilings.
 
 ## Semantic and schema gates
 

--- a/benchmarks/v19/README.md
+++ b/benchmarks/v19/README.md
@@ -32,8 +32,16 @@ Node majors, Git versions, git-cas versions, or corpora.
 
 CPU is the blocking regression metric. Wall time remains diagnostic because
 hosted-runner scheduling and filesystem noise are not stable enough for a
-trustworthy wall-time gate. The checked-in policy combines a relative ratio
-with an absolute noise floor and also applies generous bootstrap ceilings.
+trustworthy wall-time gate. Peak RSS and heap have blocking absolute envelopes.
+The checked-in policy combines a relative CPU ratio with an absolute noise
+floor and reviewed CPU/memory ceilings.
+
+The reviewed CI corpus contains 25 base nodes, a five-node suffix, and 256
+property bytes per node. The earlier 1,500-node bootstrap profile was rejected
+after one worker exceeded the ten-minute timeout. The checked-in
+[`calibration.json`](./calibration.json) records the replacement profile,
+observed medians and dispersion, the exact environment, and the policy
+rationale.
 
 ## Semantic and schema gates
 
@@ -82,10 +90,44 @@ npm run performance:streaming -- \
   --output .performance/streaming.json
 ```
 
+To reproduce the CI comparison, build clean base and head worktrees and run:
+
+```sh
+npm run performance:compare -- \
+  --base-directory ../git-warp-base \
+  --head-directory . \
+  --output-directory .performance/comparison \
+  --order-seed 1
+npm run performance:gate -- \
+  --comparison .performance/comparison/comparison.json \
+  --policy benchmarks/v19/policy.json \
+  --summary .performance/comparison/summary.md
+```
+
 Use `GIT_WARP_PERF_RUNS`, `GIT_WARP_PERF_WARMUPS`,
 `GIT_WARP_PERF_BASE_NODES`, `GIT_WARP_PERF_INCREMENTAL_NODES`, and
-`GIT_WARP_PERF_PROPERTY_BYTES` only for local calibration. A base/head CI
-workflow and durable history are tracked separately by
-[#761](https://github.com/git-stunts/git-warp/issues/761). Use
-`--profile mini` only for a fast mechanism check; it deliberately skips the
-hostile OOM control and is not release evidence.
+`GIT_WARP_PERF_PROPERTY_BYTES` only for local calibration. Use `--profile mini`
+only for a fast mechanism check; it deliberately skips the hostile OOM control
+and is not release evidence.
+
+## CI comparison and history
+
+The dedicated `Performance` workflow checks out the exact base and head SHAs
+side by side, installs and builds both under the same pinned Node 22 toolchain,
+and runs materialization in counterbalanced ABBA order. Each ref contributes
+five measured samples and one warmup per scenario. The opposite ref runs first
+for the streaming pair, reducing systematic order bias across the whole job.
+
+Strict parsing and semantic validation happen before comparison. Missing
+evidence, malformed distributions, cardinality failures, storage-evidence
+failures, materialization memory overruns, streaming heap/RSS violations, and
+CPU regressions all fail the check. Wall time and streaming latency/throughput
+remain diagnostic.
+
+Every pull request and main push receives a Markdown job summary with
+cold/warm/incremental and streaming deltas. The workflow retains the combined
+comparison, merged results, every raw batch, both streaming proofs, and the
+summary for 90 days under a commit-addressed artifact name. The
+[`history`](./history/README.md) page describes the browsable publication and
+baseline-review contract. Release workflows for v19 and later refuse to publish
+unless the release commit has a successful main-branch `Performance` run.

--- a/benchmarks/v19/calibration.json
+++ b/benchmarks/v19/calibration.json
@@ -1,15 +1,20 @@
 {
   "schemaVersion": 1,
-  "sourceCommit": "07f6223cdc52d7d22160c9ff77405356dd60a3a0",
-  "generatedAt": "2026-07-26T02:53:32.821Z",
+  "sourceCommit": "490ffc8c047033531281c58d4b431aa21a52877d",
+  "generatedAt": "2026-07-26T03:30:11.485Z",
+  "evidence": {
+    "artifact": "v19-performance-a166926815bd73e78b546095a4d142db17b2fd1b",
+    "run": "https://github.com/git-stunts/git-warp/actions/runs/30186045644"
+  },
   "environment": {
-    "architecture": "arm64",
-    "cpuCount": 10,
-    "cpuModel": "Apple M1 Pro",
-    "git": "git version 2.50.1 (Apple Git-155)",
+    "architecture": "x64",
+    "cpuCount": 4,
+    "cpuModel": "AMD EPYC 7763 64-Core Processor",
+    "git": "git version 2.54.0",
     "gitCas": "6.5.3",
-    "node": "v26.0.0",
-    "platform": "darwin"
+    "node": "v22.23.1",
+    "platform": "linux",
+    "runner": "github-hosted ubuntu-24.04"
   },
   "corpus": {
     "baseNodeCount": 25,
@@ -20,22 +25,59 @@
   },
   "observed": {
     "cold-materialize": {
-      "cpuTotalMedianMs": 3993.154,
-      "cpuTotalMadMs": 11.974,
-      "maximumRssBytes": 152158208,
-      "maximumHeapUsedBytes": 57703656
+      "cpuTotalMedianMs": 11440.000000000002,
+      "cpuTotalMadMs": 300.0000000000018,
+      "maximumRssBytes": 149114880,
+      "maximumHeapUsedBytes": 55814856
     },
     "warm-materialize": {
-      "cpuTotalMedianMs": 834.786,
-      "cpuTotalMadMs": 4.831,
-      "maximumRssBytes": 120930304,
-      "maximumHeapUsedBytes": 39929144
+      "cpuTotalMedianMs": 2889.9999999999995,
+      "cpuTotalMadMs": 90.00000000000045,
+      "maximumRssBytes": 129462272,
+      "maximumHeapUsedBytes": 44256456
     },
     "incremental-materialize": {
-      "cpuTotalMedianMs": 4276.35,
-      "cpuTotalMadMs": 89.092,
-      "maximumRssBytes": 152928256,
-      "maximumHeapUsedBytes": 58384360
+      "cpuTotalMedianMs": 11240,
+      "cpuTotalMadMs": 320,
+      "maximumRssBytes": 151187456,
+      "maximumHeapUsedBytes": 57289656
+    },
+    "streaming": {
+      "generationMaximumRssBytes": 196218880,
+      "generationPeakHeapUsedBytes": 52742016,
+      "maximumRssBytes": 145403904,
+      "peakHeapUsedBytes": 38016568
+    }
+  },
+  "localCalibration": {
+    "environment": {
+      "architecture": "arm64",
+      "cpuCount": 10,
+      "cpuModel": "Apple M1 Pro",
+      "git": "git version 2.50.1 (Apple Git-155)",
+      "gitCas": "6.5.3",
+      "node": "v26.0.0",
+      "platform": "darwin"
+    },
+    "observed": {
+      "cold-materialize": {
+        "cpuTotalMedianMs": 3993.154,
+        "cpuTotalMadMs": 11.974,
+        "maximumRssBytes": 152158208,
+        "maximumHeapUsedBytes": 57703656
+      },
+      "warm-materialize": {
+        "cpuTotalMedianMs": 834.786,
+        "cpuTotalMadMs": 4.831,
+        "maximumRssBytes": 120930304,
+        "maximumHeapUsedBytes": 39929144
+      },
+      "incremental-materialize": {
+        "cpuTotalMedianMs": 4276.35,
+        "cpuTotalMadMs": 89.092,
+        "maximumRssBytes": 152928256,
+        "maximumHeapUsedBytes": 58384360
+      }
     }
   },
   "rejectedProfiles": [
@@ -51,6 +93,8 @@
       "warm-materialize": 50,
       "incremental-materialize": 250
     },
-    "note": "Noise floors exceed observed MAD; absolute CPU and memory ceilings retain substantial hosted-runner headroom while blocking gross regressions."
+    "streamingMaxRssBytes": 268435456,
+    "streamingPeakHeapUsedBytes": 100663296,
+    "note": "CI-runner measurements are primary. Noise floors cover hosted-runner MAD; absolute materialization and streaming ceilings retain reviewed headroom while blocking gross regressions."
   }
 }

--- a/benchmarks/v19/calibration.json
+++ b/benchmarks/v19/calibration.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "sourceCommit": "07f6223cdc52d7d22160c9ff77405356dd60a3a0",
+  "generatedAt": "2026-07-26T02:53:32.821Z",
+  "environment": {
+    "architecture": "arm64",
+    "cpuCount": 10,
+    "cpuModel": "Apple M1 Pro",
+    "git": "git version 2.50.1 (Apple Git-155)",
+    "gitCas": "6.5.3",
+    "node": "v26.0.0",
+    "platform": "darwin"
+  },
+  "corpus": {
+    "baseNodeCount": 25,
+    "suffixNodeCount": 5,
+    "propertyBytesPerNode": 256,
+    "measuredRuns": 3,
+    "warmupRuns": 1
+  },
+  "observed": {
+    "cold-materialize": {
+      "cpuTotalMedianMs": 3993.154,
+      "cpuTotalMadMs": 11.974,
+      "maximumRssBytes": 152158208,
+      "maximumHeapUsedBytes": 57703656
+    },
+    "warm-materialize": {
+      "cpuTotalMedianMs": 834.786,
+      "cpuTotalMadMs": 4.831,
+      "maximumRssBytes": 120930304,
+      "maximumHeapUsedBytes": 39929144
+    },
+    "incremental-materialize": {
+      "cpuTotalMedianMs": 4276.35,
+      "cpuTotalMadMs": 89.092,
+      "maximumRssBytes": 152928256,
+      "maximumHeapUsedBytes": 58384360
+    }
+  },
+  "rejectedProfiles": [
+    {
+      "baseNodeCount": 1500,
+      "reason": "single worker exceeded the 600000 ms timeout"
+    }
+  ],
+  "policyRationale": {
+    "cpuRegressionRatio": 1.15,
+    "cpuNoiseFloorMs": {
+      "cold-materialize": 250,
+      "warm-materialize": 50,
+      "incremental-materialize": 250
+    },
+    "note": "Noise floors exceed observed MAD; absolute CPU and memory ceilings retain substantial hosted-runner headroom while blocking gross regressions."
+  }
+}

--- a/benchmarks/v19/history/README.md
+++ b/benchmarks/v19/history/README.md
@@ -1,0 +1,30 @@
+# v19 Performance History
+
+The canonical historical record is the repository's
+[`Performance`](https://github.com/git-stunts/git-warp/actions/workflows/performance.yml)
+workflow. Every successful main-branch run publishes:
+
+- a browsable Markdown job summary;
+- `comparison.json`, containing base/head materialization and oversized
+  streaming evidence;
+- the merged five-sample result for each ref;
+- every raw ABBA batch;
+- both hostile-control streaming proof reports; and
+- the exact environment, corpus, execution order, and Git/git-cas versions.
+
+Artifacts are named `v19-performance-<commit>` and retained for 90 days.
+Release tags for v19 and later must point at a commit with a successful
+main-branch performance run, so each published release is anchored to current
+evidence rather than a manually selected result.
+
+## Reviewed calibration
+
+The source-reviewed baseline is
+[`../calibration.json`](../calibration.json). It records the exact source commit
+and environment used to choose the 25-node/five-suffix corpus and demonstrates
+that the policy noise floors exceed observed median absolute deviation.
+
+Changes to the corpus, schema, baseline, CPU ratio, noise floor, or memory
+envelopes must be ordinary source changes in a pull request. The workflow never
+rewrites a generated branch and never promotes the current head into the
+baseline automatically.

--- a/benchmarks/v19/policy.json
+++ b/benchmarks/v19/policy.json
@@ -25,5 +25,9 @@
       "incremental-materialize": 250
     },
     "cpuRegressionRatio": 1.15
+  },
+  "streaming": {
+    "maxRssBytes": 268435456,
+    "peakHeapUsedBytes": 100663296
   }
 }

--- a/benchmarks/v19/policy.json
+++ b/benchmarks/v19/policy.json
@@ -3,9 +3,19 @@
   "wallTime": "diagnostic",
   "absolute": {
     "cpuTotalMedianMs": {
-      "cold-materialize": 180000,
-      "warm-materialize": 30000,
-      "incremental-materialize": 180000
+      "cold-materialize": 30000,
+      "warm-materialize": 10000,
+      "incremental-materialize": 30000
+    },
+    "maxRssBytes": {
+      "cold-materialize": 402653184,
+      "warm-materialize": 268435456,
+      "incremental-materialize": 402653184
+    },
+    "peakHeapUsedBytes": {
+      "cold-materialize": 167772160,
+      "warm-materialize": 134217728,
+      "incremental-materialize": 167772160
     }
   },
   "relative": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "benchmark:detached-reads": "vitest run test/benchmark/DetachedReadBoundary.benchmark.ts",
     "benchmark:trie-geometry": "GIT_WARP_PROFILE=1 vitest run test/unit/benchmark/TrieGeometryProfile.profile.test.ts",
     "performance:measure": "npm run build --silent && node dist/scripts/performance/RunPerformance.js",
+    "performance:compare": "npm run build --silent && node dist/scripts/performance/RunPerformanceComparison.js",
     "performance:gate": "npm run build --silent && node dist/scripts/performance/GatePerformance.js",
     "performance:streaming": "npm run build --silent && node dist/scripts/performance/RunStreamingPerformance.js",
     "setup:hooks": "node scripts/setup-hooks.ts",

--- a/scripts/performance/GatePerformance.ts
+++ b/scripts/performance/GatePerformance.ts
@@ -3,12 +3,17 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import z from 'zod';
 import {
+  parsePerformanceComparison,
+  type PerformanceComparison,
+} from './PerformanceComparisonModel.ts';
+import {
   PERFORMANCE_SCENARIOS,
   parsePerformanceResult,
   type PerformanceResult,
-  type PerformanceScenarioName,
-  type ScenarioResult,
 } from './PerformanceModel.ts';
+import { renderPerformanceSummary } from './PerformanceSummary.ts';
+import type { StreamingPerformanceReport }
+  from './StreamingPerformanceReport.ts';
 
 const scenarioThresholds = z.object({
   'cold-materialize': z.number().finite().nonnegative(),
@@ -19,6 +24,8 @@ const scenarioThresholds = z.object({
 export const PerformancePolicySchema = z.object({
   absolute: z.object({
     cpuTotalMedianMs: scenarioThresholds,
+    maxRssBytes: scenarioThresholds,
+    peakHeapUsedBytes: scenarioThresholds,
   }).strict(),
   relative: z.object({
     cpuNoiseFloorMs: scenarioThresholds,
@@ -32,10 +39,19 @@ export type PerformancePolicy = Readonly<z.infer<typeof PerformancePolicySchema>
 
 type GateOptions = Readonly<{
   basePath?: string;
-  headPath: string;
+  comparisonPath?: string;
+  headPath?: string;
   policyPath: string;
   summaryPath?: string;
 }>;
+
+type MutableGatePaths = {
+  basePath?: string;
+  comparisonPath?: string;
+  headPath?: string;
+  policyPath: string;
+  summaryPath?: string;
+};
 
 export type PerformanceGateEvaluation = Readonly<{
   failures: readonly string[];
@@ -45,11 +61,22 @@ export type PerformanceGateEvaluation = Readonly<{
 async function main(): Promise<void> {
   const options = parseOptions(process.argv.slice(2));
   const policy = await readPolicy(options.policyPath);
-  const head = await readResult(options.headPath);
-  const base = options.basePath === undefined
+  const comparison = options.comparisonPath === undefined
     ? null
-    : await readResult(options.basePath);
-  const evaluation = evaluatePerformanceGate(head, base, policy);
+    : await readComparison(options.comparisonPath);
+  const head = comparison === null
+    ? await readResult(requireHeadPath(options))
+    : comparison.head.materialization;
+  const base = comparison?.base.materialization
+    ?? (options.basePath === undefined ? null : await readResult(options.basePath));
+  const evaluation = evaluatePerformanceGate(
+    head,
+    base,
+    policy,
+    comparison?.head.streaming,
+    comparison?.base.streaming,
+    comparison?.executionOrder,
+  );
   process.stdout.write(evaluation.summary);
   if (options.summaryPath !== undefined) {
     await writeFile(options.summaryPath, evaluation.summary, 'utf8');
@@ -63,6 +90,9 @@ export function evaluatePerformanceGate(
   head: PerformanceResult,
   base: PerformanceResult | null,
   policy: PerformancePolicy,
+  streamingHead?: StreamingPerformanceReport,
+  streamingBase?: StreamingPerformanceReport,
+  executionOrder?: readonly string[],
 ): PerformanceGateEvaluation {
   const failures = [
     ...absoluteFailures(head, policy),
@@ -70,7 +100,14 @@ export function evaluatePerformanceGate(
   ];
   return Object.freeze({
     failures: Object.freeze(failures),
-    summary: renderSummary(head, base, failures),
+    summary: renderPerformanceSummary(
+      head,
+      base,
+      failures,
+      streamingHead,
+      streamingBase,
+      executionOrder,
+    ),
   });
 }
 
@@ -84,6 +121,24 @@ function absoluteFailures(
     const maximum = policy.absolute.cpuTotalMedianMs[scenario];
     if (actual > maximum) {
       failures.push(metricFailure(`${scenario} median CPU`, actual, maximum));
+    }
+    const actualRss = head.scenarios[scenario].maxRssBytes.maximum;
+    const maximumRss = policy.absolute.maxRssBytes[scenario];
+    if (actualRss > maximumRss) {
+      failures.push(byteMetricFailure(
+        `${scenario} maximum RSS`,
+        actualRss,
+        maximumRss,
+      ));
+    }
+    const actualHeap = head.scenarios[scenario].peakHeapUsedBytes.maximum;
+    const maximumHeap = policy.absolute.peakHeapUsedBytes[scenario];
+    if (actualHeap > maximumHeap) {
+      failures.push(byteMetricFailure(
+        `${scenario} peak heap`,
+        actualHeap,
+        maximumHeap,
+      ));
     }
   }
   return failures;
@@ -110,11 +165,8 @@ function relativeFailures(
 
 function requireComparable(base: PerformanceResult, head: PerformanceResult): void {
   if (
-    base.environment.architecture !== head.environment.architecture
-    || base.environment.platform !== head.environment.platform
-    || base.environment.git !== head.environment.git
-    || base.environment.gitCas !== head.environment.gitCas
-    || nodeMajor(base.environment.node) !== nodeMajor(head.environment.node)
+    JSON.stringify(base.environment) !== JSON.stringify(head.environment)
+    || JSON.stringify(base.instrumentation) !== JSON.stringify(head.instrumentation)
   ) {
     throw new Error('Base and head performance environments are not comparable');
   }
@@ -127,63 +179,14 @@ function requireComparable(base: PerformanceResult, head: PerformanceResult): vo
   }
 }
 
-function renderSummary(
-  head: PerformanceResult,
-  base: PerformanceResult | null,
-  failures: readonly string[],
-): string {
-  const lines = [
-    '# git-warp materialization performance gate',
-    '',
-    `Result: **${failures.length === 0 ? 'PASS' : 'FAIL'}**`,
-    '',
-    '| Scenario | Head CPU | Base CPU | Head wall | Base wall | Head RSS | CPU MAD |',
-    '|---|---:|---:|---:|---:|---:|---:|',
-  ];
-  for (const scenario of PERFORMANCE_SCENARIOS) {
-    lines.push(summaryRow(
-      scenario,
-      head.scenarios[scenario],
-      base?.scenarios[scenario],
-    ));
-  }
-  lines.push(
-    '',
-    'CPU is blocking. Wall time and RSS are diagnostic in this materialization slice.',
-    '',
-    base === null
-      ? 'Comparison mode: reviewed absolute bootstrap policy.'
-      : 'Comparison mode: same-environment base/head CPU gate plus absolute policy.',
-  );
-  if (failures.length > 0) {
-    lines.push('', '## Failures', '', ...failures.map((failure) => `- ${failure}`));
-  }
-  return `${lines.join('\n')}\n`;
-}
-
-function summaryRow(
-  scenario: PerformanceScenarioName,
-  head: ScenarioResult,
-  base: ScenarioResult | undefined,
-): string {
-  return `| ${scenario} | ${head.cpuTotalMs.median.toFixed(1)} ms | `
-    + `${formatMetric(base?.cpuTotalMs.median, 'ms')} | `
-    + `${head.wallMs.median.toFixed(1)} ms | `
-    + `${formatMetric(base?.wallMs.median, 'ms')} | `
-    + `${formatMebibytes(head.maxRssBytes.maximum)} | `
-    + `${head.cpuTotalMs.mad.toFixed(1)} ms |`;
-}
-
-function formatMetric(value: number | undefined, unit: string): string {
-  return value === undefined ? 'n/a' : `${value.toFixed(1)} ${unit}`;
-}
-
-function formatMebibytes(bytes: number): string {
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
-}
-
 function metricFailure(metric: string, actual: number, maximum: number): string {
   return `${metric}: ${actual.toFixed(1)} ms exceeds ${maximum.toFixed(1)} ms`;
+}
+
+function byteMetricFailure(metric: string, actual: number, maximum: number): string {
+  const mebibyte = 1024 * 1024;
+  return `${metric}: ${(actual / mebibyte).toFixed(1)} MiB exceeds `
+    + `${(maximum / mebibyte).toFixed(1)} MiB`;
 }
 
 async function readResult(path: string): Promise<PerformanceResult> {
@@ -191,48 +194,67 @@ async function readResult(path: string): Promise<PerformanceResult> {
   return parsePerformanceResult(value);
 }
 
+async function readComparison(path: string): Promise<PerformanceComparison> {
+  const value: unknown = JSON.parse(await readFile(path, 'utf8'));
+  return parsePerformanceComparison(value);
+}
+
 async function readPolicy(path: string): Promise<PerformancePolicy> {
   const value: unknown = JSON.parse(await readFile(path, 'utf8'));
   return PerformancePolicySchema.parse(value);
 }
 
-function nodeMajor(version: string): string {
-  return version.replace(/^v/u, '').split('.')[0] ?? version;
-}
-
 function parseOptions(args: readonly string[]): GateOptions {
-  let headPath: string | undefined;
-  let basePath: string | undefined;
-  let summaryPath: string | undefined;
-  let policyPath = resolve('benchmarks/v19/policy.json');
+  const paths: MutableGatePaths = {
+    policyPath: resolve('benchmarks/v19/policy.json'),
+  };
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
     const value = args[index + 1];
     if (value === undefined) {
       throw new Error(`Performance gate argument requires a value: ${String(argument)}`);
     }
-    if (argument === '--head') {
-      headPath = resolve(value);
-    } else if (argument === '--base') {
-      basePath = resolve(value);
-    } else if (argument === '--policy') {
-      policyPath = resolve(value);
-    } else if (argument === '--summary') {
-      summaryPath = resolve(value);
-    } else {
-      throw new Error(`Unknown performance gate argument: ${String(argument)}`);
-    }
+    assignPathArgument(paths, argument, value);
     index += 1;
   }
-  if (headPath === undefined) {
+  if (paths.headPath === undefined && paths.comparisonPath === undefined) {
+    throw new Error('Performance gate requires --head or --comparison');
+  }
+  if (paths.headPath !== undefined && paths.comparisonPath !== undefined) {
+    throw new Error('Performance gate accepts either --head or --comparison');
+  }
+  if (paths.basePath !== undefined && paths.comparisonPath !== undefined) {
+    throw new Error('Performance gate comparison input already contains its base');
+  }
+  return Object.freeze({ ...paths });
+}
+
+function assignPathArgument(
+  paths: MutableGatePaths,
+  argument: string | undefined,
+  value: string,
+): void {
+  const path = resolve(value);
+  if (argument === '--head') {
+    paths.headPath = path;
+  } else if (argument === '--base') {
+    paths.basePath = path;
+  } else if (argument === '--comparison') {
+    paths.comparisonPath = path;
+  } else if (argument === '--policy') {
+    paths.policyPath = path;
+  } else if (argument === '--summary') {
+    paths.summaryPath = path;
+  } else {
+    throw new Error(`Unknown performance gate argument: ${String(argument)}`);
+  }
+}
+
+function requireHeadPath(options: GateOptions): string {
+  if (options.headPath === undefined) {
     throw new Error('Performance gate requires --head');
   }
-  return Object.freeze({
-    ...(basePath === undefined ? {} : { basePath }),
-    headPath,
-    policyPath,
-    ...(summaryPath === undefined ? {} : { summaryPath }),
-  });
+  return options.headPath;
 }
 
 function isMainModule(): boolean {

--- a/scripts/performance/GatePerformance.ts
+++ b/scripts/performance/GatePerformance.ts
@@ -32,6 +32,10 @@ export const PerformancePolicySchema = z.object({
     cpuRegressionRatio: z.number().finite().gte(1),
   }).strict(),
   schemaVersion: z.literal(1),
+  streaming: z.object({
+    maxRssBytes: z.number().finite().positive(),
+    peakHeapUsedBytes: z.number().finite().positive(),
+  }).strict(),
   wallTime: z.literal('diagnostic'),
 }).strict();
 
@@ -97,6 +101,7 @@ export function evaluatePerformanceGate(
   const failures = [
     ...absoluteFailures(head, policy),
     ...(base === null ? [] : relativeFailures(base, head, policy)),
+    ...(streamingHead === undefined ? [] : streamingFailures(streamingHead, policy)),
   ];
   return Object.freeze({
     failures: Object.freeze(failures),
@@ -159,6 +164,29 @@ function relativeFailures(
     if (headCpu > maximum) {
       failures.push(metricFailure(`${scenario} median CPU regression`, headCpu, maximum));
     }
+  }
+  return failures;
+}
+
+function streamingFailures(
+  head: StreamingPerformanceReport,
+  policy: PerformancePolicy,
+): string[] {
+  const failures: string[] = [];
+  const metrics = head.streaming.metrics;
+  if (metrics.maxRssBytes > policy.streaming.maxRssBytes) {
+    failures.push(byteMetricFailure(
+      'streaming maximum RSS',
+      metrics.maxRssBytes,
+      policy.streaming.maxRssBytes,
+    ));
+  }
+  if (metrics.peakHeapUsedBytes > policy.streaming.peakHeapUsedBytes) {
+    failures.push(byteMetricFailure(
+      'streaming peak heap',
+      metrics.peakHeapUsedBytes,
+      policy.streaming.peakHeapUsedBytes,
+    ));
   }
   return failures;
 }

--- a/scripts/performance/PerformanceComparisonModel.ts
+++ b/scripts/performance/PerformanceComparisonModel.ts
@@ -1,0 +1,76 @@
+import z from 'zod';
+import { PerformanceResultSchema, validatePerformanceResult }
+  from './PerformanceModel.ts';
+import {
+  StreamingPerformanceReportSchema,
+  requireStreamingProofReport,
+} from './StreamingPerformanceReport.ts';
+
+export const PERFORMANCE_COMPARISON_SCHEMA_VERSION = 1;
+
+const executionStepSchema = z.enum([
+  'base-materialization-a',
+  'base-materialization-b',
+  'base-streaming',
+  'head-materialization-a',
+  'head-materialization-b',
+  'head-streaming',
+]);
+
+const refEvidenceSchema = z.object({
+  materialization: PerformanceResultSchema,
+  streaming: StreamingPerformanceReportSchema,
+}).strict();
+
+export const PerformanceComparisonSchema = z.object({
+  base: refEvidenceSchema,
+  executionOrder: z.array(executionStepSchema).length(6).readonly(),
+  generatedAt: z.string().datetime(),
+  head: refEvidenceSchema,
+  schemaVersion: z.literal(PERFORMANCE_COMPARISON_SCHEMA_VERSION),
+}).strict();
+
+export type PerformanceExecutionStep = Readonly<
+  z.infer<typeof executionStepSchema>
+>;
+export type PerformanceComparison = Readonly<
+  z.infer<typeof PerformanceComparisonSchema>
+>;
+
+export function parsePerformanceComparison(value: unknown): PerformanceComparison {
+  const comparison = PerformanceComparisonSchema.parse(value);
+  validatePerformanceResult(comparison.base.materialization);
+  validatePerformanceResult(comparison.head.materialization);
+  requireStreamingProofReport(comparison.base.streaming);
+  requireStreamingProofReport(comparison.head.streaming);
+  validatePerformanceExecutionOrder(comparison.executionOrder);
+  return comparison;
+}
+
+export function validatePerformanceExecutionOrder(
+  order: readonly PerformanceExecutionStep[],
+): void {
+  if (new Set(order).size !== order.length) {
+    throw new Error('Performance comparison execution order contains duplicates');
+  }
+  const materialization = order.slice(0, 4);
+  const refs = materialization.map((step) => step.split('-')[0]);
+  if (
+    refs[0] === refs[1]
+    || refs[0] !== refs[3]
+    || refs[1] !== refs[2]
+  ) {
+    throw new Error('Performance comparison did not use ABBA materialization order');
+  }
+  const phases = materialization.map((step) => step.split('-')[2]);
+  if (phases.join(',') !== 'a,a,b,b') {
+    throw new Error('Performance comparison materialization phases are inconsistent');
+  }
+  const streaming = order.slice(4);
+  if (
+    !streaming.includes('base-streaming')
+    || !streaming.includes('head-streaming')
+  ) {
+    throw new Error('Performance comparison did not run both streaming proofs');
+  }
+}

--- a/scripts/performance/PerformanceResultMerge.ts
+++ b/scripts/performance/PerformanceResultMerge.ts
@@ -1,0 +1,70 @@
+import {
+  PERFORMANCE_SCENARIOS,
+  validatePerformanceResult,
+  type PerformanceResult,
+} from './PerformanceModel.ts';
+import { summarizeScenario } from './PerformanceStatistics.ts';
+
+export function mergePerformanceResults(
+  results: readonly PerformanceResult[],
+): PerformanceResult {
+  const first = results[0];
+  if (first === undefined) {
+    throw new Error('Cannot merge an empty performance result set');
+  }
+  for (const result of results) {
+    validatePerformanceResult(result);
+    assertSharedRunIdentity(first, result);
+  }
+
+  const scenarios = Object.fromEntries(PERFORMANCE_SCENARIOS.map((scenario) => {
+    const samples = results.flatMap((result) => result.scenarios[scenario].samples);
+    const warmupRuns = results.reduce(
+      (total, result) => total + result.scenarios[scenario].warmupRuns,
+      0,
+    );
+    return [
+      scenario,
+      summarizeScenario(
+        scenario,
+        first.scenarios[scenario].corpus,
+        samples,
+        warmupRuns,
+      ),
+    ];
+  })) as PerformanceResult['scenarios'];
+
+  const merged: PerformanceResult = Object.freeze({
+    ...first,
+    generatedAt: new Date().toISOString(),
+    scenarios: Object.freeze(scenarios),
+  });
+  validatePerformanceResult(merged);
+  return merged;
+}
+
+function assertSharedRunIdentity(
+  first: PerformanceResult,
+  candidate: PerformanceResult,
+): void {
+  if (candidate.commit !== first.commit) {
+    throw new Error('Performance batches have different commits');
+  }
+  if (JSON.stringify(candidate.environment) !== JSON.stringify(first.environment)) {
+    throw new Error('Performance batches have different environments');
+  }
+  if (
+    JSON.stringify(candidate.instrumentation)
+    !== JSON.stringify(first.instrumentation)
+  ) {
+    throw new Error('Performance batches have different instrumentation');
+  }
+  for (const scenario of PERFORMANCE_SCENARIOS) {
+    if (
+      JSON.stringify(candidate.scenarios[scenario].corpus)
+      !== JSON.stringify(first.scenarios[scenario].corpus)
+    ) {
+      throw new Error(`Performance batches have different corpora: ${scenario}`);
+    }
+  }
+}

--- a/scripts/performance/PerformanceSummary.ts
+++ b/scripts/performance/PerformanceSummary.ts
@@ -1,0 +1,136 @@
+import {
+  PERFORMANCE_SCENARIOS,
+  type PerformanceResult,
+  type PerformanceScenarioName,
+  type ScenarioResult,
+} from './PerformanceModel.ts';
+import type { StreamingPerformanceReport }
+  from './StreamingPerformanceReport.ts';
+
+export function renderPerformanceSummary(
+  head: PerformanceResult,
+  base: PerformanceResult | null,
+  failures: readonly string[],
+  streamingHead?: StreamingPerformanceReport,
+  streamingBase?: StreamingPerformanceReport,
+  executionOrder?: readonly string[],
+): string {
+  const lines = [
+    '# git-warp v19 performance gate',
+    '',
+    `Result: **${failures.length === 0 ? 'PASS' : 'FAIL'}**`,
+    '',
+    '## Materialization',
+    '',
+    '| Scenario | Head CPU | Base CPU | CPU delta | Head wall | Base wall | Head RSS | CPU MAD |',
+    '|---|---:|---:|---:|---:|---:|---:|---:|',
+  ];
+  for (const scenario of PERFORMANCE_SCENARIOS) {
+    lines.push(materializationRow(
+      scenario,
+      head.scenarios[scenario],
+      base?.scenarios[scenario],
+    ));
+  }
+  lines.push(
+    '',
+    'CPU is blocking. Wall time remains diagnostic. Peak RSS and heap are '
+      + 'blocking absolute envelopes.',
+    '',
+    base === null
+      ? 'Comparison mode: reviewed absolute bootstrap policy.'
+      : 'Comparison mode: same-runner base/head CPU gate plus absolute policy.',
+  );
+  if (streamingHead !== undefined) {
+    lines.push(
+      '',
+      '## Oversized Observer streaming',
+      '',
+      '| Metric | Head | Base | Delta |',
+      '|---|---:|---:|---:|',
+      streamingRow(
+        'Throughput',
+        streamingHead.streaming.metrics.throughputPerSecond,
+        streamingBase?.streaming.metrics.throughputPerSecond,
+        ' readings/s',
+      ),
+      streamingRow(
+        'Time to first reading',
+        streamingHead.streaming.metrics.timeToFirstReadingMs,
+        streamingBase?.streaming.metrics.timeToFirstReadingMs,
+        ' ms',
+      ),
+      streamingByteRow(
+        'Peak heap',
+        streamingHead.streaming.metrics.peakHeapUsedBytes,
+        streamingBase?.streaming.metrics.peakHeapUsedBytes,
+      ),
+      streamingByteRow(
+        'Peak RSS',
+        streamingHead.streaming.metrics.maxRssBytes,
+        streamingBase?.streaming.metrics.maxRssBytes,
+      ),
+      '',
+      `Head streamed ${String(streamingHead.fixture.logicalPropertyBytes)} logical `
+        + `bytes under ${String(streamingHead.streaming.config.maxOldSpaceBytes)} `
+        + 'old-space bytes with hostile-control OOM evidence.',
+    );
+  }
+  if (executionOrder !== undefined) {
+    lines.push('', `Execution order: \`${executionOrder.join(' → ')}\`.`);
+  }
+  if (failures.length > 0) {
+    lines.push('', '## Failures', '', ...failures.map((failure) => `- ${failure}`));
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function materializationRow(
+  scenario: PerformanceScenarioName,
+  head: ScenarioResult,
+  base: ScenarioResult | undefined,
+): string {
+  return `| ${scenario} | ${head.cpuTotalMs.median.toFixed(1)} ms | `
+    + `${formatMetric(base?.cpuTotalMs.median, 'ms')} | `
+    + `${formatDelta(head.cpuTotalMs.median, base?.cpuTotalMs.median)} | `
+    + `${head.wallMs.median.toFixed(1)} ms | `
+    + `${formatMetric(base?.wallMs.median, 'ms')} | `
+    + `${formatMebibytes(head.maxRssBytes.maximum)} | `
+    + `${head.cpuTotalMs.mad.toFixed(1)} ms |`;
+}
+
+function streamingRow(
+  name: string,
+  head: number,
+  base: number | undefined,
+  unit: string,
+): string {
+  return `| ${name} | ${head.toFixed(1)}${unit} | `
+    + `${formatMetric(base, unit.trim())} | ${formatDelta(head, base)} |`;
+}
+
+function streamingByteRow(
+  name: string,
+  head: number,
+  base: number | undefined,
+): string {
+  return `| ${name} | ${formatMebibytes(head)} | `
+    + `${base === undefined ? 'n/a' : formatMebibytes(base)} | `
+    + `${formatDelta(head, base)} |`;
+}
+
+function formatMetric(value: number | undefined, unit: string): string {
+  return value === undefined ? 'n/a' : `${value.toFixed(1)} ${unit}`;
+}
+
+function formatMebibytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function formatDelta(head: number, base: number | undefined): string {
+  if (base === undefined || base === 0) {
+    return 'n/a';
+  }
+  const percent = ((head - base) / base) * 100;
+  return `${percent >= 0 ? '+' : ''}${percent.toFixed(1)}%`;
+}

--- a/scripts/performance/RunPerformance.ts
+++ b/scripts/performance/RunPerformance.ts
@@ -22,8 +22,8 @@ import {
 } from './PerformanceProcess.ts';
 import { summarizeScenario } from './PerformanceStatistics.ts';
 
-const DEFAULT_BASE_NODES = 1_500;
-const DEFAULT_INCREMENTAL_NODES = 25;
+const DEFAULT_BASE_NODES = 25;
+const DEFAULT_INCREMENTAL_NODES = 5;
 const DEFAULT_MEASURED_RUNS = 5;
 const DEFAULT_PROPERTY_BYTES = 256;
 const DEFAULT_WARMUP_RUNS = 1;

--- a/scripts/performance/RunPerformanceComparison.ts
+++ b/scripts/performance/RunPerformanceComparison.ts
@@ -1,0 +1,270 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  PERFORMANCE_COMPARISON_SCHEMA_VERSION,
+  parsePerformanceComparison,
+  type PerformanceComparison,
+  type PerformanceExecutionStep,
+} from './PerformanceComparisonModel.ts';
+import {
+  parsePerformanceResult,
+  type PerformanceResult,
+} from './PerformanceModel.ts';
+import { mergePerformanceResults } from './PerformanceResultMerge.ts';
+import {
+  requireStreamingProofReport,
+  type StreamingPerformanceReport,
+} from './StreamingPerformanceReport.ts';
+
+const CI_BASE_NODES = 25;
+const CI_INCREMENTAL_NODES = 5;
+const CI_PROPERTY_BYTES = 256;
+const FIRST_BATCH_RUNS = 3;
+const SECOND_BATCH_RUNS = 2;
+
+type RefName = 'base' | 'head';
+type RefRun = Readonly<{
+  commit: string;
+  directory: string;
+  name: RefName;
+}>;
+type ComparisonOptions = Readonly<{
+  baseDirectory: string;
+  headDirectory: string;
+  orderSeed: number;
+  outputDirectory: string;
+}>;
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+  await mkdir(options.outputDirectory, { recursive: true });
+  const refs: Readonly<Record<RefName, RefRun>> = Object.freeze({
+    base: refRun('base', options.baseDirectory),
+    head: refRun('head', options.headDirectory),
+  });
+  const first = options.orderSeed % 2 === 0 ? refs.base : refs.head;
+  const second = first.name === 'base' ? refs.head : refs.base;
+  const order: PerformanceExecutionStep[] = [];
+  const batches = new Map<string, PerformanceResult>();
+
+  await runMaterializationBatch(first, 'a', FIRST_BATCH_RUNS, 1, options, order, batches);
+  await runMaterializationBatch(second, 'a', FIRST_BATCH_RUNS, 1, options, order, batches);
+  await runMaterializationBatch(second, 'b', SECOND_BATCH_RUNS, 0, options, order, batches);
+  await runMaterializationBatch(first, 'b', SECOND_BATCH_RUNS, 0, options, order, batches);
+
+  const streaming = new Map<RefName, StreamingPerformanceReport>();
+  await runStreamingProof(second, options, order, streaming);
+  await runStreamingProof(first, options, order, streaming);
+
+  const comparison: PerformanceComparison = Object.freeze({
+    base: Object.freeze({
+      materialization: mergePerformanceResults([
+        requireBatch(batches, 'base-a'),
+        requireBatch(batches, 'base-b'),
+      ]),
+      streaming: requireStreaming(streaming, 'base'),
+    }),
+    executionOrder: Object.freeze(order),
+    generatedAt: new Date().toISOString(),
+    head: Object.freeze({
+      materialization: mergePerformanceResults([
+        requireBatch(batches, 'head-a'),
+        requireBatch(batches, 'head-b'),
+      ]),
+      streaming: requireStreaming(streaming, 'head'),
+    }),
+    schemaVersion: PERFORMANCE_COMPARISON_SCHEMA_VERSION,
+  });
+  parsePerformanceComparison(comparison);
+  await writeJson(join(options.outputDirectory, 'base.json'), comparison.base.materialization);
+  await writeJson(join(options.outputDirectory, 'head.json'), comparison.head.materialization);
+  await writeJson(join(options.outputDirectory, 'comparison.json'), comparison);
+  process.stdout.write(
+    `Performance comparison complete: ${join(options.outputDirectory, 'comparison.json')}\n`,
+  );
+}
+
+async function runMaterializationBatch(
+  ref: RefRun,
+  phase: 'a' | 'b',
+  measuredRuns: number,
+  warmupRuns: number,
+  options: ComparisonOptions,
+  order: PerformanceExecutionStep[],
+  batches: Map<string, PerformanceResult>,
+): Promise<void> {
+  const key = `${ref.name}-${phase}`;
+  const outputPath = join(options.outputDirectory, `${key}.json`);
+  order.push(`${ref.name}-materialization-${phase}`);
+  await runNode(
+    ref,
+    ['dist/scripts/performance/RunPerformance.js', '--output', outputPath],
+    {
+      GIT_WARP_PERF_BASE_NODES: String(CI_BASE_NODES),
+      GIT_WARP_PERF_COMMIT: ref.commit,
+      GIT_WARP_PERF_INCREMENTAL_NODES: String(CI_INCREMENTAL_NODES),
+      GIT_WARP_PERF_PROPERTY_BYTES: String(CI_PROPERTY_BYTES),
+      GIT_WARP_PERF_RUNS: String(measuredRuns),
+      GIT_WARP_PERF_WARMUPS: String(warmupRuns),
+    },
+  );
+  batches.set(key, parsePerformanceResult(await readJson(outputPath)));
+}
+
+async function runStreamingProof(
+  ref: RefRun,
+  options: ComparisonOptions,
+  order: PerformanceExecutionStep[],
+  reports: Map<RefName, StreamingPerformanceReport>,
+): Promise<void> {
+  const outputPath = join(options.outputDirectory, `${ref.name}-streaming.json`);
+  order.push(`${ref.name}-streaming`);
+  await runNode(
+    ref,
+    [
+      'dist/scripts/performance/RunStreamingPerformance.js',
+      '--profile',
+      'proof',
+      '--output',
+      outputPath,
+    ],
+    {},
+  );
+  reports.set(ref.name, requireStreamingProofReport(await readJson(outputPath)));
+}
+
+async function runNode(
+  ref: RefRun,
+  args: readonly string[],
+  environment: Readonly<Record<string, string>>,
+): Promise<void> {
+  process.stdout.write(`Running ${ref.name}: node ${args.join(' ')}\n`);
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(process.execPath, args, {
+      cwd: ref.directory,
+      env: {
+        ...process.env,
+        ...environment,
+        RUNNER_ENVIRONMENT: process.env['RUNNER_ENVIRONMENT'] ?? 'local-comparison',
+      },
+      stdio: 'inherit',
+    });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) {
+        resolvePromise();
+        return;
+      }
+      reject(new Error(
+        `${ref.name} performance child failed: ${signal ?? String(code)}`,
+      ));
+    });
+  });
+}
+
+function refRun(name: RefName, directory: string): RefRun {
+  return Object.freeze({
+    commit: execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: directory,
+      encoding: 'utf8',
+    }).trim(),
+    directory,
+    name,
+  });
+}
+
+function requireBatch(
+  batches: ReadonlyMap<string, PerformanceResult>,
+  key: string,
+): PerformanceResult {
+  const result = batches.get(key);
+  if (result === undefined) {
+    throw new Error(`Missing performance batch: ${key}`);
+  }
+  return result;
+}
+
+function requireStreaming(
+  reports: ReadonlyMap<RefName, StreamingPerformanceReport>,
+  name: RefName,
+): StreamingPerformanceReport {
+  const report = reports.get(name);
+  if (report === undefined) {
+    throw new Error(`Missing streaming report: ${name}`);
+  }
+  return report;
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, 'utf8')) as unknown;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function parseOptions(args: readonly string[]): ComparisonOptions {
+  const values = new Map<string, string>();
+  const allowed = new Set([
+    '--base-directory',
+    '--head-directory',
+    '--order-seed',
+    '--output-directory',
+  ]);
+  for (let index = 0; index < args.length; index += 2) {
+    const argument = args[index];
+    const value = args[index + 1];
+    if (argument === undefined || value === undefined) {
+      throw new Error('Performance comparison arguments require option/value pairs');
+    }
+    if (!allowed.has(argument)) {
+      throw new Error(`Unknown performance comparison argument: ${argument}`);
+    }
+    if (values.has(argument)) {
+      throw new Error(`Duplicate performance comparison argument: ${argument}`);
+    }
+    values.set(argument, value);
+  }
+  const baseDirectory = values.get('--base-directory');
+  const headDirectory = values.get('--head-directory');
+  const outputDirectory = values.get('--output-directory');
+  const rawSeed = values.get('--order-seed');
+  if (
+    baseDirectory === undefined
+    || headDirectory === undefined
+    || outputDirectory === undefined
+    || rawSeed === undefined
+  ) {
+    throw new Error(
+      'Performance comparison requires base/head/output directories and order seed',
+    );
+  }
+  const orderSeed = Number(rawSeed);
+  if (!Number.isSafeInteger(orderSeed) || orderSeed < 0) {
+    throw new Error('Performance comparison order seed must be non-negative');
+  }
+  if (resolve(baseDirectory) === resolve(headDirectory)) {
+    throw new Error('Performance comparison requires distinct base and head directories');
+  }
+  return Object.freeze({
+    baseDirectory: resolve(baseDirectory),
+    headDirectory: resolve(headDirectory),
+    orderSeed,
+    outputDirectory: resolve(outputDirectory),
+  });
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return entry !== undefined && import.meta.url === pathToFileURL(entry).href;
+}
+
+if (isMainModule()) {
+  void main().catch((raw: unknown) => {
+    const message = raw instanceof Error ? raw.stack ?? raw.message : String(raw);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/performance/RunStreamingPerformance.ts
+++ b/scripts/performance/RunStreamingPerformance.ts
@@ -9,6 +9,8 @@ import { validateStreamingPerformanceResult }
   from './StreamingPerformanceModel.ts';
 import { startMemorySampler }
   from './StreamingPerformanceInstrumentation.ts';
+import { parseStreamingPerformanceReport }
+  from './StreamingPerformanceReport.ts';
 import {
   assertCollectingControlExhaustsHeap,
   runStreamingPerformanceProcess,
@@ -64,6 +66,7 @@ async function main(): Promise<void> {
       profile: options.profileName,
       streaming,
     });
+    parseStreamingPerformanceReport(report);
     await mkdir(dirname(options.outputPath), { recursive: true });
     await writeFile(
       options.outputPath,

--- a/scripts/performance/StreamingPerformanceReport.ts
+++ b/scripts/performance/StreamingPerformanceReport.ts
@@ -1,0 +1,63 @@
+import z from 'zod';
+import {
+  StreamingFixtureManifestSchema,
+  StreamingPerformanceResultSchema,
+  validateStreamingPerformanceResult,
+} from './StreamingPerformanceModel.ts';
+
+const positiveInteger = z.number().int().positive();
+
+export const StreamingPerformanceReportSchema = z.object({
+  fixture: StreamingFixtureManifestSchema,
+  generation: z.object({
+    maximumHeapUsedBytes: positiveInteger,
+    maxRssBytes: positiveInteger,
+    peakHeapUsedBytes: positiveInteger,
+  }).strict(),
+  hostileControl: z.enum([
+    'failed-with-memory-exhaustion',
+    'not-run-mini-profile',
+  ]),
+  profile: z.enum(['mini', 'proof']),
+  streaming: StreamingPerformanceResultSchema,
+}).strict();
+
+export type StreamingPerformanceReport = Readonly<
+  z.infer<typeof StreamingPerformanceReportSchema>
+>;
+
+export function parseStreamingPerformanceReport(
+  value: unknown,
+): StreamingPerformanceReport {
+  const report = StreamingPerformanceReportSchema.parse(value);
+  validateStreamingPerformanceResult(report.streaming, report.fixture);
+  if (
+    report.generation.peakHeapUsedBytes
+    > report.generation.maximumHeapUsedBytes
+  ) {
+    throw new Error('Streaming report exceeded its fixture-generation heap envelope');
+  }
+  if (
+    report.profile === 'proof'
+    && report.hostileControl !== 'failed-with-memory-exhaustion'
+  ) {
+    throw new Error('Streaming proof report did not exhaust the hostile control heap');
+  }
+  if (
+    report.profile === 'mini'
+    && report.hostileControl !== 'not-run-mini-profile'
+  ) {
+    throw new Error('Streaming mini report has inconsistent hostile-control evidence');
+  }
+  return report;
+}
+
+export function requireStreamingProofReport(
+  value: unknown,
+): StreamingPerformanceReport {
+  const report = parseStreamingPerformanceReport(value);
+  if (report.profile !== 'proof') {
+    throw new Error('Performance CI requires the streaming proof profile');
+  }
+  return report;
+}

--- a/test/unit/scripts/PerformanceModel.test.ts
+++ b/test/unit/scripts/PerformanceModel.test.ts
@@ -14,6 +14,8 @@ import {
 } from '../../../scripts/performance/PerformanceModel.ts';
 import { mergePerformanceResults }
   from '../../../scripts/performance/PerformanceResultMerge.ts';
+import type { StreamingPerformanceReport }
+  from '../../../scripts/performance/StreamingPerformanceReport.ts';
 
 describe('v19 performance result contract', () => {
   it('accepts a complete result with stable cold/warm semantics and reuse evidence', () => {
@@ -134,6 +136,35 @@ describe('v19 performance result contract', () => {
       .toEqual([
         'warm-materialize peak heap: 200.0 MiB exceeds 128.0 MiB',
       ]);
+  });
+
+  it('fails synthetic streaming RSS and heap regressions deterministically', () => {
+    const head = validResult();
+    const rssRegression = streamingReport({
+      maxRssBytes: 300 * 1024 * 1024,
+      peakHeapUsedBytes: 40 * 1024 * 1024,
+    });
+    const heapRegression = streamingReport({
+      maxRssBytes: 200 * 1024 * 1024,
+      peakHeapUsedBytes: 110 * 1024 * 1024,
+    });
+
+    expect(evaluatePerformanceGate(
+      head,
+      null,
+      policy(),
+      rssRegression,
+    ).failures).toEqual([
+      'streaming maximum RSS: 300.0 MiB exceeds 256.0 MiB',
+    ]);
+    expect(evaluatePerformanceGate(
+      head,
+      null,
+      policy(),
+      heapRegression,
+    ).failures).toEqual([
+      'streaming peak heap: 110.0 MiB exceeds 96.0 MiB',
+    ]);
   });
 
   it('refuses to compare different git-cas versions', () => {
@@ -345,6 +376,75 @@ function policy(): PerformancePolicy {
       cpuRegressionRatio: 1.15,
     },
     schemaVersion: 1,
+    streaming: {
+      maxRssBytes: 256 * 1024 * 1024,
+      peakHeapUsedBytes: 96 * 1024 * 1024,
+    },
     wallTime: 'diagnostic',
+  };
+}
+
+function streamingReport(metrics: Readonly<{
+  maxRssBytes: number;
+  peakHeapUsedBytes: number;
+}>): StreamingPerformanceReport {
+  return {
+    fixture: {
+      batchNodeCount: 1,
+      expectedFingerprint: 'a'.repeat(64),
+      graphName: 'performance',
+      logicalPropertyBytes: 128 * 1024 * 1024,
+      minimumLogicalToOldSpaceRatio: 4,
+      minimumPropertyPages: 4,
+      nodeCount: 4,
+      persistenceMode: 'streaming-descriptor-checkpoint-v1',
+      propertyBytesPerNode: 32 * 1024 * 1024,
+      seed: 1,
+      writerId: 'benchmark-writer',
+    },
+    generation: {
+      maximumHeapUsedBytes: 96 * 1024 * 1024,
+      maxRssBytes: 160 * 1024 * 1024,
+      peakHeapUsedBytes: 60 * 1024 * 1024,
+    },
+    hostileControl: 'failed-with-memory-exhaustion',
+    profile: 'proof',
+    streaming: {
+      config: {
+        consumerDelayMs: 2,
+        expectedReadingCount: 4,
+        logicalPropertyBytes: 128 * 1024 * 1024,
+        logicalToOldSpaceRatio: 4,
+        maxOldSpaceBytes: 32 * 1024 * 1024,
+        maximumRssBytes: 512 * 1024 * 1024,
+        minimumPropertyPages: 4,
+        observedHeapLimitBytes: 128 * 1024 * 1024,
+      },
+      evidence: {
+        decodedReadings: 4,
+        materializeCalls: 0,
+        maximumPlanningLead: 1,
+        plannedReadings: 4,
+        uniquePropertyPages: 4,
+        wholeIndexScans: 0,
+      },
+      metrics: {
+        ...metrics,
+        throughputPerSecond: 10,
+        timeToFirstReadingMs: 5,
+        wallMs: 400,
+      },
+      receipt: {
+        basisId: 'basis',
+        status: 'completed',
+        tickId: 'tick',
+      },
+      schemaVersion: 1,
+      semantic: {
+        fingerprint: 'a'.repeat(64),
+        readingCount: 4,
+        resultBytes: 128 * 1024 * 1024,
+      },
+    },
   };
 }

--- a/test/unit/scripts/PerformanceModel.test.ts
+++ b/test/unit/scripts/PerformanceModel.test.ts
@@ -12,6 +12,8 @@ import {
   type PerformanceScenarioName,
   type ScenarioResult,
 } from '../../../scripts/performance/PerformanceModel.ts';
+import { mergePerformanceResults }
+  from '../../../scripts/performance/PerformanceResultMerge.ts';
 
 describe('v19 performance result contract', () => {
   it('accepts a complete result with stable cold/warm semantics and reuse evidence', () => {
@@ -109,6 +111,31 @@ describe('v19 performance result contract', () => {
       .toEqual([]);
   });
 
+  it('fails synthetic RSS and heap regressions deterministically', () => {
+    const base = validResult();
+    const rssRegression = replaceDistribution(
+      base,
+      'cold-materialize',
+      'maxRssBytes',
+      distribution(300 * 1024 * 1024),
+    );
+    const heapRegression = replaceDistribution(
+      base,
+      'warm-materialize',
+      'peakHeapUsedBytes',
+      distribution(200 * 1024 * 1024),
+    );
+
+    expect(evaluatePerformanceGate(rssRegression, null, policy()).failures)
+      .toEqual([
+        'cold-materialize maximum RSS: 300.0 MiB exceeds 256.0 MiB',
+      ]);
+    expect(evaluatePerformanceGate(heapRegression, null, policy()).failures)
+      .toEqual([
+        'warm-materialize peak heap: 200.0 MiB exceeds 128.0 MiB',
+      ]);
+  });
+
   it('refuses to compare different git-cas versions', () => {
     const base = validResult();
     const head: PerformanceResult = {
@@ -121,6 +148,24 @@ describe('v19 performance result contract', () => {
 
     expect(() => evaluatePerformanceGate(head, base, policy()))
       .toThrow('environments are not comparable');
+  });
+
+  it('merges counterbalanced batches without discarding raw samples', () => {
+    const first = validResult();
+    const second = {
+      ...validResult(),
+      generatedAt: '2026-07-25T00:01:00.000Z',
+    };
+    const merged = mergePerformanceResults([first, second]);
+
+    expect(merged.scenarios['cold-materialize'].measuredRuns).toBe(2);
+    expect(merged.scenarios['cold-materialize'].warmupRuns).toBe(2);
+    expect(merged.scenarios['cold-materialize'].cpuTotalMs.samples)
+      .toEqual([100, 100]);
+    expect(() => mergePerformanceResults([
+      first,
+      { ...second, commit: 'different' },
+    ])).toThrow('different commits');
   });
 });
 
@@ -256,7 +301,7 @@ function replaceSample(
 function replaceDistribution(
   result: PerformanceResult,
   scenario: PerformanceScenarioName,
-  metric: 'cpuTotalMs' | 'wallMs',
+  metric: 'cpuTotalMs' | 'maxRssBytes' | 'peakHeapUsedBytes' | 'wallMs',
   value: Distribution,
 ): PerformanceResult {
   const current = result.scenarios[scenario];
@@ -279,6 +324,16 @@ function policy(): PerformancePolicy {
         'cold-materialize': 1_000,
         'incremental-materialize': 1_000,
         'warm-materialize': 1_000,
+      },
+      maxRssBytes: {
+        'cold-materialize': 256 * 1024 * 1024,
+        'incremental-materialize': 256 * 1024 * 1024,
+        'warm-materialize': 256 * 1024 * 1024,
+      },
+      peakHeapUsedBytes: {
+        'cold-materialize': 128 * 1024 * 1024,
+        'incremental-materialize': 128 * 1024 * 1024,
+        'warm-materialize': 128 * 1024 * 1024,
       },
     },
     relative: {

--- a/test/unit/scripts/StreamingPerformanceModel.test.ts
+++ b/test/unit/scripts/StreamingPerformanceModel.test.ts
@@ -8,6 +8,10 @@ import { deterministicPayload }
   from '../../../scripts/performance/PerformanceFixture.ts';
 import { isHeapExhaustionFailure }
   from '../../../scripts/performance/StreamingPerformanceProcess.ts';
+import {
+  parseStreamingPerformanceReport,
+  requireStreamingProofReport,
+} from '../../../scripts/performance/StreamingPerformanceReport.ts';
 
 const MEBIBYTE = 1024 * 1024;
 
@@ -39,7 +43,37 @@ describe('StreamingPerformanceModel', () => {
     const candidate = result(override);
     expect(() => validateStreamingPerformanceResult(candidate, manifest())).toThrow();
   });
+
+  it('requires proof-profile hostile OOM and bounded fixture generation', () => {
+    const valid = report();
+    expect(requireStreamingProofReport(valid)).toEqual(valid);
+    expect(() => parseStreamingPerformanceReport({
+      ...valid,
+      hostileControl: 'not-run-mini-profile',
+    })).toThrow('did not exhaust');
+    expect(() => parseStreamingPerformanceReport({
+      ...valid,
+      generation: {
+        ...valid.generation,
+        peakHeapUsedBytes: 97 * MEBIBYTE,
+      },
+    })).toThrow('fixture-generation heap envelope');
+  });
 });
+
+function report() {
+  return {
+    fixture: manifest(),
+    generation: {
+      maximumHeapUsedBytes: 96 * MEBIBYTE,
+      maxRssBytes: 160 * MEBIBYTE,
+      peakHeapUsedBytes: 60 * MEBIBYTE,
+    },
+    hostileControl: 'failed-with-memory-exhaustion',
+    profile: 'proof',
+    streaming: result(),
+  } as const;
+}
 
 function manifest() {
   return StreamingFixtureManifestSchema.parse({

--- a/test/unit/scripts/performance-workflow.test.ts
+++ b/test/unit/scripts/performance-workflow.test.ts
@@ -56,6 +56,8 @@ describe('v19 performance workflow', () => {
   it('publishes summaries and raw commit-addressed evidence', () => {
     expect(workflow).toContain('RunPerformanceComparison.js');
     expect(workflow).toContain('--comparison performance-results/comparison.json');
+    expect(workflow).toContain('|| gate_status=$?');
+    expect(workflow).toContain('if [[ -f performance-results/summary.md ]]');
     expect(workflow).toContain('cat performance-results/summary.md >> "$GITHUB_STEP_SUMMARY"');
     expect(workflow).toContain(
       'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02',
@@ -74,16 +76,34 @@ describe('v19 performance workflow', () => {
       'utf8',
     )) as {
       corpus?: { baseNodeCount?: number; suffixNodeCount?: number };
-      policyRationale?: { cpuRegressionRatio?: number };
+      environment?: { node?: string; platform?: string; runner?: string };
+      policyRationale?: {
+        cpuRegressionRatio?: number;
+        streamingMaxRssBytes?: number;
+        streamingPeakHeapUsedBytes?: number;
+      };
       rejectedProfiles?: readonly unknown[];
     };
 
     expect(policy.relative.cpuRegressionRatio).toBe(1.15);
+    expect(policy.streaming).toEqual({
+      maxRssBytes: 256 * 1024 * 1024,
+      peakHeapUsedBytes: 96 * 1024 * 1024,
+    });
     expect(calibration.corpus).toMatchObject({
       baseNodeCount: 25,
       suffixNodeCount: 5,
     });
+    expect(calibration.environment).toMatchObject({
+      node: 'v22.23.1',
+      platform: 'linux',
+      runner: 'github-hosted ubuntu-24.04',
+    });
     expect(calibration.policyRationale?.cpuRegressionRatio).toBe(1.15);
+    expect(calibration.policyRationale?.streamingMaxRssBytes)
+      .toBe(policy.streaming.maxRssBytes);
+    expect(calibration.policyRationale?.streamingPeakHeapUsedBytes)
+      .toBe(policy.streaming.peakHeapUsedBytes);
     expect(calibration.rejectedProfiles).toHaveLength(1);
   });
 
@@ -92,6 +112,7 @@ describe('v19 performance workflow', () => {
     expect(releaseWorkflow).toContain('Verify current v19 performance evidence');
     expect(releaseWorkflow).toContain('actions/workflows/performance.yml/runs');
     expect(releaseWorkflow).toContain('-f head_sha="$HEAD_SHA"');
+    expect(releaseWorkflow).toContain('-f event=push');
     expect(releaseWorkflow).toContain('-f status=success');
   });
 });

--- a/test/unit/scripts/performance-workflow.test.ts
+++ b/test/unit/scripts/performance-workflow.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PerformancePolicySchema }
+  from '../../../scripts/performance/GatePerformance.ts';
+import { validatePerformanceExecutionOrder }
+  from '../../../scripts/performance/PerformanceComparisonModel.ts';
+
+const root = process.cwd();
+const workflow = readFileSync(
+  resolve(root, '.github/workflows/performance.yml'),
+  'utf8',
+);
+const releaseWorkflow = readFileSync(
+  resolve(root, '.github/workflows/release.yml'),
+  'utf8',
+);
+
+describe('v19 performance workflow', () => {
+  it('runs exact base/head refs in one bounded pinned-toolchain job', () => {
+    expect(workflow).toContain('name: Performance');
+    expect(workflow).toContain('pull_request:');
+    expect(workflow).toContain('push:');
+    expect(workflow).toContain('runs-on: ubuntu-24.04');
+    expect(workflow).toContain('timeout-minutes: 45');
+    expect(workflow).toContain('path: base');
+    expect(workflow).toContain('path: head');
+    expect(workflow).toContain(
+      'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd',
+    );
+    expect(workflow).toContain(
+      'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e',
+    );
+    expect(workflow).not.toContain('continue-on-error');
+  });
+
+  it('requires complete counterbalanced execution evidence', () => {
+    expect(() => validatePerformanceExecutionOrder([
+      'base-materialization-a',
+      'head-materialization-a',
+      'head-materialization-b',
+      'base-materialization-b',
+      'head-streaming',
+      'base-streaming',
+    ])).not.toThrow();
+    expect(() => validatePerformanceExecutionOrder([
+      'base-materialization-a',
+      'base-materialization-b',
+      'head-materialization-a',
+      'head-materialization-b',
+      'head-streaming',
+      'base-streaming',
+    ])).toThrow('ABBA');
+  });
+
+  it('publishes summaries and raw commit-addressed evidence', () => {
+    expect(workflow).toContain('RunPerformanceComparison.js');
+    expect(workflow).toContain('--comparison performance-results/comparison.json');
+    expect(workflow).toContain('cat performance-results/summary.md >> "$GITHUB_STEP_SUMMARY"');
+    expect(workflow).toContain(
+      'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02',
+    );
+    expect(workflow).toContain('name: v19-performance-${{ github.sha }}');
+    expect(workflow).toContain('retention-days: 90');
+  });
+
+  it('keeps calibration and threshold changes in ordinary source review', () => {
+    const policy = PerformancePolicySchema.parse(JSON.parse(readFileSync(
+      resolve(root, 'benchmarks/v19/policy.json'),
+      'utf8',
+    )) as unknown);
+    const calibration = JSON.parse(readFileSync(
+      resolve(root, 'benchmarks/v19/calibration.json'),
+      'utf8',
+    )) as {
+      corpus?: { baseNodeCount?: number; suffixNodeCount?: number };
+      policyRationale?: { cpuRegressionRatio?: number };
+      rejectedProfiles?: readonly unknown[];
+    };
+
+    expect(policy.relative.cpuRegressionRatio).toBe(1.15);
+    expect(calibration.corpus).toMatchObject({
+      baseNodeCount: 25,
+      suffixNodeCount: 5,
+    });
+    expect(calibration.policyRationale?.cpuRegressionRatio).toBe(1.15);
+    expect(calibration.rejectedProfiles).toHaveLength(1);
+  });
+
+  it('requires current green main performance evidence for v19 releases', () => {
+    expect(releaseWorkflow).toContain('actions: read');
+    expect(releaseWorkflow).toContain('Verify current v19 performance evidence');
+    expect(releaseWorkflow).toContain('actions/workflows/performance.yml/runs');
+    expect(releaseWorkflow).toContain('-f head_sha="$HEAD_SHA"');
+    expect(releaseWorkflow).toContain('-f status=success');
+  });
+});


### PR DESCRIPTION
Adds a pinned Ubuntu/Node 22 performance workflow that measures exact base and head SHAs in counterbalanced ABBA order, validates cold/warm/incremental and oversized streaming evidence, blocks CPU and memory regressions, and retains commit-addressed raw results plus a Markdown history summary.

The checked-in calibration replaces the non-viable 1,500-node bootstrap corpus with a reviewed 25-node/five-suffix profile while preserving exact git-cas reuse and semantic-completion proofs. v19+ releases now require a successful main-branch performance run for the release commit.

Validation: full IRONCLAD pre-push gate; 595 stable test files, 7,159 passed, 2 skipped; focused performance suite 20/20; local three-sample calibration.

Closes #759
Closes #761