### PR TITLE
Publish v19 charts and testing surfaces

### DIFF
--- a/charts.ts
+++ b/charts.ts
@@ -1,0 +1,15 @@
+/**
+ * Bounded graph-shaped observations.
+ *
+ * Charts are derived views over a Lane, never a mutable graph store or durable
+ * ontology. Each builder returns a validated Observer that emits canonical
+ * `Reading.value` data.
+ */
+
+export { graph } from './src/domain/api/GraphChartObservers.ts';
+export type {
+  GraphChartObservers,
+  GraphNeighborhoodChart,
+  GraphNeighborhoodEdge,
+  GraphNeighborhoodOptions,
+} from './src/domain/api/GraphChartObservers.ts';

--- a/charts.ts
+++ b/charts.ts
@@ -7,9 +7,11 @@
  */
 
 export { graph } from './src/domain/api/GraphChartObservers.ts';
+export { default as GraphNeighborhoodChart } from './src/domain/api/GraphNeighborhoodChart.ts';
+export { default as GraphNeighborhoodEdge } from './src/domain/api/GraphNeighborhoodEdge.ts';
 export type {
   GraphChartObservers,
-  GraphNeighborhoodChart,
-  GraphNeighborhoodEdge,
   GraphNeighborhoodOptions,
 } from './src/domain/api/GraphChartObservers.ts';
+export type { GraphNeighborhoodChartOptions } from './src/domain/api/GraphNeighborhoodChart.ts';
+export type { GraphNeighborhoodEdgeOptions } from './src/domain/api/GraphNeighborhoodEdge.ts';

--- a/docs/migrations/v19/README.md
+++ b/docs/migrations/v19/README.md
@@ -2,8 +2,8 @@
 
 > **Status:** Pre-release. The canonical Runtime, worldline Lane, Observer,
 > streaming Observation, Reading, Receipt, and write-admission core has landed.
-> Fork/settlement, generated SDK publication, charts/testing subpaths, and
-> CLI/MCP vocabulary convergence remain tracked by issue #712.
+> Fork/settlement, generated SDK publication, and CLI/MCP vocabulary
+> convergence remain tracked by issue #712.
 
 v19 replaces the transitional storage- and timeline-shaped facade with one
 application grammar:
@@ -304,8 +304,9 @@ The intended v19 expert surfaces are:
 ```
 
 `/charts` provides graph-shaped derived observations. It does not describe the
-durable ontology as a graph. `/testing` owns dependency injection and fakes.
-Both remain open v19 implementation work at the time of this guide.
+durable ontology as a graph. Its first shipped Observer is a one-hop, bounded,
+cursor-page neighborhood chart. `/testing` provides an isolated real-Git
+`Runtime` harness without exposing storage construction at package root.
 
 There is no public `/graph`, `/browser`, or `/legacy` package. The transitional
 `/storage` export remains only until testing and diagnostics no longer require
@@ -341,8 +342,8 @@ the explicit handle; ordinary v19 application code must use `Runtime.open()`.
 6. Move receipt handling from each Reading to the Observation terminal path.
 7. Match all four admission variants exhaustively.
 8. Keep existing cross-lane join code isolated until settlement plans land.
-9. Replace graph-shaped reads with `/charts` once that subpath ships.
-10. Remove imports from `/storage` after diagnostics/testing migration lands.
+9. Replace graph-shaped reads with bounded `/charts` observers.
+10. Remove imports from `/storage` when explicit diagnostics work is complete.
 
 ## Validation
 

--- a/docs/topics/api/README.md
+++ b/docs/topics/api/README.md
@@ -524,14 +524,19 @@ import { graph } from '@git-stunts/git-warp/charts';
 const observation = events.observe(
   graph.neighborhood({
     around: 'user:alice',
-    depth: 2,
+    direction: 'both',
+    limit: 100,
   })
 );
 ```
 
-This surface may expose node, edge, neighborhood, topology, and graph-diff
-Observers. It must describe their results as charts or readings, not as the
-durable territory or a mutable graph store.
+The shipped neighborhood chart is one hop and cursor-page bounded: it defaults
+to 100 edges and accepts at most 1,000. Follow `Reading.value.cursor` with
+another Observer when `Reading.value.completeness` is `truncated`.
+
+This surface may grow node, edge, topology, and graph-diff Observers. It must
+describe their results as charts or readings, not as the durable territory or
+a mutable graph store.
 
 `/charts` is absent from the first-use README path. It exists for users who
 actually need graph-shaped correlation and coordination.

--- a/docs/topics/reference.md
+++ b/docs/topics/reference.md
@@ -147,10 +147,12 @@ Bounded graph-shaped derived Observers and Reading values.
 
 ### Value exports
 
-Source: `charts.ts`. Count: 1.
+Source: `charts.ts`. Count: 3.
 
 ```text
 graph @ charts.ts#L9
+GraphNeighborhoodChart @ charts.ts#L10
+GraphNeighborhoodEdge @ charts.ts#L11
 ```
 
 ### Type exports
@@ -158,9 +160,9 @@ graph @ charts.ts#L9
 Source: `charts.ts`. Count: 4.
 
 ```text
-GraphChartObservers @ charts.ts#L11
-GraphNeighborhoodChart @ charts.ts#L12
-GraphNeighborhoodEdge @ charts.ts#L13
+GraphChartObservers @ charts.ts#L13
+GraphNeighborhoodChartOptions @ charts.ts#L16
+GraphNeighborhoodEdgeOptions @ charts.ts#L17
 GraphNeighborhoodOptions @ charts.ts#L14
 ```
 
@@ -170,19 +172,21 @@ Disposable real-Git Runtime harnesses for consumer tests.
 
 ### Value exports
 
-Source: `testing.ts`. Count: 1.
+Source: `testing.ts`. Count: 2.
 
 ```text
-createRuntimeHarness @ testing.ts#L8
+createRuntimeHarness @ testing.ts#L17
+createRuntimeHarnessWithHost @ testing.ts#L23
 ```
 
 ### Type exports
 
-Source: `testing.ts`. Count: 2.
+Source: `testing.ts`. Count: 3.
 
 ```text
-RuntimeHarness @ testing.ts#L10
-RuntimeHarnessOptions @ testing.ts#L11
+RuntimeHarness @ testing.ts#L25
+RuntimeHarnessHost @ testing.ts#L26
+RuntimeHarnessOptions @ testing.ts#L27
 ```
 
 ## CLI command registry

--- a/docs/topics/reference.md
+++ b/docs/topics/reference.md
@@ -15,11 +15,15 @@ public API export, CLI command, package entrypoint, or public error class.
 | npm export | `./storage` | `types=./dist/storage.d.ts; import=./dist/storage.js; default=./dist/storage.js` | `package.json#L33` |
 | npm export | `./advanced` | `types=./dist/advanced.d.ts; import=./dist/advanced.js; default=./dist/advanced.js` | `package.json#L38` |
 | npm export | `./diagnostics` | `types=./dist/diagnostics.d.ts; import=./dist/diagnostics.js; default=./dist/diagnostics.js` | `package.json#L43` |
-| npm export | `./package.json` | `./package.json` | `package.json#L48` |
+| npm export | `./charts` | `types=./dist/charts.d.ts; import=./dist/charts.js; default=./dist/charts.js` | `package.json#L48` |
+| npm export | `./testing` | `types=./dist/testing.d.ts; import=./dist/testing.js; default=./dist/testing.js` | `package.json#L53` |
+| npm export | `./package.json` | `./package.json` | `package.json#L58` |
 | JSR export | `.` | `./index.ts` | `jsr.json#L8` |
 | JSR export | `./storage` | `./storage.ts` | `jsr.json#L9` |
 | JSR export | `./advanced` | `./advanced.ts` | `jsr.json#L10` |
 | JSR export | `./diagnostics` | `./diagnostics.ts` | `jsr.json#L11` |
+| JSR export | `./charts` | `./charts.ts` | `jsr.json#L12` |
+| JSR export | `./testing` | `./testing.ts` | `jsr.json#L13` |
 
 ## Root API export surface
 
