### PR TITLE
Add runtime-backed strand forks

### DIFF
--- a/docs/topics/reference.md
+++ b/docs/topics/reference.md
@@ -39,33 +39,34 @@ Runtime @ index.ts#L13
 
 ### Type exports
 
-Source: `index.ts`. Count: 24.
+Source: `index.ts`. Count: 25.
 
 ```text
-AdmissionOutcome @ index.ts#L38
-CoordinateReference @ index.ts#L19
-Evidence @ index.ts#L15
-EvidenceHandle @ index.ts#L15
-Intent @ index.ts#L16
-Lane @ index.ts#L17
-LaneDescriptor @ index.ts#L20
-LaneKind @ index.ts#L21
-LaneReference @ index.ts#L22
-Observation @ index.ts#L24
-ObservationReceipt @ index.ts#L25
-ObservationStatus @ index.ts#L26
-Observer @ index.ts#L27
-ObserverCardinality @ index.ts#L28
-Reading @ index.ts#L29
-ReadingCoordinate @ index.ts#L31
-ReadingValue @ index.ts#L32
-Receipt @ index.ts#L39
-RepairHint @ index.ts#L40
-RuntimeOpenOptions @ index.ts#L14
-SupportReport @ index.ts#L33
-Tick @ index.ts#L36
-WitnessReference @ index.ts#L34
-WriteReceipt @ index.ts#L37
+AdmissionOutcome @ index.ts#L41
+CoordinateReference @ index.ts#L22
+Evidence @ index.ts#L18
+EvidenceHandle @ index.ts#L18
+Intent @ index.ts#L19
+Lane @ index.ts#L20
+LaneDescriptor @ index.ts#L23
+LaneKind @ index.ts#L24
+LaneReference @ index.ts#L25
+Observation @ index.ts#L27
+ObservationReceipt @ index.ts#L28
+ObservationStatus @ index.ts#L29
+Observer @ index.ts#L30
+ObserverCardinality @ index.ts#L31
+Reading @ index.ts#L32
+ReadingCoordinate @ index.ts#L34
+ReadingValue @ index.ts#L35
+Receipt @ index.ts#L42
+RepairHint @ index.ts#L43
+RuntimeForkOptions @ index.ts#L15
+RuntimeOpenOptions @ index.ts#L16
+SupportReport @ index.ts#L36
+Tick @ index.ts#L39
+WitnessReference @ index.ts#L37
+WriteReceipt @ index.ts#L40
 ```
 
 ## Storage export surface

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,10 @@
  */
 
 export { default as Runtime } from './src/application/Runtime.ts';
-export type { RuntimeOpenOptions } from './src/application/Runtime.ts';
+export type {
+  RuntimeForkOptions,
+  RuntimeOpenOptions,
+} from './src/application/Runtime.ts';
 export type { default as Evidence, EvidenceHandle } from './src/domain/api/Evidence.ts';
 export type { default as Intent } from './src/domain/api/Intent.ts';
 export type { default as Lane } from './src/domain/api/Lane.ts';