@@ -135,6 +139,50 @@ Source: `diagnostics.ts`. Count: 3.
 InspectReceiptOptions @ diagnostics.ts#L11
 ReceiptInspection @ diagnostics.ts#L29
 ReceiptSubstrateInspection @ diagnostics.ts#L15
+```
+
+## Charts export surface
+
+Bounded graph-shaped derived Observers and Reading values.
+
+### Value exports
+
+Source: `charts.ts`. Count: 1.
+
+```text
+graph @ charts.ts#L9
+```
+
+### Type exports
+
+Source: `charts.ts`. Count: 4.
+
+```text
+GraphChartObservers @ charts.ts#L11
+GraphNeighborhoodChart @ charts.ts#L12
+GraphNeighborhoodEdge @ charts.ts#L13
+GraphNeighborhoodOptions @ charts.ts#L14
+```
+
+## Testing export surface
+
+Disposable real-Git Runtime harnesses for consumer tests.
+
+### Value exports
+
+Source: `testing.ts`. Count: 1.
+
+```text
+createRuntimeHarness @ testing.ts#L8
+```
+
+### Type exports
+
+Source: `testing.ts`. Count: 2.
+
+```text
+RuntimeHarness @ testing.ts#L10
+RuntimeHarnessOptions @ testing.ts#L11
 ```
 
 ## CLI command registry

--- a/jsr.json
+++ b/jsr.json
@@ -8,7 +8,9 @@
     ".": "./index.ts",
     "./storage": "./storage.ts",
     "./advanced": "./advanced.ts",
-    "./diagnostics": "./diagnostics.ts"
+    "./diagnostics": "./diagnostics.ts",
+    "./charts": "./charts.ts",
+    "./testing": "./testing.ts"
   },
   "publish": {
     "include": [
@@ -16,6 +18,8 @@
       "storage.ts",
       "advanced.ts",
       "diagnostics.ts",
+      "charts.ts",
+      "testing.ts",
       "src/**/*.ts",
       "src/**/*.d.ts",
       "README.md",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,16 @@
       "import": "./dist/diagnostics.js",
       "default": "./dist/diagnostics.js"
     },
+    "./charts": {
+      "types": "./dist/charts.d.ts",
+      "import": "./dist/charts.js",
+      "default": "./dist/charts.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js",
+      "default": "./dist/testing.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/scripts/check-source-backed-reference.ts
+++ b/scripts/check-source-backed-reference.ts
@@ -229,6 +229,7 @@ function exportSurface(title: string, source: SourceText, contract: string): rea
     `Source: \`${source.path}\`. Count: ${typeExports.length}.`,
     '',
     codeList(typeExports),
+    '',
   ];
 }
 
@@ -241,6 +242,8 @@ function generate(): string {
   const storageSource = new SourceText('storage.ts');
   const advancedSource = new SourceText('advanced.ts');
   const diagnosticsSource = new SourceText('diagnostics.ts');
+  const chartsSource = new SourceText('charts.ts');
+  const testingSource = new SourceText('testing.ts');
   const packageBins = captureObjectEntries(packageSource, 'bin');
   const packageExports = captureExportEntries(packageSource, 'exports').filter((item) => item.name.startsWith('.'));
   const jsrExports = captureExportEntries(jsrSource, 'exports').filter((item) => item.name.startsWith('.'));
@@ -263,13 +266,11 @@ function generate(): string {
     ]),
     '',
     ...exportSurface('Root API export surface', rootSource, 'First-use product API: one `Runtime` value plus Lane, Intent, Observer, Observation, Reading, and Receipt types.'),
-    '',
     ...exportSurface('Storage export surface', storageSource, 'Transitional explicit storage composition; first-use applications use `Runtime.open()`.'),
-    '',
     ...exportSurface('Advanced export surface', advancedSource, 'Bounded coordinate capture, Optic, and Witness concepts for expert use.'),
-    '',
     ...exportSurface('Diagnostics export surface', diagnosticsSource, 'Operator inspection helpers that consume public receipt handles.'),
-    '',
+    ...exportSurface('Charts export surface', chartsSource, 'Bounded graph-shaped derived Observers and Reading values.'),
+    ...exportSurface('Testing export surface', testingSource, 'Disposable real-Git Runtime harnesses for consumer tests.'),
     '## CLI command registry',
     '',
     table(['Command', 'Handler', 'Source'], commands.map((item) => [`\`${item.name}\``, `\`${item.detail}\``, `\`${item.source}\``])),

--- a/scripts/storage-ownership-policy.ts
+++ b/scripts/storage-ownership-policy.ts
@@ -4,6 +4,8 @@ export const PRODUCTION_ENTRYPOINTS = [
   'storage.ts',
   'advanced.ts',
   'diagnostics.ts',
+  'charts.ts',
+  'testing.ts',
 ] as const;
 export const DOMAIN_STORAGE_ROOTS = ['src/domain', 'src/ports'] as const;
 export const STORAGE_ADAPTER_ROOT = 'src/infrastructure/adapters/';

--- a/src/domain/api/GraphChartObservers.ts
+++ b/src/domain/api/GraphChartObservers.ts
@@ -1,15 +1,10 @@
 import type Observer from './Observer.ts';
-import {
-  createObserver,
-} from './ObserverRuntime.ts';
-import LegacyReading, {
-  type NeighborhoodReadingFields,
-  type ReadingDirection,
-} from './Reading.ts';
-import type {
-  ReadingValue,
-} from './ObservedReading.ts';
+import { createObserver } from './ObserverRuntime.ts';
+import LegacyReading, { type NeighborhoodReadingFields, type ReadingDirection } from './Reading.ts';
+import type { ReadingValue } from './ObservedReading.ts';
 import WarpError from '../errors/WarpError.ts';