--- a/src/application/Runtime.ts
+++ b/src/application/Runtime.ts
@@ -80,7 +80,12 @@ export default class Runtime {
     assertTimelineNameIdentity(options.name, 'fork.name', FORK_IDENTITY_FAILURE);
     const binding = requireOwnedLaneRuntime(source, this.#laneOwner);
     const fork = requireWorldlineFork(source, binding);
-    return await this.#activity.run(async () => await fork(options.name));
+    const lease = this.#activity.acquire();
+    try {
+      return await fork(options.name);
+    } finally {
+      lease.release();
+    }
   }
 
   /** Releases local resources only. */

--- a/src/application/Runtime.ts
+++ b/src/application/Runtime.ts
@@ -1,5 +1,9 @@
-import type Lane from '../domain/api/Lane.ts';
+import Lane from '../domain/api/Lane.ts';
 import { LANE_IDENTITY_FAILURE } from '../domain/api/LaneIdentityFailure.ts';
+import {
+  requireLaneRuntime,
+  type LaneRuntime,
+} from '../domain/api/LaneRuntime.ts';
 import type Warp from '../domain/api/Warp.ts';
 import { OPEN_WARP_IDENTITY_FAILURE } from '../domain/api/OpenWarpIdentityFailure.ts';
 import { assertTimelineNameIdentity, assertWriterIdentity } from '../domain/api/assertIdentity.ts';
@@ -15,9 +19,19 @@ export type RuntimeOpenOptions = {
   readonly writer: string;
 };
 
+export type RuntimeForkOptions = {
+  readonly name: string;
+};
+
+const FORK_IDENTITY_FAILURE = Object.freeze({
+  message: 'Runtime.fork requires a non-empty strand name',
+  code: 'E_RUNTIME_FORK_IDENTITY',
+});
+
 /** Production composition root for one local git-warp runtime. */
 export default class Runtime {
   readonly #activity: RuntimeActivity;
+  readonly #laneOwner: object;
   readonly #storage: GitStorage;
   readonly #warp: Warp;
 
@@ -25,6 +39,7 @@ export default class Runtime {
     this.#warp = warp;
     this.#storage = storage;
     this.#activity = new RuntimeActivity();
+    this.#laneOwner = Object.freeze({});
     Object.freeze(this);
   }
 
@@ -55,8 +70,17 @@ export default class Runtime {
     assertTimelineNameIdentity(name, 'lane', LANE_IDENTITY_FAILURE);
     return await this.#activity.run(async () => {
       const timeline = await this.#warp.timeline(name);
-      return createWorldlineLane(timeline, this.#activity);
+      return createWorldlineLane(timeline, this.#activity, this.#laneOwner);
     });
+  }
+
+  async fork(source: Lane, options: RuntimeForkOptions): Promise<Lane> {
+    assertForkSource(source);
+    assertForkOptions(options);
+    assertTimelineNameIdentity(options.name, 'fork.name', FORK_IDENTITY_FAILURE);
+    const binding = requireOwnedLaneRuntime(source, this.#laneOwner);
+    const fork = requireWorldlineFork(source, binding);
+    return await this.#activity.run(async () => await fork(options.name));
   }
 
   /** Releases local resources only. */
@@ -67,6 +91,43 @@ export default class Runtime {
   async [Symbol.asyncDispose](): Promise<void> {
     await this.close();
   }
+}
+
+function assertForkSource(source: Lane): void {
+  if (!(source instanceof Lane)) {
+    throw new WarpError('Runtime.fork requires a Lane', 'E_RUNTIME_FORK_SOURCE');
+  }
+}
+
+function assertForkOptions(options: RuntimeForkOptions): void {
+  if (options === null || typeof options !== 'object' || Array.isArray(options)) {
+    throw new WarpError('Runtime.fork options are required', 'E_RUNTIME_FORK_OPTIONS');
+  }
+}
+
+function requireOwnedLaneRuntime(source: Lane, owner: object): LaneRuntime {
+  const binding = requireLaneRuntime(source);
+  if (binding.owner !== owner) {
+    throw new WarpError(
+      'Runtime.fork requires a Lane owned by this Runtime',
+      'E_RUNTIME_FORK_FOREIGN_LANE',
+    );
+  }
+  return binding;
+}
+
+function requireWorldlineFork(
+  source: Lane,
+  binding: LaneRuntime,
+): NonNullable<LaneRuntime['fork']> {
+  if (source.kind !== 'worldline' || binding.fork === null) {
+    throw new WarpError(
+      'Runtime.fork supports worldline Lane sources only',
+      'E_RUNTIME_FORK_SOURCE_KIND',
+      { context: { kind: source.kind } },
+    );
+  }
+  return binding.fork;
 }
 
 function assertRuntimeOpenOptions(

--- a/src/application/RuntimeLaneAdapter.ts
+++ b/src/application/RuntimeLaneAdapter.ts
@@ -4,6 +4,7 @@ import {
   createDraftReadingTarget,
   createDraftTimeline,
 } from '../domain/api/DraftTimelineRuntime.ts';
+import type { DraftReadingTarget } from '../domain/api/DraftReadingTarget.ts';
 import type Timeline from '../domain/api/Timeline.ts';
 import type TimelineView from '../domain/api/TimelineView.ts';
 import {
@@ -41,6 +42,12 @@ type ObservationLane = Readonly<{
   readonly name: string;
   readonly writer: string;
 }>;
+type WorldlineLaneSource = Readonly<{
+  readonly activity: RuntimeActivity;
+  readonly owner: object;
+  readonly parent: Readonly<{ readonly kind: 'worldline'; readonly name: string }>;
+  readonly timeline: Timeline;
+}>;
 type ReadingStreamOutcome =
   | Readonly<{ kind: 'completed'; receipt: ReadReceipt | null }>
   | Readonly<{ kind: 'settled' }>;
@@ -72,11 +79,17 @@ function bindWorldlineLaneRuntime(options: {
   readonly parent: Readonly<{ readonly kind: 'worldline'; readonly name: string }>;
   readonly timeline: Timeline;
 }): void {
+  const source: WorldlineLaneSource = Object.freeze({
+    activity: options.activity,
+    owner: options.owner,
+    parent: options.parent,
+    timeline: options.timeline,
+  });
   bindLaneRuntime(options.lane, {
     captureCoordinate: async () =>
-      await captureWorldlineCoordinate(options.timeline, options.activity),
-    fork: async (name) => await forkWorldlineLane(options, name),
-    owner: options.owner,
+      await captureWorldlineCoordinate(source.timeline, source.activity),
+    fork: async (name) => await forkWorldlineLane(source, name),
+    owner: source.owner,
   });
 }
 
@@ -92,25 +105,27 @@ async function captureWorldlineCoordinate(
 }
 
 async function forkWorldlineLane(
-  options: Parameters<typeof bindWorldlineLaneRuntime>[0],
+  options: WorldlineLaneSource,
   name: string,
 ): Promise<Lane> {
-  const runtime = requireTimelineRuntime(options.timeline);
-  const context = requireTimelineContext(options.timeline);
-  const tick = await createForkTick(runtime, context);
-  const draft = await createDraftTimeline({
-    runtime,
-    context,
-    timelineName: options.timeline.name,
-    draftName: name,
-    forkedAt: requireTickCoordinate(runtime, tick),
-  });
-  return createStrandLane({
-    activity: options.activity,
-    draft,
-    forkedAt: Object.freeze({ id: tick.id, lane: options.parent }),
-    owner: options.owner,
-    parent: options.parent,
+  return await options.activity.run(async () => {
+    const runtime = requireTimelineRuntime(options.timeline);
+    const context = requireTimelineContext(options.timeline);
+    const tick = await createForkTick(runtime, context);
+    const draft = await createDraftTimeline({
+      runtime,
+      context,
+      timelineName: options.timeline.name,
+      draftName: name,
+      forkedAt: requireTickCoordinate(runtime, tick),
+    });
+    return createStrandLane({
+      activity: options.activity,
+      draft,
+      forkedAt: Object.freeze({ id: tick.id, lane: options.parent }),
+      owner: options.owner,
+      parent: options.parent,
+    });
   });
 }
 
@@ -189,7 +204,7 @@ async function startStrandObserver<TValue extends ReadingValue>(
 ): Promise<ObservationExecution<TValue>> {
   const lease = activity.acquire();
   try {
-    const target = await createDraftReadingTarget(draft);
+    const target: DraftReadingTarget = await createDraftReadingTarget(draft);
     const settlement = createReceiptSettlement();
     return Object.freeze({
       readings: WarpStream.from(streamReadings({

--- a/src/application/RuntimeLaneAdapter.ts
+++ b/src/application/RuntimeLaneAdapter.ts
@@ -1,7 +1,15 @@
 import type ReadingResult from '../domain/api/ReadingResult.ts';
+import type DraftTimeline from '../domain/api/DraftTimeline.ts';
+import {
+  createDraftReadingTarget,
+  createDraftTimeline,
+} from '../domain/api/DraftTimelineRuntime.ts';
 import type Timeline from '../domain/api/Timeline.ts';
 import type TimelineView from '../domain/api/TimelineView.ts';
-import { requireTimelineRuntime } from '../domain/api/TimelineRuntime.ts';
+import {
+  requireTimelineContext,
+  requireTimelineRuntime,
+} from '../domain/api/TimelineRuntime.ts';
 import Lane from '../domain/api/Lane.ts';
 import { bindLaneRuntime } from '../domain/api/LaneRuntime.ts';
 import type { ObservationExecution } from '../domain/api/Observation.ts';
@@ -14,6 +22,10 @@ import ObservationReceipt from '../domain/api/ObservationReceipt.ts';
 import Reading, { type ReadingValue } from '../domain/api/ObservedReading.ts';
 import type ReadReceipt from '../domain/api/ReadReceipt.ts';
 import type Tick from '../domain/api/Tick.ts';
+import {
+  createForkTick,
+  requireTickCoordinate,
+} from '../domain/api/TickRuntime.ts';
 import WarpError from '../domain/errors/WarpError.ts';
 import WarpStream from '../domain/stream/WarpStream.ts';
 import type RuntimeActivity from './RuntimeActivity.ts';
@@ -25,6 +37,10 @@ type ReceiptSettlement = Readonly<{
   resolve(receipt: ObservationReceipt): void;
 }>;
 type ReadTarget = Pick<Timeline, 'read'> | Pick<TimelineView, 'read'>;
+type ObservationLane = Readonly<{
+  readonly name: string;
+  readonly writer: string;
+}>;
 type ReadingStreamOutcome =
   | Readonly<{ kind: 'completed'; receipt: ReadReceipt | null }>
   | Readonly<{ kind: 'settled' }>;
@@ -32,6 +48,7 @@ type ReadingStreamOutcome =
 export function createWorldlineLane(
   timeline: Timeline,
   activity: RuntimeActivity,
+  owner: object = Object.freeze({}),
 ): Lane {
   const lane = new Lane({
     descriptor: { kind: 'worldline', name: timeline.name },
@@ -40,14 +57,102 @@ export function createWorldlineLane(
     startObserver: <TValue extends ReadingValue>(observer: Observer<TValue>) =>
       startObserver(timeline, observer, activity),
   });
-  bindLaneRuntime(lane, {
-    captureCoordinate: async () => await activity.run(async () => {
-      const runtime = requireTimelineRuntime(timeline);
-      await runtime.prepareOpticBasis();
-      return await runtime.coordinate();
-    }),
+  const parent = Object.freeze({
+    kind: 'worldline' as const,
+    name: timeline.name,
   });
+  bindWorldlineLaneRuntime({ activity, lane, owner, parent, timeline });
   return lane;
+}
+
+function bindWorldlineLaneRuntime(options: {
+  readonly activity: RuntimeActivity;
+  readonly lane: Lane;
+  readonly owner: object;
+  readonly parent: Readonly<{ readonly kind: 'worldline'; readonly name: string }>;
+  readonly timeline: Timeline;
+}): void {
+  bindLaneRuntime(options.lane, {
+    captureCoordinate: async () =>
+      await captureWorldlineCoordinate(options.timeline, options.activity),
+    fork: async (name) => await forkWorldlineLane(options, name),
+    owner: options.owner,
+  });
+}
+
+async function captureWorldlineCoordinate(
+  timeline: Timeline,
+  activity: RuntimeActivity,
+) {
+  return await activity.run(async () => {
+    const runtime = requireTimelineRuntime(timeline);
+    await runtime.prepareOpticBasis();
+    return await runtime.coordinate();
+  });
+}
+
+async function forkWorldlineLane(
+  options: Parameters<typeof bindWorldlineLaneRuntime>[0],
+  name: string,
+): Promise<Lane> {
+  const runtime = requireTimelineRuntime(options.timeline);
+  const context = requireTimelineContext(options.timeline);
+  const tick = await createForkTick(runtime, context);
+  const draft = await createDraftTimeline({
+    runtime,
+    context,
+    timelineName: options.timeline.name,
+    draftName: name,
+    forkedAt: requireTickCoordinate(runtime, tick),
+  });
+  return createStrandLane({
+    activity: options.activity,
+    draft,
+    forkedAt: Object.freeze({ id: tick.id, lane: options.parent }),
+    owner: options.owner,
+    parent: options.parent,
+  });
+}
+
+function createStrandLane(options: {
+  readonly activity: RuntimeActivity;
+  readonly draft: DraftTimeline;
+  readonly forkedAt: Readonly<{
+    readonly id: string;
+    readonly lane: Readonly<{ readonly kind: 'worldline'; readonly name: string }>;
+  }>;
+  readonly owner: object;
+  readonly parent: Readonly<{ readonly kind: 'worldline'; readonly name: string }>;
+}): Lane {
+  const { activity, draft } = options;
+  const lane = new Lane({
+    descriptor: {
+      kind: 'strand',
+      name: draft.name,
+      parent: options.parent,
+      forkedAt: options.forkedAt,
+    },
+    writer: draft.writer,
+    writeIntent: async (intent) => await activity.run(async () => await draft.write(intent)),
+    startObserver: <TValue extends ReadingValue>(observer: Observer<TValue>) =>
+      startStrandObserver(draft, observer, activity),
+  });
+  bindStrandLaneRuntime(lane, options.owner);
+  return lane;
+}
+
+function bindStrandLaneRuntime(lane: Lane, owner: object): void {
+  bindLaneRuntime(lane, {
+    captureCoordinate: () => Promise.reject(
+      new WarpError(
+        'Strand Lane coordinates are not supported by captureCoordinate',
+        'E_LANE_COORDINATE_KIND',
+        { context: { kind: lane.kind } },
+      ),
+    ),
+    fork: null,
+    owner,
+  });
 }
 
 async function startObserver<TValue extends ReadingValue>(
@@ -77,6 +182,32 @@ async function startObserver<TValue extends ReadingValue>(
   }
 }
 
+async function startStrandObserver<TValue extends ReadingValue>(
+  draft: DraftTimeline,
+  observer: Observer<TValue>,
+  activity: RuntimeActivity,
+): Promise<ObservationExecution<TValue>> {
+  const lease = activity.acquire();
+  try {
+    const target = await createDraftReadingTarget(draft);
+    const settlement = createReceiptSettlement();
+    return Object.freeze({
+      readings: WarpStream.from(streamReadings({
+        lease,
+        observer,
+        settlement,
+        tick: target.tick,
+        timeline: draft,
+        target,
+      })),
+      receipt: settlement.promise,
+    });
+  } catch (error) {
+    lease.release();
+    throw error;
+  }
+}
+
 async function prepareBoundedBasis(timeline: Timeline): Promise<boolean> {
   try {
     await requireTimelineRuntime(timeline).prepareOpticBasis();
@@ -96,7 +227,7 @@ async function* streamReadings<TValue extends ReadingValue>(options: {
   readonly settlement: ReceiptSettlement;
   readonly target: ReadTarget;
   readonly tick: Tick | null;
-  readonly timeline: Timeline;
+  readonly timeline: ObservationLane;
 }): AsyncIterable<Reading<TValue>> {
   let completed = false;
   try {
@@ -117,7 +248,7 @@ async function* acceptedReadings<TValue extends ReadingValue>(options: {
   readonly observer: Observer<TValue>;
   readonly settlement: ReceiptSettlement;
   readonly target: ReadTarget;
-  readonly timeline: Timeline;
+  readonly timeline: ObservationLane;
 }): AsyncGenerator<Reading<TValue>, ReadingStreamOutcome> {
   let lastReceipt: ReadReceipt | null = null;
   for await (const plan of observerReadings(options.observer)) {
@@ -140,7 +271,7 @@ function completeReadingStream<TValue extends ReadingValue>(
     readonly observer: Observer<TValue>;
     readonly settlement: ReceiptSettlement;
     readonly tick: Tick | null;
-    readonly timeline: Timeline;
+    readonly timeline: ObservationLane;
   },
   outcome: ReadingStreamOutcome,
 ): void {
@@ -157,7 +288,7 @@ function finishReadingStream<TValue extends ReadingValue>(
     readonly observer: Observer<TValue>;
     readonly settlement: ReceiptSettlement;
     readonly tick: Tick | null;
-    readonly timeline: Timeline;
+    readonly timeline: ObservationLane;
   },
   completed: boolean,
 ): void {
@@ -199,7 +330,7 @@ function readingFrom<TValue extends ReadingValue>(
 }
 
 function emptyObservationReceipt(
-  timeline: Timeline,
+  timeline: ObservationLane,
   observer: Observer,
   tick: Tick | null,
 ): ObservationReceipt {
@@ -216,7 +347,7 @@ function emptyObservationReceipt(
 }
 
 function cancelledObservationReceipt(
-  timeline: Timeline,
+  timeline: ObservationLane,
   observer: Observer,
   tick: Tick | null,
 ): ObservationReceipt {
@@ -233,7 +364,7 @@ function cancelledObservationReceipt(
 }
 
 function missingBasisObservationReceipt(
-  timeline: Timeline,
+  timeline: ObservationLane,
   observer: Observer,
 ): ObservationReceipt {
   return new ObservationReceipt({
@@ -258,7 +389,7 @@ function tickEvidence(tick: Tick): {
 }
 
 function observationReceiptFrom(
-  timeline: Timeline,
+  timeline: ObservationLane,
   observer: Observer,
   receipt: ReadReceipt,
 ): ObservationReceipt {
@@ -281,7 +412,7 @@ function observationReceiptFrom(
 }
 
 function completedObservationReceipt(
-  timeline: Timeline,
+  timeline: ObservationLane,
   observer: Observer,
   receipt: ReadReceipt,
 ): ObservationReceipt {
@@ -310,7 +441,7 @@ function unresolvedObservationReceipt(options: {
   readonly observer: Observer;
   readonly receipt: ReadReceipt;
   readonly status: 'obstructed' | 'underdetermined';
-  readonly timeline: Timeline;
+  readonly timeline: ObservationLane;
 }): ObservationReceipt {
   const { observer, receipt, status, timeline } = options;
   const fields = {

--- a/src/domain/WarpStrandOpticBasis.ts
+++ b/src/domain/WarpStrandOpticBasis.ts
@@ -1,0 +1,10 @@
+import type WorldlineOptic from './services/optic/WorldlineOptic.ts';
+
+export type WarpStrandOpticBasis = Readonly<{
+  readonly checkpointSha: string;
+  readonly frontierEntries: readonly Readonly<{
+    readonly patchSha: string;
+    readonly writerId: string;
+  }>[];
+  readonly optic: WorldlineOptic;
+}>;

--- a/src/domain/WarpWorldline.ts
+++ b/src/domain/WarpWorldline.ts
@@ -15,8 +15,9 @@ import type { Aperture } from './types/Aperture.ts';
 import type { PatchBuilder } from './services/PatchBuilder.ts';
 import type ProjectionHandle from './services/ProjectionHandle.ts';
 import type Observer from './services/query/Observer.ts';
-import type WorldlineOptic from './services/optic/WorldlineOptic.ts';
+import WorldlineOptic from './services/optic/WorldlineOptic.ts';
 import CheckpointTailBasisVerifier from './services/optic/CheckpointTailBasisVerifier.ts';
+import CoordinateCheckpointTailOpticSource from './services/optic/CoordinateCheckpointTailOpticSource.ts';
 import createBoundedMemoryCapabilityReport from './memory/createBoundedMemoryCapabilityReport.ts';
 import type { IntentAdmissionReceipt } from './admission/IntentAdmissionReceipt.ts';
 import type { WarpIntentDescriptor } from './types/WarpIntentDescriptor.ts';
@@ -33,7 +34,10 @@ export type WarpWorldlinePatchBuild = (
 
 type CommitPatch = (build: WarpWorldlinePatchBuild) => Promise<string>;
 type CommitPatchWithEvidence = (build: WarpWorldlinePatchBuild) => Promise<PatchCommitResult>;
-type CreateDraft = (name: string) => Promise<void>;
+type CreateDraft = (
+  name: string,
+  coordinate?: WarpWorldlineCoordinate,
+) => Promise<void>;
 type WorldlineOptions = Parameters<ProjectionHandle['seek']>[0];
 type CreateWorldline = (options?: WorldlineOptions) => ProjectionHandle;
 type PatchDraft = (name: string, build: WarpWorldlinePatchBuild) => Promise<string>;
@@ -44,14 +48,32 @@ type PatchDraftWithEvidence = (
 type PreviewDraftJoin = (name: string) => Promise<readonly string[]>;
 type RuntimeGraph = Awaited<ReturnType<typeof openRuntimeHostProduct>>;
 type PrepareOpticBasis = () => Promise<WarpWorldlineOpticBasis>;
+type PrepareForkOpticBasis = () => Promise<WarpWorldlineOpticBasis>;
 type DraftWorldlineOptions = Pick<
   WarpWorldlineConstructionOptions,
-  'createDraft' | 'patchDraft' | 'patchDraftWithEvidence' | 'previewDraftJoin'
+  | 'createDraft'
+  | 'patchDraft'
+  | 'patchDraftWithEvidence'
+  | 'prepareStrandOptic'
+  | 'previewDraftJoin'
 >;
 type GetFrontier = () => Promise<Map<string, string>>;
 type ReadOpticBasis = () => WarpWorldlineOpticBasis | null;
 type ReadCapabilities = typeof createBoundedMemoryCapabilityReport;
 type AdmitIntent = (descriptor: WarpIntentDescriptor) => Promise<IntentAdmissionReceipt>;
+type PrepareStrandOptic = (
+  name: string,
+  checkpointSha: string,
+) => Promise<WarpStrandOpticBasis>;
+
+export type WarpStrandOpticBasis = Readonly<{
+  readonly checkpointSha: string;
+  readonly frontierEntries: readonly Readonly<{
+    readonly patchSha: string;
+    readonly writerId: string;
+  }>[];
+  readonly optic: WorldlineOptic;
+}>;
 
 type WarpWorldlineConstructionOptions = {
   readonly worldlineName: string;
@@ -63,7 +85,9 @@ type WarpWorldlineConstructionOptions = {
   readonly patchDraft?: PatchDraft;
   readonly patchDraftWithEvidence?: PatchDraftWithEvidence;
   readonly previewDraftJoin?: PreviewDraftJoin;
+  readonly prepareStrandOptic?: PrepareStrandOptic;
   readonly prepareOpticBasis?: PrepareOpticBasis;
+  readonly prepareForkOpticBasis?: PrepareForkOpticBasis;
   readonly getFrontier?: GetFrontier;
   readonly readOpticBasis?: ReadOpticBasis;
   readonly readCapabilities?: ReadCapabilities;
@@ -80,7 +104,9 @@ export default class WarpWorldline {
   private readonly _patchDraft: PatchDraft | null;
   private readonly _patchDraftWithEvidence: PatchDraftWithEvidence | null;
   private readonly _previewDraftJoin: PreviewDraftJoin | null;
+  private readonly _prepareStrandOptic: PrepareStrandOptic | null;
   private readonly _prepareOpticBasis: PrepareOpticBasis | null;
+  private readonly _prepareForkOpticBasis: PrepareForkOpticBasis | null;
   private readonly _getFrontier: GetFrontier | null;
   private readonly _readOpticBasis: ReadOpticBasis | null;
   private readonly _readCapabilities: ReadCapabilities;
@@ -98,7 +124,9 @@ export default class WarpWorldline {
     this._patchDraft = optionalPort(options.patchDraft);
     this._patchDraftWithEvidence = optionalPort(options.patchDraftWithEvidence);
     this._previewDraftJoin = optionalPort(options.previewDraftJoin);
+    this._prepareStrandOptic = optionalPort(options.prepareStrandOptic);
     this._prepareOpticBasis = optionalPort(options.prepareOpticBasis);
+    this._prepareForkOpticBasis = optionalPort(options.prepareForkOpticBasis);
     this._getFrontier = optionalPort(options.getFrontier);
     this._readOpticBasis = optionalPort(options.readOpticBasis);
     this._readCapabilities = options.readCapabilities ?? createBoundedMemoryCapabilityReport;
@@ -124,11 +152,14 @@ export default class WarpWorldline {
     return await this._admitIntent(descriptor);
   }
 
-  async createDraft(name: string): Promise<void> {
+  async createDraft(
+    name: string,
+    coordinate?: WarpWorldlineCoordinate,
+  ): Promise<void> {
     if (this._createDraft === null) {
       throw new WarpError('WarpWorldline was not opened with draft support', 'E_WARP_WORLDLINE_DRAFT_UNAVAILABLE');
     }
-    await this._createDraft(name);
+    await this._createDraft(name, coordinate);
   }
 
   async patchDraft(name: string, build: WarpWorldlinePatchBuild): Promise<string> {
@@ -156,6 +187,19 @@ export default class WarpWorldline {
       throw new WarpError('WarpWorldline was not opened with draft support', 'E_WARP_WORLDLINE_DRAFT_UNAVAILABLE');
     }
     return await this._previewDraftJoin(name);
+  }
+
+  async prepareStrandOptic(
+    name: string,
+    checkpointSha: string,
+  ): Promise<WarpStrandOpticBasis> {
+    if (this._prepareStrandOptic === null) {
+      throw new WarpError(
+        'WarpWorldline was not opened with bounded strand read support',
+        'E_WARP_WORLDLINE_STRAND_OPTIC_UNAVAILABLE',
+      );
+    }
+    return await this._prepareStrandOptic(name, checkpointSha);
   }
 
   live(): ProjectionHandle {
@@ -201,6 +245,16 @@ export default class WarpWorldline {
       );
     }
     return await this._prepareOpticBasis();
+  }
+
+  async prepareForkOpticBasis(): Promise<WarpWorldlineOpticBasis> {
+    if (this._prepareForkOpticBasis === null) {
+      throw new WarpError(
+        'WarpWorldline was not opened with fork coordinate support',
+        'E_WARP_WORLDLINE_FORK_BASIS_UNAVAILABLE',
+      );
+    }
+    return await this._prepareForkOpticBasis();
   }
 
   async coordinate(): Promise<WarpWorldlineCoordinate> {
@@ -254,6 +308,14 @@ export async function openWarpWorldline(
 
 function createWarpWorldline(worldlineName: string, graph: RuntimeGraph): WarpWorldline {
   let preparedOpticBasis: WarpWorldlineOpticBasis | null = null;
+  const prepareOpticBasis = async (): Promise<WarpWorldlineOpticBasis> => {
+    const basis = await new CheckpointTailBasisVerifier({ source: graph }).verify();
+    preparedOpticBasis = new WarpWorldlineOpticBasis({
+      worldlineName,
+      checkpointSha: basis.checkpointSha,
+    });
+    return preparedOpticBasis;
+  };
 
   return new WarpWorldline({
     worldlineName,
@@ -262,36 +324,120 @@ function createWarpWorldline(worldlineName: string, graph: RuntimeGraph): WarpWo
     commitPatchWithEvidence: async (build) => await graph.patchWithEvidence(build),
     ...draftWorldlineOptions(graph),
     createWorldline: (worldlineOptions) => graph.worldline(worldlineOptions),
-    prepareOpticBasis: async () => {
-      const basis = await new CheckpointTailBasisVerifier({ source: graph }).verify();
-      preparedOpticBasis = new WarpWorldlineOpticBasis({
-        worldlineName,
-        checkpointSha: basis.checkpointSha,
-      });
-      return preparedOpticBasis;
-    },
+    prepareOpticBasis,
+    prepareForkOpticBasis: async () =>
+      await prepareForkOpticBasis(graph, prepareOpticBasis),
     getFrontier: async () => await graph.getFrontier(),
     readOpticBasis: () => preparedOpticBasis,
     admitIntent: async (descriptor) => await graph.admitIntent(descriptor),
   });
 }
 
+async function prepareForkOpticBasis(
+  graph: RuntimeGraph,
+  prepare: PrepareOpticBasis,
+): Promise<WarpWorldlineOpticBasis> {
+  try {
+    return await prepare();
+  } catch (error) {
+    if (!(error instanceof QueryError) || error.code !== 'E_OPTIC_NO_BOUNDED_BASIS') {
+      throw error;
+    }
+  }
+  await graph.materialize();
+  await graph.createCheckpoint();
+  return await prepare();
+}
+
 function draftWorldlineOptions(graph: RuntimeGraph): DraftWorldlineOptions {
   return {
-    createDraft: async (name) => {
-      await graph.createStrand({
-        strandId: name,
-        owner: graph.writerId,
-      });
-    },
+    createDraft: async (name, coordinate) =>
+      await createDraft(graph, name, coordinate),
     patchDraft: async (name, build) => await graph.patchStrand(name, build),
     patchDraftWithEvidence: async (name, build) =>
       await graph.patchStrandWithEvidence(name, build),
-    previewDraftJoin: async (name) => {
-      await graph.materializeStrand(name, { receipts: true });
-      return (await graph.getStrandPatches(name)).map((entry) => entry.sha);
-    },
+    previewDraftJoin: async (name) => await previewDraftJoin(graph, name),
+    prepareStrandOptic: async (name, checkpointSha) =>
+      await prepareStrandOpticBasis(graph, name, checkpointSha),
   };
+}
+
+async function createDraft(
+  graph: RuntimeGraph,
+  name: string,
+  coordinate: WarpWorldlineCoordinate | undefined,
+): Promise<void> {
+  await graph.createStrand({
+    strandId: name,
+    owner: graph.writerId,
+    ...(coordinate === undefined ? {} : { baseFrontier: coordinate.frontier() }),
+  });
+}
+
+async function previewDraftJoin(
+  graph: RuntimeGraph,
+  name: string,
+): Promise<readonly string[]> {
+  await graph.materializeStrand(name, { receipts: true });
+  return (await graph.getStrandPatches(name)).map((entry) => entry.sha);
+}
+
+async function prepareStrandOpticBasis(
+  graph: RuntimeGraph,
+  name: string,
+  checkpointSha: string,
+): Promise<WarpStrandOpticBasis> {
+  const descriptor = await graph.getStrand(name);
+  if (descriptor === null) {
+    throw new WarpError(
+      `Strand '${name}' is unavailable`,
+      'E_WARP_WORLDLINE_STRAND_UNAVAILABLE',
+      { context: { name } },
+    );
+  }
+  // A strand overlay already has its own writer identity. Adding its pinned
+  // head to the captured parent frontier lets the checkpoint-tail optic scan
+  // it as one more bounded writer tail, without materializing the graph.
+  const frontier = strandFrontier(descriptor);
+  return Object.freeze({
+    checkpointSha,
+    frontierEntries: freezeFrontierEntries(frontier),
+    optic: new WorldlineOptic({
+      source: new CoordinateCheckpointTailOpticSource({
+        source: graph,
+        checkpointSha,
+        frontier,
+      }),
+    }),
+  });
+}
+
+function strandFrontier(
+  descriptor: NonNullable<Awaited<ReturnType<RuntimeGraph['getStrand']>>>,
+): Map<string, string> {
+  const frontier = new Map(Object.entries(descriptor.baseObservation.frontier));
+  addOverlayHead(frontier, descriptor.overlay);
+  for (const overlay of descriptor.braid.readOverlays) {
+    addOverlayHead(frontier, overlay);
+  }
+  return frontier;
+}
+
+function addOverlayHead(
+  frontier: Map<string, string>,
+  overlay: { readonly overlayId: string; readonly headPatchSha: string | null },
+): void {
+  if (overlay.headPatchSha !== null) {
+    frontier.set(overlay.overlayId, overlay.headPatchSha);
+  }
+}
+
+function freezeFrontierEntries(frontier: Map<string, string>) {
+  return Object.freeze(
+    [...frontier.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([writerId, patchSha]) => Object.freeze({ writerId, patchSha })),
+  );
 }
 
 function assertNonEmpty(value: string | null | undefined, field: string): void {

--- a/src/domain/WarpWorldline.ts
+++ b/src/domain/WarpWorldline.ts
@@ -22,6 +22,9 @@ import createBoundedMemoryCapabilityReport from './memory/createBoundedMemoryCap
 import type { IntentAdmissionReceipt } from './admission/IntentAdmissionReceipt.ts';
 import type { WarpIntentDescriptor } from './types/WarpIntentDescriptor.ts';
 import type { PatchCommitResult } from './types/PatchCommitResult.ts';
+import type { WarpStrandOpticBasis } from './WarpStrandOpticBasis.ts';
+
+export type { WarpStrandOpticBasis } from './WarpStrandOpticBasis.ts';
 
 export type WarpWorldlineOpenOptions = Omit<WarpGraphDeps, 'graphName'> & {
   readonly worldlineName: string;
@@ -65,15 +68,6 @@ type PrepareStrandOptic = (
   name: string,
   checkpointSha: string,
 ) => Promise<WarpStrandOpticBasis>;
-
-export type WarpStrandOpticBasis = Readonly<{
-  readonly checkpointSha: string;
-  readonly frontierEntries: readonly Readonly<{
-    readonly patchSha: string;
-    readonly writerId: string;
-  }>[];
-  readonly optic: WorldlineOptic;
-}>;
 
 type WarpWorldlineConstructionOptions = {
   readonly worldlineName: string;

--- a/src/domain/api/DraftReadingTarget.ts
+++ b/src/domain/api/DraftReadingTarget.ts
@@ -1,0 +1,8 @@
+import type Reading from './Reading.ts';
+import type ReadingResult from './ReadingResult.ts';
+import type Tick from './Tick.ts';
+
+export type DraftReadingTarget = Readonly<{
+  readonly read: (reading: Reading) => Promise<ReadingResult>;
+  readonly tick: Tick;
+}>;

--- a/src/domain/api/DraftTimelineRuntime.ts
+++ b/src/domain/api/DraftTimelineRuntime.ts
@@ -1,8 +1,9 @@
 import type WarpWorldline from '../WarpWorldline.ts';
-import type { WarpStrandOpticBasis } from '../WarpWorldline.ts';
+import type { WarpStrandOpticBasis } from '../WarpStrandOpticBasis.ts';
 import type WarpWorldlineCoordinate from '../WarpWorldlineCoordinate.ts';
 import WarpError from '../errors/WarpError.ts';
 import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
+import type { DraftReadingTarget } from './DraftReadingTarget.ts';
 import DraftTimeline from './DraftTimeline.ts';
 import type Evidence from './Evidence.ts';
 import { createJoinEvidence, createJoinRecoveryEvidence } from './EvidenceRuntime.ts';
@@ -11,12 +12,13 @@ import { applyIntentToPatch } from './IntentRuntime.ts';
 import JoinReceipt from './JoinReceipt.ts';
 import JoinResult from './JoinResult.ts';
 import type Reading from './Reading.ts';
-import type ReadingResult from './ReadingResult.ts';
 import { executeReading } from './ReadingRuntime.ts';
 import Tick from './Tick.ts';
 import type { JoinOptions } from './Timeline.ts';
 import type WriteReceipt from './WriteReceipt.ts';
 import { executeIntentWrite } from './WriteRuntime.ts';
+
+export type { DraftReadingTarget } from './DraftReadingTarget.ts';
 
 type DraftTimelineState = {
   readonly context: ApiRuntimeContext;
@@ -45,11 +47,6 @@ type CreateDraftTimelineFields = {
   readonly draftName: string;
   readonly forkedAt?: WarpWorldlineCoordinate;
 };
-
-export type DraftReadingTarget = Readonly<{
-  readonly read: (reading: Reading) => Promise<ReadingResult>;
-  readonly tick: Tick;
-}>;
 
 type JoinResultFieldsBase = {
   readonly runtime: WarpWorldline;

--- a/src/domain/api/DraftTimelineRuntime.ts
+++ b/src/domain/api/DraftTimelineRuntime.ts
@@ -1,4 +1,6 @@
 import type WarpWorldline from '../WarpWorldline.ts';
+import type { WarpStrandOpticBasis } from '../WarpWorldline.ts';
+import type WarpWorldlineCoordinate from '../WarpWorldlineCoordinate.ts';
 import WarpError from '../errors/WarpError.ts';
 import type { ApiRuntimeContext } from './ApiRuntimeContext.ts';
 import DraftTimeline from './DraftTimeline.ts';
@@ -8,6 +10,10 @@ import type Intent from './Intent.ts';
 import { applyIntentToPatch } from './IntentRuntime.ts';
 import JoinReceipt from './JoinReceipt.ts';
 import JoinResult from './JoinResult.ts';
+import type Reading from './Reading.ts';
+import type ReadingResult from './ReadingResult.ts';
+import { executeReading } from './ReadingRuntime.ts';
+import Tick from './Tick.ts';
 import type { JoinOptions } from './Timeline.ts';
 import type WriteReceipt from './WriteReceipt.ts';
 import { executeIntentWrite } from './WriteRuntime.ts';
@@ -17,6 +23,7 @@ type DraftTimelineState = {
   readonly runtime: WarpWorldline;
   readonly draftPatchShas: string[];
   readonly intents: Intent[];
+  readonly forkedAt: WarpWorldlineCoordinate | null;
   readonly joinPatchShas: string[];
   joinRecoveryEvidence: Evidence | undefined;
   joinFailed: boolean;
@@ -36,7 +43,13 @@ type CreateDraftTimelineFields = {
   readonly context: ApiRuntimeContext;
   readonly timelineName: string;
   readonly draftName: string;
+  readonly forkedAt?: WarpWorldlineCoordinate;
 };
+
+export type DraftReadingTarget = Readonly<{
+  readonly read: (reading: Reading) => Promise<ReadingResult>;
+  readonly tick: Tick;
+}>;
 
 type JoinResultFieldsBase = {
   readonly runtime: WarpWorldline;
@@ -86,8 +99,8 @@ export async function createDraftTimeline(
   fields: CreateDraftTimelineFields
 ): Promise<DraftTimeline> {
   const { runtime, context, timelineName, draftName } = fields;
-  await runtime.createDraft(draftName);
-  const state = createDraftState(runtime, context);
+  await runtime.createDraft(draftName, fields.forkedAt);
+  const state = createDraftState(runtime, context, fields.forkedAt ?? null);
   const draft = new DraftTimeline({
     name: draftName,
     timeline: timelineName,
@@ -102,6 +115,54 @@ export async function createDraftTimeline(
   });
   draftStates.set(draft, state);
   return draft;
+}
+
+export async function createDraftReadingTarget(
+  draft: DraftTimeline,
+): Promise<DraftReadingTarget> {
+  const state = requireDraftStateForReading(draft);
+  const coordinate = state.forkedAt;
+  if (coordinate === null) {
+    throw new WarpError(
+      'DraftTimeline was not forked from a captured Runtime coordinate',
+      'E_DRAFT_TIMELINE_BOUNDED_BASIS_UNAVAILABLE',
+    );
+  }
+  const basis = await state.runtime.prepareStrandOptic(
+    draft.name,
+    coordinate.checkpointSha,
+  );
+  const tick = await createDraftReadingTick(draft, state, basis);
+  return Object.freeze({
+    tick,
+    read: async (reading: Reading) =>
+      await executeReading({
+        runtime: state.runtime,
+        context: state.context,
+        reading,
+        basis: { optic: basis.optic, tick },
+      }),
+  });
+}
+
+async function createDraftReadingTick(
+  draft: DraftTimeline,
+  state: DraftTimelineState,
+  basis: WarpStrandOpticBasis,
+): Promise<Tick> {
+  const frontier = basis.frontierEntries.flatMap(({ writerId, patchSha }) => [
+    writerId,
+    patchSha,
+  ]);
+  return new Tick({
+    timeline: draft.name,
+    id: await state.context.createOpaqueId('tick', [
+      state.runtime.worldlineName,
+      draft.name,
+      basis.checkpointSha,
+      ...frontier,
+    ]),
+  });
 }
 
 export async function previewDraftJoin(
@@ -217,11 +278,16 @@ async function acceptedJoin(fields: JoinCompletionFields): Promise<JoinResult> {
   });
 }
 
-function createDraftState(runtime: WarpWorldline, context: ApiRuntimeContext): DraftTimelineState {
+function createDraftState(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext,
+  forkedAt: WarpWorldlineCoordinate | null,
+): DraftTimelineState {
   return {
     context,
     runtime,
     draftPatchShas: [],
+    forkedAt,
     intents: [],
     joinPatchShas: [],
     joinRecoveryEvidence: undefined,
@@ -229,6 +295,17 @@ function createDraftState(runtime: WarpWorldline, context: ApiRuntimeContext): D
     joining: false,
     joined: false,
   };
+}
+
+function requireDraftStateForReading(draft: DraftTimeline): DraftTimelineState {
+  const state = draftStates.get(draft);
+  if (state === undefined) {
+    throw new WarpError(
+      'DraftTimeline does not belong to this runtime',
+      'E_DRAFT_TIMELINE_RUNTIME_MISMATCH',
+    );
+  }
+  return state;
 }
 
 async function writeDraftIntent(fields: DraftWriteFields): Promise<WriteReceipt> {

--- a/src/domain/api/LaneRuntime.ts
+++ b/src/domain/api/LaneRuntime.ts
@@ -2,8 +2,10 @@ import WarpError from '../errors/WarpError.ts';
 import type WarpWorldlineCoordinate from '../WarpWorldlineCoordinate.ts';
 import type Lane from './Lane.ts';
 
-type LaneRuntime = Readonly<{
+export type LaneRuntime = Readonly<{
   readonly captureCoordinate: () => Promise<WarpWorldlineCoordinate>;
+  readonly fork: ((name: string) => Promise<Lane>) | null;
+  readonly owner: object;
 }>;
 
 const LANE_RUNTIMES = new WeakMap<Lane, LaneRuntime>();
@@ -14,6 +16,8 @@ export function bindLaneRuntime(lane: Lane, runtime: LaneRuntime): void {
   }
   LANE_RUNTIMES.set(lane, Object.freeze({
     captureCoordinate: runtime.captureCoordinate,
+    fork: runtime.fork,
+    owner: runtime.owner,
   }));
 }
 

--- a/src/domain/api/TickRuntime.ts
+++ b/src/domain/api/TickRuntime.ts
@@ -20,6 +20,15 @@ export async function createTick(
   return await createTickFromCoordinate(runtime, context, coordinate);
 }
 
+export async function createForkTick(
+  runtime: WarpWorldline,
+  context: ApiRuntimeContext,
+): Promise<Tick> {
+  await runtime.prepareForkOpticBasis();
+  const coordinate = await runtime.coordinate();
+  return await createTickFromCoordinate(runtime, context, coordinate);
+}
+
 export async function createTickFromCoordinate(
   runtime: WarpWorldline,
   context: ApiRuntimeContext,

--- a/src/domain/api/TimelineRuntime.ts
+++ b/src/domain/api/TimelineRuntime.ts
@@ -12,7 +12,12 @@ import Timeline from './Timeline.ts';
 import { createTimelineView } from './TimelineViewRuntime.ts';
 import { executeIntentWrite } from './WriteRuntime.ts';
 
-const timelineRuntimes = new WeakMap<Timeline, WarpWorldline>();
+type TimelineRuntimeBinding = Readonly<{
+  readonly context: ApiRuntimeContext;
+  readonly runtime: WarpWorldline;
+}>;
+
+const timelineRuntimes = new WeakMap<Timeline, TimelineRuntimeBinding>();
 
 export function createTimeline(runtime: WarpWorldline, context: ApiRuntimeContext): Timeline {
   const timeline = new Timeline({
@@ -38,14 +43,22 @@ export function createTimeline(runtime: WarpWorldline, context: ApiRuntimeContex
         commit: runtime.commitWithEvidence.bind(runtime),
       }),
   });
-  timelineRuntimes.set(timeline, runtime);
+  timelineRuntimes.set(timeline, Object.freeze({ context, runtime }));
   return timeline;
 }
 
 export function requireTimelineRuntime(timeline: Timeline): WarpWorldline {
-  const runtime = timelineRuntimes.get(timeline);
-  if (runtime === undefined) {
+  const binding = timelineRuntimes.get(timeline);
+  if (binding === undefined) {
     throw new WarpError('Timeline was not opened by openWarp', 'E_TIMELINE_RUNTIME_UNAVAILABLE');
   }
-  return runtime;
+  return binding.runtime;
+}
+
+export function requireTimelineContext(timeline: Timeline): ApiRuntimeContext {
+  const binding = timelineRuntimes.get(timeline);
+  if (binding === undefined) {
+    throw new WarpError('Timeline was not opened by openWarp', 'E_TIMELINE_RUNTIME_UNAVAILABLE');
+  }
+  return binding.context;
 }

--- a/src/domain/services/controllers/StrandController.ts
+++ b/src/domain/services/controllers/StrandController.ts
@@ -35,7 +35,7 @@ export default class StrandController {
 
   // ── Strand lifecycle ────────────────────────────────────────────────────
 
-  async createStrand(options?: { strandId?: string; lamportCeiling?: number | null; owner?: string | null; scope?: string | null; leaseExpiresAt?: string | null }): Promise<StrandDescriptor> {
+  async createStrand(options?: { strandId?: string; lamportCeiling?: number | null; owner?: string | null; scope?: string | null; leaseExpiresAt?: string | null; baseFrontier?: ReadonlyMap<string, string> }): Promise<StrandDescriptor> {
     return await this._strandService.create(options);
   }
 

--- a/src/domain/services/strand/StrandCoordinator.ts
+++ b/src/domain/services/strand/StrandCoordinator.ts
@@ -14,7 +14,7 @@ import {
   createImmutableWarpStateSnapshot,
 } from '../ImmutableSnapshot.ts';
 import {
-  normalizeCreateOptions, normalizeLamportCeiling,
+  normalizeBaseFrontier, normalizeCreateOptions, normalizeLamportCeiling,
   normalizeWritable, normalizeBraidedStrandIds, patchTouchesEntity,
   frontierToRecord,
   type NormalizedCreateOptions,
@@ -181,11 +181,11 @@ export default class StrandCoordinator {
 
   // ── Lifecycle (owns the logic) ──────────────────────────────────
 
-  async create(options: { strandId?: string; lamportCeiling?: number | null; owner?: string | null; scope?: string | null; leaseExpiresAt?: string | null } = {}): Promise<StrandDescriptor> {
+  async create(options: { strandId?: string; lamportCeiling?: number | null; owner?: string | null; scope?: string | null; leaseExpiresAt?: string | null; baseFrontier?: ReadonlyMap<string, string> } = {}): Promise<StrandDescriptor> {
     const normalized = normalizeCreateOptions(options);
     await this._assertStrandDoesNotExist(normalized.strandId);
 
-    const frontier = await this._getFrontier();
+    const frontier = normalizeBaseFrontier(options.baseFrontier) ?? await this._getFrontier();
     const frontierRecord = frontierToRecord(frontier);
     const frontierDigest = await computeChecksum(frontierRecord, this._deps.crypto);
     const now = String(this._deps.maxObservedLamport());

--- a/src/domain/services/strand/StrandDescriptorValidation.ts
+++ b/src/domain/services/strand/StrandDescriptorValidation.ts
@@ -114,6 +114,51 @@ export function normalizeCreateOptions(options: {
   };
 }
 
+/** Copy and validate an explicitly captured parent frontier. */
+export function normalizeBaseFrontier(
+  frontier: ReadonlyMap<string, string> | undefined,
+): Map<string, string> | null {
+  if (frontier === undefined) {
+    return null;
+  }
+  if (!isMap(frontier)) {
+    throw new StrandError('baseFrontier must be a Map', {
+      code: 'E_STRAND_INVALID_ARGS',
+      context: { field: 'baseFrontier' },
+    });
+  }
+  const entries = Array.from(frontier.entries(), normalizeBaseFrontierEntry);
+  const normalized = new Map<string, string>();
+  for (const [writerId, patchSha] of entries.sort(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    normalized.set(writerId, patchSha);
+  }
+  return normalized;
+}
+
+function normalizeBaseFrontierEntry(
+  entry: [string, string],
+): [string, string] {
+  const [writerId, patchSha] = entry;
+  if (
+    typeof writerId !== 'string' ||
+    writerId.length === 0 ||
+    typeof patchSha !== 'string' ||
+    patchSha.length === 0
+  ) {
+    throw new StrandError('baseFrontier entries must be non-empty strings', {
+      code: 'E_STRAND_INVALID_ARGS',
+      context: { field: 'baseFrontier' },
+    });
+  }
+  return [writerId, patchSha];
+}
+
+function isMap(value: object): boolean {
+  return value instanceof Map;
+}
+
 /** Check whether a patch touches a given entity in its reads or writes. */
 export function patchTouchesEntity(patch: { reads?: string[]; writes?: string[] }, entityId: string): boolean {
   if (patch.reads !== undefined && patch.reads.includes(entityId)) { return true; }

--- a/src/domain/types/StrandDescriptor.ts
+++ b/src/domain/types/StrandDescriptor.ts
@@ -89,6 +89,12 @@ export type StrandCreateOptions = {
   owner?: string | null;
   scope?: string | null;
   leaseExpiresAt?: string | null;
+  /**
+   * Internal composition seam for callers that have already captured the
+   * exact parent coordinate. Ordinary strand creation omits this field and
+   * captures the live frontier.
+   */
+  baseFrontier?: ReadonlyMap<string, string>;
 };
 
 export type StrandBraidOptions = {

--- a/test/conformance/v18FirstUseOpticsHonesty.test.ts
+++ b/test/conformance/v18FirstUseOpticsHonesty.test.ts
@@ -135,8 +135,10 @@ function readRepoFile(path: string): string {
 
 function prepareOpticBasisImplementation(): string {
   const source = readRepoFile('src/domain/WarpWorldline.ts');
-  const start = source.indexOf('prepareOpticBasis: async () => {');
-  const end = source.indexOf('    getFrontier:', start);
+  const start = source.indexOf(
+    'const prepareOpticBasis = async (): Promise<WarpWorldlineOpticBasis> => {',
+  );
+  const end = source.indexOf('\n\n  return new WarpWorldline', start);
   if (start < 0 || end < 0) {
     throw new Error('WarpWorldline prepareOpticBasis implementation not found');
   }

--- a/test/integration/application/Runtime.fork.integration.test.ts
+++ b/test/integration/application/Runtime.fork.integration.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Runtime } from '../../../index.ts';
+import RuntimeHost from '../../../src/domain/RuntimeHost.ts';
+import Intent from '../../../src/domain/api/Intent.ts';
+import { createObserver } from '../../../src/domain/api/ObserverRuntime.ts';
+import LegacyReading from '../../../src/domain/api/Reading.ts';
+import { createTestRepo } from '../api/helpers/setup.ts';
+
+describe('Runtime fork composition', () => {
+  let repository: Awaited<ReturnType<typeof createTestRepo>>;
+
+  beforeEach(async () => {
+    repository = await createTestRepo('runtime-fork');
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await repository.cleanup();
+  });
+
+  it('pins a real-Git parent coordinate and reads the strand without full materialization', async () => {
+    const materialize = vi.spyOn(RuntimeHost.prototype, 'materialize');
+    const runtime = await Runtime.open({
+      at: repository.tempDir,
+      writer: 'agent-1',
+    });
+    try {
+      const events = await runtime.lane('events');
+      await events.write(Intent.addNode({ subject: 'user:alice' }));
+      await events.write(Intent.setProperty({
+        subject: 'user:alice',
+        key: 'role',
+        value: 'member',
+      }));
+      const strand = await runtime.fork(events, { name: 'try-admin-role' });
+      expect(strand.descriptor).toMatchObject({
+        kind: 'strand',
+        name: 'try-admin-role',
+        parent: { kind: 'worldline', name: 'events' },
+        forkedAt: {
+          id: expect.stringMatching(/^tick:/u),
+          lane: { kind: 'worldline', name: 'events' },
+        },
+      });
+      await expect(runtime.fork(events, { name: 'try-admin-role' }))
+        .rejects.toMatchObject({ code: 'E_STRAND_ALREADY_EXISTS' });
+      materialize.mockClear();
+
+      await events.write(Intent.setProperty({
+        subject: 'user:alice',
+        key: 'role',
+        value: 'owner',
+      }));
+      const observer = createObserver<string>(
+        'users.role-of',
+        LegacyReading.property({ subject: 'user:alice', key: 'role' }),
+        (value) => {
+          if (typeof value !== 'string') {
+            throw new TypeError('users.role-of expected a string');
+          }
+          return value;
+        },
+      );
+
+      await expect(strand.observe(observer).one()).resolves.toMatchObject({
+        value: 'member',
+      });
+      await strand.write(Intent.setProperty({
+        subject: 'user:alice',
+        key: 'role',
+        value: 'admin',
+      }));
+      await expect(strand.observe(observer).one()).resolves.toMatchObject({
+        value: 'admin',
+      });
+      await expect(events.observe(observer).one()).resolves.toMatchObject({
+        value: 'owner',
+      });
+      expect(materialize).not.toHaveBeenCalled();
+    } finally {
+      await runtime.close();
+    }
+  });
+});

--- a/test/type-check/v19-consumer.ts
+++ b/test/type-check/v19-consumer.ts
@@ -13,6 +13,7 @@ import {
   type Observer,
   type Reading,
   type Receipt,
+  type RuntimeForkOptions,
   type RuntimeOpenOptions,
   type SupportReport,
   type Tick,
@@ -23,6 +24,8 @@ import { users } from './generated-users.ts';
 const options: RuntimeOpenOptions = { at: '.', writer: 'agent-1' };
 const runtime: Runtime = await Runtime.open(options);
 const lane: Lane = await runtime.lane('events');
+const forkOptions: RuntimeForkOptions = { name: 'try-admin-role' };
+const strand: Lane = await runtime.fork(lane, forkOptions);
 const intent: Intent = users.intents.assignRole({
   subject: 'user:alice',
   role: 'admin',
@@ -84,6 +87,7 @@ const readingTick: Tick | undefined = emitted.coordinate.tick;
 
 void admissionWitnessHandle(admission);
 void laneName(lane.descriptor);
+void laneName(strand.descriptor);
 void writeEvidence;
 void writeLane;
 void readingTick;

--- a/test/unit/application/Runtime.test.ts
+++ b/test/unit/application/Runtime.test.ts
@@ -19,6 +19,8 @@ vi.mock('../../../src/application/openWarp.ts', () => ({
 }));
 
 import Runtime from '../../../src/application/Runtime.ts';
+import Lane, { type LaneDescriptor } from '../../../src/domain/api/Lane.ts';
+import { bindLaneRuntime } from '../../../src/domain/api/LaneRuntime.ts';
 
 describe('Runtime', () => {
   const closeStorage = vi.fn();
@@ -26,7 +28,9 @@ describe('Runtime', () => {
   const timeline = Object.freeze({ name: 'events' });
   const openTimeline = vi.fn();
   const warp = Object.freeze({ timeline: openTimeline, writer: 'agent-1' });
-  const lane = Object.freeze({ kind: 'worldline', name: 'events' });
+  const forkLane = vi.fn();
+  let lane: Lane;
+  let runtimeOwner: object;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -34,7 +38,16 @@ describe('Runtime', () => {
     openTimeline.mockResolvedValue(timeline);
     mocks.openStorage.mockResolvedValue(storage);
     mocks.openWarp.mockResolvedValue(warp);
-    mocks.createWorldlineLane.mockReturnValue(lane);
+    forkLane.mockReset();
+    mocks.createWorldlineLane.mockImplementation((_timeline, _activity, owner: object) => {
+      runtimeOwner = owner;
+      lane = createBoundLane({
+        descriptor: { kind: 'worldline', name: 'events' },
+        fork: forkLane,
+        owner,
+      });
+      return lane;
+    });
   });
 
   it('validates public open options before acquiring storage', async () => {
@@ -55,12 +68,14 @@ describe('Runtime', () => {
     const runtime = await Runtime.open({ at: '/repo', writer: 'agent-1' });
 
     expect(runtime.writer).toBe('agent-1');
-    await expect(runtime.lane('events')).resolves.toBe(lane);
+    const openedLane = await runtime.lane('events');
+    expect(openedLane).toBe(lane);
     expect(mocks.openStorage).toHaveBeenCalledWith({ cwd: '/repo' });
     expect(mocks.openWarp).toHaveBeenCalledWith({ storage, writer: 'agent-1' });
     expect(openTimeline).toHaveBeenCalledWith('events');
     expect(mocks.createWorldlineLane).toHaveBeenCalledWith(
       timeline,
+      expect.any(Object),
       expect.any(Object),
     );
 
@@ -85,6 +100,61 @@ describe('Runtime', () => {
       message: 'Runtime.lane requires a non-empty Lane name',
     });
     expect(openTimeline).not.toHaveBeenCalled();
+  });
+
+  it('forks only worldline Lanes owned by the same open Runtime', async () => {
+    const runtime = await Runtime.open({ at: '/repo', writer: 'agent-1' });
+    const source = await runtime.lane('events');
+    const strand = createBoundLane({
+      descriptor: {
+        kind: 'strand',
+        name: 'try-admin',
+        parent: source.reference,
+        forkedAt: { id: 'tick:1', lane: source.reference },
+      },
+      fork: null,
+      owner: runtimeOwner,
+    });
+    forkLane.mockResolvedValue(strand);
+
+    await expect(runtime.fork(source, { name: 'try-admin' })).resolves.toBe(strand);
+    expect(forkLane).toHaveBeenCalledWith('try-admin');
+
+    await expect(runtime.fork(strand, { name: 'nested' })).rejects.toMatchObject({
+      code: 'E_RUNTIME_FORK_SOURCE_KIND',
+      context: { kind: 'strand' },
+    });
+    const foreign = createBoundLane({
+      descriptor: { kind: 'worldline', name: 'foreign' },
+      fork: vi.fn(),
+      owner: {},
+    });
+    await expect(runtime.fork(foreign, { name: 'foreign-draft' }))
+      .rejects.toMatchObject({ code: 'E_RUNTIME_FORK_FOREIGN_LANE' });
+  });
+
+  it('validates fork arguments and rejects fork work after close', async () => {
+    const runtime = await Runtime.open({ at: '/repo', writer: 'agent-1' });
+    const source = await runtime.lane('events');
+
+    // @ts-expect-error Exercise the JavaScript boundary.
+    await expect(runtime.fork({}, { name: 'draft' })).rejects.toMatchObject({
+      code: 'E_RUNTIME_FORK_SOURCE',
+    });
+    // @ts-expect-error Exercise the JavaScript boundary.
+    await expect(runtime.fork(source, null)).rejects.toMatchObject({
+      code: 'E_RUNTIME_FORK_OPTIONS',
+    });
+    await expect(runtime.fork(source, { name: '' })).rejects.toMatchObject({
+      code: 'E_RUNTIME_FORK_IDENTITY',
+      context: { field: 'fork.name' },
+    });
+
+    await runtime.close();
+    await expect(runtime.fork(source, { name: 'later' })).rejects.toMatchObject({
+      code: 'E_RUNTIME_CLOSED',
+    });
+    expect(forkLane).not.toHaveBeenCalled();
   });
 
   it('releases storage when Warp composition fails', async () => {
@@ -113,3 +183,28 @@ describe('Runtime', () => {
     });
   });
 });
+
+function createBoundLane(options: {
+  readonly descriptor: LaneDescriptor;
+  readonly fork: ((name: string) => Promise<Lane>) | null;
+  readonly owner: object;
+}): Lane {
+  const lane = new Lane({
+    descriptor: options.descriptor,
+    writer: 'agent-1',
+    startObserver: async () => {
+      throw new Error('not exercised');
+    },
+    writeIntent: async () => {
+      throw new Error('not exercised');
+    },
+  });
+  bindLaneRuntime(lane, {
+    captureCoordinate: async () => {
+      throw new Error('not exercised');
+    },
+    fork: options.fork,
+    owner: options.owner,
+  });
+  return lane;
+}

--- a/test/unit/application/RuntimeLaneAdapter.test.ts
+++ b/test/unit/application/RuntimeLaneAdapter.test.ts
@@ -4,6 +4,7 @@ import { openWarp } from '../../../src/application/openWarp.ts';
 import RuntimeActivity from '../../../src/application/RuntimeActivity.ts';
 import { createWorldlineLane } from '../../../src/application/RuntimeLaneAdapter.ts';
 import Intent from '../../../src/domain/api/Intent.ts';
+import { requireLaneRuntime } from '../../../src/domain/api/LaneRuntime.ts';
 import {
   createManyObserver,
   createObserver,
@@ -54,6 +55,148 @@ describe('Runtime Lane adapter', () => {
         writer: 'agent-1',
       });
       expect(receipt.observer).toBe(observer);
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it('forks an exact parent coordinate and observes strand overlays through bounded optics', async () => {
+    const storage = MemoryStorage.create();
+    try {
+      const warp = await openWarp({ storage, writer: 'agent-1' });
+      const timeline = await warp.timeline('events');
+      const lane = createWorldlineLane(timeline, new RuntimeActivity());
+      await lane.write(Intent.addNode({ subject: 'user:alice' }));
+      await lane.write(Intent.setProperty({
+        subject: 'user:alice',
+        key: 'role',
+        value: 'member',
+      }));
+      await createBoundedReadBasis(storage, 'events');
+
+      const fork = requireLaneRuntime(lane).fork;
+      expect(fork).not.toBeNull();
+      const strand = await fork!('try-admin-role');
+      expect(strand.descriptor).toMatchObject({
+        kind: 'strand',
+        name: 'try-admin-role',
+        parent: { kind: 'worldline', name: 'events' },
+        forkedAt: {
+          lane: { kind: 'worldline', name: 'events' },
+        },
+      });
+
+      await lane.write(Intent.setProperty({
+        subject: 'user:alice',
+        key: 'role',
+        value: 'owner',
+      }));
+      const roleObserver = createObserver<string>(
+        'users.role-of',
+        LegacyReading.property({ subject: 'user:alice', key: 'role' }),
+        (value) => {
+          if (typeof value !== 'string') {
+            throw new TypeError('users.role-of expected a string');
+          }
+          return value;
+        },
+      );
+
+      await expect(strand.observe(roleObserver).one()).resolves.toMatchObject({
+        value: 'member',
+        coordinate: { lane: 'try-admin-role' },
+      });
+      await strand.write(Intent.setProperty({
+        subject: 'user:alice',
+        key: 'role',
+        value: 'admin',
+      }));
+      const observation = strand.observe(roleObserver);
+      await expect(observation.one()).resolves.toMatchObject({
+        value: 'admin',
+        coordinate: { lane: 'try-admin-role' },
+      });
+      await expect(observation.receipt).resolves.toMatchObject({
+        lane: 'try-admin-role',
+        status: 'completed',
+        writer: 'agent-1',
+      });
+      await expect(lane.observe(roleObserver).one()).resolves.toMatchObject({
+        value: 'owner',
+        coordinate: { lane: 'events' },
+      });
+      await expect(captureCoordinate(strand)).rejects.toMatchObject({
+        code: 'E_LANE_COORDINATE_KIND',
+      });
+    } finally {
+      await storage.close();
+    }
+  });
+
+  it('pins one strand overlay frontier across lazy Observer demand', async () => {
+    const storage = MemoryStorage.create();
+    try {
+      const warp = await openWarp({ storage, writer: 'agent-1' });
+      const timeline = await warp.timeline('events');
+      const activity = new RuntimeActivity();
+      const lane = createWorldlineLane(timeline, activity);
+      for (const subject of ['user:alice', 'user:bob']) {
+        await lane.write(Intent.addNode({ subject }));
+        await lane.write(Intent.setProperty({
+          subject,
+          key: 'rank',
+          value: 1,
+        }));
+      }
+      await createBoundedReadBasis(storage, 'events');
+      const fork = requireLaneRuntime(lane).fork;
+      if (fork === null) {
+        throw new Error('worldline Lane is missing its fork port');
+      }
+      const strand = await fork('ranking-experiment');
+      const observer = createManyObserver<number>(
+        'users.ranks',
+        function* () {
+          yield LegacyReading.property({ subject: 'user:alice', key: 'rank' });
+          yield LegacyReading.property({ subject: 'user:bob', key: 'rank' });
+        },
+        (value) => {
+          if (typeof value !== 'number') {
+            throw new TypeError('users.ranks expected a number');
+          }
+          return value;
+        },
+      );
+      const observation = strand.observe(observer);
+      const iterator = observation[Symbol.asyncIterator]();
+
+      const first = await iterator.next();
+      expect(first).toMatchObject({ done: false, value: { value: 1 } });
+      await strand.write(Intent.setProperty({
+        subject: 'user:bob',
+        key: 'rank',
+        value: 2,
+      }));
+      const second = await iterator.next();
+      expect(second).toMatchObject({ done: false, value: { value: 1 } });
+      expect(
+        first.done === false && second.done === false
+          ? first.value.coordinate.tick?.id
+          : null,
+      ).toBe(
+        first.done === false && second.done === false
+          ? second.value.coordinate.tick?.id
+          : null,
+      );
+      await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+      const latest: unknown[] = [];
+      for await (const reading of strand.observe(observer)) {
+        latest.push(reading);
+      }
+      expect(latest).toMatchObject([
+        { value: 1 },
+        { value: 2 },
+      ]);
     } finally {
       await storage.close();
     }

--- a/test/unit/application/RuntimeLaneAdapter.test.ts
+++ b/test/unit/application/RuntimeLaneAdapter.test.ts
@@ -75,8 +75,10 @@ describe('Runtime Lane adapter', () => {
       await createBoundedReadBasis(storage, 'events');
 
       const fork = requireLaneRuntime(lane).fork;
-      expect(fork).not.toBeNull();
-      const strand = await fork!('try-admin-role');
+      if (fork === null) {
+        throw new Error('worldline Lane is missing its fork port');
+      }
+      const strand = await fork('try-admin-role');
       expect(strand.descriptor).toMatchObject({
         kind: 'strand',
         name: 'try-admin-role',
@@ -179,15 +181,10 @@ describe('Runtime Lane adapter', () => {
       }));
       const second = await iterator.next();
       expect(second).toMatchObject({ done: false, value: { value: 1 } });
-      expect(
-        first.done === false && second.done === false
-          ? first.value.coordinate.tick?.id
-          : null,
-      ).toBe(
-        first.done === false && second.done === false
-          ? second.value.coordinate.tick?.id
-          : null,
+      const tickIds = [first, second].map((result) =>
+        result.done === false ? result.value.coordinate.tick?.id : undefined
       );
+      expect(new Set(tickIds).size).toBe(1);
       await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
       const latest: unknown[] = [];
       for await (const reading of strand.observe(observer)) {
@@ -457,16 +454,23 @@ describe('Runtime Lane adapter', () => {
     }
   });
 
-  it('guards advanced coordinate capture with the Runtime lifecycle', async () => {
+  it('guards advanced coordinate capture and fork ports with the Runtime lifecycle', async () => {
     const storage = MemoryStorage.create();
     try {
       const warp = await openWarp({ storage, writer: 'agent-1' });
       const timeline = await warp.timeline('events');
       const activity = new RuntimeActivity();
       const lane = createWorldlineLane(timeline, activity);
+      const fork = requireLaneRuntime(lane).fork;
+      if (fork === null) {
+        throw new Error('worldline Lane is missing its fork port');
+      }
       await activity.close(async () => {});
 
       await expect(captureCoordinate(lane)).rejects.toMatchObject({
+        code: 'E_RUNTIME_CLOSED',
+      });
+      await expect(fork('closed-fork')).rejects.toMatchObject({
         code: 'E_RUNTIME_CLOSED',
       });
     } finally {

--- a/test/unit/domain/services/strand/StrandService.test.ts
+++ b/test/unit/domain/services/strand/StrandService.test.ts
@@ -714,19 +714,25 @@ describe('StrandService', () => {
     });
 
     it('rejects malformed explicit parent frontiers with a stable error', async () => {
-      await expect(
-        Reflect.apply(service.create, service, [{
-          strandId: 'invalid-frontier',
-          baseFrontier: { writer: 'sha' },
-        }]),
-      ).rejects.toMatchObject({
+      const coordinator: Pick<
+        ReturnType<typeof createStrandCoordinator>,
+        'create'
+      > = service;
+      await expect(coordinator.create({
+        strandId: 'invalid-frontier',
+        // @ts-expect-error Exercise the JavaScript boundary.
+        baseFrontier: { writer: 'sha' },
+      })).rejects.toMatchObject({
         code: 'E_STRAND_INVALID_ARGS',
         context: { field: 'baseFrontier' },
       });
-      await expect(service.create({
+      await expect(coordinator.create({
         strandId: 'invalid-entry',
         baseFrontier: new Map([['', 'sha']]),
-      })).rejects.toMatchObject({ code: 'E_STRAND_INVALID_ARGS' });
+      })).rejects.toMatchObject({
+        code: 'E_STRAND_INVALID_ARGS',
+        context: { field: 'baseFrontier' },
+      });
     });
 
     it('publishes the descriptor through the semantic strand store', async () => {

--- a/test/unit/domain/services/strand/StrandService.test.ts
+++ b/test/unit/domain/services/strand/StrandService.test.ts
@@ -695,6 +695,40 @@ describe('StrandService', () => {
       expect(descriptor.materialization.cacheAuthority).toBe('derived');
     });
 
+    it('persists an explicitly captured parent frontier exactly', async () => {
+      const baseFrontier = new Map([
+        ['writer-a', 'captured-a'],
+        ['writer-b', 'captured-b'],
+      ]);
+
+      const descriptor = await service.create({
+        strandId: 'captured',
+        baseFrontier,
+      });
+      baseFrontier.set('writer-c', 'too-late');
+
+      expect(descriptor.baseObservation.frontier).toEqual({
+        'writer-a': 'captured-a',
+        'writer-b': 'captured-b',
+      });
+    });
+
+    it('rejects malformed explicit parent frontiers with a stable error', async () => {
+      await expect(
+        Reflect.apply(service.create, service, [{
+          strandId: 'invalid-frontier',
+          baseFrontier: { writer: 'sha' },
+        }]),
+      ).rejects.toMatchObject({
+        code: 'E_STRAND_INVALID_ARGS',
+        context: { field: 'baseFrontier' },
+      });
+      await expect(service.create({
+        strandId: 'invalid-entry',
+        baseFrontier: new Map([['', 'sha']]),
+      })).rejects.toMatchObject({ code: 'E_STRAND_INVALID_ARGS' });
+    });
+
     it('publishes the descriptor through the semantic strand store', async () => {
       await service.create({ strandId: 'alpha' });
 

--- a/test/unit/scripts/v19-public-api-boundary.test.ts
+++ b/test/unit/scripts/v19-public-api-boundary.test.ts
@@ -26,6 +26,7 @@ const ROOT_TYPE_EXPORTS = [
   'ReadingValue',
   'Receipt',
   'RepairHint',
+  'RuntimeForkOptions',
   'RuntimeOpenOptions',
   'SupportReport',
   'Tick',


### PR DESCRIPTION
Closes #792.

Adds `Runtime.fork()` with same-runtime ownership, exact captured-frontier persistence, runtime-backed strand writes, and checkpoint-tail bounded strand observations. A first fork establishes a missing checkpoint through the composition root; observations never full-materialize the graph.

Validation: full pre-push gate, 7,338/2 skipped coverage tests at 92.96% lines, consumer/declaration/reference checks, real-Git fork integration, and 27/28 integration files in the aggregate run plus 7/7 on the resource-timed traversal file in isolation.