+import GraphNeighborhoodChart from './GraphNeighborhoodChart.ts';
+import GraphNeighborhoodEdge from './GraphNeighborhoodEdge.ts';
 
 export type GraphNeighborhoodOptions = {
   readonly around: string;
@@ -18,20 +13,6 @@ export type GraphNeighborhoodOptions = {
   readonly limit?: number;
   readonly cursor?: string;
 };
-
-export type GraphNeighborhoodEdge = Readonly<{
-  readonly direction: 'out' | 'in';
-  readonly neighborId: string;
-  readonly label: string;
-}> & Readonly<Record<string, ReadingValue>>;
-
-export type GraphNeighborhoodChart = Readonly<{
-  readonly subject: string;
-  readonly direction: ReadingDirection;
-  readonly edges: readonly GraphNeighborhoodEdge[];
-  readonly completeness: 'complete' | 'truncated';
-  readonly cursor: string | null;
-}> & Readonly<Record<string, ReadingValue>>;
 
 export type GraphChartObservers = Readonly<{
   neighborhood(options: GraphNeighborhoodOptions): Observer<GraphNeighborhoodChart>;
@@ -43,7 +24,7 @@ export const graph: GraphChartObservers = Object.freeze({
     return createObserver<GraphNeighborhoodChart>(
       'charts.graph.neighborhood',
       neighborhoodReading(options),
-      decodeNeighborhoodChart,
+      decodeNeighborhoodChart
     );
   },
 });
@@ -70,13 +51,13 @@ function decodeNeighborhoodChart(value: ReadingValue): GraphNeighborhoodChart {
   const edges = requireArray(rawEdges, 'chart edges').map(decodeNeighborhoodEdge);
   const completeness = requireCompleteness(rawCompleteness);
   const cursor = requireNullableString(rawCursor, 'chart cursor');
-  return Object.freeze({
+  return new GraphNeighborhoodChart({
     subject,
     direction,
-    edges: Object.freeze(edges),
+    edges,
     completeness,
     cursor,
-  }) as GraphNeighborhoodChart;
+  });
 }
 
 function decodeNeighborhoodEdge(value: ReadingValue): GraphNeighborhoodEdge {
@@ -88,16 +69,16 @@ function decodeNeighborhoodEdge(value: ReadingValue): GraphNeighborhoodEdge {
   const direction = requireEdgeDirection(rawDirection);
   const neighborId = requireString(rawNeighborId, 'chart edge neighborId');
   const label = requireString(rawLabel, 'chart edge label');
-  return Object.freeze({
+  return new GraphNeighborhoodEdge({
     direction,
     neighborId,
     label,
-  }) as GraphNeighborhoodEdge;
+  });
 }
 
 function requireRecord(
   value: ReadingValue | undefined,
-  field: string,
+  field: string
 ): Readonly<Record<string, ReadingValue>> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw chartError(`graph.neighborhood received an invalid ${field}`, 'E_CHART_VALUE');
@@ -105,10 +86,7 @@ function requireRecord(
   return value as Readonly<Record<string, ReadingValue>>;
 }
 
-function requireArray(
-  value: ReadingValue | undefined,
-  field: string,
-): readonly ReadingValue[] {
+function requireArray(value: ReadingValue | undefined, field: string): readonly ReadingValue[] {
   if (!Array.isArray(value)) {
     throw chartError(`graph.neighborhood received invalid ${field}`, 'E_CHART_VALUE');
   }
@@ -122,10 +100,7 @@ function requireString(value: ReadingValue | undefined, field: string): string {
   return value;
 }
 
-function requireNullableString(
-  value: ReadingValue | undefined,
-  field: string,
-): string | null {
+function requireNullableString(value: ReadingValue | undefined, field: string): string | null {
   if (value !== null && typeof value !== 'string') {
     throw chartError(`graph.neighborhood received invalid ${field}`, 'E_CHART_VALUE');
   }
@@ -146,9 +121,7 @@ function requireEdgeDirection(value: ReadingValue | undefined): 'out' | 'in' {
   return value;
 }
 
-function requireCompleteness(
-  value: ReadingValue | undefined,
-): 'complete' | 'truncated' {
+function requireCompleteness(value: ReadingValue | undefined): 'complete' | 'truncated' {
   if (value !== 'complete' && value !== 'truncated') {
     throw chartError('graph.neighborhood received invalid chart completeness', 'E_CHART_VALUE');
   }

--- a/src/domain/api/GraphChartObservers.ts
+++ b/src/domain/api/GraphChartObservers.ts
@@ -1,0 +1,160 @@
+import type Observer from './Observer.ts';
+import {
+  createObserver,
+} from './ObserverRuntime.ts';
+import LegacyReading, {
+  type NeighborhoodReadingFields,
+  type ReadingDirection,
+} from './Reading.ts';
+import type {
+  ReadingValue,
+} from './ObservedReading.ts';
+import WarpError from '../errors/WarpError.ts';
+
+export type GraphNeighborhoodOptions = {
+  readonly around: string;
+  readonly direction?: ReadingDirection;
+  readonly labels?: readonly string[];
+  readonly limit?: number;
+  readonly cursor?: string;
+};
+
+export type GraphNeighborhoodEdge = Readonly<{
+  readonly direction: 'out' | 'in';
+  readonly neighborId: string;
+  readonly label: string;
+}> & Readonly<Record<string, ReadingValue>>;
+
+export type GraphNeighborhoodChart = Readonly<{
+  readonly subject: string;
+  readonly direction: ReadingDirection;
+  readonly edges: readonly GraphNeighborhoodEdge[];
+  readonly completeness: 'complete' | 'truncated';
+  readonly cursor: string | null;
+}> & Readonly<Record<string, ReadingValue>>;
+
+export type GraphChartObservers = Readonly<{
+  neighborhood(options: GraphNeighborhoodOptions): Observer<GraphNeighborhoodChart>;
+}>;
+
+/** Bounded, graph-shaped derived observers. */
+export const graph: GraphChartObservers = Object.freeze({
+  neighborhood(options: GraphNeighborhoodOptions): Observer<GraphNeighborhoodChart> {
+    return createObserver<GraphNeighborhoodChart>(
+      'charts.graph.neighborhood',
+      neighborhoodReading(options),
+      decodeNeighborhoodChart,
+    );
+  },
+});
+
+function neighborhoodReading(options: GraphNeighborhoodOptions): LegacyReading {
+  if (options === null || options === undefined) {
+    throw chartError('graph.neighborhood options are required', 'E_CHART_OPTIONS');
+  }
+  const { around: subject, ...settings } = options;
+  const fields: NeighborhoodReadingFields = { subject, ...settings };
+  return LegacyReading.neighborhood(fields);
+}
+
+function decodeNeighborhoodChart(value: ReadingValue): GraphNeighborhoodChart {
+  const {
+    subject: rawSubject,
+    direction: rawDirection,
+    edges: rawEdges,
+    completeness: rawCompleteness,
+    cursor: rawCursor,
+  } = requireRecord(value, 'chart value');
+  const subject = requireString(rawSubject, 'chart subject');
+  const direction = requireReadingDirection(rawDirection);
+  const edges = requireArray(rawEdges, 'chart edges').map(decodeNeighborhoodEdge);
+  const completeness = requireCompleteness(rawCompleteness);
+  const cursor = requireNullableString(rawCursor, 'chart cursor');
+  return Object.freeze({
+    subject,
+    direction,
+    edges: Object.freeze(edges),
+    completeness,
+    cursor,
+  }) as GraphNeighborhoodChart;
+}
+
+function decodeNeighborhoodEdge(value: ReadingValue): GraphNeighborhoodEdge {
+  const {
+    direction: rawDirection,
+    neighborId: rawNeighborId,
+    label: rawLabel,
+  } = requireRecord(value, 'chart edge');
+  const direction = requireEdgeDirection(rawDirection);
+  const neighborId = requireString(rawNeighborId, 'chart edge neighborId');
+  const label = requireString(rawLabel, 'chart edge label');
+  return Object.freeze({
+    direction,
+    neighborId,
+    label,
+  }) as GraphNeighborhoodEdge;
+}
+
+function requireRecord(
+  value: ReadingValue | undefined,
+  field: string,
+): Readonly<Record<string, ReadingValue>> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw chartError(`graph.neighborhood received an invalid ${field}`, 'E_CHART_VALUE');
+  }
+  return value as Readonly<Record<string, ReadingValue>>;
+}
+
+function requireArray(
+  value: ReadingValue | undefined,
+  field: string,
+): readonly ReadingValue[] {
+  if (!Array.isArray(value)) {
+    throw chartError(`graph.neighborhood received invalid ${field}`, 'E_CHART_VALUE');
+  }
+  return value as readonly ReadingValue[];
+}
+
+function requireString(value: ReadingValue | undefined, field: string): string {
+  if (typeof value !== 'string') {
+    throw chartError(`graph.neighborhood received invalid ${field}`, 'E_CHART_VALUE');
+  }
+  return value;
+}
+
+function requireNullableString(
+  value: ReadingValue | undefined,
+  field: string,
+): string | null {
+  if (value !== null && typeof value !== 'string') {
+    throw chartError(`graph.neighborhood received invalid ${field}`, 'E_CHART_VALUE');
+  }
+  return value;
+}
+
+function requireReadingDirection(value: ReadingValue | undefined): ReadingDirection {
+  if (value !== 'out' && value !== 'in' && value !== 'both') {
+    throw chartError('graph.neighborhood received invalid chart direction', 'E_CHART_VALUE');
+  }
+  return value;
+}
+
+function requireEdgeDirection(value: ReadingValue | undefined): 'out' | 'in' {
+  if (value !== 'out' && value !== 'in') {
+    throw chartError('graph.neighborhood received an invalid chart edge', 'E_CHART_VALUE');
+  }
+  return value;
+}
+
+function requireCompleteness(
+  value: ReadingValue | undefined,
+): 'complete' | 'truncated' {
+  if (value !== 'complete' && value !== 'truncated') {
+    throw chartError('graph.neighborhood received invalid chart completeness', 'E_CHART_VALUE');
+  }
+  return value;
+}
+
+function chartError(message: string, code: string): WarpError {
+  return new WarpError(message, code);
+}

--- a/src/domain/api/GraphNeighborhoodChart.ts
+++ b/src/domain/api/GraphNeighborhoodChart.ts
@@ -1,0 +1,84 @@
+import WarpError from '../errors/WarpError.ts';
+import type { ReadingDirection } from './Reading.ts';
+import type { ReadingValue } from './ReadingValue.ts';
+import { registerReadingDomainObject } from './ReadingValueRuntime.ts';
+import GraphNeighborhoodEdge from './GraphNeighborhoodEdge.ts';
+
+export type GraphNeighborhoodChartOptions = Readonly<{
+  readonly subject: string;
+  readonly direction: ReadingDirection;
+  readonly edges: readonly GraphNeighborhoodEdge[];
+  readonly completeness: 'complete' | 'truncated';
+  readonly cursor: string | null;
+}>;
+
+export default class GraphNeighborhoodChart {
+  readonly [key: string]: ReadingValue;
+  readonly subject: string;
+  readonly direction: ReadingDirection;
+  readonly edges: readonly GraphNeighborhoodEdge[];
+  readonly completeness: 'complete' | 'truncated';
+  readonly cursor: string | null;
+
+  constructor(options: GraphNeighborhoodChartOptions | null | undefined) {
+    const fields = requireGraphNeighborhoodChartOptions(options);
+    this.subject = requireChartSubject(fields.subject);
+    this.direction = requireChartDirection(fields.direction);
+    this.edges = requireChartEdges(fields.edges);
+    this.completeness = requireChartCompleteness(fields.completeness);
+    this.cursor = requireChartCursor(fields.cursor);
+    Object.freeze(this);
+    registerReadingDomainObject(this);
+  }
+}
+
+function requireGraphNeighborhoodChartOptions(
+  options: GraphNeighborhoodChartOptions | null | undefined
+): GraphNeighborhoodChartOptions {
+  if (options === null || options === undefined) {
+    throw new WarpError('GraphNeighborhoodChart options are required', 'E_CHART_VALUE_OPTIONS');
+  }
+  return options;
+}
+
+function requireChartSubject(subject: string): string {
+  if (typeof subject !== 'string') {
+    throw new WarpError('GraphNeighborhoodChart subject is invalid', 'E_CHART_VALUE_SUBJECT');
+  }
+  return subject;
+}
+
+function requireChartDirection(direction: ReadingDirection): ReadingDirection {
+  if (direction !== 'out' && direction !== 'in' && direction !== 'both') {
+    throw new WarpError('GraphNeighborhoodChart direction is invalid', 'E_CHART_VALUE_DIRECTION');
+  }
+  return direction;
+}
+
+function requireChartEdges(
+  edges: readonly GraphNeighborhoodEdge[]
+): readonly GraphNeighborhoodEdge[] {
+  if (!Array.isArray(edges) || !edges.every((edge) => edge instanceof GraphNeighborhoodEdge)) {
+    throw new WarpError('GraphNeighborhoodChart edges are invalid', 'E_CHART_VALUE_EDGES');
+  }
+  return Object.freeze([...edges]);
+}
+
+function requireChartCompleteness(
+  completeness: 'complete' | 'truncated'
+): 'complete' | 'truncated' {
+  if (completeness !== 'complete' && completeness !== 'truncated') {
+    throw new WarpError(
+      'GraphNeighborhoodChart completeness is invalid',
+      'E_CHART_VALUE_COMPLETENESS'
+    );
+  }
+  return completeness;
+}
+
+function requireChartCursor(cursor: string | null): string | null {
+  if (cursor !== null && typeof cursor !== 'string') {
+    throw new WarpError('GraphNeighborhoodChart cursor is invalid', 'E_CHART_VALUE_CURSOR');
+  }
+  return cursor;
+}

--- a/src/domain/api/GraphNeighborhoodEdge.ts
+++ b/src/domain/api/GraphNeighborhoodEdge.ts
@@ -1,0 +1,48 @@
+import WarpError from '../errors/WarpError.ts';
+import type { ReadingValue } from './ReadingValue.ts';
+import { registerReadingDomainObject } from './ReadingValueRuntime.ts';
+
+export type GraphNeighborhoodEdgeOptions = Readonly<{
+  readonly direction: 'out' | 'in';
+  readonly neighborId: string;
+  readonly label: string;
+}>;
+
+export default class GraphNeighborhoodEdge {
+  readonly [key: string]: ReadingValue;
+  readonly direction: 'out' | 'in';
+  readonly neighborId: string;
+  readonly label: string;
+
+  constructor(options: GraphNeighborhoodEdgeOptions | null | undefined) {
+    const fields = requireGraphNeighborhoodEdgeOptions(options);
+    this.direction = requireEdgeDirection(fields.direction);
+    this.neighborId = requireEdgeString(fields.neighborId, 'neighborId', 'E_CHART_EDGE_NEIGHBOR');
+    this.label = requireEdgeString(fields.label, 'label', 'E_CHART_EDGE_LABEL');
+    Object.freeze(this);
+    registerReadingDomainObject(this);
+  }
+}
+
+function requireGraphNeighborhoodEdgeOptions(
+  options: GraphNeighborhoodEdgeOptions | null | undefined
+): GraphNeighborhoodEdgeOptions {
+  if (options === null || options === undefined) {
+    throw new WarpError('GraphNeighborhoodEdge options are required', 'E_CHART_EDGE_OPTIONS');
+  }
+  return options;
+}
+
+function requireEdgeDirection(direction: 'out' | 'in'): 'out' | 'in' {
+  if (direction !== 'out' && direction !== 'in') {
+    throw new WarpError('GraphNeighborhoodEdge direction is invalid', 'E_CHART_EDGE_DIRECTION');
+  }
+  return direction;
+}
+
+function requireEdgeString(value: string, field: string, code: string): string {
+  if (typeof value !== 'string') {
+    throw new WarpError(`GraphNeighborhoodEdge ${field} is invalid`, code);
+  }
+  return value;
+}

--- a/src/domain/api/ReadingValueRuntime.ts
+++ b/src/domain/api/ReadingValueRuntime.ts
@@ -1,19 +1,40 @@
 import ImmutableBytes from '../services/snapshot/ImmutableBytes.ts';
+import WarpError from '../errors/WarpError.ts';
 import type { ReadingValue } from './ReadingValue.ts';
 
 const FORBIDDEN_READING_VALUE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const READING_DOMAIN_OBJECTS = new WeakSet<object>();
+
+export function registerReadingDomainObject<TValue extends ReadingValue & object>(
+  value: TValue
+): void {
+  if (!Object.isFrozen(value)) {
+    throw new WarpError(
+      'Reading domain objects must be frozen before registration',
+      'E_READING_DOMAIN_OBJECT_FROZEN'
+    );
+  }
+  if (!readingValueObjectEntriesAreValid(value, new WeakSet<object>())) {
+    throw new WarpError(
+      'Reading domain objects must contain snapshot-compatible data',
+      'E_READING_DOMAIN_OBJECT_VALUE'
+    );
+  }
+  READING_DOMAIN_OBJECTS.add(value);
+}
 
 export function isReadingValue<T>(value: T): value is T & ReadingValue {
   return isReadingValueWithSeen(value, new WeakSet<object>());
 }
 
-export function snapshotReadingValue<TValue extends ReadingValue>(
-  value: TValue,
-): TValue {
+export function snapshotReadingValue<TValue extends ReadingValue>(value: TValue): TValue {
   return snapshotReadingValueValue(value) as TValue;
 }
 
 function snapshotReadingValueValue(value: ReadingValue): ReadingValue {
+  if (isRegisteredReadingDomainObject(value)) {
+    return value;
+  }
   if (value instanceof Uint8Array) {
     return new ImmutableBytes(value);
   }
@@ -38,29 +59,31 @@ function snapshotReadingValueObjectOrPrimitive(value: ReadingValue): ReadingValu
 }
 
 function isReadingValueWithSeen<T>(value: T, seen: WeakSet<object>): value is T & ReadingValue {
-  return isScalarReadingValue(value)
-    || isReadingValueArray(value, seen)
-    || isReadingValueObject(value, seen);
+  return (
+    isScalarReadingValue(value) ||
+    isReadingValueArray(value, seen) ||
+    isReadingValueObject(value, seen)
+  );
 }
 
 function isScalarReadingValue<T>(
-  value: T,
+  value: T
 ): value is T & (string | number | boolean | null | Uint8Array | ImmutableBytes) {
-  return value === null
-    || isPrimitiveReadingValue(value)
-    || value instanceof Uint8Array
-    || value instanceof ImmutableBytes;
+  return (
+    value === null ||
+    isPrimitiveReadingValue(value) ||
+    value instanceof Uint8Array ||
+    value instanceof ImmutableBytes
+  );
 }
 
 function isPrimitiveReadingValue<T>(value: T): value is T & (string | number | boolean) {
-  return typeof value === 'string'
-    || typeof value === 'number'
-    || typeof value === 'boolean';
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
 }
 
 function isReadingValueArray<T>(
   value: T,
-  seen: WeakSet<object>,
+  seen: WeakSet<object>
 ): value is T & readonly ReadingValue[] {
   if (!Array.isArray(value) || seen.has(value)) {
     return false;
@@ -75,7 +98,7 @@ function isReadingValueArray<T>(
 
 function isReadingValueObject<T>(
   value: T,
-  seen: WeakSet<object>,
+  seen: WeakSet<object>
 ): value is T & { readonly [key: string]: ReadingValue } {
   if (!isReadingValueObjectCandidate(value) || seen.has(value)) {
     return false;
@@ -92,7 +115,7 @@ function isReadingValueObjectCandidate<T>(value: T): value is T & object {
   if (value === null || typeof value !== 'object') {
     return false;
   }
-  return isNonArrayPlainObject(value);
+  return isRegisteredReadingDomainObject(value) || isNonArrayPlainObject(value);
 }
 
 function readingValueObjectEntriesAreValid(value: object, seen: WeakSet<object>): boolean {
@@ -105,13 +128,12 @@ function readingValueObjectEntriesAreValid(value: object, seen: WeakSet<object>)
 }
 
 function isNonArrayPlainObject(value: object): boolean {
-  if (
-    Array.isArray(value)
-    || value instanceof Uint8Array
-    || value instanceof ImmutableBytes
-  ) {
+  if (Array.isArray(value) || value instanceof Uint8Array || value instanceof ImmutableBytes) {
     return false;
   }
-  return Object.getPrototypeOf(value) === Object.prototype
-    || Object.getPrototypeOf(value) === null;
+  return Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null;
+}
+
+function isRegisteredReadingDomainObject(value: ReadingValue | object): boolean {
+  return typeof value === 'object' && value !== null && READING_DOMAIN_OBJECTS.has(value);
 }

--- a/src/infrastructure/adapters/RuntimeHarnessHostAdapter.ts
+++ b/src/infrastructure/adapters/RuntimeHarnessHostAdapter.ts
@@ -1,0 +1,30 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Runtime from '../../application/Runtime.ts';
+import type { RuntimeHarnessHost } from '../../testing/RuntimeHarness.ts';
+import { openDefaultGitPlumbing } from './GitPlumbingRuntimeAdapter.ts';
+
+const RUNTIME_HARNESS_PREFIX = 'git-warp-runtime-';
+
+export function createDefaultRuntimeHarnessHost(): RuntimeHarnessHost {
+  return Object.freeze({
+    createRepository,
+    openRuntime: async ({ at, writer }) => await Runtime.open({ at, writer }),
+    removeRepository: async (at) => await rm(at, { recursive: true, force: true }),
+  });
+}
+
+async function createRepository(): Promise<string> {
+  const at = await mkdtemp(join(tmpdir(), RUNTIME_HARNESS_PREFIX));
+  try {
+    const plumbing = await openDefaultGitPlumbing(at);
+    await plumbing.execute({ args: ['init', '--quiet'] });
+    await plumbing.execute({ args: ['config', 'user.name', 'git-warp test harness'] });
+    await plumbing.execute({ args: ['config', 'user.email', 'git-warp-testing@invalid'] });
+    return at;
+  } catch (error) {
+    await rm(at, { recursive: true, force: true });
+    throw error;
+  }
+}

--- a/src/testing/RuntimeHarness.ts
+++ b/src/testing/RuntimeHarness.ts
@@ -1,12 +1,16 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import Runtime from '../application/Runtime.ts';
+import type Runtime from '../application/Runtime.ts';
 import WarpError from '../domain/errors/WarpError.ts';
-import { openDefaultGitPlumbing } from '../infrastructure/adapters/GitPlumbingRuntimeAdapter.ts';
 
 export type RuntimeHarnessOptions = Readonly<{
   readonly writer: string;
+}>;
+
+export type RuntimeHarnessHost = Readonly<{
+  readonly createRepository: () => Promise<string>;
+  readonly openRuntime: (
+    options: RuntimeHarnessOptions & Readonly<{ at: string }>
+  ) => Promise<Runtime>;
+  readonly removeRepository: (at: string) => Promise<void>;
 }>;
 
 export type RuntimeHarness = Readonly<{
@@ -20,32 +24,33 @@ export type RuntimeHarness = Readonly<{
  *
  * The harness writes only inside the temporary repository it creates.
  */
-export async function createRuntimeHarness(
+export async function createRuntimeHarnessWithHost(
   options: RuntimeHarnessOptions,
+  host: RuntimeHarnessHost
 ): Promise<RuntimeHarness> {
   const { writer } = requireRuntimeHarnessOptions(options);
-  const at = await mkdtemp(join(tmpdir(), 'git-warp-runtime-'));
+  const capabilities = requireRuntimeHarnessHost(host);
+  const at = await capabilities.createRepository();
   try {
-    await initializeRepository(at);
-    const runtime = await Runtime.open({ at, writer });
-    let closed = false;
+    const runtime = await capabilities.openRuntime({ at, writer });
+    let closePromise: Promise<void> | undefined;
     return Object.freeze({
       at,
       runtime,
-      close: async (): Promise<void> => {
-        if (closed) {
-          return;
+      close: (): Promise<void> => {
+        if (closePromise !== undefined) {
+          return closePromise;
         }
-        closed = true;
-        try {
-          await runtime.close();
-        } finally {
-          await rm(at, { recursive: true, force: true });
-        }
+        const attempt = closeRuntimeHarness(runtime, at, capabilities);
+        closePromise = attempt.catch((error) => {
+          closePromise = undefined;
+          throw error;
+        });
+        return closePromise;
       },
     });
   } catch (error) {
-    await rm(at, { recursive: true, force: true });
+    await capabilities.removeRepository(at);
     throw error;
   }
 }
@@ -57,9 +62,25 @@ function requireRuntimeHarnessOptions(options: RuntimeHarnessOptions): RuntimeHa
   return options;
 }
 
-async function initializeRepository(at: string): Promise<void> {
-  const plumbing = await openDefaultGitPlumbing(at);
-  await plumbing.execute({ args: ['init', '--quiet'] });
-  await plumbing.execute({ args: ['config', 'user.name', 'git-warp test harness'] });
-  await plumbing.execute({ args: ['config', 'user.email', 'git-warp-testing@invalid'] });
+function requireRuntimeHarnessHost(host: RuntimeHarnessHost): RuntimeHarnessHost {
+  if (host === null || host === undefined) {
+    throw new WarpError('Runtime harness host is required', 'E_RUNTIME_HARNESS_HOST');
+  }
+  const capabilities = [host.createRepository, host.openRuntime, host.removeRepository];
+  if (!capabilities.every((capability) => typeof capability === 'function')) {
+    throw new WarpError('Runtime harness host is invalid', 'E_RUNTIME_HARNESS_HOST');
+  }
+  return host;
+}
+
+async function closeRuntimeHarness(
+  runtime: Runtime,
+  at: string,
+  host: RuntimeHarnessHost
+): Promise<void> {
+  try {
+    await runtime.close();
+  } finally {
+    await host.removeRepository(at);
+  }
 }

--- a/src/testing/RuntimeHarness.ts
+++ b/src/testing/RuntimeHarness.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Runtime from '../application/Runtime.ts';
+import WarpError from '../domain/errors/WarpError.ts';
+import { openDefaultGitPlumbing } from '../infrastructure/adapters/GitPlumbingRuntimeAdapter.ts';
+
+export type RuntimeHarnessOptions = Readonly<{
+  readonly writer: string;
+}>;
+
+export type RuntimeHarness = Readonly<{
+  readonly at: string;
+  readonly runtime: Runtime;
+  readonly close: () => Promise<void>;
+}>;
+
+/**
+ * Creates an isolated real-Git Runtime and removes it when closed.
+ *
+ * The harness writes only inside the temporary repository it creates.
+ */
+export async function createRuntimeHarness(
+  options: RuntimeHarnessOptions,
+): Promise<RuntimeHarness> {
+  const { writer } = requireRuntimeHarnessOptions(options);
+  const at = await mkdtemp(join(tmpdir(), 'git-warp-runtime-'));
+  try {
+    await initializeRepository(at);
+    const runtime = await Runtime.open({ at, writer });
+    let closed = false;
+    return Object.freeze({
+      at,
+      runtime,
+      close: async (): Promise<void> => {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        try {
+          await runtime.close();
+        } finally {
+          await rm(at, { recursive: true, force: true });
+        }
+      },
+    });
+  } catch (error) {
+    await rm(at, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function requireRuntimeHarnessOptions(options: RuntimeHarnessOptions): RuntimeHarnessOptions {
+  if (options === null || options === undefined) {
+    throw new WarpError('Runtime harness options are required', 'E_RUNTIME_HARNESS_OPTIONS');
+  }
+  return options;
+}
+
+async function initializeRepository(at: string): Promise<void> {
+  const plumbing = await openDefaultGitPlumbing(at);
+  await plumbing.execute({ args: ['init', '--quiet'] });
+  await plumbing.execute({ args: ['config', 'user.name', 'git-warp test harness'] });
+  await plumbing.execute({ args: ['config', 'user.email', 'git-warp-testing@invalid'] });
+}

--- a/test/type-check/v19-subpaths.ts
+++ b/test/type-check/v19-subpaths.ts
@@ -8,11 +8,7 @@
 import { GitStorage, type GitStorageOptions } from '../../storage.ts';
 import { type Lane, type WriteReceipt } from '../../index.ts';
 import { captureCoordinate, Coordinate, Optic, type Witness } from '../../advanced.ts';
-import {
-  graph,
-  type GraphNeighborhoodChart,
-  type GraphNeighborhoodOptions,
-} from '../../charts.ts';
+import { graph, GraphNeighborhoodChart, type GraphNeighborhoodOptions } from '../../charts.ts';
 import {
   inspectReceipt,
   type InspectReceiptOptions,
@@ -45,6 +41,7 @@ const neighborhoodOptions: GraphNeighborhoodOptions = {
 };
 const neighborhood = lane.observe(graph.neighborhood(neighborhoodOptions));
 const chart: GraphNeighborhoodChart = (await neighborhood.one()).value;
+const isRuntimeChart: boolean = chart instanceof GraphNeighborhoodChart;
 const harnessOptions: RuntimeHarnessOptions = { writer: 'agent-1' };
 const harness: RuntimeHarness = await createRuntimeHarness(harnessOptions);
 
@@ -62,3 +59,4 @@ void inspection;
 void inspectedLane;
 void substrate;
 void chart;
+void isRuntimeChart;

--- a/test/type-check/v19-subpaths.ts
+++ b/test/type-check/v19-subpaths.ts
@@ -1,19 +1,29 @@
 /**
  * v19 explicit subpath consumer fixture -- compile-only.
  *
- * Storage, advanced, and diagnostics imports stay reachable only from their
- * named expert surfaces.
+ * Storage, advanced, charts, diagnostics, and testing imports stay reachable
+ * only from their named expert surfaces.
  */
 
 import { GitStorage, type GitStorageOptions } from '../../storage.ts';
 import { type Lane, type WriteReceipt } from '../../index.ts';
 import { captureCoordinate, Coordinate, Optic, type Witness } from '../../advanced.ts';
 import {
+  graph,
+  type GraphNeighborhoodChart,
+  type GraphNeighborhoodOptions,
+} from '../../charts.ts';
+import {
   inspectReceipt,
   type InspectReceiptOptions,
   type ReceiptInspection,
   type ReceiptSubstrateInspection,
 } from '../../diagnostics.ts';
+import {
+  createRuntimeHarness,
+  type RuntimeHarness,
+  type RuntimeHarnessOptions,
+} from '../../testing.ts';
 
 declare const gitStorageOptions: GitStorageOptions;
 
@@ -28,6 +38,15 @@ const inspectionOptions: InspectReceiptOptions = { storage: gitStorage };
 const inspection: ReceiptInspection = inspectReceipt(receipt, inspectionOptions);
 const inspectedLane: string = inspection.lane;
 const substrate: ReceiptSubstrateInspection = inspection.substrate;
+const neighborhoodOptions: GraphNeighborhoodOptions = {
+  around: 'user:alice',
+  direction: 'both',
+  limit: 100,
+};
+const neighborhood = lane.observe(graph.neighborhood(neighborhoodOptions));
+const chart: GraphNeighborhoodChart = (await neighborhood.one()).value;
+const harnessOptions: RuntimeHarnessOptions = { writer: 'agent-1' };
+const harness: RuntimeHarness = await createRuntimeHarness(harnessOptions);
 
 // @ts-expect-error diagnostics require explicit storage context.
 inspectReceipt(receipt);
@@ -36,8 +55,10 @@ inspectReceipt(receipt);
 inspection.timeline;
 
 await gitStorage.close();
+await harness.close();
 void optic;
 void witness;
 void inspection;
 void inspectedLane;
 void substrate;
+void chart;

--- a/test/unit/domain/GraphChartObservers.test.ts
+++ b/test/unit/domain/GraphChartObservers.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { graph } from '../../../charts.ts';
+import { graph, GraphNeighborhoodChart, GraphNeighborhoodEdge } from '../../../charts.ts';
 import {
   decodeObserverValue,
   requireObserverReading,
 } from '../../../src/domain/api/ObserverRuntime.ts';
+import {
+  registerReadingDomainObject,
+  snapshotReadingValue,
+} from '../../../src/domain/api/ReadingValueRuntime.ts';
 
 describe('graph chart observers', () => {
   it('builds one bounded neighborhood reading plan', () => {
@@ -32,9 +36,7 @@ describe('graph chart observers', () => {
     const value = decodeObserverValue(observer, {
       subject: 'user:alice',
       direction: 'both',
-      edges: [
-        { direction: 'out', neighborId: 'team:warp', label: 'member-of' },
-      ],
+      edges: [{ direction: 'out', neighborId: 'team:warp', label: 'member-of' }],
       completeness: 'truncated',
       cursor: 'next-page',
     });
@@ -42,33 +44,138 @@ describe('graph chart observers', () => {
     expect(value).toEqual({
       subject: 'user:alice',
       direction: 'both',
-      edges: [
-        { direction: 'out', neighborId: 'team:warp', label: 'member-of' },
-      ],
+      edges: [{ direction: 'out', neighborId: 'team:warp', label: 'member-of' }],
       completeness: 'truncated',
       cursor: 'next-page',
     });
     expect(Object.isFrozen(value)).toBe(true);
     expect(Object.isFrozen(value.edges)).toBe(true);
     expect(Object.isFrozen(value.edges[0])).toBe(true);
+    expect(value).toBeInstanceOf(GraphNeighborhoodChart);
+    expect(value.edges[0]).toBeInstanceOf(GraphNeighborhoodEdge);
+    expect(snapshotReadingValue(value)).toBe(value);
   });
 
   it('rejects malformed chart values at the Observer boundary', () => {
     const observer = graph.neighborhood({ around: 'user:alice' });
 
-    expect(() => decodeObserverValue(observer, {
-      subject: 'user:alice',
-      direction: 'sideways',
-      edges: [],
-      completeness: 'complete',
-      cursor: null,
-    })).toThrow('invalid chart direction');
-    expect(() => decodeObserverValue(observer, {
-      subject: 'user:alice',
-      direction: 'both',
-      edges: [{ direction: 'sideways', neighborId: 'team:warp', label: 'member-of' }],
-      completeness: 'complete',
-      cursor: null,
-    })).toThrow('invalid chart edge');
+    expect(() =>
+      decodeObserverValue(observer, {
+        subject: 'user:alice',
+        direction: 'sideways',
+        edges: [],
+        completeness: 'complete',
+        cursor: null,
+      })
+    ).toThrow('invalid chart direction');
+    expect(() =>
+      decodeObserverValue(observer, {
+        subject: 'user:alice',
+        direction: 'both',
+        edges: [{ direction: 'sideways', neighborId: 'team:warp', label: 'member-of' }],
+        completeness: 'complete',
+        cursor: null,
+      })
+    ).toThrow('invalid chart edge');
+  });
+
+  it('validates runtime-backed chart edges at construction', () => {
+    expect(() => new GraphNeighborhoodEdge(null)).toThrow('options are required');
+    expect(
+      () =>
+        new GraphNeighborhoodEdge({
+          direction: 'sideways',
+          neighborId: 'team:warp',
+          label: 'member-of',
+        } as never)
+    ).toThrow('direction is invalid');
+    expect(
+      () =>
+        new GraphNeighborhoodEdge({
+          direction: 'out',
+          neighborId: 42,
+          label: 'member-of',
+        } as never)
+    ).toThrow('neighborId is invalid');
+    expect(
+      () =>
+        new GraphNeighborhoodEdge({
+          direction: 'out',
+          neighborId: 'team:warp',
+          label: 42,
+        } as never)
+    ).toThrow('label is invalid');
+  });
+
+  it('validates runtime-backed neighborhood charts at construction', () => {
+    const edge = new GraphNeighborhoodEdge({
+      direction: 'out',
+      neighborId: 'team:warp',
+      label: 'member-of',
+    });
+    expect(() => new GraphNeighborhoodChart(null)).toThrow('options are required');
+    expect(
+      () =>
+        new GraphNeighborhoodChart({
+          subject: 42,
+          direction: 'both',
+          edges: [edge],
+          completeness: 'complete',
+          cursor: null,
+        } as never)
+    ).toThrow('subject is invalid');
+    expect(
+      () =>
+        new GraphNeighborhoodChart({
+          subject: 'user:alice',
+          direction: 'sideways',
+          edges: [edge],
+          completeness: 'complete',
+          cursor: null,
+        } as never)
+    ).toThrow('direction is invalid');
+    expect(
+      () =>
+        new GraphNeighborhoodChart({
+          subject: 'user:alice',
+          direction: 'both',
+          edges: [
+            Object.freeze({
+              direction: 'out',
+              neighborId: 'team:warp',
+              label: 'member-of',
+            }),
+          ],
+          completeness: 'complete',
+          cursor: null,
+        } as never)
+    ).toThrow('edges are invalid');
+    expect(
+      () =>
+        new GraphNeighborhoodChart({
+          subject: 'user:alice',
+          direction: 'both',
+          edges: [edge],
+          completeness: 'partial',
+          cursor: null,
+        } as never)
+    ).toThrow('completeness is invalid');
+    expect(
+      () =>
+        new GraphNeighborhoodChart({
+          subject: 'user:alice',
+          direction: 'both',
+          edges: [edge],
+          completeness: 'complete',
+          cursor: 42,
+        } as never)
+    ).toThrow('cursor is invalid');
+  });
+
+  it('registers only frozen snapshot-compatible domain objects', () => {
+    expect(() => registerReadingDomainObject({ value: 'mutable' })).toThrow('must be frozen');
+    expect(() =>
+      registerReadingDomainObject(Object.freeze({ value: () => undefined }) as never)
+    ).toThrow('snapshot-compatible');
   });
 });

--- a/test/unit/domain/GraphChartObservers.test.ts
+++ b/test/unit/domain/GraphChartObservers.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { graph } from '../../../charts.ts';
+import {
+  decodeObserverValue,
+  requireObserverReading,
+} from '../../../src/domain/api/ObserverRuntime.ts';
+
+describe('graph chart observers', () => {
+  it('builds one bounded neighborhood reading plan', () => {
+    const observer = graph.neighborhood({
+      around: 'user:alice',
+      direction: 'out',
+      labels: ['member-of'],
+      limit: 25,
+      cursor: 'next-page',
+    });
+
+    expect(observer.id).toBe('charts.graph.neighborhood');
+    expect(observer.cardinality).toBe('exactly-one');
+    expect(requireObserverReading(observer).descriptor).toEqual({
+      kind: 'neighborhood',
+      subject: 'user:alice',
+      direction: 'out',
+      labels: ['member-of'],
+      limit: 25,
+      cursor: 'next-page',
+    });
+  });
+
+  it('decodes the canonical graph-shaped Reading value', () => {
+    const observer = graph.neighborhood({ around: 'user:alice' });
+    const value = decodeObserverValue(observer, {
+      subject: 'user:alice',
+      direction: 'both',
+      edges: [
+        { direction: 'out', neighborId: 'team:warp', label: 'member-of' },
+      ],
+      completeness: 'truncated',
+      cursor: 'next-page',
+    });
+
+    expect(value).toEqual({
+      subject: 'user:alice',
+      direction: 'both',
+      edges: [
+        { direction: 'out', neighborId: 'team:warp', label: 'member-of' },
+      ],
+      completeness: 'truncated',
+      cursor: 'next-page',
+    });
+    expect(Object.isFrozen(value)).toBe(true);
+    expect(Object.isFrozen(value.edges)).toBe(true);
+    expect(Object.isFrozen(value.edges[0])).toBe(true);
+  });
+
+  it('rejects malformed chart values at the Observer boundary', () => {
+    const observer = graph.neighborhood({ around: 'user:alice' });
+
+    expect(() => decodeObserverValue(observer, {
+      subject: 'user:alice',
+      direction: 'sideways',
+      edges: [],
+      completeness: 'complete',
+      cursor: null,
+    })).toThrow('invalid chart direction');
+    expect(() => decodeObserverValue(observer, {
+      subject: 'user:alice',
+      direction: 'both',
+      edges: [{ direction: 'sideways', neighborId: 'team:warp', label: 'member-of' }],
+      completeness: 'complete',
+      cursor: null,
+    })).toThrow('invalid chart edge');
+  });
+});

--- a/test/unit/scripts/v19-public-api-boundary.test.ts
+++ b/test/unit/scripts/v19-public-api-boundary.test.ts
@@ -227,12 +227,14 @@ describe('v19 public API boundary', () => {
   it('keeps charts limited to bounded derived observers', () => {
     const surface = moduleSurface('charts.ts');
     expect(surface.starExports).toEqual([]);
-    expect(surface.valueExports).toEqual(['graph']);
+    expect(surface.valueExports).toEqual(
+      sorted(['GraphNeighborhoodChart', 'GraphNeighborhoodEdge', 'graph'])
+    );
     expect(surface.typeExports).toEqual(
       sorted([
         'GraphChartObservers',
-        'GraphNeighborhoodChart',
-        'GraphNeighborhoodEdge',
+        'GraphNeighborhoodChartOptions',
+        'GraphNeighborhoodEdgeOptions',
         'GraphNeighborhoodOptions',
       ])
     );
@@ -241,8 +243,12 @@ describe('v19 public API boundary', () => {
   it('keeps testing limited to the explicit Runtime harness', () => {
     const surface = moduleSurface('testing.ts');
     expect(surface.starExports).toEqual([]);
-    expect(surface.valueExports).toEqual(['createRuntimeHarness']);
-    expect(surface.typeExports).toEqual(['RuntimeHarness', 'RuntimeHarnessOptions']);
+    expect(surface.valueExports).toEqual(
+      sorted(['createRuntimeHarness', 'createRuntimeHarnessWithHost'])
+    );
+    expect(surface.typeExports).toEqual(
+      sorted(['RuntimeHarness', 'RuntimeHarnessHost', 'RuntimeHarnessOptions'])
+    );
   });
 
   it('publishes only the supported v19 subpaths', () => {

--- a/test/unit/scripts/v19-public-api-boundary.test.ts
+++ b/test/unit/scripts/v19-public-api-boundary.test.ts
@@ -224,19 +224,44 @@ describe('v19 public API boundary', () => {
     );
   });
 
+  it('keeps charts limited to bounded derived observers', () => {
+    const surface = moduleSurface('charts.ts');
+    expect(surface.starExports).toEqual([]);
+    expect(surface.valueExports).toEqual(['graph']);
+    expect(surface.typeExports).toEqual(
+      sorted([
+        'GraphChartObservers',
+        'GraphNeighborhoodChart',
+        'GraphNeighborhoodEdge',
+        'GraphNeighborhoodOptions',
+      ])
+    );
+  });
+
+  it('keeps testing limited to the explicit Runtime harness', () => {
+    const surface = moduleSurface('testing.ts');
+    expect(surface.starExports).toEqual([]);
+    expect(surface.valueExports).toEqual(['createRuntimeHarness']);
+    expect(surface.typeExports).toEqual(['RuntimeHarness', 'RuntimeHarnessOptions']);
+  });
+
   it('publishes only the supported v19 subpaths', () => {
     expect(packageExportNames('package.json')).toEqual([
       '.',
       './advanced',
+      './charts',
       './diagnostics',
       './package.json',
       './storage',
+      './testing',
     ]);
     expect(packageExportNames('jsr.json')).toEqual([
       '.',
       './advanced',
+      './charts',
       './diagnostics',
       './storage',
+      './testing',
     ]);
   });
 

--- a/test/unit/testing/RuntimeHarness.test.ts
+++ b/test/unit/testing/RuntimeHarness.test.ts
@@ -1,0 +1,30 @@
+import { stat } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { createRuntimeHarness } from '../../../testing.ts';
+
+describe('Runtime testing harness', () => {
+  it('rejects missing options before creating a repository', async () => {
+    await expect(createRuntimeHarness(null as never)).rejects.toMatchObject({
+      code: 'E_RUNTIME_HARNESS_OPTIONS',
+    });
+  });
+
+  it('opens the production Runtime boundary in a disposable repository', async () => {
+    const harness = await createRuntimeHarness({ writer: 'agent-1' });
+    const at = harness.at;
+    try {
+      expect((await stat(at)).isDirectory()).toBe(true);
+      expect(harness.runtime.writer).toBe('agent-1');
+      await expect(harness.runtime.lane('events')).resolves.toMatchObject({
+        kind: 'worldline',
+        name: 'events',
+        writer: 'agent-1',
+      });
+    } finally {
+      await harness.close();
+    }
+
+    await expect(stat(at)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(harness.close()).resolves.toBeUndefined();
+  });
+});

--- a/test/unit/testing/RuntimeHarness.test.ts
+++ b/test/unit/testing/RuntimeHarness.test.ts
@@ -1,12 +1,48 @@
 import { stat } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
-import { createRuntimeHarness } from '../../../testing.ts';
+import {
+  createRuntimeHarness,
+  createRuntimeHarnessWithHost,
+  type RuntimeHarnessHost,
+} from '../../../testing.ts';
+import { createDefaultRuntimeHarnessHost } from '../../../src/infrastructure/adapters/RuntimeHarnessHostAdapter.ts';
 
 describe('Runtime testing harness', () => {
   it('rejects missing options before creating a repository', async () => {
     await expect(createRuntimeHarness(null as never)).rejects.toMatchObject({
       code: 'E_RUNTIME_HARNESS_OPTIONS',
     });
+  });
+
+  it('rejects a missing host before creating a repository', async () => {
+    await expect(
+      createRuntimeHarnessWithHost({ writer: 'agent-1' }, null as never)
+    ).rejects.toMatchObject({
+      code: 'E_RUNTIME_HARNESS_HOST',
+    });
+    await expect(
+      createRuntimeHarnessWithHost({ writer: 'agent-1' }, Object.freeze({}) as never)
+    ).rejects.toMatchObject({
+      code: 'E_RUNTIME_HARNESS_HOST',
+    });
+  });
+
+  it('removes the repository when Runtime creation fails', async () => {
+    let removed = false;
+    const host: RuntimeHarnessHost = Object.freeze({
+      createRepository: async () => '/tmp/git-warp-runtime-failed-open',
+      openRuntime: async () => {
+        throw new Error('open failed');
+      },
+      removeRepository: async () => {
+        removed = true;
+      },
+    });
+
+    await expect(createRuntimeHarnessWithHost({ writer: 'agent-1' }, host)).rejects.toThrow(
+      'open failed'
+    );
+    expect(removed).toBe(true);
   });
 
   it('opens the production Runtime boundary in a disposable repository', async () => {
@@ -26,5 +62,30 @@ describe('Runtime testing harness', () => {
 
     await expect(stat(at)).rejects.toMatchObject({ code: 'ENOENT' });
     await expect(harness.close()).resolves.toBeUndefined();
+  });
+
+  it('retries cleanup after a transient host failure', async () => {
+    const defaultHost = createDefaultRuntimeHarnessHost();
+    let removalAttempts = 0;
+    const host: RuntimeHarnessHost = Object.freeze({
+      ...defaultHost,
+      removeRepository: async (at): Promise<void> => {
+        removalAttempts += 1;
+        if (removalAttempts === 1) {
+          throw new Error('transient cleanup failure');
+        }
+        await defaultHost.removeRepository(at);
+      },
+    });
+    const harness = await createRuntimeHarnessWithHost({ writer: 'agent-1' }, host);
+    const at = harness.at;
+
+    await expect(harness.close()).rejects.toThrow('transient cleanup failure');
+    expect(removalAttempts).toBe(1);
+    await expect(stat(at)).resolves.toMatchObject({});
+
+    await expect(harness.close()).resolves.toBeUndefined();
+    expect(removalAttempts).toBe(2);
+    await expect(stat(at)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 });

--- a/testing.ts
+++ b/testing.ts
@@ -5,8 +5,24 @@
  * the same production composition boundary as `Runtime.open()`.
  */
 
-export { createRuntimeHarness } from './src/testing/RuntimeHarness.ts';
+import { createDefaultRuntimeHarnessHost } from './src/infrastructure/adapters/RuntimeHarnessHostAdapter.ts';
+import {
+  createRuntimeHarnessWithHost,
+  type RuntimeHarness,
+  type RuntimeHarnessOptions,
+} from './src/testing/RuntimeHarness.ts';
+
+const DEFAULT_RUNTIME_HARNESS_HOST = createDefaultRuntimeHarnessHost();
+
+export async function createRuntimeHarness(
+  options: RuntimeHarnessOptions
+): Promise<RuntimeHarness> {
+  return await createRuntimeHarnessWithHost(options, DEFAULT_RUNTIME_HARNESS_HOST);
+}
+
+export { createRuntimeHarnessWithHost };
 export type {
   RuntimeHarness,
+  RuntimeHarnessHost,
   RuntimeHarnessOptions,
 } from './src/testing/RuntimeHarness.ts';

--- a/testing.ts
+++ b/testing.ts
@@ -1,0 +1,12 @@
+/**
+ * Explicit Runtime testing support.
+ *
+ * The harness uses a disposable real Git repository so consumer tests exercise
+ * the same production composition boundary as `Runtime.open()`.
+ */
+
+export { createRuntimeHarness } from './src/testing/RuntimeHarness.ts';
+export type {
+  RuntimeHarness,
+  RuntimeHarnessOptions,
+} from './src/testing/RuntimeHarness.ts';

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -13,6 +13,8 @@
     "storage.ts",
     "advanced.ts",
     "diagnostics.ts",
+    "charts.ts",
+    "testing.ts",
     "src/**/*.ts",
     "src/globals.d.ts",
     "bin/**/*.ts",

--- a/tsconfig.src.json
+++ b/tsconfig.src.json
@@ -5,6 +5,8 @@
     "storage.ts",
     "advanced.ts",
     "diagnostics.ts",
+    "charts.ts",
+    "testing.ts",
     "src/**/*.ts",
     "src/globals.d.ts",
     "bin/warp-graph.ts",


### PR DESCRIPTION
## Summary

- Publish bounded `/charts` observers and the disposable real-Git `/testing` runtime harness.
- Keep npm and JSR exports, docs, ownership policy, and consumer declarations in sync.

## Issue

Refs #712

## Test plan

- Stable suite: 7,146 passed, 2 skipped.
- Exact coverage: 7,326 passed, 2 skipped; 92.95% lines.
- Pre-push, source/consumer typechecks, package boundaries, docs, lint, and package dry-run passed.

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] If this PR touches persisted op formats, I linked the ADR 3 readiness issue
- [x] If this PR touches wire compatibility, I confirmed canonical-only ops are still rejected on the wire pre-cutover
- [x] If this PR touches schema constants, I confirmed patch and checkpoint namespaces remain distinct
