### PR TITLE
Make v18-to-v19 migration safe and observable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: 'Gate 6: Markdown lint (fenced code blocks require language)'
+        env:
+          GIT_WARP_MERMAID_DISABLE_SANDBOX: "1"
         run: npm run lint:md
       - name: 'Gate 7: Markdown JS/TS code-sample syntax check'
         run: npm run lint:md:code

--- a/.github/workflows/main-push-release-branch-check.yml
+++ b/.github/workflows/main-push-release-branch-check.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Final release preflight
         if: steps.release_pr.outputs.should_release == 'true' && steps.metadata.outputs.tag_exists != 'true'
         env:
+          GIT_WARP_MERMAID_DISABLE_SANDBOX: "1"
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.metadata.outputs.tag }}
           WARP_LINKCHECK_EXTERNAL_OK: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,8 @@ jobs:
           jobSummary: true
 
       - name: Verify release tests and docs
+        env:
+          GIT_WARP_MERMAID_DISABLE_SANDBOX: "1"
         run: |
           npm run lint
           npm run lint:md

--- a/docker/Dockerfile.bun
+++ b/docker/Dockerfile.bun
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY git-warp/package*.json ./
 COPY git-warp/scripts ./scripts
 COPY git-warp/patches ./patches
+ENV PUPPETEER_SKIP_DOWNLOAD=true
 RUN bun install
 COPY git-warp .
 # Init a git repo so plumbing operations work inside the container.

--- a/docs/migrations/v19/README.md
+++ b/docs/migrations/v19/README.md
@@ -39,7 +39,9 @@ In an interactive terminal, a framed summary asks for confirmation before the
 inventory begins. After confirmation, the command completes the migration in
 one pass. It reports the current phase, writer, item count, and progress bar.
 Use `--yes` for non-interactive automation and `--json` for a machine-readable
-final report.
+final report. Before confirmation, the summary also reports current Git object
+storage, the scratch path, free space on the scratch and source Git volumes,
+and whether scratch free space meets the operating budget.
 
 ### What the command does
 
@@ -111,11 +113,16 @@ or packing objects; follow the phase and progress display instead of the size
 of the source repository alone.
 
 The scratch repository defaults to the operating system's temporary volume.
-Use `--scratch-root <path>` to place it on a volume with more space. Keep at
-least twice the source repository's current on-disk size free on that volume.
-That is an operating minimum, not a mathematical upper bound: object reuse,
-pack layout, retained checkpoint state, and repository-local Git configuration
-all affect the result.
+Use `--scratch-root <path>` to place it on a volume with more space. The
+preflight operating budget is twice the source repository's current Git object
+storage. It deliberately counts the complete object database, even when only
+one of several graph namespaces is selected: shared and blob-indirected
+objects cannot always be attributed reliably to one graph before inventory.
+That makes the estimate conservative for multi-graph repositories.
+
+The budget is an operating minimum, not a mathematical upper bound. Object
+reuse, pack layout, retained checkpoint state, and repository-local Git
+configuration all affect the result.
 
 The source repository can also grow because recovery refs keep the old graph
 reachable while the promoted graph becomes authoritative. Do not expect the
@@ -237,10 +244,11 @@ const roleOfAlice = users.observers.roleOf({
 Generated builders return validated, runtime-backed `Intent` and `Observer`
 objects. Loose JSON envelopes are not accepted at Lane boundaries.
 
-Wesley is a schema compiler. The application authors a GraphQL schema whose
-directives describe domain operations; Wesley turns that schema into typed
-operation metadata. A git-warp SDK renderer then binds that metadata to
-runtime-backed `Intent` and `Observer` builders.
+[Wesley](https://github.com/flyingrobots/wesley) is a domain-free GraphQL-to-IR
+compiler. The application authors a GraphQL schema whose directives describe
+domain operations; Wesley turns that schema into deterministic typed operation
+metadata. A git-warp SDK renderer then binds that metadata to runtime-backed
+`Intent` and `Observer` builders.
 
 The checked-in `users` example is a reference fixture, not yet a published
 general-purpose SDK generator. Its authored source is
@@ -267,6 +275,19 @@ The second command is deliberately fixture-specific: it validates the exact
 cannot yet point it at an arbitrary domain and receive a supported SDK. Until
 general SDK generation is published, use the fixture as an executable contract
 for the intended shape, but do not describe it as a consumer CLI.
+
+These are two separate migrations:
+
+- the retained-substrate command rewrites Git objects and refs once; it does
+  not modify application source;
+- the Wesley and SDK generation path produces TypeScript source; it does not
+  open or mutate a retained WARP graph.
+
+The fixture pipeline produces
+`test/fixtures/generated-sdk/users.wesley.generated.ts` followed by
+`test/fixtures/generated-sdk/users.generated.ts`. The import at the beginning
+of this section consumes the second file. The write and observation examples
+below then show the complete application-side use of its generated builders.
 
 ## Write Migration
 

--- a/docs/migrations/v19/README.md
+++ b/docs/migrations/v19/README.md
@@ -112,13 +112,34 @@ size, and Git process overhead. The command may look idle while Git is writing
 or packing objects; follow the phase and progress display instead of the size
 of the source repository alone.
 
-The scratch repository defaults to the operating system's temporary volume.
-Use `--scratch-root <path>` to place it on a volume with more space. The
-preflight operating budget is twice the source repository's current Git object
-storage. It deliberately counts the complete object database, even when only
+The scratch and disposable verification repositories default to the operating
+system's temporary volume. Use `--scratch-root <path>` to place all of them on
+a volume with more space.
+
+The preflight operating budget is the greater of:
+
+```text
+4 × current Git object-storage bytes
+
+current Git object-storage bytes
+  + current object count × scratch-filesystem allocation block size
+```
+
+The second term matters because migration writes many small loose objects. A
+packed source object may occupy only a few bytes in a pack delta, while its
+replacement still consumes at least one filesystem allocation block before
+later Git maintenance packs it.
+
+The preflight deliberately counts the complete object database, even when only
 one of several graph namespaces is selected: shared and blob-indirected
 objects cannot always be attributed reliably to one graph before inventory.
 That makes the estimate conservative for multi-graph repositories.
+
+In the 11,708-commit Think rehearsal, the source object database was about
+78.5 MiB across 172,644 objects. A naive 2× estimate reported only 157 MiB,
+but scratch exceeded 300 MiB while the new objects were loose. The
+count-and-allocation formula recommends about 753 MiB on a 4 KiB-block
+filesystem.
 
 The budget is an operating minimum, not a mathematical upper bound. Object
 reuse, pack layout, retained checkpoint state, and repository-local Git

--- a/docs/migrations/v19/README.md
+++ b/docs/migrations/v19/README.md
@@ -1,9 +1,9 @@
 # v19 Public API Migration Guide
 
-> **Status:** Pre-release. The canonical Runtime, worldline Lane, Observer,
-> streaming Observation, Reading, Receipt, and write-admission core has landed.
-> Fork/settlement, generated SDK publication, and CLI/MCP vocabulary
-> convergence remain tracked by issue #712.
+> **Status:** The public grammar shipped in `v19.0.0`. The retained-state
+> migration described below requires `v19.0.1`; do not use the `v19.0.0`
+> migrator on an authoritative repository. General generated-SDK publication
+> remains future work.
 
 v19 replaces the transitional storage- and timeline-shaped facade with one
 application grammar:
@@ -20,18 +20,72 @@ non-empty lane before migration fails with
 writer chain.
 
 Stop every process that can write to the repository, make a normal repository
-backup, and run the complete disposable proof:
+backup, and identify the graph name used by the application. Graph names are
+not fixed: one Git repository may contain several independent WARP graphs.
+
+Run the migration once:
 
 ```bash
-npm exec --package=@git-stunts/git-warp@19.0.0 -- git-warp-v18-to-v19 \
+npm exec --package=@git-stunts/git-warp@19.0.1 -- git-warp-v18-to-v19 \
   --repo /path/to/repository \
-  --graph events
+  --graph <graph-name>
 ```
 
-Without `--apply`, the command inventories every writer commit, translates the
-legacy patch and content references in an isolated repository, builds a fresh
-v19 checkpoint, verifies a public v19 read, and verifies a disposable v19
-append. It leaves authoritative refs unchanged.
+The command first discovers every graph namespace in the repository. If the
+requested name does not exist, it stops with `Graph not found` and lists each
+graph it did find, its version posture, writer count, and ref count.
+
+In an interactive terminal, a framed summary asks for confirmation before the
+inventory begins. After confirmation, the command completes the migration in
+one pass. It reports the current phase, writer, item count, and progress bar.
+Use `--yes` for non-interactive automation and `--json` for a machine-readable
+final report.
+
+### What the command does
+
+The source repository is read-only until the final ref transaction:
+
+```mermaid
+flowchart LR
+  source["Source repository<br/>authoritative refs"]
+  inventory["Inventory<br/>refs + writer commits"]
+  scratch["Scratch repository<br/>translated objects"]
+  verify["Scratch verification<br/>reopen + append + read"]
+  compare["Recheck source heads"]
+  promote["Atomic ref transaction"]
+  recovery["Recovery refs<br/>old objects retained"]
+
+  source --> inventory
+  inventory --> scratch
+  scratch --> verify
+  verify --> compare
+  compare -->|all OIDs unchanged| promote
+  compare -->|any OID changed| abort["Abort without cutover"]
+  promote --> source
+  promote --> recovery
+```
+
+At the Git level, migration does not edit commits in place. Git objects are
+immutable:
+
+1. It inventories refs below `refs/warp/<graph>/` and walks every writer
+   commit from its ref toward its root.
+2. It creates new blobs and trees for v19 git-cas asset handles.
+3. It writes a new commit chain. Preserved author, committer, timestamp, tree,
+   and message bytes can still produce a different commit OID because a
+   translated commit names a different parent OID.
+4. It builds a bounded v19 checkpoint and substrate marker in the scratch
+   repository.
+5. It proves that the scratch graph can reopen, accept a disposable append,
+   return a bounded public reading, and produce a valid receipt.
+6. It fetches the verified scratch objects into private import refs in the
+   source repository.
+7. One `git update-ref --stdin` transaction compares every original ref with
+   its inventoried OID, archives the original refs, and promotes the verified
+   refs. If any expected OID moved, the transaction fails as a unit.
+8. It verifies the promoted graph. If that proof fails, another guarded ref
+   transaction restores the original authoritative refs while retaining
+   recovery refs for diagnosis.
 
 Current v18 audit, intent, strand, overlay, braid, and trust publication refs
 are carried through unchanged and included in the compare-and-swap inventory.
@@ -39,27 +93,58 @@ If one of those refs still targets a retired pre-v18 blob or tree shape, the
 command fails before scratch work. Run the older one-shot migration first;
 production v19 contains no fallback reader for that substrate.
 
-After the proof succeeds, rerun it with promotion enabled:
-
-```bash
-npm exec --package=@git-stunts/git-warp@19.0.0 -- git-warp-v18-to-v19 \
-  --repo /path/to/repository \
-  --graph events \
-  --apply
-```
-
-Promotion rechecks every source head and uses one Git ref transaction. The
-transaction preserves the old writer, checkpoint, coverage, state-cache, and
-carried publication refs below:
+The old refs and blob-backed state-cache payload roots remain reachable below:
 
 ```text
 refs/warp/<graph>/recovery/v18-to-v19/<run-id>/
 ```
 
-It also retains each payload tree named only inside the old blob-backed state
-cache. No old ref is deleted or replaced unless every expected source OID is
-unchanged. Keep the recovery refs until application reads, writes, and backups
-have been independently confirmed.
+Keep those recovery refs until application reads, writes, and backups have
+been independently confirmed. They are deliberately additive: migration does
+not immediately reclaim old objects.
+
+### Time, memory, and disk
+
+Migration time scales mainly with writer-commit count, retained checkpoint
+size, and Git process overhead. The command may look idle while Git is writing
+or packing objects; follow the phase and progress display instead of the size
+of the source repository alone.
+
+The scratch repository defaults to the operating system's temporary volume.
+Use `--scratch-root <path>` to place it on a volume with more space. Keep at
+least twice the source repository's current on-disk size free on that volume.
+That is an operating minimum, not a mathematical upper bound: object reuse,
+pack layout, retained checkpoint state, and repository-local Git configuration
+all affect the result.
+
+The source repository can also grow because recovery refs keep the old graph
+reachable while the promoted graph becomes authoritative. Do not expect the
+source repository to shrink during migration. A later, separately approved
+retention and garbage-collection decision is what can make old objects
+collectable.
+
+Production v19 public reads are bounded and do not decode a full graph state.
+The one-shot migration has one explicit legacy bridge: it may decode a
+monolithic v18 checkpoint, with a 64 MiB encoded-byte ceiling plus depth and
+item limits, to seed bounded v19 indexes. Repositories without a usable
+checkpoint fall back to replaying the complete writer history.
+
+### Rehearse only when you mean to
+
+The normal command performs the scratch proof and promotion in one invocation.
+Use `--dry-run` only when you explicitly want a rehearsal whose result will be
+discarded:
+
+```bash
+npm exec --package=@git-stunts/git-warp@19.0.1 -- git-warp-v18-to-v19 \
+  --repo /path/to/repository \
+  --graph <graph-name> \
+  --dry-run
+```
+
+Because the scratch repository is intentionally deleted, a later normal run
+must repeat the work. `--apply` remains accepted as a compatibility alias for
+the normal one-pass behavior; it is no longer required.
 
 For an encrypted v18 substrate, provide the passphrase through
 `GIT_WARP_MIGRATION_PASSPHRASE`; never place it in command-line arguments or
@@ -151,6 +236,37 @@ const roleOfAlice = users.observers.roleOf({
 
 Generated builders return validated, runtime-backed `Intent` and `Observer`
 objects. Loose JSON envelopes are not accepted at Lane boundaries.
+
+Wesley is a schema compiler. The application authors a GraphQL schema whose
+directives describe domain operations; Wesley turns that schema into typed
+operation metadata. A git-warp SDK renderer then binds that metadata to
+runtime-backed `Intent` and `Observer` builders.
+
+The checked-in `users` example is a reference fixture, not yet a published
+general-purpose SDK generator. Its authored source is
+`test/fixtures/generated-sdk/users.graphql`. In a git-warp checkout with
+Wesley `0.3.0-alpha.1` on `PATH`, reproduce it with:
+
+```bash
+npm run generate:sdk-fixture
+```
+
+The command is equivalent to these two conceptual stages:
+
+```bash
+wesley emit typescript \
+  --schema test/fixtures/generated-sdk/users.graphql \
+  --out test/fixtures/generated-sdk/users.wesley.generated.ts
+
+node scripts/generated-sdk/RenderUsersSdkFixture.ts \
+  --out test/fixtures/generated-sdk/users.generated.ts
+```
+
+The second command is deliberately fixture-specific: it validates the exact
+`registerUser`, `assignRole`, `roleOf`, and `rolesOf` contract. Consumers
+cannot yet point it at an arbitrary domain and receive a supported SDK. Until
+general SDK generation is published, use the fixture as an executable contract
+for the intended shape, but do not describe it as a consumer CLI.
 
 ## Write Migration
 

--- a/docs/topics/api/README.md
+++ b/docs/topics/api/README.md
@@ -46,6 +46,74 @@ The canonical sentence is:
 > An Observer runs against a Lane, producing an Observation that emits
 > Readings and leaves a Receipt.
 
+The following class diagram shows ownership and operation results. It is a
+vocabulary map, not a claim that every noun is implemented as a concrete
+class:
+
+```mermaid
+classDiagram
+  direction LR
+
+  class Runtime {
+    +open(options) Runtime
+    +lane(name) Lane
+    +fork(source, options) Lane
+    +strand(parent, options) Lane
+    +close()
+  }
+
+  class Lane {
+    +write(intent) Receipt
+    +observe(observer) Observation
+  }
+
+  class Intent {
+    <<validated write proposal>>
+  }
+
+  class Observer {
+    <<immutable observation plan>>
+  }
+
+  class Observation {
+    <<AsyncIterable of Reading>>
+    +one() Reading
+    +receipt ObservationReceiptPromise
+  }
+
+  class Reading {
+    <<bounded semantic result>>
+  }
+
+  class Receipt {
+    <<durable terminal record>>
+  }
+
+  class GeneratedDomainSDK {
+    +intents
+    +observers
+  }
+
+  Runtime "1" *-- "0..*" Lane : owns access
+  GeneratedDomainSDK ..> Intent : builds
+  GeneratedDomainSDK ..> Observer : builds
+  Lane ..> Intent : admits
+  Lane ..> Receipt : write returns
+  Lane ..> Observer : executes
+  Lane ..> Observation : creates
+  Observation --> Reading : emits
+  Observation --> Receipt : leaves
+```
+
+Read the diagram from left to right:
+
+1. Open one `Runtime`, then obtain one or more named or forked `Lane` handles.
+2. Use a generated domain SDK to construct validated `Intent` and `Observer`
+   values.
+3. A write admits an `Intent` and returns a terminal `Receipt`.
+4. An observation executes an `Observer`, streams bounded `Reading` values,
+   and leaves its own terminal `Receipt`.
+
 ## Disclosure Order
 
 Documentation, generated APIs, CLI help, and MCP descriptions must disclose

--- a/docs/topics/api/README.md
+++ b/docs/topics/api/README.md
@@ -114,6 +114,20 @@ Read the diagram from left to right:
 4. An observation executes an `Observer`, streams bounded `Reading` values,
    and leaves its own terminal `Receipt`.
 
+Each diagram noun is anchored to its current implementation or executable
+reference:
+
+| Diagram noun  | Source                                                                          |
+| ------------- | ------------------------------------------------------------------------------- |
+| `Runtime`     | [`src/application/Runtime.ts`](../../../src/application/Runtime.ts)             |
+| `Lane`        | [`src/domain/api/Lane.ts`](../../../src/domain/api/Lane.ts)                     |
+| `Intent`      | [`src/domain/api/Intent.ts`](../../../src/domain/api/Intent.ts)                 |
+| `Observer`    | [`src/domain/api/Observer.ts`](../../../src/domain/api/Observer.ts)             |
+| `Observation` | [`src/domain/api/Observation.ts`](../../../src/domain/api/Observation.ts)       |
+| `Reading`     | [`src/domain/api/Reading.ts`](../../../src/domain/api/Reading.ts)               |
+| `Receipt`     | [`src/domain/api/Receipt.ts`](../../../src/domain/api/Receipt.ts)               |
+| Generated SDK | [`users.generated.ts`](../../../test/fixtures/generated-sdk/users.generated.ts) |
+
 ## Disclosure Order
 
 Documentation, generated APIs, CLI help, and MCP descriptions must disclose

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "packages/*"
       ],
       "dependencies": {
+        "@flyingrobots/bijou": "^7.2.0",
+        "@flyingrobots/bijou-node": "^7.2.0",
+        "@flyingrobots/bijou-tui": "^7.2.0",
         "@git-stunts/alfred": "^0.10.4",
         "@git-stunts/git-cas": "^6.5.5",
         "@git-stunts/plumbing": "^3.2.0",
@@ -409,30 +412,30 @@
       }
     },
     "node_modules/@flyingrobots/bijou": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou/-/bijou-5.0.0.tgz",
-      "integrity": "sha512-Vmcs1jZYIxwb2NOn+LCDMK8ZmIKz64eTQI+gEk11Odn32s4ipIrzawrfrrAWZ4UTsdD5c9xWwwJH6SYgo5klBg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou/-/bijou-7.2.0.tgz",
+      "integrity": "sha512-f7Ik7Wx/DBgaVoplt5QmrFiH84ri1p1DIfyYpxkcCAEwbhf3i+IU3bd3rohWaHWXtC7J5FINOmW8Cgbo9SVSuw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@flyingrobots/bijou-i18n": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-i18n/-/bijou-i18n-5.0.0.tgz",
-      "integrity": "sha512-S3HUHBBLh7fZlijcyuJvtrcJYa+rlhmfW5AAaMZmvIS1P9yd38t7P3JaPGsmKPJjCIVsVgiH3zrjWY15TKB6xA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-i18n/-/bijou-i18n-7.2.0.tgz",
+      "integrity": "sha512-1c2DPftoSxBRfp7EDpNknRpoQsODbjyy3SMY1soRSU4C61lEX/FM3P1mtbO5HmYRkYuzBolgWZhLZ7e1BMP5KA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@flyingrobots/bijou-node": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-node/-/bijou-node-5.0.0.tgz",
-      "integrity": "sha512-Ano8ydJKF/M8MGPeQDMjOuLouKFEOnEaTwYOKAHHMWxDh03G0Yt9HqZPPu364puzJuyFkY1APxtsxUCbru+5IA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-node/-/bijou-node-7.2.0.tgz",
+      "integrity": "sha512-8PCWqr3WsBclZAnTqtnNd5xi85VFiCpbVjVrJ+jbb3UhC6QShz0meREUjSaSdfdguol9tribuy4a7hZaiqsvRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-tui": "5.0.0",
+        "@flyingrobots/bijou-tui": "7.2.0",
         "chalk": "^5.6.2",
         "gifenc": "^1.0.3",
         "oled-font-5x7": "^1.0.3"
@@ -441,35 +444,22 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "5.0.0"
+        "@flyingrobots/bijou": "7.2.0"
       }
     },
     "node_modules/@flyingrobots/bijou-tui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-tui/-/bijou-tui-5.0.0.tgz",
-      "integrity": "sha512-dJAWBIZ8osXIM5y6Mc2KsawHPYR/3JxQEO78yVzzdsQiAx9PZLTQvB8fY6oUQRf+/n3sU9l2Ep0UUsJIbhAmpA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-tui/-/bijou-tui-7.2.0.tgz",
+      "integrity": "sha512-cwr4Lh38toZCt+DDCAkaxcJn7DLST0fZDVfbTL8CRmtO9611SxvDqmw8Ij18reEmY63G72qVXlBsyfza7QhKdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@flyingrobots/bijou-i18n": "5.0.0"
+        "@flyingrobots/bijou-i18n": "7.2.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@flyingrobots/bijou": "5.0.0"
-      }
-    },
-    "node_modules/@flyingrobots/bijou-tui-app": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-tui-app/-/bijou-tui-app-5.0.0.tgz",
-      "integrity": "sha512-NrmTalkI1uIEBosE4tzSF04pMbP+Rs32NNlCRY6njDawDYr8mDBLErziyomio/zhHVVKvnrLuo6g4aLsDPKqHw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@flyingrobots/bijou": "5.0.0",
-        "@flyingrobots/bijou-tui": "5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "@flyingrobots/bijou": "7.2.0"
       }
     },
     "node_modules/@git-stunts/alfred": {
@@ -510,6 +500,70 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@git-stunts/git-cas/node_modules/@flyingrobots/bijou": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou/-/bijou-5.0.0.tgz",
+      "integrity": "sha512-Vmcs1jZYIxwb2NOn+LCDMK8ZmIKz64eTQI+gEk11Odn32s4ipIrzawrfrrAWZ4UTsdD5c9xWwwJH6SYgo5klBg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@git-stunts/git-cas/node_modules/@flyingrobots/bijou-i18n": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-i18n/-/bijou-i18n-5.0.0.tgz",
+      "integrity": "sha512-S3HUHBBLh7fZlijcyuJvtrcJYa+rlhmfW5AAaMZmvIS1P9yd38t7P3JaPGsmKPJjCIVsVgiH3zrjWY15TKB6xA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@git-stunts/git-cas/node_modules/@flyingrobots/bijou-node": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-node/-/bijou-node-5.0.0.tgz",
+      "integrity": "sha512-Ano8ydJKF/M8MGPeQDMjOuLouKFEOnEaTwYOKAHHMWxDh03G0Yt9HqZPPu364puzJuyFkY1APxtsxUCbru+5IA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@flyingrobots/bijou-tui": "5.0.0",
+        "chalk": "^5.6.2",
+        "gifenc": "^1.0.3",
+        "oled-font-5x7": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@flyingrobots/bijou": "5.0.0"
+      }
+    },
+    "node_modules/@git-stunts/git-cas/node_modules/@flyingrobots/bijou-tui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-tui/-/bijou-tui-5.0.0.tgz",
+      "integrity": "sha512-dJAWBIZ8osXIM5y6Mc2KsawHPYR/3JxQEO78yVzzdsQiAx9PZLTQvB8fY6oUQRf+/n3sU9l2Ep0UUsJIbhAmpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@flyingrobots/bijou-i18n": "5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@flyingrobots/bijou": "5.0.0"
+      }
+    },
+    "node_modules/@git-stunts/git-cas/node_modules/@flyingrobots/bijou-tui-app": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@flyingrobots/bijou-tui-app/-/bijou-tui-app-5.0.0.tgz",
+      "integrity": "sha512-NrmTalkI1uIEBosE4tzSF04pMbP+Rs32NNlCRY6njDawDYr8mDBLErziyomio/zhHVVKvnrLuo6g4aLsDPKqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@flyingrobots/bijou": "5.0.0",
+        "@flyingrobots/bijou-tui": "5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@git-stunts/plumbing": {
@@ -1278,9 +1332,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1719,9 +1773,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2924,13 +2978,13 @@
       }
     },
     "node_modules/ini": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/is-alphabetical": {
@@ -3583,9 +3637,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {
@@ -3664,9 +3718,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
       "funding": [
         {
@@ -3681,8 +3735,8 @@
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -3692,9 +3746,9 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.0.tgz",
-      "integrity": "sha512-xMUI3ChBuRuxuLF4ENvCZyS8z/+Jly1coUcZwErKLIB3sDj7ojpaTBa1e9YVPhSN4jGEIjYGQCldbTJS/hqS+A==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
+      "integrity": "sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3716,23 +3770,23 @@
       }
     },
     "node_modules/markdownlint-cli": {
-      "version": "0.49.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.49.0.tgz",
-      "integrity": "sha512-vS5tWq5W91Gg33LD4pyAaXPclnz/sRvo6/RGOyDQjQ3eds2DkK6H4szUuE0M9TiRB/u/VBx1gtd9Ktrtx5WlSA==",
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.49.1.tgz",
+      "integrity": "sha512-qpYqJbSYf3jv57bdnFmCaZ/Wlu6IYHp2b6SOKrKBJ7OnPrDHIKmx4NERWH49QH9viTI6yO6raVDDn5nrf60VQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "~15.0.0",
         "deep-extend": "~0.6.0",
-        "ignore": "~7.0.5",
-        "js-yaml": "~4.2.0",
+        "ignore": "~7.0.6",
+        "js-yaml": "~5.2.1",
         "jsonc-parser": "~3.3.1",
         "jsonpointer": "~5.0.1",
-        "markdown-it": "~14.2.0",
-        "markdownlint": "~0.41.0",
+        "markdown-it": "~14.3.0",
+        "markdownlint": "~0.41.1",
         "minimatch": "~10.2.5",
-        "run-con": "~1.3.2",
-        "smol-toml": "~1.6.1",
+        "run-con": "~1.3.3",
+        "smol-toml": "~1.7.0",
         "tinyglobby": "~0.2.17"
       },
       "bin": {
@@ -3753,16 +3807,16 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/markdownlint-cli/node_modules/commander": {
@@ -3776,13 +3830,36 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/markdownlint-cli/node_modules/js-yaml": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/markdownlint-cli/node_modules/minimatch": {
@@ -3829,9 +3906,9 @@
       }
     },
     "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4429,9 +4506,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4731,9 +4808,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4751,7 +4828,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4889,14 +4966,14 @@
       }
     },
     "node_modules/run-con": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
-      "integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.3.tgz",
+      "integrity": "sha512-Lb7OKM9aaykzyoNiHGhSVCjZsvbyy6qDMp2vDXL+MoCfz3GfNJtHYH7uYsU3QNMyInBk++xx+EZ8xZ8Sxs5fNQ==",
       "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
-        "ini": "~4.1.0",
+        "ini": "~7.0.0",
         "minimist": "^1.2.8",
         "strip-json-comments": "~3.1.1"
       },
@@ -4976,9 +5053,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
-      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@git-stunts/docker-guard": "^0.1.0",
+        "@mermaid-js/mermaid-cli": "^11.16.0",
         "@types/node": "^22.15.29",
         "@typescript-eslint/eslint-plugin": "^8.54.0",
         "@typescript-eslint/parser": "^8.54.0",
@@ -56,6 +57,20 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -117,6 +132,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
       "version": "2.2.0",
@@ -195,6 +217,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -411,6 +440,64 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.20",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.20.tgz",
+      "integrity": "sha512-CMqMy7OaXl9W0eq1Uy7L7i2Y/anPvHmFmESd2CEw0t5YvZhcVCeo4MBevAmswRllX7Y2dEidA4ozGPunLSTQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.9",
+        "@floating-ui/utils": "^0.2.12",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+      "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.8.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@flyingrobots/bijou": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@flyingrobots/bijou/-/bijou-7.2.0.tgz",
@@ -460,6 +547,16 @@
       },
       "peerDependencies": {
         "@flyingrobots/bijou": "7.2.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.3.1.tgz",
+      "integrity": "sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg==",
+      "dev": true,
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@git-stunts/alfred": {
@@ -636,6 +733,56 @@
       "resolved": "packages/warp-orset",
       "link": true
     },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.10.tgz",
+      "integrity": "sha512-5pVLNK9wlpxTUTy9GpgbX/SdcRh+HBnPktjM2wbiLTH4p+2EPHBO1aoSryUCuKUIItdDWO9ITlhUL8UnUN/oIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@headlessui/react/node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@headlessui/tailwindcss": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/tailwindcss/-/tailwindcss-0.2.2.tgz",
+      "integrity": "sha512-xNe42KjdyA4kfUKLLPGzME9zkH7Q3rOZ5huFihWNWOQFxnItxPB3/67yBI8/qBfY8nwBRx5GHn4VprsoluVMGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.0 || ^4.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -688,6 +835,55 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -714,6 +910,410 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/layout-elk": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-elk/-/layout-elk-0.2.2.tgz",
+      "integrity": "sha512-vnH3gtqfhyBiRVKNpT8iDENTw18q/OF0GF/SfYfHN43KZpu+6eZDEOMHTfNYAkpmUWJNgtRQFIS6BTc7vH/DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "elkjs": "^0.9.3"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/layout-elk/node_modules/elkjs": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
+      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+      "dev": true,
+      "license": "EPL-2.0"
+    },
+    "node_modules/@mermaid-js/layout-tidy-tree": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/layout-tidy-tree/-/layout-tidy-tree-0.2.2.tgz",
+      "integrity": "sha512-8RmjDXjKJBxqTS1mICStm8zWRM45fSzs0SOrkp28+KsOGS2YEMFMVTwwRU8CsC6M1L+pDYZVjf1m9AC1c9Wndg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "d3": "^7.9.0"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-cli": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-cli/-/mermaid-cli-11.16.0.tgz",
+      "integrity": "sha512-0InK2nbVIMtzVzCugmdvPkAuvS6wRUqU6Utntff1n8c7lgfRZAdhKY6PSKvcIK9nFmuOUzAgB5+x/XWcroZ7Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.0.0 || ^7.0.1",
+        "@mermaid-js/layout-elk": "^0.1.5 || ^0.2.0",
+        "@mermaid-js/mermaid-zenuml": "^0.2.0",
+        "chalk": "^5.0.1",
+        "commander": "^13.1.0",
+        "import-meta-resolve": "^4.1.0",
+        "katex": "^0.16.25",
+        "mermaid": "^11.14.0",
+        "p-limit": "^6.2.0"
+      },
+      "bin": {
+        "mmdc": "src/cli.js"
+      },
+      "engines": {
+        "node": "^18.19 || >=20.0"
+      },
+      "optionalDependencies": {
+        "@mermaid-js/layout-tidy-tree": "^0.2.1"
+      },
+      "peerDependencies": {
+        "puppeteer": "^23 || ^24 || ^25"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-cli/node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-cli/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-zenuml": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-zenuml/-/mermaid-zenuml-0.2.3.tgz",
+      "integrity": "sha512-RGBtgL6fc+5Y2Jm9odOH9HRJ80BP4l6atBYnAK5bBzEowF0PU3UtvZRRcbFxImPGPuLIzqZq31ur8lVO0AoF3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zenuml/core": "^3.47.0"
+      },
+      "peerDependencies": {
+        "mermaid": "^10 || ^11"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -755,6 +1355,77 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
+      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.22.1.tgz",
+      "integrity": "sha512-CPxtkyrBi/HYY5P3lE/57sQ6qfa0lN8E55TOm89H0kNGv0lKt+/0zP7lWERzBjRr5IxBVrQX4gFEowBN52LPaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.28.1.tgz",
+      "integrity": "sha512-Bqb+HrD5I5MHS2SKBhISYqo2SW8Y2dfzgF/Y1lIJq7xqLxheo9vzxPGEHhz+XzkgGfoqEJx8A6a3C7uiqS3HWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.34.0",
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
+      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1059,6 +1730,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.8.tgz",
+      "integrity": "sha512-O39GJQpAYEJcIu3uN1//YtmhjSEOyw75vg9CKCatBDPiD5hKtZQoJHfferyrB/LdOD3UWaoMLWtdEjarwIwdDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.6.tgz",
+      "integrity": "sha512-h0/Ebo18CkOrChlQIhNtQkM5ySUnh/GumQ/D1st3hG2HWUPEF+ILUc2k29UtivCi/9G7w7G3/f7Xyd5cCFbKBw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -1079,6 +1789,290 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/debug": {
@@ -1102,6 +2096,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1135,6 +2136,14 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.11",
@@ -1399,6 +2408,17 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
@@ -1550,6 +2570,47 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/@zenuml/core": {
+      "version": "3.50.1",
+      "resolved": "https://registry.npmjs.org/@zenuml/core/-/core-3.50.1.tgz",
+      "integrity": "sha512-Q18BXvIfhRuGw0JfO4e+pltG04Phhv2E7n35EWTNSZKKH/HEkyE4Sh7KERb9dqaOfjOdRdKvLG0YekjK3fcDXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.16",
+        "@headlessui/react": "^2.2.9",
+        "@headlessui/tailwindcss": "^0.2.2",
+        "antlr4": "~4.11.0",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "color-string": "^2.1.4",
+        "dompurify": "^3.3.1",
+        "highlight.js": "^11.10.0",
+        "html-to-image": "^1.11.13",
+        "jotai": "^2.16.1",
+        "marked": "^4.3.0",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
+        "tailwind-merge": "^3.4.0"
+      },
+      "bin": {
+        "zenuml": "dist/cli/zenuml.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.97"
+      },
+      "peerDependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "peerDependenciesMeta": {
+        "playwright-core": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1664,6 +2725,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/antlr4": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.11.0.tgz",
+      "integrity": "sha512-GUGlpE2JUjAN+G8G5vY+nOoeyNhHsXoIJwP1XF1oRw89vifA1K46T6SEkwLwr7drihN7I/lf0DIjKc4OZvBX8w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
@@ -1680,6 +2751,19 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1954,6 +3038,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -1968,6 +3070,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
       }
     },
     "node_modules/cli-boxes": {
@@ -2038,6 +3153,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2057,6 +3198,29 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -2091,6 +3255,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2105,6 +3279,564 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2173,6 +3905,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -2205,6 +3947,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1653615",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
+      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -2291,6 +4051,29 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2764,6 +4547,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
@@ -2867,6 +4661,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2916,6 +4717,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -2939,6 +4750,26 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2967,6 +4798,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2985,6 +4827,16 @@
       "license": "ISC",
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -3181,6 +5033,36 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jotai": {
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.20.2.tgz",
+      "integrity": "sha512-aHB4CNb9qRcyf0mwSB6EO5bCGAjx8cTwFgOFCE2leOnTzqACbnSWG8XoWB3LxCT1Qoj03I1OWAHszDmN4uHb/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0",
+        "@babel/template": ">=7.0.0",
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/template": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -3339,6 +5221,12 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+      "dev": true
+    },
     "node_modules/klaw-sync": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
@@ -3348,6 +5236,13 @@
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -3636,6 +5531,20 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
@@ -3671,6 +5580,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3895,6 +5811,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3911,6 +5840,49 @@
       "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -4498,6 +6470,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4647,6 +6638,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4760,6 +6758,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4805,6 +6810,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -4882,6 +6905,48 @@
         "node": ">=6"
       }
     },
+    "node_modules/puppeteer": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.4.0.tgz",
+      "integrity": "sha512-xfQp8dFBcGaLc1hEMaVr7s+oW4ZkAurr8Y9H81ilKhu6QoLfSTkZjU7IavnyJ/VWpB9ni3KNJUQHUatslLWyGw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.6",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.4.0",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.4.0.tgz",
+      "integrity": "sha512-K1plkLOdeoUnGeT1OvdqF3qxl33v+Ra/uH5VyPEhXdMcpvGiEskHzxxEU3fgpccJpJLIipB/rPUsvkZRWeKqOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.6",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -4898,6 +6963,69 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-aria": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
+      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.48.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-stately": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
+      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",
@@ -4930,6 +7058,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/rolldown": {
       "version": "1.0.3",
@@ -4965,6 +7100,19 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/run-con": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.3.tgz",
@@ -4980,6 +7128,27 @@
       "bin": {
         "run-con": "cli.js"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -5159,6 +7328,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5171,6 +7347,32 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5269,13 +7471,22 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5301,6 +7512,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -5372,6 +7591,30 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -5534,6 +7777,14 @@
         }
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5632,6 +7883,40 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -5646,6 +7931,54 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "check:sdk-fixture": "node scripts/generated-sdk/GenerateUsersSdkFixture.ts --check",
     "lint": "sh -c 'eslint . \"$@\" && npm run lint:test-law && npm run lint:source-size && npm run lint:cas-invariants' --",
     "lint:ratchet": "sh scripts/lint-ratchet.sh",
-    "lint:md": "markdownlint \"**/*.md\" --ignore node_modules --ignore \"**/node_modules/**\"",
+    "lint:md": "markdownlint \"**/*.md\" --ignore node_modules --ignore \"**/node_modules/**\" && npm run lint:mermaid",
+    "lint:mermaid": "node scripts/validate-mermaid.ts",
     "lint:md:code": "node scripts/lint-markdown-code-samples.ts",
     "lint:docs-topology": "bash scripts/check-docs-topology.sh && npm run lint:source-backed-reference",
     "lint:links": "lychee --config .lychee.toml --include-fragments '**/*.md'",
@@ -158,6 +159,7 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@git-stunts/docker-guard": "^0.1.0",
+    "@mermaid-js/mermaid-cli": "^11.16.0",
     "@types/node": "^22.15.29",
     "@typescript-eslint/eslint-plugin": "^8.54.0",
     "@typescript-eslint/parser": "^8.54.0",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,9 @@
     "ratchet:delta": "node scripts/ratchet-delta.ts"
   },
   "dependencies": {
+    "@flyingrobots/bijou": "^7.2.0",
+    "@flyingrobots/bijou-node": "^7.2.0",
+    "@flyingrobots/bijou-tui": "^7.2.0",
     "@git-stunts/alfred": "^0.10.4",
     "@git-stunts/git-cas": "^6.5.5",
     "@git-stunts/plumbing": "^3.2.0",

--- a/scripts/formatFailure.ts
+++ b/scripts/formatFailure.ts
@@ -1,0 +1,18 @@
+/** Format nested failures without losing AggregateError members or causes. */
+export function formatFailure(error: unknown, seen = new Set<unknown>()): string {
+  if (seen.has(error)) {
+    return '[circular failure]';
+  }
+  seen.add(error);
+  const message = error instanceof Error ? error.message : String(error);
+  const nested: string[] = [];
+  if (error instanceof AggregateError) {
+    error.errors.forEach((entry, index) => {
+      nested.push(`failure ${String(index + 1)}: ${formatFailure(entry, seen)}`);
+    });
+  }
+  if (error instanceof Error && error.cause !== undefined) {
+    nested.push(`cause: ${formatFailure(error.cause, seen)}`);
+  }
+  return nested.length === 0 ? message : `${message}\n${nested.join('\n')}`;
+}

--- a/scripts/v18-to-v19/README.md
+++ b/scripts/v18-to-v19/README.md
@@ -38,13 +38,14 @@ count. A repository may contain any number of independently named graphs.
 In an interactive terminal, the command displays the selected graph and exact
 mode in a framed application, then waits for confirmation before inventory or
 scratch work. The preflight reads `git count-objects -v` and filesystem
-capacity, reports the complete Git object-store size, source and scratch free
-space, and a scratch operating budget of twice the object-store size. Counting
-the complete store is conservative for a repository with several graphs,
-because shared and blob-indirected objects cannot be attributed reliably
-before inventory. After confirmation, the normal command completes all five
-boundaries in one pass. Long writer chains remain observable through the
-current phase, writer, count, and progress bar.
+capacity, reports the complete Git object-store byte size and object count,
+source and scratch free space, and a scratch operating budget that accounts
+for both byte volume and loose-object allocation blocks. Counting the complete
+store is conservative for a repository with several graphs, because shared
+and blob-indirected objects cannot be attributed reliably before inventory.
+After confirmation, the normal command completes all five boundaries in one
+pass. Long writer chains remain observable through the current phase, writer,
+count, and progress bar.
 
 For automation, pass `--yes`; progress is written to standard error and the
 final report to standard output. Add `--json` for a machine-readable report.
@@ -52,14 +53,15 @@ For encrypted v18 patches, provide `GIT_WARP_MIGRATION_PASSPHRASE` in the
 environment; the passphrase is never accepted as an argument or included in
 the report.
 
-The scratch repository defaults to the operating system's temporary volume.
-Use `--scratch-root <path>` to place it on a volume with more space. The exact
-size depends on reachable Git objects and checkpoint state; as a conservative
-operating budget, keep free space equal to at least twice the source
-repository's current on-disk size on the scratch volume. The scratch
-repository is deleted after success or failure. Promotion retains recovery
-refs in the source repository, so do not expect the source repository to
-shrink during migration.
+The scratch and disposable verification repositories default to the operating
+system's temporary volume. Use `--scratch-root <path>` to place all migration
+temporaries on a volume with more space. The exact size depends on reachable
+Git objects and checkpoint state. The reported operating budget is the greater
+of four times the current object-store bytes and the object-store bytes plus
+one scratch-filesystem allocation block for every current Git object. Scratch
+and verifier repositories are deleted after success or failure. Promotion
+retains recovery refs in the source repository, so do not expect the source
+repository to shrink during migration.
 
 Monolithic v18 checkpoint CBOR is decoded only inside this migration with a
 64 MiB byte ceiling plus explicit depth and item limits. Promoted verification

--- a/scripts/v18-to-v19/README.md
+++ b/scripts/v18-to-v19/README.md
@@ -25,7 +25,7 @@ Stop every process that can write to the repository and make a normal backup.
 After installing v19 without starting the application, run the migration:
 
 ```bash
-npm exec --package=@git-stunts/git-warp@19.0.0 -- git-warp-v18-to-v19 \
+npm exec --package=@git-stunts/git-warp@19.0.1 -- git-warp-v18-to-v19 \
   --repo /path/to/repository \
   --graph <graph-name>
 ```
@@ -72,7 +72,7 @@ public API, and validates its receipt.
 Use `--dry-run` only when you explicitly want a disposable rehearsal:
 
 ```bash
-npm exec --package=@git-stunts/git-warp@19.0.0 -- git-warp-v18-to-v19 \
+npm exec --package=@git-stunts/git-warp@19.0.1 -- git-warp-v18-to-v19 \
   --repo /path/to/repository \
   --graph <graph-name> \
   --dry-run

--- a/scripts/v18-to-v19/README.md
+++ b/scripts/v18-to-v19/README.md
@@ -37,7 +37,12 @@ count. A repository may contain any number of independently named graphs.
 
 In an interactive terminal, the command displays the selected graph and exact
 mode in a framed application, then waits for confirmation before inventory or
-scratch work. After confirmation, the normal command completes all five
+scratch work. The preflight reads `git count-objects -v` and filesystem
+capacity, reports the complete Git object-store size, source and scratch free
+space, and a scratch operating budget of twice the object-store size. Counting
+the complete store is conservative for a repository with several graphs,
+because shared and blob-indirected objects cannot be attributed reliably
+before inventory. After confirmation, the normal command completes all five
 boundaries in one pass. Long writer chains remain observable through the
 current phase, writer, count, and progress bar.
 

--- a/scripts/v18-to-v19/README.md
+++ b/scripts/v18-to-v19/README.md
@@ -4,54 +4,82 @@ This directory owns every v18 retained-substrate reader and translator needed
 by the one-shot v19 migration. Production runtime code only recognizes the
 exact v19 marker and fails closed for non-empty unmarked timelines.
 
-The migration has four boundaries:
+The migration has five boundaries:
 
-1. Inventory every graph ref and every writer commit without writing.
-2. Recreate the graph in a disposable repository, translating legacy patch
+1. Discover every graph namespace and report whether it is current, needs this
+   upgrade, or has an unsupported retained shape.
+2. Inventory every selected-graph ref and every writer commit without writing.
+3. Recreate the graph in a disposable repository, translating legacy patch
    trailers and raw content OIDs into explicit git-cas asset handles while
    preserving current audit, intent, strand, overlay, braid, and trust refs.
-3. Translate a retained v18 checkpoint when available, rebuild current bounded
+4. Translate a retained v18 checkpoint when available, rebuild current bounded
    indexes from its authoritative state, replay only the writer tail, then
    prove a public v19 read and a disposable v19 append. Repositories without a
    usable checkpoint safely fall back to full writer-history materialization.
-4. Recheck source heads and atomically promote all verified refs while retaining
-   old refs and state-cache payload roots below additive recovery refs.
-
-The default command stops after boundary 3. `--apply` explicitly enables
-boundary 4.
+5. Recheck source heads, atomically promote all verified refs while retaining
+   old refs and state-cache payload roots below additive recovery refs, then
+   verify the promoted graph through another disposable append and bounded
+   public reading.
 
 Stop every process that can write to the repository and make a normal backup.
-After installing v19 without starting the application, run the disposable
-proof:
+After installing v19 without starting the application, run the migration:
 
 ```bash
 npm exec --package=@git-stunts/git-warp@19.0.0 -- git-warp-v18-to-v19 \
   --repo /path/to/repository \
-  --graph events
+  --graph <graph-name>
 ```
 
-Progress is written to standard error so long writer chains remain observable.
-Use `--json` when a machine-readable report is needed on standard output. For
-encrypted v18 patches, provide `GIT_WARP_MIGRATION_PASSPHRASE` in the
+The command discovers the repository's graph names before it does migration
+work. If `<graph-name>` is wrong, it stops with `Graph not found` and lists the
+graphs it did find, including their version posture, writer count, and ref
+count. A repository may contain any number of independently named graphs.
+
+In an interactive terminal, the command displays the selected graph and exact
+mode in a framed application, then waits for confirmation before inventory or
+scratch work. After confirmation, the normal command completes all five
+boundaries in one pass. Long writer chains remain observable through the
+current phase, writer, count, and progress bar.
+
+For automation, pass `--yes`; progress is written to standard error and the
+final report to standard output. Add `--json` for a machine-readable report.
+For encrypted v18 patches, provide `GIT_WARP_MIGRATION_PASSPHRASE` in the
 environment; the passphrase is never accepted as an argument or included in
 the report.
 
-Monolithic v18 checkpoint CBOR is decoded only inside this migration with a
-64 MiB byte ceiling plus explicit depth and item limits. The normal v19 runtime
-keeps its stricter 5 MiB decode boundary.
+The scratch repository defaults to the operating system's temporary volume.
+Use `--scratch-root <path>` to place it on a volume with more space. The exact
+size depends on reachable Git objects and checkpoint state; as a conservative
+operating budget, keep free space equal to at least twice the source
+repository's current on-disk size on the scratch volume. The scratch
+repository is deleted after success or failure. Promotion retains recovery
+refs in the source repository, so do not expect the source repository to
+shrink during migration.
 
-Only after the dry-run reports `verified-dry-run`, promote the verified refs:
+Monolithic v18 checkpoint CBOR is decoded only inside this migration with a
+64 MiB byte ceiling plus explicit depth and item limits. Promoted verification
+does not call full graph materialization: it fetches the promoted refs into
+another disposable repository, appends a canary, reads it through the bounded
+public API, and validates its receipt.
+
+Use `--dry-run` only when you explicitly want a disposable rehearsal:
 
 ```bash
 npm exec --package=@git-stunts/git-warp@19.0.0 -- git-warp-v18-to-v19 \
   --repo /path/to/repository \
-  --graph events \
-  --apply
+  --graph <graph-name> \
+  --dry-run
 ```
 
-Promotion re-inventories the source, detects concurrent ref movement, and uses
-one compare-and-swap Git ref transaction. Original refs and blob-backed
-state-cache payload roots remain reachable below
+The rehearsal performs and verifies the complete scratch migration but
+discards the result without changing authoritative refs. A later normal run
+must repeat that work because the disposable repository is intentionally not
+trusted or retained across invocations. `--apply` remains accepted as a
+compatibility alias for the normal one-pass behavior; it is no longer required.
+
+Promotion detects concurrent ref movement and uses one compare-and-swap Git ref
+transaction. Original refs and blob-backed state-cache payload roots remain
+reachable below
 `refs/warp/<graph>/recovery/v18-to-v19/<run-id>/`. Keep those recovery refs
 until application reads, writes, and backups have been independently verified.
 Rerunning the command after promotion verifies the current repository and

--- a/scripts/v18-to-v19/V18MigrationApp.ts
+++ b/scripts/v18-to-v19/V18MigrationApp.ts
@@ -13,6 +13,7 @@ import { runV18ToV19Migration, type V18MigrationCommandReport } from './V18Migra
 import type V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
 import type V18MigrationGraph from './V18MigrationGraph.ts';
 import type { V18MigrationProgress } from './V18MigrationProgress.ts';
+import type { V18MigrationPreflight } from './V18MigrationPreflight.ts';
 import {
   renderV18MigrationApp,
   type V18MigrationAppModel,
@@ -36,6 +37,7 @@ export type RunV18MigrationAppOptions = Readonly<{
   graph: V18MigrationGraph;
   mode: V18MigrationExecutionMode;
   passphrase?: string;
+  preflight: V18MigrationPreflight;
   recoveryId?: string;
   repositoryPath: string;
   scratchRoot?: string;

--- a/scripts/v18-to-v19/V18MigrationApp.ts
+++ b/scripts/v18-to-v19/V18MigrationApp.ts
@@ -9,6 +9,7 @@ import {
   type FramePageMsg,
 } from '@flyingrobots/bijou-tui';
 
+import { formatFailure } from '../formatFailure.ts';
 import { runV18ToV19Migration, type V18MigrationCommandReport } from './V18MigrationCommand.ts';
 import type V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
 import type V18MigrationGraph from './V18MigrationGraph.ts';
@@ -70,7 +71,16 @@ export async function runV18MigrationApp(
       });
     }
   };
-  const page = migrationPage(options, execute);
+  const page = migrationPage(
+    Object.freeze({
+      context: options.context,
+      graph: options.graph,
+      mode: options.mode,
+      preflight: options.preflight,
+      repositoryPath: options.repositoryPath,
+    }),
+    execute
+  );
   const app = createFramedApp({
     ctx: options.context,
     defaultPageId: page.id,
@@ -85,7 +95,7 @@ export async function runV18MigrationApp(
 }
 
 function migrationPage(
-  options: RunV18MigrationAppOptions,
+  options: Parameters<typeof renderV18MigrationApp>[0],
   execute: Cmd<V18MigrationAppMsg>
 ): FramePage<V18MigrationAppModel, V18MigrationAppMsg> {
   return {
@@ -157,22 +167,4 @@ function updateMigrationApp(
     case 'pulse':
       return [model, []];
   }
-}
-
-function formatFailure(error: unknown, seen = new Set<unknown>()): string {
-  if (seen.has(error)) {
-    return '[circular failure]';
-  }
-  seen.add(error);
-  const message = error instanceof Error ? error.message : String(error);
-  const nested: string[] = [];
-  if (error instanceof AggregateError) {
-    error.errors.forEach((entry, index) => {
-      nested.push(`failure ${String(index + 1)}: ${formatFailure(entry, seen)}`);
-    });
-  }
-  if (error instanceof Error && error.cause !== undefined) {
-    nested.push(`cause: ${formatFailure(error.cause, seen)}`);
-  }
-  return nested.length === 0 ? message : `${message}\n${nested.join('\n')}`;
 }

--- a/scripts/v18-to-v19/V18MigrationApp.ts
+++ b/scripts/v18-to-v19/V18MigrationApp.ts
@@ -1,0 +1,176 @@
+import type { BijouContext } from '@flyingrobots/bijou';
+import { startApp } from '@flyingrobots/bijou-node';
+import {
+  createFramedApp,
+  createKeyMap,
+  quit,
+  type Cmd,
+  type FramePage,
+  type FramePageMsg,
+} from '@flyingrobots/bijou-tui';
+
+import { runV18ToV19Migration, type V18MigrationCommandReport } from './V18MigrationCommand.ts';
+import type V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
+import type V18MigrationGraph from './V18MigrationGraph.ts';
+import type { V18MigrationProgress } from './V18MigrationProgress.ts';
+import {
+  renderV18MigrationApp,
+  type V18MigrationAppModel,
+  v18MigrationPhaseTitle,
+} from './V18MigrationAppSurface.ts';
+
+export type V18MigrationAppResult =
+  | Readonly<{ status: 'cancelled' }>
+  | Readonly<{ report: V18MigrationCommandReport; status: 'completed' }>
+  | Readonly<{ error: unknown; status: 'failed' }>;
+
+type V18MigrationAppMsg =
+  | Readonly<{ type: 'primary-action' }>
+  | Readonly<{ type: 'secondary-action' }>
+  | Readonly<{ progress: V18MigrationProgress; type: 'progress' }>
+  | Readonly<{ report: V18MigrationCommandReport; type: 'succeeded' }>
+  | Readonly<{ error: unknown; message: string; type: 'failed' }>;
+
+export type RunV18MigrationAppOptions = Readonly<{
+  context: BijouContext;
+  graph: V18MigrationGraph;
+  mode: V18MigrationExecutionMode;
+  passphrase?: string;
+  recoveryId?: string;
+  repositoryPath: string;
+  scratchRoot?: string;
+}>;
+
+/** Run the confirmation, progress, and result flow inside Bijou's framed shell. */
+export async function runV18MigrationApp(
+  options: RunV18MigrationAppOptions
+): Promise<V18MigrationAppResult> {
+  let result: V18MigrationAppResult = Object.freeze({ status: 'cancelled' });
+  const execute: Cmd<V18MigrationAppMsg> = async (emit) => {
+    try {
+      const report = await runV18ToV19Migration({
+        graph: options.graph.name,
+        mode: options.mode,
+        progress: (progress) => emit(Object.freeze({ progress, type: 'progress' })),
+        repositoryPath: options.repositoryPath,
+        ...(options.passphrase === undefined ? {} : { passphrase: options.passphrase }),
+        ...(options.recoveryId === undefined ? {} : { recoveryId: options.recoveryId }),
+        ...(options.scratchRoot === undefined ? {} : { scratchRoot: options.scratchRoot }),
+      });
+      result = Object.freeze({ report, status: 'completed' });
+      return Object.freeze({ report, type: 'succeeded' });
+    } catch (error: unknown) {
+      result = Object.freeze({ error, status: 'failed' });
+      return Object.freeze({
+        error,
+        message: formatFailure(error),
+        type: 'failed',
+      });
+    }
+  };
+  const page = migrationPage(options, execute);
+  const app = createFramedApp({
+    ctx: options.context,
+    defaultPageId: page.id,
+    enableCommandPalette: false,
+    keyPriority: 'page-first',
+    pages: [page],
+    runtimeNotifications: true,
+    title: 'git-warp v18 to v19',
+  });
+  await startApp(app, { ctx: options.context });
+  return result;
+}
+
+function migrationPage(
+  options: RunV18MigrationAppOptions,
+  execute: Cmd<V18MigrationAppMsg>
+): FramePage<V18MigrationAppModel, V18MigrationAppMsg> {
+  return {
+    id: 'migration',
+    title: (model) => v18MigrationPhaseTitle(model.phase),
+    init: () => [Object.freeze({ phase: 'confirm' }), []],
+    update: (message, model) => updateMigrationApp(message, model, execute),
+    layout: (model) => ({
+      kind: 'pane',
+      paneId: 'migration',
+      render: (width, height) => renderV18MigrationApp(options, model, width, height),
+    }),
+    keyMap: createKeyMap<V18MigrationAppMsg>().group('Migration', (group) =>
+      group
+        .bind('y', 'Confirm or continue', { type: 'primary-action' })
+        .bind('enter', 'Confirm or continue', { type: 'primary-action' })
+        .bind('n', 'Cancel or close', { type: 'secondary-action' })
+        .bind('escape', 'Cancel or close', { type: 'secondary-action' })
+        .bind('q', 'Cancel or close', { type: 'secondary-action' })
+        .bind('ctrl+c', 'Cancel or close', { type: 'secondary-action' })
+    ),
+  };
+}
+
+function updateMigrationApp(
+  message: FramePageMsg<V18MigrationAppMsg>,
+  model: V18MigrationAppModel,
+  execute: Cmd<V18MigrationAppMsg>
+): [V18MigrationAppModel, Cmd<V18MigrationAppMsg>[]] {
+  switch (message.type) {
+    case 'primary-action':
+      if (model.phase === 'confirm') {
+        return [Object.freeze({ phase: 'running' }), [execute]];
+      }
+      if (model.phase === 'failed' || model.phase === 'succeeded') {
+        return [model, [quit()]];
+      }
+      return [model, []];
+    case 'secondary-action':
+      if (model.phase === 'running') {
+        return [model, []];
+      }
+      return [model, [quit()]];
+    case 'progress':
+      return [
+        Object.freeze({
+          phase: 'running',
+          progress: message.progress,
+        }),
+        [],
+      ];
+    case 'succeeded':
+      return [
+        Object.freeze({
+          phase: 'succeeded',
+          report: message.report,
+        }),
+        [],
+      ];
+    case 'failed':
+      return [
+        Object.freeze({
+          failure: message.message,
+          phase: 'failed',
+        }),
+        [],
+      ];
+    case 'mouse':
+    case 'pulse':
+      return [model, []];
+  }
+}
+
+function formatFailure(error: unknown, seen = new Set<unknown>()): string {
+  if (seen.has(error)) {
+    return '[circular failure]';
+  }
+  seen.add(error);
+  const message = error instanceof Error ? error.message : String(error);
+  const nested: string[] = [];
+  if (error instanceof AggregateError) {
+    error.errors.forEach((entry, index) => {
+      nested.push(`failure ${String(index + 1)}: ${formatFailure(entry, seen)}`);
+    });
+  }
+  if (error instanceof Error && error.cause !== undefined) {
+    nested.push(`cause: ${formatFailure(error.cause, seen)}`);
+  }
+  return nested.length === 0 ? message : `${message}\n${nested.join('\n')}`;
+}

--- a/scripts/v18-to-v19/V18MigrationAppSurface.ts
+++ b/scripts/v18-to-v19/V18MigrationAppSurface.ts
@@ -1,0 +1,215 @@
+import { createSurface, type Cell, type Surface, type TokenValue } from '@flyingrobots/bijou';
+
+import type { V18MigrationCommandReport } from './V18MigrationCommand.ts';
+import type V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
+import type V18MigrationGraph from './V18MigrationGraph.ts';
+import type { V18MigrationProgress } from './V18MigrationProgress.ts';
+import { V18_MIGRATION_THEME } from './V18MigrationTheme.ts';
+
+export type V18MigrationAppPhase = 'confirm' | 'failed' | 'running' | 'succeeded';
+
+export type V18MigrationAppModel = Readonly<{
+  failure?: string;
+  phase: V18MigrationAppPhase;
+  progress?: V18MigrationProgress;
+  report?: V18MigrationCommandReport;
+}>;
+
+export type V18MigrationAppViewOptions = Readonly<{
+  graph: V18MigrationGraph;
+  mode: V18MigrationExecutionMode;
+  repositoryPath: string;
+}>;
+
+/** Render the migration page to a bounded, high-contrast terminal surface. */
+export function renderV18MigrationApp(
+  options: V18MigrationAppViewOptions,
+  model: V18MigrationAppModel,
+  width: number,
+  height: number
+): Surface {
+  const surfaceToken = V18_MIGRATION_THEME.surface.primary;
+  const surface = createSurface(
+    Math.max(0, width),
+    Math.max(0, height),
+    cellFrom(surfaceToken, ' ')
+  );
+  const lines = migrationLines(options, model, width);
+  lines.slice(0, surface.height).forEach((line, row) => {
+    writeLine(surface, row, line.text, line.token);
+  });
+  return surface;
+}
+
+export function v18MigrationPhaseTitle(phase: V18MigrationAppPhase): string {
+  switch (phase) {
+    case 'confirm':
+      return 'Confirm';
+    case 'running':
+      return 'Migrating';
+    case 'succeeded':
+      return 'Complete';
+    case 'failed':
+      return 'Recovery';
+  }
+}
+
+type StyledLine = Readonly<{ text: string; token: TokenValue }>;
+
+function migrationLines(
+  options: V18MigrationAppViewOptions,
+  model: V18MigrationAppModel,
+  width: number
+): StyledLine[] {
+  const body = V18_MIGRATION_THEME.surface.primary;
+  const accent = V18_MIGRATION_THEME.semantic.accent;
+  const primary = V18_MIGRATION_THEME.semantic.primary;
+  const warning = V18_MIGRATION_THEME.semantic.warning;
+  const success = V18_MIGRATION_THEME.semantic.success;
+  const error = V18_MIGRATION_THEME.semantic.error;
+  const lines: StyledLine[] = [
+    { text: 'Retained-substrate migration', token: primary },
+    { text: '', token: body },
+    ...wrapStyled(`Repository: ${options.repositoryPath}`, width, body),
+    ...wrapStyled(`Selected graph: ${options.graph.summary()}`, width, body),
+    {
+      text: `Mode: ${options.mode.promotesVerifiedRefs() ? 'verified migration and atomic promotion' : 'disposable rehearsal'}`,
+      token: accent,
+    },
+    { text: '', token: body },
+  ];
+  if (model.phase === 'confirm') {
+    lines.push(
+      { text: 'Nothing changes before you confirm.', token: warning },
+      {
+        text: 'The tool builds and verifies a disposable repository before promoting refs.',
+        token: body,
+      },
+      {
+        text: options.mode.promotesVerifiedRefs()
+          ? 'Promotion archives source refs under recovery refs and can roll back atomically.'
+          : 'This rehearsal discards its scratch repository and never changes authoritative refs.',
+        token: body,
+      },
+      { text: '', token: body },
+      { text: 'Press Y or Enter to continue. Press N, Esc, or Q to cancel.', token: primary }
+    );
+    return lines;
+  }
+  if (model.phase === 'running') {
+    const progress = model.progress;
+    lines.push(
+      {
+        text:
+          progress === undefined
+            ? 'Starting migration...'
+            : `[${progress.phase}]${progress.writer === undefined ? '' : ` ${progress.writer}`}`,
+        token: accent,
+      },
+      ...wrapStyled(progress?.message ?? 'Preparing migration command', width, body)
+    );
+    if (progress?.completed !== undefined && progress.total !== undefined) {
+      const percent = progressPercent(progress.completed, progress.total);
+      lines.push({
+        text: progressLine(percent, progress.completed, progress.total, width),
+        token: success,
+      });
+    }
+    lines.push(
+      { text: '', token: body },
+      {
+        text: 'Migration is running. Exit keys are disabled until it reaches a safe boundary.',
+        token: warning,
+      }
+    );
+    return lines;
+  }
+  if (model.phase === 'succeeded' && model.report !== undefined) {
+    const report = model.report;
+    lines.push(
+      { text: `Migration ${report.status}.`, token: success },
+      { text: `Writers: ${String(report.plan.writers.length)}`, token: body },
+      {
+        text: `Scratch verified: ${report.scratchVerified ? 'yes' : 'no'}`,
+        token: body,
+      }
+    );
+    if (report.finalization !== null) {
+      lines.push(
+        ...wrapStyled(`Recovery refs: ${report.finalization.recoveryPrefix}`, width, body)
+      );
+    }
+    lines.push({ text: '', token: body }, { text: 'Press Enter or Q to close.', token: primary });
+    return lines;
+  }
+  lines.push(
+    { text: 'Migration failed.', token: error },
+    ...wrapStyled(model.failure ?? 'Unknown failure', width, body),
+    { text: '', token: body },
+    {
+      text: 'Authoritative promotion failures are rolled back; retained recovery refs are not deleted.',
+      token: warning,
+    },
+    { text: 'Press Enter or Q to close and inspect the error.', token: primary }
+  );
+  return lines;
+}
+
+function progressPercent(completed: number, total: number): number {
+  return total === 0 ? 100 : Math.min(100, Math.max(0, (completed / total) * 100));
+}
+
+function progressLine(percent: number, completed: number, total: number, width: number): string {
+  const label = ` ${String(completed)}/${String(total)} ${percent.toFixed(1)}%`;
+  const barWidth = Math.max(4, Math.min(42, width - label.length - 3));
+  const filled = Math.round((percent / 100) * barWidth);
+  return `[${'█'.repeat(filled)}${'░'.repeat(barWidth - filled)}]${label}`;
+}
+
+function wrapStyled(text: string, width: number, token: TokenValue): StyledLine[] {
+  const maximum = Math.max(1, width);
+  const words = text.split(/\s+/u);
+  const lines: string[] = [];
+  let current = '';
+  for (const word of words) {
+    if (word.length > maximum) {
+      if (current.length > 0) {
+        lines.push(current);
+        current = '';
+      }
+      for (let offset = 0; offset < word.length; offset += maximum) {
+        lines.push(word.slice(offset, offset + maximum));
+      }
+      continue;
+    }
+    const candidate = current.length === 0 ? word : `${current} ${word}`;
+    if (candidate.length > maximum) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current.length > 0 || lines.length === 0) {
+    lines.push(current);
+  }
+  return lines.map((line) => Object.freeze({ text: line, token }));
+}
+
+function writeLine(surface: Surface, row: number, text: string, token: TokenValue): void {
+  Array.from(text)
+    .slice(0, surface.width)
+    .forEach((character, column) => {
+      surface.set(column, row, cellFrom(token, character));
+    });
+}
+
+function cellFrom(token: TokenValue, char: string): Cell {
+  const background = token.bg ?? V18_MIGRATION_THEME.surface.primary.bg;
+  return {
+    char,
+    ...(background === undefined ? {} : { bg: background }),
+    fg: token.hex,
+    ...(token.modifiers === undefined ? {} : { modifiers: token.modifiers }),
+  };
+}

--- a/scripts/v18-to-v19/V18MigrationAppSurface.ts
+++ b/scripts/v18-to-v19/V18MigrationAppSurface.ts
@@ -4,6 +4,7 @@ import type { V18MigrationCommandReport } from './V18MigrationCommand.ts';
 import type V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
 import type V18MigrationGraph from './V18MigrationGraph.ts';
 import type { V18MigrationProgress } from './V18MigrationProgress.ts';
+import { formatV18MigrationBytes, type V18MigrationPreflight } from './V18MigrationPreflight.ts';
 import { V18_MIGRATION_THEME } from './V18MigrationTheme.ts';
 
 export type V18MigrationAppPhase = 'confirm' | 'failed' | 'running' | 'succeeded';
@@ -18,6 +19,7 @@ export type V18MigrationAppModel = Readonly<{
 export type V18MigrationAppViewOptions = Readonly<{
   graph: V18MigrationGraph;
   mode: V18MigrationExecutionMode;
+  preflight: V18MigrationPreflight;
   repositoryPath: string;
 }>;
 
@@ -81,6 +83,29 @@ function migrationLines(
   if (model.phase === 'confirm') {
     lines.push(
       { text: 'Nothing changes before you confirm.', token: warning },
+      {
+        text: `Git object storage: ${formatV18MigrationBytes(options.preflight.repositoryObjectBytes)}`,
+        token: body,
+      },
+      ...wrapStyled(
+        `Scratch: ${options.preflight.scratchPath} · ${formatV18MigrationBytes(options.preflight.scratchAvailableBytes)} free`,
+        width,
+        body
+      ),
+      {
+        text: `Operating budget: ${formatV18MigrationBytes(options.preflight.scratchMinimumBytes)} minimum (2x object storage)`,
+        token: options.preflight.scratchSufficient ? success : warning,
+      },
+      {
+        text: `Source Git volume free: ${formatV18MigrationBytes(options.preflight.sourceAvailableBytes)}`,
+        token: body,
+      },
+      {
+        text: options.preflight.scratchSufficient
+          ? 'Scratch capacity check: sufficient.'
+          : 'Scratch capacity check: BELOW OPERATING BUDGET.',
+        token: options.preflight.scratchSufficient ? success : warning,
+      },
       {
         text: 'The tool builds and verifies a disposable repository before promoting refs.',
         token: body,

--- a/scripts/v18-to-v19/V18MigrationAppSurface.ts
+++ b/scripts/v18-to-v19/V18MigrationAppSurface.ts
@@ -84,7 +84,9 @@ function migrationLines(
     lines.push(
       { text: 'Nothing changes before you confirm.', token: warning },
       {
-        text: `Git object storage: ${formatV18MigrationBytes(options.preflight.repositoryObjectBytes)}`,
+        text:
+          `Git object storage: ${formatV18MigrationBytes(options.preflight.repositoryObjectBytes)}` +
+          ` across ${String(options.preflight.repositoryObjectCount)} objects`,
         token: body,
       },
       ...wrapStyled(
@@ -93,7 +95,9 @@ function migrationLines(
         body
       ),
       {
-        text: `Operating budget: ${formatV18MigrationBytes(options.preflight.scratchMinimumBytes)} minimum (2x object storage)`,
+        text:
+          `Operating budget: ${formatV18MigrationBytes(options.preflight.scratchMinimumBytes)}` +
+          ' minimum (byte volume and loose-object allocation)',
         token: options.preflight.scratchSufficient ? success : warning,
       },
       {

--- a/scripts/v18-to-v19/V18MigrationAppSurface.ts
+++ b/scripts/v18-to-v19/V18MigrationAppSurface.ts
@@ -1,9 +1,16 @@
-import { createSurface, type Cell, type Surface, type TokenValue } from '@flyingrobots/bijou';
+import {
+  createSurface,
+  type BijouContext,
+  type Cell,
+  type Surface,
+  type TokenValue,
+} from '@flyingrobots/bijou';
 
 import type { V18MigrationCommandReport } from './V18MigrationCommand.ts';
 import type V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
 import type V18MigrationGraph from './V18MigrationGraph.ts';
-import type { V18MigrationProgress } from './V18MigrationProgress.ts';
+import { type V18MigrationProgress, v18MigrationProgressPercent } from './V18MigrationProgress.ts';
+import { renderV18MigrationProgressBar } from './V18MigrationProgressBar.ts';
 import { formatV18MigrationBytes, type V18MigrationPreflight } from './V18MigrationPreflight.ts';
 import { V18_MIGRATION_THEME } from './V18MigrationTheme.ts';
 
@@ -17,6 +24,7 @@ export type V18MigrationAppModel = Readonly<{
 }>;
 
 export type V18MigrationAppViewOptions = Readonly<{
+  context: BijouContext;
   graph: V18MigrationGraph;
   mode: V18MigrationExecutionMode;
   preflight: V18MigrationPreflight;
@@ -37,7 +45,7 @@ export function renderV18MigrationApp(
     cellFrom(surfaceToken, ' ')
   );
   const lines = migrationLines(options, model, width);
-  lines.slice(0, surface.height).forEach((line, row) => {
+  visibleLines(lines, model.phase, surface.height).forEach((line, row) => {
     writeLine(surface, row, line.text, line.token);
   });
   return surface;
@@ -74,54 +82,59 @@ function migrationLines(
     { text: '', token: body },
     ...wrapStyled(`Repository: ${options.repositoryPath}`, width, body),
     ...wrapStyled(`Selected graph: ${options.graph.summary()}`, width, body),
-    {
-      text: `Mode: ${options.mode.promotesVerifiedRefs() ? 'verified migration and atomic promotion' : 'disposable rehearsal'}`,
-      token: accent,
-    },
+    ...wrapStyled(
+      `Mode: ${options.mode.promotesVerifiedRefs() ? 'verified migration and atomic promotion' : 'disposable rehearsal'}`,
+      width,
+      accent
+    ),
     { text: '', token: body },
   ];
   if (model.phase === 'confirm') {
     lines.push(
       { text: 'Nothing changes before you confirm.', token: warning },
-      {
-        text:
-          `Git object storage: ${formatV18MigrationBytes(options.preflight.repositoryObjectBytes)}` +
+      ...wrapStyled(
+        `Git object storage: ${formatV18MigrationBytes(options.preflight.repositoryObjectBytes)}` +
           ` across ${String(options.preflight.repositoryObjectCount)} objects`,
-        token: body,
-      },
+        width,
+        body
+      ),
       ...wrapStyled(
         `Scratch: ${options.preflight.scratchPath} · ${formatV18MigrationBytes(options.preflight.scratchAvailableBytes)} free`,
         width,
         body
       ),
-      {
-        text:
-          `Operating budget: ${formatV18MigrationBytes(options.preflight.scratchMinimumBytes)}` +
+      ...wrapStyled(
+        `Operating budget: ${formatV18MigrationBytes(options.preflight.scratchMinimumBytes)}` +
           ' minimum (byte volume and loose-object allocation)',
-        token: options.preflight.scratchSufficient ? success : warning,
-      },
-      {
-        text: `Source Git volume free: ${formatV18MigrationBytes(options.preflight.sourceAvailableBytes)}`,
-        token: body,
-      },
-      {
-        text: options.preflight.scratchSufficient
+        width,
+        options.preflight.scratchSufficient ? success : warning
+      ),
+      ...wrapStyled(
+        `Source Git volume free: ${formatV18MigrationBytes(options.preflight.sourceAvailableBytes)}`,
+        width,
+        body
+      ),
+      ...wrapStyled(
+        options.preflight.scratchSufficient
           ? 'Scratch capacity check: sufficient.'
           : 'Scratch capacity check: BELOW OPERATING BUDGET.',
-        token: options.preflight.scratchSufficient ? success : warning,
-      },
-      {
-        text: 'The tool builds and verifies a disposable repository before promoting refs.',
-        token: body,
-      },
-      {
-        text: options.mode.promotesVerifiedRefs()
+        width,
+        options.preflight.scratchSufficient ? success : warning
+      ),
+      ...wrapStyled(
+        'The tool builds and verifies a disposable repository before promoting refs.',
+        width,
+        body
+      ),
+      ...wrapStyled(
+        options.mode.promotesVerifiedRefs()
           ? 'Promotion archives source refs under recovery refs and can roll back atomically.'
           : 'This rehearsal discards its scratch repository and never changes authoritative refs.',
-        token: body,
-      },
+        width,
+        body
+      ),
       { text: '', token: body },
-      { text: 'Press Y or Enter to continue. Press N, Esc, or Q to cancel.', token: primary }
+      ...wrapStyled('Press Y or Enter to continue. Press N, Esc, or Q to cancel.', width, primary)
     );
     return lines;
   }
@@ -138,9 +151,15 @@ function migrationLines(
       ...wrapStyled(progress?.message ?? 'Preparing migration command', width, body)
     );
     if (progress?.completed !== undefined && progress.total !== undefined) {
-      const percent = progressPercent(progress.completed, progress.total);
+      const percent = v18MigrationProgressPercent(progress.completed, progress.total);
       lines.push({
-        text: progressLine(percent, progress.completed, progress.total, width),
+        text: renderV18MigrationProgressBar(
+          options.context,
+          percent,
+          progress.completed,
+          progress.total,
+          width
+        ),
         token: success,
       });
     }
@@ -171,28 +190,44 @@ function migrationLines(
     lines.push({ text: '', token: body }, { text: 'Press Enter or Q to close.', token: primary });
     return lines;
   }
+  if (model.phase === 'failed') {
+    lines.push(
+      { text: 'Migration failed.', token: error },
+      ...wrapStyled(model.failure ?? 'Unknown failure', width, body),
+      { text: '', token: body },
+      ...wrapStyled(
+        'Authoritative promotion failures are rolled back; retained recovery refs are not deleted.',
+        width,
+        warning
+      ),
+      ...wrapStyled('Press Enter or Q to close and inspect the error.', width, primary)
+    );
+    return lines;
+  }
   lines.push(
-    { text: 'Migration failed.', token: error },
-    ...wrapStyled(model.failure ?? 'Unknown failure', width, body),
-    { text: '', token: body },
-    {
-      text: 'Authoritative promotion failures are rolled back; retained recovery refs are not deleted.',
-      token: warning,
-    },
-    { text: 'Press Enter or Q to close and inspect the error.', token: primary }
+    { text: 'Internal migration UI state is incomplete.', token: error },
+    ...wrapStyled(
+      'No success report is available. Close the application and inspect the command output.',
+      width,
+      body
+    ),
+    ...wrapStyled('Press Enter or Q to close.', width, primary)
   );
   return lines;
 }
 
-function progressPercent(completed: number, total: number): number {
-  return total === 0 ? 100 : Math.min(100, Math.max(0, (completed / total) * 100));
-}
-
-function progressLine(percent: number, completed: number, total: number, width: number): string {
-  const label = ` ${String(completed)}/${String(total)} ${percent.toFixed(1)}%`;
-  const barWidth = Math.max(4, Math.min(42, width - label.length - 3));
-  const filled = Math.round((percent / 100) * barWidth);
-  return `[${'█'.repeat(filled)}${'░'.repeat(barWidth - filled)}]${label}`;
+function visibleLines(
+  lines: readonly StyledLine[],
+  phase: V18MigrationAppPhase,
+  height: number
+): readonly StyledLine[] {
+  if (height <= 0 || lines.length <= height) {
+    return lines.slice(0, Math.max(0, height));
+  }
+  if (phase !== 'confirm') {
+    return lines.slice(0, height);
+  }
+  return [...lines.slice(0, Math.max(0, height - 1)), lines.at(-1)!];
 }
 
 function wrapStyled(text: string, width: number, token: TokenValue): StyledLine[] {

--- a/scripts/v18-to-v19/V18MigrationCommand.ts
+++ b/scripts/v18-to-v19/V18MigrationCommand.ts
@@ -1,3 +1,4 @@
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 
 import {
@@ -33,6 +34,7 @@ export async function runV18ToV19Migration(
   }>
 ): Promise<V18MigrationCommandReport> {
   const repositoryPath = resolve(options.repositoryPath);
+  const scratchRoot = resolve(options.scratchRoot ?? tmpdir());
   const plan = await planV18ToV19Migration({
     graph: options.graph,
     passphraseAvailable: options.passphrase !== undefined,
@@ -40,7 +42,7 @@ export async function runV18ToV19Migration(
     repositoryPath,
   });
   if (plan.status === 'current') {
-    await verifyPromotedV19Repository(repositoryPath, options.graph);
+    await verifyPromotedV19Repository(repositoryPath, options.graph, scratchRoot);
     return report(plan, 'already-current', false, null);
   }
   if (plan.status === 'empty') {
@@ -51,7 +53,7 @@ export async function runV18ToV19Migration(
     plan,
     ...(options.passphrase === undefined ? {} : { passphrase: options.passphrase }),
     ...(options.progress === undefined ? {} : { progress: options.progress }),
-    ...(options.scratchRoot === undefined ? {} : { scratchRoot: resolve(options.scratchRoot) }),
+    scratchRoot,
   });
   try {
     if (!options.mode.promotesVerifiedRefs()) {
@@ -78,7 +80,7 @@ export async function runV18ToV19Migration(
         message: 'verifying promoted refs through a disposable append and bounded reading',
         phase: 'verify',
       });
-      await verifyPromotedV19Repository(repositoryPath, options.graph);
+      await verifyPromotedV19Repository(repositoryPath, options.graph, scratchRoot);
     } catch (verificationError) {
       try {
         await rollbackV18Migration({ finalization, plan });

--- a/scripts/v18-to-v19/V18MigrationCommand.ts
+++ b/scripts/v18-to-v19/V18MigrationCommand.ts
@@ -5,8 +5,14 @@ import {
   rollbackV18Migration,
   type V18MigrationFinalization,
 } from './V18MigrationFinalizer.ts';
-import { planV18ToV19Migration, type V18MigrationPlan } from './V18MigrationPlan.ts';
-import { prepareV18MigrationScratch, verifyPromotedV19Repository } from './V18MigrationScratch.ts';
+import {
+  planV18ToV19Migration,
+  type V18MigrationPlan,
+} from './V18MigrationPlan.ts';
+import {
+  prepareV18MigrationScratch,
+  verifyPromotedV19Repository,
+} from './V18MigrationScratch.ts';
 import {
   reportV18MigrationProgress,
   type V18MigrationProgressReporter,
@@ -20,17 +26,15 @@ export type V18MigrationCommandReport = Readonly<{
 }>;
 
 /** Runs the fail-closed one-shot migration command. */
-export async function runV18ToV19Migration(
-  options: Readonly<{
-    apply: boolean;
-    graph: string;
-    passphrase?: string;
-    progress?: V18MigrationProgressReporter;
-    recoveryId?: string;
-    repositoryPath: string;
-    scratchRoot?: string;
-  }>
-): Promise<V18MigrationCommandReport> {
+export async function runV18ToV19Migration(options: Readonly<{
+  apply: boolean;
+  graph: string;
+  passphrase?: string;
+  progress?: V18MigrationProgressReporter;
+  recoveryId?: string;
+  repositoryPath: string;
+  scratchRoot?: string;
+}>): Promise<V18MigrationCommandReport> {
   const repositoryPath = resolve(options.repositoryPath);
   const plan = await planV18ToV19Migration({
     graph: options.graph,
@@ -84,13 +88,13 @@ export async function runV18ToV19Migration(
       } catch (rollbackError) {
         throw new AggregateError(
           [verificationError, rollbackError],
-          `v19 verification failed and automatic rollback could not complete; ` +
-            `use recovery refs below ${finalization.recoveryPrefix}`
+          `v19 verification failed and automatic rollback could not complete; `
+            + `use recovery refs below ${finalization.recoveryPrefix}`,
         );
       }
       throw new Error(
         'v19 verification failed; authoritative refs were rolled back and recovery refs retained',
-        { cause: verificationError }
+        { cause: verificationError },
       );
     }
     return report(plan, 'migrated', true, finalization);
@@ -99,13 +103,16 @@ export async function runV18ToV19Migration(
   }
 }
 
-function requireUnchangedPlan(before: V18MigrationPlan, after: V18MigrationPlan): void {
+function requireUnchangedPlan(
+  before: V18MigrationPlan,
+  after: V18MigrationPlan,
+): void {
   if (
-    after.status !== 'migration-required' ||
-    JSON.stringify(planIdentity(after)) !== JSON.stringify(planIdentity(before))
+    after.status !== 'migration-required'
+    || JSON.stringify(planIdentity(after)) !== JSON.stringify(planIdentity(before))
   ) {
     throw new Error(
-      'retained state changed after scratch verification; no authoritative refs were updated'
+      'retained state changed after scratch verification; no authoritative refs were updated',
     );
   }
 }
@@ -125,7 +132,7 @@ function report(
   plan: V18MigrationPlan,
   status: V18MigrationCommandReport['status'],
   scratchVerified: boolean,
-  finalization: V18MigrationFinalization | null
+  finalization: V18MigrationFinalization | null,
 ): V18MigrationCommandReport {
   return Object.freeze({
     finalization,

--- a/scripts/v18-to-v19/V18MigrationCommand.ts
+++ b/scripts/v18-to-v19/V18MigrationCommand.ts
@@ -5,18 +5,13 @@ import {
   rollbackV18Migration,
   type V18MigrationFinalization,
 } from './V18MigrationFinalizer.ts';
-import {
-  planV18ToV19Migration,
-  type V18MigrationPlan,
-} from './V18MigrationPlan.ts';
-import {
-  prepareV18MigrationScratch,
-  verifyPromotedV19Repository,
-} from './V18MigrationScratch.ts';
+import { planV18ToV19Migration, type V18MigrationPlan } from './V18MigrationPlan.ts';
+import { prepareV18MigrationScratch, verifyPromotedV19Repository } from './V18MigrationScratch.ts';
 import {
   reportV18MigrationProgress,
   type V18MigrationProgressReporter,
 } from './V18MigrationProgress.ts';
+import V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
 
 export type V18MigrationCommandReport = Readonly<{
   finalization: V18MigrationFinalization | null;
@@ -26,15 +21,17 @@ export type V18MigrationCommandReport = Readonly<{
 }>;
 
 /** Runs the fail-closed one-shot migration command. */
-export async function runV18ToV19Migration(options: Readonly<{
-  apply: boolean;
-  graph: string;
-  passphrase?: string;
-  progress?: V18MigrationProgressReporter;
-  recoveryId?: string;
-  repositoryPath: string;
-  scratchRoot?: string;
-}>): Promise<V18MigrationCommandReport> {
+export async function runV18ToV19Migration(
+  options: Readonly<{
+    graph: string;
+    mode: V18MigrationExecutionMode;
+    passphrase?: string;
+    progress?: V18MigrationProgressReporter;
+    recoveryId?: string;
+    repositoryPath: string;
+    scratchRoot?: string;
+  }>
+): Promise<V18MigrationCommandReport> {
   const repositoryPath = resolve(options.repositoryPath);
   const plan = await planV18ToV19Migration({
     graph: options.graph,
@@ -57,7 +54,7 @@ export async function runV18ToV19Migration(options: Readonly<{
     ...(options.scratchRoot === undefined ? {} : { scratchRoot: resolve(options.scratchRoot) }),
   });
   try {
-    if (!options.apply) {
+    if (!options.mode.promotesVerifiedRefs()) {
       return report(plan, 'verified-dry-run', true, null);
     }
     const refreshed = await planV18ToV19Migration({
@@ -88,13 +85,13 @@ export async function runV18ToV19Migration(options: Readonly<{
       } catch (rollbackError) {
         throw new AggregateError(
           [verificationError, rollbackError],
-          `v19 verification failed and automatic rollback could not complete; `
-            + `use recovery refs below ${finalization.recoveryPrefix}`,
+          `v19 verification failed and automatic rollback could not complete; ` +
+            `use recovery refs below ${finalization.recoveryPrefix}`
         );
       }
       throw new Error(
         'v19 verification failed; authoritative refs were rolled back and recovery refs retained',
-        { cause: verificationError },
+        { cause: verificationError }
       );
     }
     return report(plan, 'migrated', true, finalization);
@@ -103,16 +100,13 @@ export async function runV18ToV19Migration(options: Readonly<{
   }
 }
 
-function requireUnchangedPlan(
-  before: V18MigrationPlan,
-  after: V18MigrationPlan,
-): void {
+function requireUnchangedPlan(before: V18MigrationPlan, after: V18MigrationPlan): void {
   if (
-    after.status !== 'migration-required'
-    || JSON.stringify(planIdentity(after)) !== JSON.stringify(planIdentity(before))
+    after.status !== 'migration-required' ||
+    JSON.stringify(planIdentity(after)) !== JSON.stringify(planIdentity(before))
   ) {
     throw new Error(
-      'retained state changed after scratch verification; no authoritative refs were updated',
+      'retained state changed after scratch verification; no authoritative refs were updated'
     );
   }
 }
@@ -132,7 +126,7 @@ function report(
   plan: V18MigrationPlan,
   status: V18MigrationCommandReport['status'],
   scratchVerified: boolean,
-  finalization: V18MigrationFinalization | null,
+  finalization: V18MigrationFinalization | null
 ): V18MigrationCommandReport {
   return Object.freeze({
     finalization,

--- a/scripts/v18-to-v19/V18MigrationCommand.ts
+++ b/scripts/v18-to-v19/V18MigrationCommand.ts
@@ -5,14 +5,8 @@ import {
   rollbackV18Migration,
   type V18MigrationFinalization,
 } from './V18MigrationFinalizer.ts';
-import {
-  planV18ToV19Migration,
-  type V18MigrationPlan,
-} from './V18MigrationPlan.ts';
-import {
-  prepareV18MigrationScratch,
-  verifyPromotedV19Repository,
-} from './V18MigrationScratch.ts';
+import { planV18ToV19Migration, type V18MigrationPlan } from './V18MigrationPlan.ts';
+import { prepareV18MigrationScratch, verifyPromotedV19Repository } from './V18MigrationScratch.ts';
 import {
   reportV18MigrationProgress,
   type V18MigrationProgressReporter,
@@ -26,15 +20,17 @@ export type V18MigrationCommandReport = Readonly<{
 }>;
 
 /** Runs the fail-closed one-shot migration command. */
-export async function runV18ToV19Migration(options: Readonly<{
-  apply: boolean;
-  graph: string;
-  passphrase?: string;
-  progress?: V18MigrationProgressReporter;
-  recoveryId?: string;
-  repositoryPath: string;
-  scratchRoot?: string;
-}>): Promise<V18MigrationCommandReport> {
+export async function runV18ToV19Migration(
+  options: Readonly<{
+    apply: boolean;
+    graph: string;
+    passphrase?: string;
+    progress?: V18MigrationProgressReporter;
+    recoveryId?: string;
+    repositoryPath: string;
+    scratchRoot?: string;
+  }>
+): Promise<V18MigrationCommandReport> {
   const repositoryPath = resolve(options.repositoryPath);
   const plan = await planV18ToV19Migration({
     graph: options.graph,
@@ -78,7 +74,7 @@ export async function runV18ToV19Migration(options: Readonly<{
     });
     try {
       reportV18MigrationProgress(options.progress, {
-        message: 'verifying promoted repository',
+        message: 'verifying promoted refs through a disposable append and bounded reading',
         phase: 'verify',
       });
       await verifyPromotedV19Repository(repositoryPath, options.graph);
@@ -88,13 +84,13 @@ export async function runV18ToV19Migration(options: Readonly<{
       } catch (rollbackError) {
         throw new AggregateError(
           [verificationError, rollbackError],
-          `v19 verification failed and automatic rollback could not complete; `
-            + `use recovery refs below ${finalization.recoveryPrefix}`,
+          `v19 verification failed and automatic rollback could not complete; ` +
+            `use recovery refs below ${finalization.recoveryPrefix}`
         );
       }
       throw new Error(
         'v19 verification failed; authoritative refs were rolled back and recovery refs retained',
-        { cause: verificationError },
+        { cause: verificationError }
       );
     }
     return report(plan, 'migrated', true, finalization);
@@ -103,16 +99,13 @@ export async function runV18ToV19Migration(options: Readonly<{
   }
 }
 
-function requireUnchangedPlan(
-  before: V18MigrationPlan,
-  after: V18MigrationPlan,
-): void {
+function requireUnchangedPlan(before: V18MigrationPlan, after: V18MigrationPlan): void {
   if (
-    after.status !== 'migration-required'
-    || JSON.stringify(planIdentity(after)) !== JSON.stringify(planIdentity(before))
+    after.status !== 'migration-required' ||
+    JSON.stringify(planIdentity(after)) !== JSON.stringify(planIdentity(before))
   ) {
     throw new Error(
-      'retained state changed after scratch verification; no authoritative refs were updated',
+      'retained state changed after scratch verification; no authoritative refs were updated'
     );
   }
 }
@@ -132,7 +125,7 @@ function report(
   plan: V18MigrationPlan,
   status: V18MigrationCommandReport['status'],
   scratchVerified: boolean,
-  finalization: V18MigrationFinalization | null,
+  finalization: V18MigrationFinalization | null
 ): V18MigrationCommandReport {
   return Object.freeze({
     finalization,

--- a/scripts/v18-to-v19/V18MigrationExecutionMode.ts
+++ b/scripts/v18-to-v19/V18MigrationExecutionMode.ts
@@ -1,0 +1,26 @@
+export type V18MigrationExecutionModeName = 'promote' | 'rehearse';
+
+/** Explicitly selects whether verified scratch refs are promoted. */
+export default class V18MigrationExecutionMode {
+  static readonly #PROMOTE = new V18MigrationExecutionMode('promote');
+  static readonly #REHEARSE = new V18MigrationExecutionMode('rehearse');
+
+  readonly name: V18MigrationExecutionModeName;
+
+  private constructor(name: V18MigrationExecutionModeName) {
+    this.name = name;
+    Object.freeze(this);
+  }
+
+  static promote(): V18MigrationExecutionMode {
+    return V18MigrationExecutionMode.#PROMOTE;
+  }
+
+  static rehearse(): V18MigrationExecutionMode {
+    return V18MigrationExecutionMode.#REHEARSE;
+  }
+
+  promotesVerifiedRefs(): boolean {
+    return this === V18MigrationExecutionMode.#PROMOTE;
+  }
+}

--- a/scripts/v18-to-v19/V18MigrationGitCommitWriter.ts
+++ b/scripts/v18-to-v19/V18MigrationGitCommitWriter.ts
@@ -54,6 +54,7 @@ export class V18MigrationGitCommitWriter {
       this.#child.once('error', reject);
       this.#child.once('close', resolve);
     });
+    void this.#exit.catch(() => undefined);
   }
 
   writeCommit(record: V18MigrationCommitRecord): Promise<string> {
@@ -63,7 +64,7 @@ export class V18MigrationGitCommitWriter {
     const operation = this.#tail.then(async () => await this.#writeCommit(record));
     this.#tail = operation.then(
       () => undefined,
-      () => undefined,
+      () => undefined
     );
     return operation;
   }
@@ -89,10 +90,7 @@ export class V18MigrationGitCommitWriter {
         if (error === null || error === undefined) {
           resolve();
         } else {
-          reject(this.#error(
-            `failed to write hash-object request: ${error.message}`,
-            null,
-          ));
+          reject(this.#error(`failed to write hash-object request: ${error.message}`, null));
         }
       });
     });
@@ -111,13 +109,11 @@ export class V18MigrationGitCommitWriter {
         const exitCode = await this.#exit;
         throw this.#error(
           `hash-object closed unexpectedly with exit ${String(exitCode)}`,
-          exitCode,
+          exitCode
         );
       }
       const chunk = Buffer.from(next.value);
-      this.#buffer = this.#buffer.length === 0
-        ? chunk
-        : Buffer.concat([this.#buffer, chunk]);
+      this.#buffer = this.#buffer.length === 0 ? chunk : Buffer.concat([this.#buffer, chunk]);
     }
   }
 
@@ -127,10 +123,7 @@ export class V18MigrationGitCommitWriter {
       this.#child.stdin.end();
       const exitCode = await this.#exit;
       if (exitCode !== 0) {
-        throw this.#error(
-          `hash-object failed with exit ${String(exitCode)}`,
-          exitCode,
-        );
+        throw this.#error(`hash-object failed with exit ${String(exitCode)}`, exitCode);
       }
     } finally {
       await rm(this.#commitPath, { force: true });
@@ -152,22 +145,25 @@ function serializeCommit(record: V18MigrationCommitRecord): Uint8Array {
   if (record.parent !== null) {
     requireOid(record.parent, 'parent');
   }
-  return Buffer.from([
-    `tree ${record.tree}`,
-    ...(record.parent === null ? [] : [`parent ${record.parent}`]),
-    `author ${formatIdentity(record.author, 'author')}`,
-    `committer ${formatIdentity(record.committer, 'committer')}`,
-    '',
-    record.message,
-  ].join('\n'), 'utf8');
+  return Buffer.from(
+    [
+      `tree ${record.tree}`,
+      ...(record.parent === null ? [] : [`parent ${record.parent}`]),
+      `author ${formatIdentity(record.author, 'author')}`,
+      `committer ${formatIdentity(record.committer, 'committer')}`,
+      '',
+      record.message,
+    ].join('\n'),
+    'utf8'
+  );
 }
 
 function formatIdentity(identity: V18CommitIdentity, label: string): string {
   if (
-    /[\u0000\n\r]/u.test(identity.name)
-    || /[\u0000\n\r<>]/u.test(identity.email)
-    || !/^[0-9]+$/u.test(identity.timestamp)
-    || !/^[+-][0-9]{4}$/u.test(identity.timezone)
+    /[\u0000\n\r]/u.test(identity.name) ||
+    /[\u0000\n\r<>]/u.test(identity.email) ||
+    !/^[0-9]+$/u.test(identity.timestamp) ||
+    !/^[+-][0-9]{4}$/u.test(identity.timezone)
   ) {
     throw new Error(`unsupported ${label} identity for Git commit serialization`);
   }

--- a/scripts/v18-to-v19/V18MigrationGitCommitWriter.ts
+++ b/scripts/v18-to-v19/V18MigrationGitCommitWriter.ts
@@ -1,0 +1,181 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { V18CommitIdentity } from './V18PatchCommit.ts';
+import { V18MigrationGitError } from './V18MigrationGit.ts';
+
+const OID_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u;
+const HASH_OBJECT_ARGS = Object.freeze([
+  'hash-object',
+  '-t',
+  'commit',
+  '-w',
+  '--stdin-paths',
+  '--no-filters',
+]);
+const COMMIT_FILE = '.git-warp-v18-to-v19-commit-object';
+
+export type V18MigrationCommitRecord = Readonly<{
+  author: V18CommitIdentity;
+  committer: V18CommitIdentity;
+  message: string;
+  parent: string | null;
+  tree: string;
+}>;
+
+/**
+ * Writes ordered commit objects through one long-lived `hash-object` process.
+ * A reusable scratch file carries each commit body because `--stdin-paths`
+ * reserves the process stdin for file names.
+ */
+export class V18MigrationGitCommitWriter {
+  readonly #child: ChildProcessWithoutNullStreams;
+  readonly #commitPath: string;
+  readonly #exit: Promise<number | null>;
+  readonly #iterator: AsyncIterator<Uint8Array>;
+  readonly #stderr: Uint8Array[] = [];
+  #buffer = Buffer.alloc(0);
+  #closePromise: Promise<void> | null = null;
+  #tail: Promise<void> = Promise.resolve();
+
+  constructor(cwd: string) {
+    this.#commitPath = join(cwd, COMMIT_FILE);
+    if (/[\n\r]/u.test(this.#commitPath)) {
+      throw new Error('Git commit writer path cannot contain a newline');
+    }
+    this.#child = spawn('git', HASH_OBJECT_ARGS, { cwd });
+    this.#iterator = this.#child.stdout[Symbol.asyncIterator]();
+    this.#child.stderr.on('data', (chunk: Uint8Array) => this.#stderr.push(chunk));
+    this.#child.stdin.on('error', () => {
+      // Individual writes and the process exit surface the actionable error.
+    });
+    this.#exit = new Promise<number | null>((resolve, reject) => {
+      this.#child.once('error', reject);
+      this.#child.once('close', resolve);
+    });
+  }
+
+  writeCommit(record: V18MigrationCommitRecord): Promise<string> {
+    if (this.#closePromise !== null) {
+      return Promise.reject(new Error('cannot write through a closing Git commit writer'));
+    }
+    const operation = this.#tail.then(async () => await this.#writeCommit(record));
+    this.#tail = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
+  }
+
+  close(): Promise<void> {
+    this.#closePromise ??= this.#close();
+    return this.#closePromise;
+  }
+
+  async #writeCommit(record: V18MigrationCommitRecord): Promise<string> {
+    await writeFile(this.#commitPath, serializeCommit(record));
+    await this.#write(`${this.#commitPath}\n`);
+    const oid = await this.#readLine();
+    if (!OID_PATTERN.test(oid)) {
+      throw this.#error(`hash-object returned an invalid object ID: ${oid}`, null);
+    }
+    return oid;
+  }
+
+  async #write(value: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.#child.stdin.write(value, (error) => {
+        if (error === null || error === undefined) {
+          resolve();
+        } else {
+          reject(this.#error(
+            `failed to write hash-object request: ${error.message}`,
+            null,
+          ));
+        }
+      });
+    });
+  }
+
+  async #readLine(): Promise<string> {
+    while (true) {
+      const newline = this.#buffer.indexOf(0x0a);
+      if (newline >= 0) {
+        const line = this.#buffer.subarray(0, newline);
+        this.#buffer = this.#buffer.subarray(newline + 1);
+        return line.toString('utf8');
+      }
+      const next = await this.#iterator.next();
+      if (next.done === true) {
+        const exitCode = await this.#exit;
+        throw this.#error(
+          `hash-object closed unexpectedly with exit ${String(exitCode)}`,
+          exitCode,
+        );
+      }
+      const chunk = Buffer.from(next.value);
+      this.#buffer = this.#buffer.length === 0
+        ? chunk
+        : Buffer.concat([this.#buffer, chunk]);
+    }
+  }
+
+  async #close(): Promise<void> {
+    try {
+      await this.#tail;
+      this.#child.stdin.end();
+      const exitCode = await this.#exit;
+      if (exitCode !== 0) {
+        throw this.#error(
+          `hash-object failed with exit ${String(exitCode)}`,
+          exitCode,
+        );
+      }
+    } finally {
+      await rm(this.#commitPath, { force: true });
+    }
+  }
+
+  #error(message: string, exitCode: number | null): V18MigrationGitError {
+    const stderr = Buffer.concat(this.#stderr).toString('utf8').trim();
+    return new V18MigrationGitError({
+      args: HASH_OBJECT_ARGS,
+      exitCode,
+      stderr: [message, stderr].filter(Boolean).join('\n'),
+    });
+  }
+}
+
+function serializeCommit(record: V18MigrationCommitRecord): Uint8Array {
+  requireOid(record.tree, 'tree');
+  if (record.parent !== null) {
+    requireOid(record.parent, 'parent');
+  }
+  return Buffer.from([
+    `tree ${record.tree}`,
+    ...(record.parent === null ? [] : [`parent ${record.parent}`]),
+    `author ${formatIdentity(record.author, 'author')}`,
+    `committer ${formatIdentity(record.committer, 'committer')}`,
+    '',
+    record.message,
+  ].join('\n'), 'utf8');
+}
+
+function formatIdentity(identity: V18CommitIdentity, label: string): string {
+  if (
+    /[\u0000\n\r]/u.test(identity.name)
+    || /[\u0000\n\r<>]/u.test(identity.email)
+    || !/^[0-9]+$/u.test(identity.timestamp)
+    || !/^[+-][0-9]{4}$/u.test(identity.timezone)
+  ) {
+    throw new Error(`unsupported ${label} identity for Git commit serialization`);
+  }
+  return `${identity.name} <${identity.email}> ${identity.timestamp} ${identity.timezone}`;
+}
+
+function requireOid(value: string, label: string): void {
+  if (!OID_PATTERN.test(value)) {
+    throw new Error(`invalid Git ${label} object ID: ${value}`);
+  }
+}

--- a/scripts/v18-to-v19/V18MigrationGitObjectReader.ts
+++ b/scripts/v18-to-v19/V18MigrationGitObjectReader.ts
@@ -1,0 +1,169 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import { V18MigrationGitError } from './V18MigrationGit.ts';
+
+const OID_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u;
+const CAT_FILE_BATCH_ARGS = Object.freeze(['cat-file', '--batch']);
+
+class V18MigrationGitObjectError extends Error {
+  constructor(message: string, stderr: string) {
+    super(
+      `git ${CAT_FILE_BATCH_ARGS.join(' ')} object read failed: ` +
+        [message, stderr].filter(Boolean).join('\n')
+    );
+    this.name = 'V18MigrationGitObjectError';
+  }
+}
+
+/**
+ * Reads many immutable Git objects through one long-lived `cat-file --batch`
+ * process. Calls are serialized because the batch protocol returns responses
+ * in request order.
+ */
+export class V18MigrationGitObjectReader {
+  readonly #child: ChildProcessWithoutNullStreams;
+  readonly #exit: Promise<number | null>;
+  readonly #iterator: AsyncIterator<Uint8Array>;
+  readonly #stderr: Uint8Array[] = [];
+  #buffer = Buffer.alloc(0);
+  #closePromise: Promise<void> | null = null;
+  #closed = false;
+  #tail: Promise<void> = Promise.resolve();
+
+  constructor(cwd: string) {
+    this.#child = spawn('git', CAT_FILE_BATCH_ARGS, { cwd });
+    this.#iterator = this.#child.stdout[Symbol.asyncIterator]();
+    this.#child.stderr.on('data', (chunk: Uint8Array) => this.#stderr.push(chunk));
+    this.#child.stdin.on('error', () => {
+      // Individual writes and the process exit surface the actionable error.
+    });
+    this.#exit = new Promise<number | null>((resolve, reject) => {
+      this.#child.once('error', reject);
+      this.#child.once('close', resolve);
+    });
+  }
+
+  readObject(oid: string, expectedType: string): Promise<Uint8Array> {
+    if (this.#closePromise !== null) {
+      return Promise.reject(new Error('cannot read from a closing Git object reader'));
+    }
+    const operation = this.#tail.then(async () => await this.#readObject(oid, expectedType));
+    this.#tail = operation.then(
+      () => undefined,
+      () => undefined
+    );
+    return operation;
+  }
+
+  close(): Promise<void> {
+    this.#closePromise ??= this.#close();
+    return this.#closePromise;
+  }
+
+  async #readObject(oid: string, expectedType: string): Promise<Uint8Array> {
+    if (this.#closed) {
+      throw new Error('cannot read from a closed Git object reader');
+    }
+    if (!OID_PATTERN.test(oid)) {
+      throw new TypeError(`invalid Git object ID: ${oid}`);
+    }
+    await this.#write(`${oid}\n`);
+    const header = await this.#readLine();
+    if (header === `${oid} missing`) {
+      throw this.#objectError(`object ${oid} is missing`);
+    }
+    const match = header.match(/^([0-9a-f]{40}(?:[0-9a-f]{24})?) ([a-z]+) ([0-9]+)$/u);
+    if (match === null) {
+      throw this.#objectError(`unexpected cat-file header: ${header}`);
+    }
+    const [, actualOid, actualType, sizeText] = match;
+    if (actualOid !== oid) {
+      throw this.#objectError(`cat-file returned ${actualOid} for ${oid}`);
+    }
+    const size = Number(sizeText);
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw this.#objectError(`cat-file returned invalid size for ${oid}: ${sizeText}`);
+    }
+    const bytes = await this.#readBytes(size);
+    const delimiter = await this.#readBytes(1);
+    if (delimiter[0] !== 0x0a) {
+      throw this.#objectError(`cat-file omitted the payload delimiter for ${oid}`);
+    }
+    if (actualType !== expectedType) {
+      throw this.#objectError(`object ${oid} has type ${actualType}; expected ${expectedType}`);
+    }
+    return bytes;
+  }
+
+  async #write(value: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.#child.stdin.write(value, (error) => {
+        if (error === null || error === undefined) {
+          resolve();
+        } else {
+          reject(this.#processError(`failed to write cat-file request: ${error.message}`, null));
+        }
+      });
+    });
+  }
+
+  async #readLine(): Promise<string> {
+    while (true) {
+      const newline = this.#buffer.indexOf(0x0a);
+      if (newline >= 0) {
+        const line = this.#buffer.subarray(0, newline);
+        this.#buffer = this.#buffer.subarray(newline + 1);
+        return line.toString('utf8');
+      }
+      await this.#readMore();
+    }
+  }
+
+  async #readBytes(size: number): Promise<Uint8Array> {
+    while (this.#buffer.length < size) {
+      await this.#readMore();
+    }
+    const bytes = Buffer.from(this.#buffer.subarray(0, size));
+    this.#buffer = this.#buffer.subarray(size);
+    return bytes;
+  }
+
+  async #readMore(): Promise<void> {
+    const next = await this.#iterator.next();
+    if (next.done === true) {
+      const exitCode = await this.#exit;
+      throw this.#processError(
+        `cat-file closed unexpectedly with exit ${String(exitCode)}`,
+        exitCode
+      );
+    }
+    const chunk = Buffer.from(next.value);
+    this.#buffer = this.#buffer.length === 0 ? chunk : Buffer.concat([this.#buffer, chunk]);
+  }
+
+  async #close(): Promise<void> {
+    await this.#tail;
+    this.#closed = true;
+    this.#child.stdin.end();
+    const exitCode = await this.#exit;
+    if (exitCode !== 0) {
+      throw this.#processError(`cat-file failed with exit ${String(exitCode)}`, exitCode);
+    }
+  }
+
+  #objectError(message: string): V18MigrationGitObjectError {
+    return new V18MigrationGitObjectError(message, this.#stderrText());
+  }
+
+  #processError(message: string, exitCode: number | null): V18MigrationGitError {
+    return new V18MigrationGitError({
+      args: CAT_FILE_BATCH_ARGS,
+      exitCode,
+      stderr: [message, this.#stderrText()].filter(Boolean).join('\n'),
+    });
+  }
+
+  #stderrText(): string {
+    return Buffer.concat(this.#stderr).toString('utf8').trim();
+  }
+}

--- a/scripts/v18-to-v19/V18MigrationGitObjectReader.ts
+++ b/scripts/v18-to-v19/V18MigrationGitObjectReader.ts
@@ -25,7 +25,8 @@ export class V18MigrationGitObjectReader {
   readonly #exit: Promise<number | null>;
   readonly #iterator: AsyncIterator<Uint8Array>;
   readonly #stderr: Uint8Array[] = [];
-  #buffer = Buffer.alloc(0);
+  readonly #chunks: Buffer[] = [];
+  #bufferedBytes = 0;
   #closePromise: Promise<void> | null = null;
   #closed = false;
   #tail: Promise<void> = Promise.resolve();
@@ -41,6 +42,7 @@ export class V18MigrationGitObjectReader {
       this.#child.once('error', reject);
       this.#child.once('close', resolve);
     });
+    void this.#exit.catch(() => undefined);
   }
 
   readObject(oid: string, expectedType: string): Promise<Uint8Array> {
@@ -109,10 +111,10 @@ export class V18MigrationGitObjectReader {
 
   async #readLine(): Promise<string> {
     while (true) {
-      const newline = this.#buffer.indexOf(0x0a);
+      const newline = this.#newlineOffset();
       if (newline >= 0) {
-        const line = this.#buffer.subarray(0, newline);
-        this.#buffer = this.#buffer.subarray(newline + 1);
+        const line = this.#consume(newline);
+        this.#consume(1);
         return line.toString('utf8');
       }
       await this.#readMore();
@@ -120,12 +122,10 @@ export class V18MigrationGitObjectReader {
   }
 
   async #readBytes(size: number): Promise<Uint8Array> {
-    while (this.#buffer.length < size) {
+    while (this.#bufferedBytes < size) {
       await this.#readMore();
     }
-    const bytes = Buffer.from(this.#buffer.subarray(0, size));
-    this.#buffer = this.#buffer.subarray(size);
-    return bytes;
+    return this.#consume(size);
   }
 
   async #readMore(): Promise<void> {
@@ -138,7 +138,41 @@ export class V18MigrationGitObjectReader {
       );
     }
     const chunk = Buffer.from(next.value);
-    this.#buffer = this.#buffer.length === 0 ? chunk : Buffer.concat([this.#buffer, chunk]);
+    this.#chunks.push(chunk);
+    this.#bufferedBytes += chunk.length;
+  }
+
+  #consume(size: number): Buffer {
+    const output = Buffer.allocUnsafe(size);
+    let copied = 0;
+    while (copied < size) {
+      const chunk = this.#chunks[0];
+      if (chunk === undefined) {
+        throw new Error('Git object reader buffer accounting failed');
+      }
+      const length = Math.min(chunk.length, size - copied);
+      chunk.copy(output, copied, 0, length);
+      copied += length;
+      this.#bufferedBytes -= length;
+      if (length === chunk.length) {
+        this.#chunks.shift();
+      } else {
+        this.#chunks[0] = chunk.subarray(length);
+      }
+    }
+    return output;
+  }
+
+  #newlineOffset(): number {
+    let offset = 0;
+    for (const chunk of this.#chunks) {
+      const index = chunk.indexOf(0x0a);
+      if (index >= 0) {
+        return offset + index;
+      }
+      offset += chunk.length;
+    }
+    return -1;
   }
 
   async #close(): Promise<void> {

--- a/scripts/v18-to-v19/V18MigrationGraph.ts
+++ b/scripts/v18-to-v19/V18MigrationGraph.ts
@@ -1,0 +1,46 @@
+import { validateGraphName } from '../../src/domain/utils/RefLayout.ts';
+
+export type V18MigrationGraphRecord = Readonly<{
+  name: string;
+  refCount: number;
+  version: string;
+  writerCount: number;
+}>;
+
+/** One discovered git-warp graph namespace and its migration posture. */
+export default class V18MigrationGraph {
+  readonly name: string;
+  readonly refCount: number;
+  readonly version: string;
+  readonly writerCount: number;
+
+  constructor(record: V18MigrationGraphRecord) {
+    validateGraphName(record.name);
+    requireCount(record.refCount, 'refCount');
+    requireCount(record.writerCount, 'writerCount');
+    if (record.version.length === 0) {
+      throw new Error('migration graph version label cannot be empty');
+    }
+    this.name = record.name;
+    this.refCount = record.refCount;
+    this.version = record.version;
+    this.writerCount = record.writerCount;
+    Object.freeze(this);
+  }
+
+  summary(): string {
+    const refs = `${String(this.refCount)} ${plural(this.refCount, 'ref')}`;
+    const writers = `${String(this.writerCount)} ${plural(this.writerCount, 'writer')}`;
+    return `${this.name} — ${this.version}; ${writers}; ${refs}`;
+  }
+}
+
+function requireCount(value: number, label: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+}
+
+function plural(count: number, noun: string): string {
+  return count === 1 ? noun : `${noun}s`;
+}

--- a/scripts/v18-to-v19/V18MigrationGraphCatalog.ts
+++ b/scripts/v18-to-v19/V18MigrationGraphCatalog.ts
@@ -87,6 +87,9 @@ function assignRefsToGraphs(
   const assignments = new Map(names.map((name) => [name, [] as string[]]));
   const longestFirst = [...names].sort((left, right) => right.length - left.length);
   for (const refName of refs) {
+    if (refName.slice(WARP_REF_PREFIX.length).includes(RECOVERY_SEGMENT)) {
+      continue;
+    }
     const name = assignedGraphName(refName, longestFirst);
     if (name !== null) {
       assignments.get(name)?.push(refName);

--- a/scripts/v18-to-v19/V18MigrationGraphCatalog.ts
+++ b/scripts/v18-to-v19/V18MigrationGraphCatalog.ts
@@ -1,0 +1,136 @@
+import {
+  buildSubstrateVersionRef,
+  buildWritersPrefix,
+  REF_PREFIX,
+  validateGraphName,
+} from '../../src/domain/utils/RefLayout.ts';
+import { textDecode } from '../../src/domain/utils/bytes.ts';
+import { CURRENT_SUBSTRATE_MARKER } from '../../src/infrastructure/adapters/SubstrateVersionGate.ts';
+import V18MigrationGraph from './V18MigrationGraph.ts';
+import {
+  listV18MigrationRefs,
+  readV18MigrationRef,
+  runV18MigrationGit,
+  v18MigrationGitText,
+} from './V18MigrationGit.ts';
+
+const WARP_REF_PREFIX = `${REF_PREFIX}/`;
+const RECOVERY_SEGMENT = '/recovery/';
+const SUBSTRATE_VERSION_SUFFIX = '/substrate-version';
+const WRITERS_SEGMENT = '/writers/';
+
+/** Read-only catalog of git-warp graphs present in one Git repository. */
+export default class V18MigrationGraphCatalog {
+  readonly graphs: readonly V18MigrationGraph[];
+
+  private constructor(graphs: readonly V18MigrationGraph[]) {
+    this.graphs = Object.freeze([...graphs]);
+    Object.freeze(this);
+  }
+
+  static async discover(repositoryPath: string): Promise<V18MigrationGraphCatalog> {
+    const refs = await listV18MigrationRefs(repositoryPath, WARP_REF_PREFIX);
+    const names = discoverGraphNames(refs);
+    const assignments = assignRefsToGraphs(refs, names);
+    const graphs: V18MigrationGraph[] = [];
+    for (const name of names) {
+      graphs.push(await inspectGraph(repositoryPath, name, assignments.get(name) ?? []));
+    }
+    return new V18MigrationGraphCatalog(graphs);
+  }
+
+  require(name: string): V18MigrationGraph {
+    validateGraphName(name);
+    const graph = this.graphs.find((candidate) => candidate.name === name);
+    if (graph === undefined) {
+      throw new Error(`Graph not found: ${name}\n${this.summary()}`);
+    }
+    return graph;
+  }
+
+  summary(): string {
+    if (this.graphs.length === 0) {
+      return 'Graphs found: none';
+    }
+    return ['Graphs found:', ...this.graphs.map((graph) => `  - ${graph.summary()}`)].join('\n');
+  }
+}
+
+function discoverGraphNames(refs: readonly string[]): readonly string[] {
+  const names = new Set<string>();
+  for (const refName of refs) {
+    const candidate = graphNameCandidate(refName);
+    if (candidate !== null) {
+      validateGraphName(candidate);
+      names.add(candidate);
+    }
+  }
+  return [...names].sort();
+}
+
+function graphNameCandidate(refName: string): string | null {
+  const relative = refName.slice(WARP_REF_PREFIX.length);
+  if (relative.includes(RECOVERY_SEGMENT)) {
+    return null;
+  }
+  if (relative.endsWith(SUBSTRATE_VERSION_SUFFIX)) {
+    return relative.slice(0, -SUBSTRATE_VERSION_SUFFIX.length);
+  }
+  const writersIndex = relative.indexOf(WRITERS_SEGMENT);
+  return writersIndex <= 0 ? null : relative.slice(0, writersIndex);
+}
+
+function assignRefsToGraphs(
+  refs: readonly string[],
+  names: readonly string[]
+): ReadonlyMap<string, readonly string[]> {
+  const assignments = new Map(names.map((name) => [name, [] as string[]]));
+  const longestFirst = [...names].sort((left, right) => right.length - left.length);
+  for (const refName of refs) {
+    const name = assignedGraphName(refName, longestFirst);
+    if (name !== null) {
+      assignments.get(name)?.push(refName);
+    }
+  }
+  return assignments;
+}
+
+function assignedGraphName(refName: string, names: readonly string[]): string | null {
+  const relative = refName.slice(WARP_REF_PREFIX.length);
+  return names.find((name) => relative === name || relative.startsWith(`${name}/`)) ?? null;
+}
+
+async function inspectGraph(
+  repositoryPath: string,
+  name: string,
+  refs: readonly string[]
+): Promise<V18MigrationGraph> {
+  const writerPrefix = buildWritersPrefix(name);
+  return new V18MigrationGraph({
+    name,
+    refCount: refs.length,
+    version: await versionLabel(repositoryPath, name),
+    writerCount: refs.filter((refName) => refName.startsWith(writerPrefix)).length,
+  });
+}
+
+async function versionLabel(repositoryPath: string, graph: string): Promise<string> {
+  const markerOid = await readV18MigrationRef(repositoryPath, buildSubstrateVersionRef(graph));
+  if (markerOid === null) {
+    return 'upgrade required (legacy unmarked substrate)';
+  }
+  const objectType = await v18MigrationGitText(repositoryPath, ['cat-file', '-t', markerOid]);
+  if (objectType !== 'blob') {
+    return `unsupported marker (${objectType} ${markerOid.slice(0, 12)})`;
+  }
+  const marker = textDecode(
+    await runV18MigrationGit(repositoryPath, ['cat-file', 'blob', markerOid])
+  );
+  return marker === CURRENT_SUBSTRATE_MARKER
+    ? 'v19 current'
+    : `unsupported marker (${sanitizeMarker(marker)})`;
+}
+
+function sanitizeMarker(marker: string): string {
+  return marker.replaceAll('\n', '\\n').slice(0, 80);
+}

--- a/scripts/v18-to-v19/V18MigrationPlan.ts
+++ b/scripts/v18-to-v19/V18MigrationPlan.ts
@@ -10,6 +10,7 @@ import {
 } from '../../src/domain/utils/RefLayout.ts';
 import { textDecode } from '../../src/domain/utils/bytes.ts';
 import { CURRENT_SUBSTRATE_MARKER } from '../../src/infrastructure/adapters/SubstrateVersionGate.ts';
+import { completeWithCleanup } from '../../src/infrastructure/adapters/OperationCleanup.ts';
 import { readV18PatchCommit } from './V18PatchCommit.ts';
 import {
   listV18MigrationRefs,
@@ -45,12 +46,14 @@ export type V18MigrationPlan = Readonly<{
 }>;
 
 /** Inventories every graph ref and validates all writer commits before scratch work. */
-export async function planV18ToV19Migration(options: Readonly<{
-  graph: string;
-  passphraseAvailable: boolean;
-  progress?: V18MigrationProgressReporter;
-  repositoryPath: string;
-}>): Promise<V18MigrationPlan> {
+export async function planV18ToV19Migration(
+  options: Readonly<{
+    graph: string;
+    passphraseAvailable: boolean;
+    progress?: V18MigrationProgressReporter;
+    repositoryPath: string;
+  }>
+): Promise<V18MigrationPlan> {
   validateGraphName(options.graph);
   const markerRef = buildSubstrateVersionRef(options.graph);
   const graphPrefix = `${REF_PREFIX}/${options.graph}/`;
@@ -107,37 +110,46 @@ export async function planV18ToV19Migration(options: Readonly<{
   if (writerRefs.length === 0) {
     throw new Error(`timeline '${options.graph}' has retained state but no writer refs`);
   }
-  const writers: V18MigrationWriterPlan[] = [];
   const objectReader = new V18MigrationGitObjectReader(options.repositoryPath);
-  try {
-    for (const refName of writerRefs.sort()) {
-      writers.push(await planWriter({
-        ...options,
-        objectReader,
-        refName,
-      }));
-    }
-  } finally {
-    await objectReader.close();
-  }
+  const writers = await completeWithCleanup(
+    async () => {
+      const plannedWriters: V18MigrationWriterPlan[] = [];
+      for (const refName of writerRefs.sort()) {
+        plannedWriters.push(
+          await planWriter({
+            ...options,
+            objectReader,
+            refName,
+          })
+        );
+      }
+      return plannedWriters;
+    },
+    async () => {
+      await objectReader.close();
+    },
+    'v18 migration planning and Git object reader cleanup both failed'
+  );
   return migrationPlan(
     options,
     markerRef,
     'migration-required',
     derivedRefs,
     preservedRefs,
-    writers,
+    writers
   );
 }
 
-async function planWriter(options: Readonly<{
-  graph: string;
-  passphraseAvailable: boolean;
-  progress?: V18MigrationProgressReporter;
-  objectReader: V18MigrationGitObjectReader;
-  refName: string;
-  repositoryPath: string;
-}>): Promise<V18MigrationWriterPlan> {
+async function planWriter(
+  options: Readonly<{
+    graph: string;
+    passphraseAvailable: boolean;
+    progress?: V18MigrationProgressReporter;
+    objectReader: V18MigrationGitObjectReader;
+    refName: string;
+    repositoryPath: string;
+  }>
+): Promise<V18MigrationWriterPlan> {
   const writer = parseWriterIdFromRef(options.refName);
   if (writer === null) {
     throw new Error(`invalid writer ref: ${options.refName}`);
@@ -162,15 +174,11 @@ async function planWriter(options: Readonly<{
     writer,
   });
   for (const sha of commits) {
-    const patch = await readV18PatchCommit(
-      options.repositoryPath,
-      sha,
-      options.objectReader,
-    );
+    const patch = await readV18PatchCommit(options.repositoryPath, sha, options.objectReader);
     if (
-      patch.graph !== options.graph
-      || patch.writer !== writer
-      || (patch.commit.parents[0] ?? null) !== previous
+      patch.graph !== options.graph ||
+      patch.writer !== writer ||
+      (patch.commit.parents[0] ?? null) !== previous
     ) {
       throw new Error(`writer chain identity or parent mismatch at ${sha}`);
     }
@@ -199,8 +207,8 @@ async function planWriter(options: Readonly<{
   }
   if (encryptedCount > 0 && !options.passphraseAvailable) {
     throw new Error(
-      `${options.refName} contains encrypted legacy patches; set `
-        + 'GIT_WARP_MIGRATION_PASSPHRASE before retrying',
+      `${options.refName} contains encrypted legacy patches; set ` +
+        'GIT_WARP_MIGRATION_PASSPHRASE before retrying'
     );
   }
   return Object.freeze({
@@ -216,9 +224,8 @@ async function planWriter(options: Readonly<{
 
 async function requireCurrentMarker(repositoryPath: string, oid: string): Promise<void> {
   const type = await v18MigrationGitText(repositoryPath, ['cat-file', '-t', oid]);
-  const bytes = type === 'blob'
-    ? await runV18MigrationGit(repositoryPath, ['cat-file', 'blob', oid])
-    : null;
+  const bytes =
+    type === 'blob' ? await runV18MigrationGit(repositoryPath, ['cat-file', 'blob', oid]) : null;
   if (bytes === null || textDecode(bytes) !== CURRENT_SUBSTRATE_MARKER) {
     throw new Error(`unsupported retained-substrate marker: ${oid}`);
   }
@@ -237,7 +244,7 @@ async function requireCommitRef(repositoryPath: string, refName: string): Promis
   const objectType = await v18MigrationGitText(repositoryPath, ['cat-file', '-t', oid]);
   if (objectType !== 'commit') {
     throw new Error(
-      `retained ref requires a pre-v18 migration before v19: ${refName} targets ${objectType}`,
+      `retained ref requires a pre-v18 migration before v19: ${refName} targets ${objectType}`
     );
   }
   return oid;
@@ -249,7 +256,7 @@ function migrationPlan(
   status: V18MigrationPlan['status'],
   derivedRefs: Readonly<Record<string, string>>,
   preservedRefs: Readonly<Record<string, string>>,
-  writers: readonly V18MigrationWriterPlan[],
+  writers: readonly V18MigrationWriterPlan[]
 ): V18MigrationPlan {
   return Object.freeze({
     derivedRefs: Object.freeze({ ...derivedRefs }),

--- a/scripts/v18-to-v19/V18MigrationPlan.ts
+++ b/scripts/v18-to-v19/V18MigrationPlan.ts
@@ -17,6 +17,7 @@ import {
   runV18MigrationGit,
   v18MigrationGitText,
 } from './V18MigrationGit.ts';
+import { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 import {
   reportV18MigrationProgress,
   shouldReportV18CommitProgress,
@@ -107,11 +108,17 @@ export async function planV18ToV19Migration(options: Readonly<{
     throw new Error(`timeline '${options.graph}' has retained state but no writer refs`);
   }
   const writers: V18MigrationWriterPlan[] = [];
-  for (const refName of writerRefs.sort()) {
-    writers.push(await planWriter({
-      ...options,
-      refName,
-    }));
+  const objectReader = new V18MigrationGitObjectReader(options.repositoryPath);
+  try {
+    for (const refName of writerRefs.sort()) {
+      writers.push(await planWriter({
+        ...options,
+        objectReader,
+        refName,
+      }));
+    }
+  } finally {
+    await objectReader.close();
   }
   return migrationPlan(
     options,
@@ -127,6 +134,7 @@ async function planWriter(options: Readonly<{
   graph: string;
   passphraseAvailable: boolean;
   progress?: V18MigrationProgressReporter;
+  objectReader: V18MigrationGitObjectReader;
   refName: string;
   repositoryPath: string;
 }>): Promise<V18MigrationWriterPlan> {
@@ -154,7 +162,11 @@ async function planWriter(options: Readonly<{
     writer,
   });
   for (const sha of commits) {
-    const patch = await readV18PatchCommit(options.repositoryPath, sha);
+    const patch = await readV18PatchCommit(
+      options.repositoryPath,
+      sha,
+      options.objectReader,
+    );
     if (
       patch.graph !== options.graph
       || patch.writer !== writer

--- a/scripts/v18-to-v19/V18MigrationPreflight.ts
+++ b/scripts/v18-to-v19/V18MigrationPreflight.ts
@@ -1,0 +1,92 @@
+import { statfs } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+import { v18MigrationGitText } from './V18MigrationGit.ts';
+
+const KIBIBYTE = 1_024n;
+const SCRATCH_MULTIPLIER = 2n;
+
+export type V18MigrationPreflight = Readonly<{
+  repositoryObjectBytes: bigint;
+  scratchAvailableBytes: bigint;
+  scratchMinimumBytes: bigint;
+  scratchPath: string;
+  scratchSufficient: boolean;
+  sourceAvailableBytes: bigint;
+  sourceGitDirectory: string;
+}>;
+
+export async function inspectV18MigrationPreflight(options: {
+  readonly repositoryPath: string;
+  readonly scratchRoot?: string;
+}): Promise<V18MigrationPreflight> {
+  const scratchPath = resolve(options.scratchRoot ?? tmpdir());
+  const [countObjects, sourceGitDirectory] = await Promise.all([
+    v18MigrationGitText(options.repositoryPath, ['count-objects', '-v']),
+    v18MigrationGitText(options.repositoryPath, ['rev-parse', '--absolute-git-dir']),
+  ]);
+  const [scratchFileSystem, sourceFileSystem] = await Promise.all([
+    statfs(scratchPath, { bigint: true }),
+    statfs(sourceGitDirectory, { bigint: true }),
+  ]);
+  const repositoryObjectBytes = parseV18MigrationObjectBytes(countObjects);
+  const scratchMinimumBytes = repositoryObjectBytes * SCRATCH_MULTIPLIER;
+  const scratchAvailableBytes = scratchFileSystem.bavail * scratchFileSystem.bsize;
+  const sourceAvailableBytes = sourceFileSystem.bavail * sourceFileSystem.bsize;
+  return Object.freeze({
+    repositoryObjectBytes,
+    scratchAvailableBytes,
+    scratchMinimumBytes,
+    scratchPath,
+    scratchSufficient: scratchAvailableBytes >= scratchMinimumBytes,
+    sourceAvailableBytes,
+    sourceGitDirectory,
+  });
+}
+
+export function parseV18MigrationObjectBytes(output: string): bigint {
+  const fields = new Map(
+    output
+      .split('\n')
+      .map((line) => line.split(':', 2).map((part) => part.trim()))
+      .filter((parts): parts is [string, string] => parts.length === 2)
+  );
+  return (
+    kibibytes(fields, 'size') + kibibytes(fields, 'size-pack') + kibibytes(fields, 'size-garbage')
+  );
+}
+
+export function formatV18MigrationBytes(bytes: bigint): string {
+  const units = [
+    { name: 'TiB', size: 1_099_511_627_776n },
+    { name: 'GiB', size: 1_073_741_824n },
+    { name: 'MiB', size: 1_048_576n },
+    { name: 'KiB', size: KIBIBYTE },
+  ] as const;
+  const unit = units.find((candidate) => bytes >= candidate.size);
+  if (unit === undefined) {
+    return `${String(bytes)} B`;
+  }
+  const tenths = (bytes * 10n + unit.size / 2n) / unit.size;
+  return `${String(tenths / 10n)}.${String(tenths % 10n)} ${unit.name}`;
+}
+
+export function formatV18MigrationPreflight(preflight: V18MigrationPreflight): string {
+  const posture = preflight.scratchSufficient ? 'sufficient' : 'BELOW OPERATING BUDGET';
+  return [
+    `Git object storage: ${formatV18MigrationBytes(preflight.repositoryObjectBytes)}`,
+    `Scratch volume: ${preflight.scratchPath}`,
+    `Scratch operating budget: ${formatV18MigrationBytes(preflight.scratchMinimumBytes)} minimum (2x Git object storage)`,
+    `Scratch free: ${formatV18MigrationBytes(preflight.scratchAvailableBytes)} (${posture})`,
+    `Source Git free: ${formatV18MigrationBytes(preflight.sourceAvailableBytes)}`,
+  ].join('\n');
+}
+
+function kibibytes(fields: ReadonlyMap<string, string>, name: string): bigint {
+  const value = fields.get(name);
+  if (value === undefined || !/^(?:0|[1-9]\d*)$/u.test(value)) {
+    throw new Error(`git count-objects did not report a valid ${name}: ${String(value)}`);
+  }
+  return BigInt(value) * KIBIBYTE;
+}

--- a/scripts/v18-to-v19/V18MigrationPreflight.ts
+++ b/scripts/v18-to-v19/V18MigrationPreflight.ts
@@ -5,10 +5,11 @@ import { resolve } from 'node:path';
 import { v18MigrationGitText } from './V18MigrationGit.ts';
 
 const KIBIBYTE = 1_024n;
-const SCRATCH_MULTIPLIER = 2n;
+const OBJECT_BYTES_MULTIPLIER = 4n;
 
 export type V18MigrationPreflight = Readonly<{
   repositoryObjectBytes: bigint;
+  repositoryObjectCount: bigint;
   scratchAvailableBytes: bigint;
   scratchMinimumBytes: bigint;
   scratchPath: string;
@@ -31,11 +32,17 @@ export async function inspectV18MigrationPreflight(options: {
     statfs(sourceGitDirectory, { bigint: true }),
   ]);
   const repositoryObjectBytes = parseV18MigrationObjectBytes(countObjects);
-  const scratchMinimumBytes = repositoryObjectBytes * SCRATCH_MULTIPLIER;
+  const repositoryObjectCount = parseV18MigrationObjectCount(countObjects);
+  const scratchMinimumBytes = estimateV18MigrationScratchBytes({
+    repositoryObjectBytes,
+    repositoryObjectCount,
+    scratchBlockBytes: scratchFileSystem.bsize,
+  });
   const scratchAvailableBytes = scratchFileSystem.bavail * scratchFileSystem.bsize;
   const sourceAvailableBytes = sourceFileSystem.bavail * sourceFileSystem.bsize;
   return Object.freeze({
     repositoryObjectBytes,
+    repositoryObjectCount,
     scratchAvailableBytes,
     scratchMinimumBytes,
     scratchPath,
@@ -45,16 +52,27 @@ export async function inspectV18MigrationPreflight(options: {
   });
 }
 
+export function parseV18MigrationObjectCount(output: string): bigint {
+  const fields = parseCountObjectsFields(output);
+  return integer(fields, 'count') + integer(fields, 'in-pack');
+}
+
 export function parseV18MigrationObjectBytes(output: string): bigint {
-  const fields = new Map(
-    output
-      .split('\n')
-      .map((line) => line.split(':', 2).map((part) => part.trim()))
-      .filter((parts): parts is [string, string] => parts.length === 2)
-  );
+  const fields = parseCountObjectsFields(output);
   return (
     kibibytes(fields, 'size') + kibibytes(fields, 'size-pack') + kibibytes(fields, 'size-garbage')
   );
+}
+
+export function estimateV18MigrationScratchBytes(options: {
+  readonly repositoryObjectBytes: bigint;
+  readonly repositoryObjectCount: bigint;
+  readonly scratchBlockBytes: bigint;
+}): bigint {
+  const byteVolumeBudget = options.repositoryObjectBytes * OBJECT_BYTES_MULTIPLIER;
+  const looseObjectBudget =
+    options.repositoryObjectBytes + options.repositoryObjectCount * options.scratchBlockBytes;
+  return byteVolumeBudget > looseObjectBudget ? byteVolumeBudget : looseObjectBudget;
 }
 
 export function formatV18MigrationBytes(bytes: bigint): string {
@@ -75,18 +93,31 @@ export function formatV18MigrationBytes(bytes: bigint): string {
 export function formatV18MigrationPreflight(preflight: V18MigrationPreflight): string {
   const posture = preflight.scratchSufficient ? 'sufficient' : 'BELOW OPERATING BUDGET';
   return [
-    `Git object storage: ${formatV18MigrationBytes(preflight.repositoryObjectBytes)}`,
+    `Git object storage: ${formatV18MigrationBytes(preflight.repositoryObjectBytes)} across ${String(preflight.repositoryObjectCount)} objects`,
     `Scratch volume: ${preflight.scratchPath}`,
-    `Scratch operating budget: ${formatV18MigrationBytes(preflight.scratchMinimumBytes)} minimum (2x Git object storage)`,
+    `Scratch operating budget: ${formatV18MigrationBytes(preflight.scratchMinimumBytes)} minimum (byte volume and loose-object allocation)`,
     `Scratch free: ${formatV18MigrationBytes(preflight.scratchAvailableBytes)} (${posture})`,
     `Source Git free: ${formatV18MigrationBytes(preflight.sourceAvailableBytes)}`,
   ].join('\n');
 }
 
-function kibibytes(fields: ReadonlyMap<string, string>, name: string): bigint {
+function parseCountObjectsFields(output: string): ReadonlyMap<string, string> {
+  return new Map(
+    output
+      .split('\n')
+      .map((line) => line.split(':', 2).map((part) => part.trim()))
+      .filter((parts): parts is [string, string] => parts.length === 2)
+  );
+}
+
+function integer(fields: ReadonlyMap<string, string>, name: string): bigint {
   const value = fields.get(name);
   if (value === undefined || !/^(?:0|[1-9]\d*)$/u.test(value)) {
     throw new Error(`git count-objects did not report a valid ${name}: ${String(value)}`);
   }
-  return BigInt(value) * KIBIBYTE;
+  return BigInt(value);
+}
+
+function kibibytes(fields: ReadonlyMap<string, string>, name: string): bigint {
+  return integer(fields, name) * KIBIBYTE;
 }

--- a/scripts/v18-to-v19/V18MigrationProgress.ts
+++ b/scripts/v18-to-v19/V18MigrationProgress.ts
@@ -1,11 +1,6 @@
 const COMMIT_PROGRESS_INTERVAL = 250;
 
-export type V18MigrationPhase =
-  | 'finalize'
-  | 'inventory'
-  | 'rewrite'
-  | 'scratch'
-  | 'verify';
+export type V18MigrationPhase = 'finalize' | 'inventory' | 'rewrite' | 'scratch' | 'verify';
 
 export type V18MigrationProgress = Readonly<{
   completed?: number;
@@ -15,20 +10,20 @@ export type V18MigrationProgress = Readonly<{
   writer?: string;
 }>;
 
-export type V18MigrationProgressReporter = (
-  progress: V18MigrationProgress,
-) => void;
+export type V18MigrationProgressReporter = (progress: V18MigrationProgress) => void;
 
 export function reportV18MigrationProgress(
   reporter: V18MigrationProgressReporter | undefined,
-  progress: V18MigrationProgress,
+  progress: V18MigrationProgress
 ): void {
   reporter?.(Object.freeze({ ...progress }));
 }
 
-export function shouldReportV18CommitProgress(
-  completed: number,
-  total: number,
-): boolean {
+export function shouldReportV18CommitProgress(completed: number, total: number): boolean {
   return completed === total || completed % COMMIT_PROGRESS_INTERVAL === 0;
+}
+
+/** Convert bounded work counts into the percentage expected by Bijou. */
+export function v18MigrationProgressPercent(completed: number, total: number): number {
+  return total === 0 ? 100 : Math.min(100, Math.max(0, (completed / total) * 100));
 }

--- a/scripts/v18-to-v19/V18MigrationProgressBar.ts
+++ b/scripts/v18-to-v19/V18MigrationProgressBar.ts
@@ -1,0 +1,21 @@
+import { progressBar, stripAnsi, type BijouContext } from '@flyingrobots/bijou';
+
+/** Render bounded migration progress through Bijou for insertion in a Surface. */
+export function renderV18MigrationProgressBar(
+  context: BijouContext,
+  percent: number,
+  completed: number,
+  total: number,
+  width: number
+): string {
+  const label = ` ${String(completed)}/${String(total)} ${percent.toFixed(1)}%`;
+  const barWidth = Math.max(4, Math.min(42, width - label.length - 2));
+  const bar = progressBar(percent, {
+    ctx: context,
+    empty: '░',
+    filled: '█',
+    showPercent: false,
+    width: barWidth,
+  });
+  return `${stripAnsi(bar)}${label}`;
+}

--- a/scripts/v18-to-v19/V18MigrationScratch.ts
+++ b/scripts/v18-to-v19/V18MigrationScratch.ts
@@ -6,11 +6,17 @@ import { buildCheckpointRef } from '../../src/domain/utils/RefLayout.ts';
 import { CURRENT_SUBSTRATE_MARKER } from '../../src/infrastructure/adapters/SubstrateVersionGate.ts';
 import { seedV18Checkpoint } from './V18CheckpointSeed.ts';
 import type { V18MigrationPlan } from './V18MigrationPlan.ts';
-import { listV18MigrationRefs, v18MigrationGitText } from './V18MigrationGit.ts';
+import {
+  listV18MigrationRefs,
+  v18MigrationGitText,
+} from './V18MigrationGit.ts';
 import { V18MigrationGitCommitWriter } from './V18MigrationGitCommitWriter.ts';
 import { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 import V18PatchTranslator from './V18PatchTranslator.ts';
-import { rewriteV18WriterChain, type V18WriterChainRewrite } from './V18WriterChainRewriter.ts';
+import {
+  rewriteV18WriterChain,
+  type V18WriterChainRewrite,
+} from './V18WriterChainRewriter.ts';
 import {
   reportV18MigrationProgress,
   type V18MigrationProgressReporter,
@@ -29,14 +35,12 @@ export type V18PreparedMigration = Readonly<{
 }>;
 
 /** Builds and verifies the complete migration in disposable repositories. */
-export async function prepareV18MigrationScratch(
-  options: Readonly<{
-    passphrase?: string;
-    plan: V18MigrationPlan;
-    progress?: V18MigrationProgressReporter;
-    scratchRoot?: string;
-  }>
-): Promise<V18PreparedMigration> {
+export async function prepareV18MigrationScratch(options: Readonly<{
+  passphrase?: string;
+  plan: V18MigrationPlan;
+  progress?: V18MigrationProgressReporter;
+  scratchRoot?: string;
+}>): Promise<V18PreparedMigration> {
   if (options.plan.status !== 'migration-required') {
     throw new Error(`cannot prepare migration with status ${options.plan.status}`);
   }
@@ -49,31 +53,28 @@ export async function prepareV18MigrationScratch(
     });
     await initializeScratch(scratchPath);
     await fetchPlanRefs(scratchPath, options.plan);
-    const objectReader = new V18MigrationGitObjectReader(scratchPath);
     const translator = await V18PatchTranslator.open({
-      objectReader,
       repositoryPath: scratchPath,
       ...(options.passphrase === undefined ? {} : { passphrase: options.passphrase }),
     });
+    const objectReader = new V18MigrationGitObjectReader(scratchPath);
     const commitWriter = new V18MigrationGitCommitWriter(scratchPath);
     const rewrites: V18WriterChainRewrite[] = [];
     const commitMap = new Map<string, string>();
     let seededCheckpointRef: string | null = null;
     try {
       for (const writer of options.plan.writers) {
-        rewrites.push(
-          await rewriteV18WriterChain({
-            commitWriter,
-            commitMap,
-            graph: options.plan.graph,
-            objectReader,
-            ...(options.progress === undefined ? {} : { progress: options.progress }),
-            refName: writer.refName,
-            repositoryPath: scratchPath,
-            translator,
-            writer: writer.writer,
-          })
-        );
+        rewrites.push(await rewriteV18WriterChain({
+          commitWriter,
+          commitMap,
+          graph: options.plan.graph,
+          objectReader,
+          ...(options.progress === undefined ? {} : { progress: options.progress }),
+          refName: writer.refName,
+          repositoryPath: scratchPath,
+          translator,
+          writer: writer.writer,
+        }));
       }
       reportV18MigrationProgress(options.progress, {
         message: 'publishing current substrate marker',
@@ -91,7 +92,11 @@ export async function prepareV18MigrationScratch(
       });
       seededCheckpointRef = seed.status === 'seeded' ? seed.checkpointRef : null;
     } finally {
-      await Promise.all([commitWriter.close(), objectReader.close(), translator.close()]);
+      await Promise.all([
+        commitWriter.close(),
+        objectReader.close(),
+        translator.close(),
+      ]);
     }
     reportV18MigrationProgress(options.progress, {
       message: 'retiring superseded derived refs',
@@ -124,18 +129,29 @@ export async function prepareV18MigrationScratch(
 /** Verifies promoted refs through a disposable append and bounded public reading. */
 export async function verifyPromotedV19Repository(
   repositoryPath: string,
-  graph: string
+  graph: string,
 ): Promise<void> {
   await verifyRepositoryInDisposableCopy(repositoryPath, graph, tmpdir());
 }
 
 async function initializeScratch(scratchPath: string): Promise<void> {
   await v18MigrationGitText(scratchPath, ['init', '-q']);
-  await v18MigrationGitText(scratchPath, ['config', 'user.name', 'git-warp v18-to-v19 migration']);
-  await v18MigrationGitText(scratchPath, ['config', 'user.email', 'git-warp@example.invalid']);
+  await v18MigrationGitText(scratchPath, [
+    'config',
+    'user.name',
+    'git-warp v18-to-v19 migration',
+  ]);
+  await v18MigrationGitText(scratchPath, [
+    'config',
+    'user.email',
+    'git-warp@example.invalid',
+  ]);
 }
 
-async function fetchPlanRefs(scratchPath: string, plan: V18MigrationPlan): Promise<void> {
+async function fetchPlanRefs(
+  scratchPath: string,
+  plan: V18MigrationPlan,
+): Promise<void> {
   const refs = [
     ...plan.writers.map((writer) => writer.refName),
     ...Object.keys(plan.derivedRefs),
@@ -155,7 +171,7 @@ async function fetchPlanRefs(scratchPath: string, plan: V18MigrationPlan): Promi
 async function deleteDerivedRefs(
   scratchPath: string,
   plan: V18MigrationPlan,
-  preservedRef: string | null
+  preservedRef: string | null,
 ): Promise<void> {
   for (const [refName, oid] of Object.entries(plan.derivedRefs)) {
     if (refName === preservedRef) {
@@ -166,18 +182,24 @@ async function deleteDerivedRefs(
 }
 
 async function writeCurrentMarker(scratchPath: string, markerRef: string): Promise<void> {
-  const markerOid = await v18MigrationGitText(scratchPath, ['hash-object', '-w', '--stdin'], {
-    input: CURRENT_SUBSTRATE_MARKER,
-  });
+  const markerOid = await v18MigrationGitText(
+    scratchPath,
+    ['hash-object', '-w', '--stdin'],
+    { input: CURRENT_SUBSTRATE_MARKER },
+  );
   await v18MigrationGitText(scratchPath, ['update-ref', markerRef, markerOid]);
 }
 
 async function createCurrentCheckpoint(
   repositoryPath: string,
   graph: string,
-  progress?: V18MigrationProgressReporter
+  progress?: V18MigrationProgressReporter,
 ): Promise<void> {
-  const opened = await openScratchGraph(repositoryPath, graph, V18_MIGRATION_VERIFICATION_WRITER);
+  const opened = await openScratchGraph(
+    repositoryPath,
+    graph,
+    V18_MIGRATION_VERIFICATION_WRITER,
+  );
   try {
     reportV18MigrationProgress(progress, {
       message: 'materializing writer history without a checkpoint seed',
@@ -197,12 +219,15 @@ async function createCurrentCheckpoint(
 async function verifyRepositoryInDisposableCopy(
   sourcePath: string,
   graph: string,
-  scratchRoot: string
+  scratchRoot: string,
 ): Promise<void> {
   const verificationPath = await mkdtemp(join(scratchRoot, 'git-warp-v19-verify-'));
   try {
     await initializeScratch(verificationPath);
-    for (const refName of await listV18MigrationRefs(sourcePath, `refs/warp/${graph}/`)) {
+    for (const refName of await listV18MigrationRefs(
+      sourcePath,
+      `refs/warp/${graph}/`,
+    )) {
       await v18MigrationGitText(verificationPath, [
         'fetch',
         '-q',
@@ -219,11 +244,17 @@ async function verifyRepositoryInDisposableCopy(
 
 async function collectDesiredRefs(
   scratchPath: string,
-  graph: string
+  graph: string,
 ): Promise<Readonly<Record<string, string>>> {
   const desired: Record<string, string> = {};
-  for (const refName of await listV18MigrationRefs(scratchPath, `refs/warp/${graph}/`)) {
-    desired[refName] = await v18MigrationGitText(scratchPath, ['rev-parse', '--verify', refName]);
+  for (const refName of await listV18MigrationRefs(
+    scratchPath,
+    `refs/warp/${graph}/`,
+  )) {
+    desired[refName] = await v18MigrationGitText(
+      scratchPath,
+      ['rev-parse', '--verify', refName],
+    );
   }
   return Object.freeze(desired);
 }

--- a/scripts/v18-to-v19/V18MigrationScratch.ts
+++ b/scripts/v18-to-v19/V18MigrationScratch.ts
@@ -2,20 +2,13 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import Runtime from '../../src/application/Runtime.ts';
 import { buildCheckpointRef } from '../../src/domain/utils/RefLayout.ts';
 import { CURRENT_SUBSTRATE_MARKER } from '../../src/infrastructure/adapters/SubstrateVersionGate.ts';
 import { seedV18Checkpoint } from './V18CheckpointSeed.ts';
 import type { V18MigrationPlan } from './V18MigrationPlan.ts';
-import {
-  listV18MigrationRefs,
-  v18MigrationGitText,
-} from './V18MigrationGit.ts';
+import { listV18MigrationRefs, v18MigrationGitText } from './V18MigrationGit.ts';
 import V18PatchTranslator from './V18PatchTranslator.ts';
-import {
-  rewriteV18WriterChain,
-  type V18WriterChainRewrite,
-} from './V18WriterChainRewriter.ts';
+import { rewriteV18WriterChain, type V18WriterChainRewrite } from './V18WriterChainRewriter.ts';
 import {
   reportV18MigrationProgress,
   type V18MigrationProgressReporter,
@@ -34,12 +27,14 @@ export type V18PreparedMigration = Readonly<{
 }>;
 
 /** Builds and verifies the complete migration in disposable repositories. */
-export async function prepareV18MigrationScratch(options: Readonly<{
-  passphrase?: string;
-  plan: V18MigrationPlan;
-  progress?: V18MigrationProgressReporter;
-  scratchRoot?: string;
-}>): Promise<V18PreparedMigration> {
+export async function prepareV18MigrationScratch(
+  options: Readonly<{
+    passphrase?: string;
+    plan: V18MigrationPlan;
+    progress?: V18MigrationProgressReporter;
+    scratchRoot?: string;
+  }>
+): Promise<V18PreparedMigration> {
   if (options.plan.status !== 'migration-required') {
     throw new Error(`cannot prepare migration with status ${options.plan.status}`);
   }
@@ -61,15 +56,17 @@ export async function prepareV18MigrationScratch(options: Readonly<{
     let seededCheckpointRef: string | null = null;
     try {
       for (const writer of options.plan.writers) {
-        rewrites.push(await rewriteV18WriterChain({
-          commitMap,
-          graph: options.plan.graph,
-          ...(options.progress === undefined ? {} : { progress: options.progress }),
-          refName: writer.refName,
-          repositoryPath: scratchPath,
-          translator,
-          writer: writer.writer,
-        }));
+        rewrites.push(
+          await rewriteV18WriterChain({
+            commitMap,
+            graph: options.plan.graph,
+            ...(options.progress === undefined ? {} : { progress: options.progress }),
+            refName: writer.refName,
+            repositoryPath: scratchPath,
+            translator,
+            writer: writer.writer,
+          })
+        );
       }
       reportV18MigrationProgress(options.progress, {
         message: 'publishing current substrate marker',
@@ -102,7 +99,7 @@ export async function prepareV18MigrationScratch(options: Readonly<{
       message: 'proving reopen, append, public reading, and receipt',
       phase: 'verify',
     });
-    await verifyPreparedScratch(scratchPath, options.plan.graph, scratchRoot);
+    await verifyRepositoryInDisposableCopy(scratchPath, options.plan.graph, scratchRoot);
     return Object.freeze({
       async cleanup(): Promise<void> {
         await rm(scratchPath, { recursive: true, force: true });
@@ -117,50 +114,21 @@ export async function prepareV18MigrationScratch(options: Readonly<{
   }
 }
 
-/** Replays every promoted patch and opens the public v19 lane without appending. */
+/** Verifies promoted refs through a disposable append and bounded public reading. */
 export async function verifyPromotedV19Repository(
   repositoryPath: string,
-  graph: string,
+  graph: string
 ): Promise<void> {
-  const opened = await openScratchGraph(
-    repositoryPath,
-    graph,
-    V18_MIGRATION_VERIFICATION_WRITER,
-  );
-  try {
-    await opened.graph.materialize();
-  } finally {
-    await opened.close();
-  }
-  const runtime = await Runtime.open({
-    at: repositoryPath,
-    writer: V18_MIGRATION_VERIFICATION_WRITER,
-  });
-  try {
-    await runtime.lane(graph);
-  } finally {
-    await runtime.close();
-  }
+  await verifyRepositoryInDisposableCopy(repositoryPath, graph, tmpdir());
 }
 
 async function initializeScratch(scratchPath: string): Promise<void> {
   await v18MigrationGitText(scratchPath, ['init', '-q']);
-  await v18MigrationGitText(scratchPath, [
-    'config',
-    'user.name',
-    'git-warp v18-to-v19 migration',
-  ]);
-  await v18MigrationGitText(scratchPath, [
-    'config',
-    'user.email',
-    'git-warp@example.invalid',
-  ]);
+  await v18MigrationGitText(scratchPath, ['config', 'user.name', 'git-warp v18-to-v19 migration']);
+  await v18MigrationGitText(scratchPath, ['config', 'user.email', 'git-warp@example.invalid']);
 }
 
-async function fetchPlanRefs(
-  scratchPath: string,
-  plan: V18MigrationPlan,
-): Promise<void> {
+async function fetchPlanRefs(scratchPath: string, plan: V18MigrationPlan): Promise<void> {
   const refs = [
     ...plan.writers.map((writer) => writer.refName),
     ...Object.keys(plan.derivedRefs),
@@ -180,7 +148,7 @@ async function fetchPlanRefs(
 async function deleteDerivedRefs(
   scratchPath: string,
   plan: V18MigrationPlan,
-  preservedRef: string | null,
+  preservedRef: string | null
 ): Promise<void> {
   for (const [refName, oid] of Object.entries(plan.derivedRefs)) {
     if (refName === preservedRef) {
@@ -191,24 +159,18 @@ async function deleteDerivedRefs(
 }
 
 async function writeCurrentMarker(scratchPath: string, markerRef: string): Promise<void> {
-  const markerOid = await v18MigrationGitText(
-    scratchPath,
-    ['hash-object', '-w', '--stdin'],
-    { input: CURRENT_SUBSTRATE_MARKER },
-  );
+  const markerOid = await v18MigrationGitText(scratchPath, ['hash-object', '-w', '--stdin'], {
+    input: CURRENT_SUBSTRATE_MARKER,
+  });
   await v18MigrationGitText(scratchPath, ['update-ref', markerRef, markerOid]);
 }
 
 async function createCurrentCheckpoint(
   repositoryPath: string,
   graph: string,
-  progress?: V18MigrationProgressReporter,
+  progress?: V18MigrationProgressReporter
 ): Promise<void> {
-  const opened = await openScratchGraph(
-    repositoryPath,
-    graph,
-    V18_MIGRATION_VERIFICATION_WRITER,
-  );
+  const opened = await openScratchGraph(repositoryPath, graph, V18_MIGRATION_VERIFICATION_WRITER);
   try {
     reportV18MigrationProgress(progress, {
       message: 'materializing writer history without a checkpoint seed',
@@ -225,18 +187,15 @@ async function createCurrentCheckpoint(
   }
 }
 
-async function verifyPreparedScratch(
+async function verifyRepositoryInDisposableCopy(
   sourcePath: string,
   graph: string,
-  scratchRoot: string,
+  scratchRoot: string
 ): Promise<void> {
   const verificationPath = await mkdtemp(join(scratchRoot, 'git-warp-v19-verify-'));
   try {
     await initializeScratch(verificationPath);
-    for (const refName of await listV18MigrationRefs(
-      sourcePath,
-      `refs/warp/${graph}/`,
-    )) {
+    for (const refName of await listV18MigrationRefs(sourcePath, `refs/warp/${graph}/`)) {
       await v18MigrationGitText(verificationPath, [
         'fetch',
         '-q',
@@ -253,17 +212,11 @@ async function verifyPreparedScratch(
 
 async function collectDesiredRefs(
   scratchPath: string,
-  graph: string,
+  graph: string
 ): Promise<Readonly<Record<string, string>>> {
   const desired: Record<string, string> = {};
-  for (const refName of await listV18MigrationRefs(
-    scratchPath,
-    `refs/warp/${graph}/`,
-  )) {
-    desired[refName] = await v18MigrationGitText(
-      scratchPath,
-      ['rev-parse', '--verify', refName],
-    );
+  for (const refName of await listV18MigrationRefs(scratchPath, `refs/warp/${graph}/`)) {
+    desired[refName] = await v18MigrationGitText(scratchPath, ['rev-parse', '--verify', refName]);
   }
   return Object.freeze(desired);
 }

--- a/scripts/v18-to-v19/V18MigrationScratch.ts
+++ b/scripts/v18-to-v19/V18MigrationScratch.ts
@@ -131,8 +131,9 @@ export async function prepareV18MigrationScratch(options: Readonly<{
 export async function verifyPromotedV19Repository(
   repositoryPath: string,
   graph: string,
+  scratchRoot = tmpdir(),
 ): Promise<void> {
-  await verifyRepositoryInDisposableCopy(repositoryPath, graph, tmpdir());
+  await verifyRepositoryInDisposableCopy(repositoryPath, graph, scratchRoot);
 }
 
 async function initializeScratch(scratchPath: string): Promise<void> {

--- a/scripts/v18-to-v19/V18MigrationScratch.ts
+++ b/scripts/v18-to-v19/V18MigrationScratch.ts
@@ -6,9 +6,15 @@ import { buildCheckpointRef } from '../../src/domain/utils/RefLayout.ts';
 import { CURRENT_SUBSTRATE_MARKER } from '../../src/infrastructure/adapters/SubstrateVersionGate.ts';
 import { seedV18Checkpoint } from './V18CheckpointSeed.ts';
 import type { V18MigrationPlan } from './V18MigrationPlan.ts';
-import { listV18MigrationRefs, v18MigrationGitText } from './V18MigrationGit.ts';
+import {
+  listV18MigrationRefs,
+  v18MigrationGitText,
+} from './V18MigrationGit.ts';
 import V18PatchTranslator from './V18PatchTranslator.ts';
-import { rewriteV18WriterChain, type V18WriterChainRewrite } from './V18WriterChainRewriter.ts';
+import {
+  rewriteV18WriterChain,
+  type V18WriterChainRewrite,
+} from './V18WriterChainRewriter.ts';
 import {
   reportV18MigrationProgress,
   type V18MigrationProgressReporter,
@@ -27,14 +33,12 @@ export type V18PreparedMigration = Readonly<{
 }>;
 
 /** Builds and verifies the complete migration in disposable repositories. */
-export async function prepareV18MigrationScratch(
-  options: Readonly<{
-    passphrase?: string;
-    plan: V18MigrationPlan;
-    progress?: V18MigrationProgressReporter;
-    scratchRoot?: string;
-  }>
-): Promise<V18PreparedMigration> {
+export async function prepareV18MigrationScratch(options: Readonly<{
+  passphrase?: string;
+  plan: V18MigrationPlan;
+  progress?: V18MigrationProgressReporter;
+  scratchRoot?: string;
+}>): Promise<V18PreparedMigration> {
   if (options.plan.status !== 'migration-required') {
     throw new Error(`cannot prepare migration with status ${options.plan.status}`);
   }
@@ -56,17 +60,15 @@ export async function prepareV18MigrationScratch(
     let seededCheckpointRef: string | null = null;
     try {
       for (const writer of options.plan.writers) {
-        rewrites.push(
-          await rewriteV18WriterChain({
-            commitMap,
-            graph: options.plan.graph,
-            ...(options.progress === undefined ? {} : { progress: options.progress }),
-            refName: writer.refName,
-            repositoryPath: scratchPath,
-            translator,
-            writer: writer.writer,
-          })
-        );
+        rewrites.push(await rewriteV18WriterChain({
+          commitMap,
+          graph: options.plan.graph,
+          ...(options.progress === undefined ? {} : { progress: options.progress }),
+          refName: writer.refName,
+          repositoryPath: scratchPath,
+          translator,
+          writer: writer.writer,
+        }));
       }
       reportV18MigrationProgress(options.progress, {
         message: 'publishing current substrate marker',
@@ -117,18 +119,29 @@ export async function prepareV18MigrationScratch(
 /** Verifies promoted refs through a disposable append and bounded public reading. */
 export async function verifyPromotedV19Repository(
   repositoryPath: string,
-  graph: string
+  graph: string,
 ): Promise<void> {
   await verifyRepositoryInDisposableCopy(repositoryPath, graph, tmpdir());
 }
 
 async function initializeScratch(scratchPath: string): Promise<void> {
   await v18MigrationGitText(scratchPath, ['init', '-q']);
-  await v18MigrationGitText(scratchPath, ['config', 'user.name', 'git-warp v18-to-v19 migration']);
-  await v18MigrationGitText(scratchPath, ['config', 'user.email', 'git-warp@example.invalid']);
+  await v18MigrationGitText(scratchPath, [
+    'config',
+    'user.name',
+    'git-warp v18-to-v19 migration',
+  ]);
+  await v18MigrationGitText(scratchPath, [
+    'config',
+    'user.email',
+    'git-warp@example.invalid',
+  ]);
 }
 
-async function fetchPlanRefs(scratchPath: string, plan: V18MigrationPlan): Promise<void> {
+async function fetchPlanRefs(
+  scratchPath: string,
+  plan: V18MigrationPlan,
+): Promise<void> {
   const refs = [
     ...plan.writers.map((writer) => writer.refName),
     ...Object.keys(plan.derivedRefs),
@@ -148,7 +161,7 @@ async function fetchPlanRefs(scratchPath: string, plan: V18MigrationPlan): Promi
 async function deleteDerivedRefs(
   scratchPath: string,
   plan: V18MigrationPlan,
-  preservedRef: string | null
+  preservedRef: string | null,
 ): Promise<void> {
   for (const [refName, oid] of Object.entries(plan.derivedRefs)) {
     if (refName === preservedRef) {
@@ -159,18 +172,24 @@ async function deleteDerivedRefs(
 }
 
 async function writeCurrentMarker(scratchPath: string, markerRef: string): Promise<void> {
-  const markerOid = await v18MigrationGitText(scratchPath, ['hash-object', '-w', '--stdin'], {
-    input: CURRENT_SUBSTRATE_MARKER,
-  });
+  const markerOid = await v18MigrationGitText(
+    scratchPath,
+    ['hash-object', '-w', '--stdin'],
+    { input: CURRENT_SUBSTRATE_MARKER },
+  );
   await v18MigrationGitText(scratchPath, ['update-ref', markerRef, markerOid]);
 }
 
 async function createCurrentCheckpoint(
   repositoryPath: string,
   graph: string,
-  progress?: V18MigrationProgressReporter
+  progress?: V18MigrationProgressReporter,
 ): Promise<void> {
-  const opened = await openScratchGraph(repositoryPath, graph, V18_MIGRATION_VERIFICATION_WRITER);
+  const opened = await openScratchGraph(
+    repositoryPath,
+    graph,
+    V18_MIGRATION_VERIFICATION_WRITER,
+  );
   try {
     reportV18MigrationProgress(progress, {
       message: 'materializing writer history without a checkpoint seed',
@@ -190,12 +209,15 @@ async function createCurrentCheckpoint(
 async function verifyRepositoryInDisposableCopy(
   sourcePath: string,
   graph: string,
-  scratchRoot: string
+  scratchRoot: string,
 ): Promise<void> {
   const verificationPath = await mkdtemp(join(scratchRoot, 'git-warp-v19-verify-'));
   try {
     await initializeScratch(verificationPath);
-    for (const refName of await listV18MigrationRefs(sourcePath, `refs/warp/${graph}/`)) {
+    for (const refName of await listV18MigrationRefs(
+      sourcePath,
+      `refs/warp/${graph}/`,
+    )) {
       await v18MigrationGitText(verificationPath, [
         'fetch',
         '-q',
@@ -212,11 +234,17 @@ async function verifyRepositoryInDisposableCopy(
 
 async function collectDesiredRefs(
   scratchPath: string,
-  graph: string
+  graph: string,
 ): Promise<Readonly<Record<string, string>>> {
   const desired: Record<string, string> = {};
-  for (const refName of await listV18MigrationRefs(scratchPath, `refs/warp/${graph}/`)) {
-    desired[refName] = await v18MigrationGitText(scratchPath, ['rev-parse', '--verify', refName]);
+  for (const refName of await listV18MigrationRefs(
+    scratchPath,
+    `refs/warp/${graph}/`,
+  )) {
+    desired[refName] = await v18MigrationGitText(
+      scratchPath,
+      ['rev-parse', '--verify', refName],
+    );
   }
   return Object.freeze(desired);
 }

--- a/scripts/v18-to-v19/V18MigrationScratch.ts
+++ b/scripts/v18-to-v19/V18MigrationScratch.ts
@@ -53,11 +53,12 @@ export async function prepareV18MigrationScratch(options: Readonly<{
     });
     await initializeScratch(scratchPath);
     await fetchPlanRefs(scratchPath, options.plan);
+    const objectReader = new V18MigrationGitObjectReader(scratchPath);
     const translator = await V18PatchTranslator.open({
+      objectReader,
       repositoryPath: scratchPath,
       ...(options.passphrase === undefined ? {} : { passphrase: options.passphrase }),
     });
-    const objectReader = new V18MigrationGitObjectReader(scratchPath);
     const commitWriter = new V18MigrationGitCommitWriter(scratchPath);
     const rewrites: V18WriterChainRewrite[] = [];
     const commitMap = new Map<string, string>();

--- a/scripts/v18-to-v19/V18MigrationScratch.ts
+++ b/scripts/v18-to-v19/V18MigrationScratch.ts
@@ -6,17 +6,11 @@ import { buildCheckpointRef } from '../../src/domain/utils/RefLayout.ts';
 import { CURRENT_SUBSTRATE_MARKER } from '../../src/infrastructure/adapters/SubstrateVersionGate.ts';
 import { seedV18Checkpoint } from './V18CheckpointSeed.ts';
 import type { V18MigrationPlan } from './V18MigrationPlan.ts';
-import {
-  listV18MigrationRefs,
-  v18MigrationGitText,
-} from './V18MigrationGit.ts';
+import { listV18MigrationRefs, v18MigrationGitText } from './V18MigrationGit.ts';
 import { V18MigrationGitCommitWriter } from './V18MigrationGitCommitWriter.ts';
 import { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 import V18PatchTranslator from './V18PatchTranslator.ts';
-import {
-  rewriteV18WriterChain,
-  type V18WriterChainRewrite,
-} from './V18WriterChainRewriter.ts';
+import { rewriteV18WriterChain, type V18WriterChainRewrite } from './V18WriterChainRewriter.ts';
 import {
   reportV18MigrationProgress,
   type V18MigrationProgressReporter,
@@ -35,12 +29,14 @@ export type V18PreparedMigration = Readonly<{
 }>;
 
 /** Builds and verifies the complete migration in disposable repositories. */
-export async function prepareV18MigrationScratch(options: Readonly<{
-  passphrase?: string;
-  plan: V18MigrationPlan;
-  progress?: V18MigrationProgressReporter;
-  scratchRoot?: string;
-}>): Promise<V18PreparedMigration> {
+export async function prepareV18MigrationScratch(
+  options: Readonly<{
+    passphrase?: string;
+    plan: V18MigrationPlan;
+    progress?: V18MigrationProgressReporter;
+    scratchRoot?: string;
+  }>
+): Promise<V18PreparedMigration> {
   if (options.plan.status !== 'migration-required') {
     throw new Error(`cannot prepare migration with status ${options.plan.status}`);
   }
@@ -53,28 +49,31 @@ export async function prepareV18MigrationScratch(options: Readonly<{
     });
     await initializeScratch(scratchPath);
     await fetchPlanRefs(scratchPath, options.plan);
+    const objectReader = new V18MigrationGitObjectReader(scratchPath);
     const translator = await V18PatchTranslator.open({
+      objectReader,
       repositoryPath: scratchPath,
       ...(options.passphrase === undefined ? {} : { passphrase: options.passphrase }),
     });
-    const objectReader = new V18MigrationGitObjectReader(scratchPath);
     const commitWriter = new V18MigrationGitCommitWriter(scratchPath);
     const rewrites: V18WriterChainRewrite[] = [];
     const commitMap = new Map<string, string>();
     let seededCheckpointRef: string | null = null;
     try {
       for (const writer of options.plan.writers) {
-        rewrites.push(await rewriteV18WriterChain({
-          commitWriter,
-          commitMap,
-          graph: options.plan.graph,
-          objectReader,
-          ...(options.progress === undefined ? {} : { progress: options.progress }),
-          refName: writer.refName,
-          repositoryPath: scratchPath,
-          translator,
-          writer: writer.writer,
-        }));
+        rewrites.push(
+          await rewriteV18WriterChain({
+            commitWriter,
+            commitMap,
+            graph: options.plan.graph,
+            objectReader,
+            ...(options.progress === undefined ? {} : { progress: options.progress }),
+            refName: writer.refName,
+            repositoryPath: scratchPath,
+            translator,
+            writer: writer.writer,
+          })
+        );
       }
       reportV18MigrationProgress(options.progress, {
         message: 'publishing current substrate marker',
@@ -92,11 +91,7 @@ export async function prepareV18MigrationScratch(options: Readonly<{
       });
       seededCheckpointRef = seed.status === 'seeded' ? seed.checkpointRef : null;
     } finally {
-      await Promise.all([
-        commitWriter.close(),
-        objectReader.close(),
-        translator.close(),
-      ]);
+      await Promise.all([commitWriter.close(), objectReader.close(), translator.close()]);
     }
     reportV18MigrationProgress(options.progress, {
       message: 'retiring superseded derived refs',
@@ -129,29 +124,18 @@ export async function prepareV18MigrationScratch(options: Readonly<{
 /** Verifies promoted refs through a disposable append and bounded public reading. */
 export async function verifyPromotedV19Repository(
   repositoryPath: string,
-  graph: string,
+  graph: string
 ): Promise<void> {
   await verifyRepositoryInDisposableCopy(repositoryPath, graph, tmpdir());
 }
 
 async function initializeScratch(scratchPath: string): Promise<void> {
   await v18MigrationGitText(scratchPath, ['init', '-q']);
-  await v18MigrationGitText(scratchPath, [
-    'config',
-    'user.name',
-    'git-warp v18-to-v19 migration',
-  ]);
-  await v18MigrationGitText(scratchPath, [
-    'config',
-    'user.email',
-    'git-warp@example.invalid',
-  ]);
+  await v18MigrationGitText(scratchPath, ['config', 'user.name', 'git-warp v18-to-v19 migration']);
+  await v18MigrationGitText(scratchPath, ['config', 'user.email', 'git-warp@example.invalid']);
 }
 
-async function fetchPlanRefs(
-  scratchPath: string,
-  plan: V18MigrationPlan,
-): Promise<void> {
+async function fetchPlanRefs(scratchPath: string, plan: V18MigrationPlan): Promise<void> {
   const refs = [
     ...plan.writers.map((writer) => writer.refName),
     ...Object.keys(plan.derivedRefs),
@@ -171,7 +155,7 @@ async function fetchPlanRefs(
 async function deleteDerivedRefs(
   scratchPath: string,
   plan: V18MigrationPlan,
-  preservedRef: string | null,
+  preservedRef: string | null
 ): Promise<void> {
   for (const [refName, oid] of Object.entries(plan.derivedRefs)) {
     if (refName === preservedRef) {
@@ -182,24 +166,18 @@ async function deleteDerivedRefs(
 }
 
 async function writeCurrentMarker(scratchPath: string, markerRef: string): Promise<void> {
-  const markerOid = await v18MigrationGitText(
-    scratchPath,
-    ['hash-object', '-w', '--stdin'],
-    { input: CURRENT_SUBSTRATE_MARKER },
-  );
+  const markerOid = await v18MigrationGitText(scratchPath, ['hash-object', '-w', '--stdin'], {
+    input: CURRENT_SUBSTRATE_MARKER,
+  });
   await v18MigrationGitText(scratchPath, ['update-ref', markerRef, markerOid]);
 }
 
 async function createCurrentCheckpoint(
   repositoryPath: string,
   graph: string,
-  progress?: V18MigrationProgressReporter,
+  progress?: V18MigrationProgressReporter
 ): Promise<void> {
-  const opened = await openScratchGraph(
-    repositoryPath,
-    graph,
-    V18_MIGRATION_VERIFICATION_WRITER,
-  );
+  const opened = await openScratchGraph(repositoryPath, graph, V18_MIGRATION_VERIFICATION_WRITER);
   try {
     reportV18MigrationProgress(progress, {
       message: 'materializing writer history without a checkpoint seed',
@@ -219,15 +197,12 @@ async function createCurrentCheckpoint(
 async function verifyRepositoryInDisposableCopy(
   sourcePath: string,
   graph: string,
-  scratchRoot: string,
+  scratchRoot: string
 ): Promise<void> {
   const verificationPath = await mkdtemp(join(scratchRoot, 'git-warp-v19-verify-'));
   try {
     await initializeScratch(verificationPath);
-    for (const refName of await listV18MigrationRefs(
-      sourcePath,
-      `refs/warp/${graph}/`,
-    )) {
+    for (const refName of await listV18MigrationRefs(sourcePath, `refs/warp/${graph}/`)) {
       await v18MigrationGitText(verificationPath, [
         'fetch',
         '-q',
@@ -244,17 +219,11 @@ async function verifyRepositoryInDisposableCopy(
 
 async function collectDesiredRefs(
   scratchPath: string,
-  graph: string,
+  graph: string
 ): Promise<Readonly<Record<string, string>>> {
   const desired: Record<string, string> = {};
-  for (const refName of await listV18MigrationRefs(
-    scratchPath,
-    `refs/warp/${graph}/`,
-  )) {
-    desired[refName] = await v18MigrationGitText(
-      scratchPath,
-      ['rev-parse', '--verify', refName],
-    );
+  for (const refName of await listV18MigrationRefs(scratchPath, `refs/warp/${graph}/`)) {
+    desired[refName] = await v18MigrationGitText(scratchPath, ['rev-parse', '--verify', refName]);
   }
   return Object.freeze(desired);
 }

--- a/scripts/v18-to-v19/V18MigrationScratch.ts
+++ b/scripts/v18-to-v19/V18MigrationScratch.ts
@@ -10,6 +10,7 @@ import {
   listV18MigrationRefs,
   v18MigrationGitText,
 } from './V18MigrationGit.ts';
+import { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 import V18PatchTranslator from './V18PatchTranslator.ts';
 import {
   rewriteV18WriterChain,
@@ -55,6 +56,7 @@ export async function prepareV18MigrationScratch(options: Readonly<{
       repositoryPath: scratchPath,
       ...(options.passphrase === undefined ? {} : { passphrase: options.passphrase }),
     });
+    const objectReader = new V18MigrationGitObjectReader(scratchPath);
     const rewrites: V18WriterChainRewrite[] = [];
     const commitMap = new Map<string, string>();
     let seededCheckpointRef: string | null = null;
@@ -63,6 +65,7 @@ export async function prepareV18MigrationScratch(options: Readonly<{
         rewrites.push(await rewriteV18WriterChain({
           commitMap,
           graph: options.plan.graph,
+          objectReader,
           ...(options.progress === undefined ? {} : { progress: options.progress }),
           refName: writer.refName,
           repositoryPath: scratchPath,
@@ -86,7 +89,7 @@ export async function prepareV18MigrationScratch(options: Readonly<{
       });
       seededCheckpointRef = seed.status === 'seeded' ? seed.checkpointRef : null;
     } finally {
-      await translator.close();
+      await Promise.all([objectReader.close(), translator.close()]);
     }
     reportV18MigrationProgress(options.progress, {
       message: 'retiring superseded derived refs',

--- a/scripts/v18-to-v19/V18MigrationScratch.ts
+++ b/scripts/v18-to-v19/V18MigrationScratch.ts
@@ -10,6 +10,7 @@ import {
   listV18MigrationRefs,
   v18MigrationGitText,
 } from './V18MigrationGit.ts';
+import { V18MigrationGitCommitWriter } from './V18MigrationGitCommitWriter.ts';
 import { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 import V18PatchTranslator from './V18PatchTranslator.ts';
 import {
@@ -57,12 +58,14 @@ export async function prepareV18MigrationScratch(options: Readonly<{
       ...(options.passphrase === undefined ? {} : { passphrase: options.passphrase }),
     });
     const objectReader = new V18MigrationGitObjectReader(scratchPath);
+    const commitWriter = new V18MigrationGitCommitWriter(scratchPath);
     const rewrites: V18WriterChainRewrite[] = [];
     const commitMap = new Map<string, string>();
     let seededCheckpointRef: string | null = null;
     try {
       for (const writer of options.plan.writers) {
         rewrites.push(await rewriteV18WriterChain({
+          commitWriter,
           commitMap,
           graph: options.plan.graph,
           objectReader,
@@ -89,7 +92,11 @@ export async function prepareV18MigrationScratch(options: Readonly<{
       });
       seededCheckpointRef = seed.status === 'seeded' ? seed.checkpointRef : null;
     } finally {
-      await Promise.all([objectReader.close(), translator.close()]);
+      await Promise.all([
+        commitWriter.close(),
+        objectReader.close(),
+        translator.close(),
+      ]);
     }
     reportV18MigrationProgress(options.progress, {
       message: 'retiring superseded derived refs',

--- a/scripts/v18-to-v19/V18MigrationScratch.ts
+++ b/scripts/v18-to-v19/V18MigrationScratch.ts
@@ -4,19 +4,14 @@ import { join } from 'node:path';
 
 import { buildCheckpointRef } from '../../src/domain/utils/RefLayout.ts';
 import { CURRENT_SUBSTRATE_MARKER } from '../../src/infrastructure/adapters/SubstrateVersionGate.ts';
+import { completeWithCleanup } from '../../src/infrastructure/adapters/OperationCleanup.ts';
 import { seedV18Checkpoint } from './V18CheckpointSeed.ts';
 import type { V18MigrationPlan } from './V18MigrationPlan.ts';
-import {
-  listV18MigrationRefs,
-  v18MigrationGitText,
-} from './V18MigrationGit.ts';
+import { listV18MigrationRefs, v18MigrationGitText } from './V18MigrationGit.ts';
 import { V18MigrationGitCommitWriter } from './V18MigrationGitCommitWriter.ts';
 import { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 import V18PatchTranslator from './V18PatchTranslator.ts';
-import {
-  rewriteV18WriterChain,
-  type V18WriterChainRewrite,
-} from './V18WriterChainRewriter.ts';
+import { rewriteV18WriterChain, type V18WriterChainRewrite } from './V18WriterChainRewriter.ts';
 import {
   reportV18MigrationProgress,
   type V18MigrationProgressReporter,
@@ -35,12 +30,14 @@ export type V18PreparedMigration = Readonly<{
 }>;
 
 /** Builds and verifies the complete migration in disposable repositories. */
-export async function prepareV18MigrationScratch(options: Readonly<{
-  passphrase?: string;
-  plan: V18MigrationPlan;
-  progress?: V18MigrationProgressReporter;
-  scratchRoot?: string;
-}>): Promise<V18PreparedMigration> {
+export async function prepareV18MigrationScratch(
+  options: Readonly<{
+    passphrase?: string;
+    plan: V18MigrationPlan;
+    progress?: V18MigrationProgressReporter;
+    scratchRoot?: string;
+  }>
+): Promise<V18PreparedMigration> {
   if (options.plan.status !== 'migration-required') {
     throw new Error(`cannot prepare migration with status ${options.plan.status}`);
   }
@@ -54,51 +51,55 @@ export async function prepareV18MigrationScratch(options: Readonly<{
     await initializeScratch(scratchPath);
     await fetchPlanRefs(scratchPath, options.plan);
     const objectReader = new V18MigrationGitObjectReader(scratchPath);
-    const translator = await V18PatchTranslator.open({
-      objectReader,
-      repositoryPath: scratchPath,
-      ...(options.passphrase === undefined ? {} : { passphrase: options.passphrase }),
-    });
-    const commitWriter = new V18MigrationGitCommitWriter(scratchPath);
+    let translator: V18PatchTranslator | null = null;
+    let commitWriter: V18MigrationGitCommitWriter | null = null;
     const rewrites: V18WriterChainRewrite[] = [];
     const commitMap = new Map<string, string>();
     let seededCheckpointRef: string | null = null;
-    try {
-      for (const writer of options.plan.writers) {
-        rewrites.push(await rewriteV18WriterChain({
-          commitWriter,
+    await completeWithCleanup(
+      async () => {
+        translator = await V18PatchTranslator.open({
+          objectReader,
+          repositoryPath: scratchPath,
+          ...(options.passphrase === undefined ? {} : { passphrase: options.passphrase }),
+        });
+        commitWriter = new V18MigrationGitCommitWriter(scratchPath);
+        for (const writer of options.plan.writers) {
+          rewrites.push(
+            await rewriteV18WriterChain({
+              commitWriter,
+              commitMap,
+              graph: options.plan.graph,
+              objectReader,
+              ...(options.progress === undefined ? {} : { progress: options.progress }),
+              refName: writer.refName,
+              repositoryPath: scratchPath,
+              translator,
+              writer: writer.writer,
+            })
+          );
+        }
+        reportV18MigrationProgress(options.progress, {
+          message: 'publishing current substrate marker',
+          phase: 'scratch',
+        });
+        await writeCurrentMarker(scratchPath, options.plan.markerRef);
+        const checkpointRef = buildCheckpointRef(options.plan.graph);
+        const seed = await seedV18Checkpoint({
           commitMap,
           graph: options.plan.graph,
-          objectReader,
+          legacyCheckpointSha: options.plan.derivedRefs[checkpointRef] ?? null,
           ...(options.progress === undefined ? {} : { progress: options.progress }),
-          refName: writer.refName,
           repositoryPath: scratchPath,
           translator,
-          writer: writer.writer,
-        }));
-      }
-      reportV18MigrationProgress(options.progress, {
-        message: 'publishing current substrate marker',
-        phase: 'scratch',
-      });
-      await writeCurrentMarker(scratchPath, options.plan.markerRef);
-      const checkpointRef = buildCheckpointRef(options.plan.graph);
-      const seed = await seedV18Checkpoint({
-        commitMap,
-        graph: options.plan.graph,
-        legacyCheckpointSha: options.plan.derivedRefs[checkpointRef] ?? null,
-        ...(options.progress === undefined ? {} : { progress: options.progress }),
-        repositoryPath: scratchPath,
-        translator,
-      });
-      seededCheckpointRef = seed.status === 'seeded' ? seed.checkpointRef : null;
-    } finally {
-      await Promise.all([
-        commitWriter.close(),
-        objectReader.close(),
-        translator.close(),
-      ]);
-    }
+        });
+        seededCheckpointRef = seed.status === 'seeded' ? seed.checkpointRef : null;
+      },
+      async () => {
+        await closeScratchResources(commitWriter, objectReader, translator);
+      },
+      'v18 scratch migration and resource cleanup both failed'
+    );
     reportV18MigrationProgress(options.progress, {
       message: 'retiring superseded derived refs',
       phase: 'scratch',
@@ -131,49 +132,30 @@ export async function prepareV18MigrationScratch(options: Readonly<{
 export async function verifyPromotedV19Repository(
   repositoryPath: string,
   graph: string,
-  scratchRoot = tmpdir(),
+  scratchRoot = tmpdir()
 ): Promise<void> {
   await verifyRepositoryInDisposableCopy(repositoryPath, graph, scratchRoot);
 }
 
 async function initializeScratch(scratchPath: string): Promise<void> {
   await v18MigrationGitText(scratchPath, ['init', '-q']);
-  await v18MigrationGitText(scratchPath, [
-    'config',
-    'user.name',
-    'git-warp v18-to-v19 migration',
-  ]);
-  await v18MigrationGitText(scratchPath, [
-    'config',
-    'user.email',
-    'git-warp@example.invalid',
-  ]);
+  await v18MigrationGitText(scratchPath, ['config', 'user.name', 'git-warp v18-to-v19 migration']);
+  await v18MigrationGitText(scratchPath, ['config', 'user.email', 'git-warp@example.invalid']);
 }
 
-async function fetchPlanRefs(
-  scratchPath: string,
-  plan: V18MigrationPlan,
-): Promise<void> {
+async function fetchPlanRefs(scratchPath: string, plan: V18MigrationPlan): Promise<void> {
   const refs = [
     ...plan.writers.map((writer) => writer.refName),
     ...Object.keys(plan.derivedRefs),
     ...Object.keys(plan.preservedRefs),
   ];
-  for (const refName of refs) {
-    await v18MigrationGitText(scratchPath, [
-      'fetch',
-      '-q',
-      '--no-tags',
-      plan.repositoryPath,
-      `+${refName}:${refName}`,
-    ]);
-  }
+  await fetchMigrationRefs(scratchPath, plan.repositoryPath, refs);
 }
 
 async function deleteDerivedRefs(
   scratchPath: string,
   plan: V18MigrationPlan,
-  preservedRef: string | null,
+  preservedRef: string | null
 ): Promise<void> {
   for (const [refName, oid] of Object.entries(plan.derivedRefs)) {
     if (refName === preservedRef) {
@@ -184,24 +166,18 @@ async function deleteDerivedRefs(
 }
 
 async function writeCurrentMarker(scratchPath: string, markerRef: string): Promise<void> {
-  const markerOid = await v18MigrationGitText(
-    scratchPath,
-    ['hash-object', '-w', '--stdin'],
-    { input: CURRENT_SUBSTRATE_MARKER },
-  );
+  const markerOid = await v18MigrationGitText(scratchPath, ['hash-object', '-w', '--stdin'], {
+    input: CURRENT_SUBSTRATE_MARKER,
+  });
   await v18MigrationGitText(scratchPath, ['update-ref', markerRef, markerOid]);
 }
 
 async function createCurrentCheckpoint(
   repositoryPath: string,
   graph: string,
-  progress?: V18MigrationProgressReporter,
+  progress?: V18MigrationProgressReporter
 ): Promise<void> {
-  const opened = await openScratchGraph(
-    repositoryPath,
-    graph,
-    V18_MIGRATION_VERIFICATION_WRITER,
-  );
+  const opened = await openScratchGraph(repositoryPath, graph, V18_MIGRATION_VERIFICATION_WRITER);
   try {
     reportV18MigrationProgress(progress, {
       message: 'materializing writer history without a checkpoint seed',
@@ -221,23 +197,13 @@ async function createCurrentCheckpoint(
 async function verifyRepositoryInDisposableCopy(
   sourcePath: string,
   graph: string,
-  scratchRoot: string,
+  scratchRoot: string
 ): Promise<void> {
   const verificationPath = await mkdtemp(join(scratchRoot, 'git-warp-v19-verify-'));
   try {
     await initializeScratch(verificationPath);
-    for (const refName of await listV18MigrationRefs(
-      sourcePath,
-      `refs/warp/${graph}/`,
-    )) {
-      await v18MigrationGitText(verificationPath, [
-        'fetch',
-        '-q',
-        '--no-tags',
-        sourcePath,
-        `+${refName}:${refName}`,
-      ]);
-    }
+    const refs = await listV18MigrationRefs(sourcePath, `refs/warp/${graph}/`);
+    await fetchMigrationRefs(verificationPath, sourcePath, refs);
     await appendAndVerifyV18MigrationReading(verificationPath, graph);
   } finally {
     await rm(verificationPath, { recursive: true, force: true });
@@ -246,17 +212,49 @@ async function verifyRepositoryInDisposableCopy(
 
 async function collectDesiredRefs(
   scratchPath: string,
-  graph: string,
+  graph: string
 ): Promise<Readonly<Record<string, string>>> {
   const desired: Record<string, string> = {};
-  for (const refName of await listV18MigrationRefs(
-    scratchPath,
-    `refs/warp/${graph}/`,
-  )) {
-    desired[refName] = await v18MigrationGitText(
-      scratchPath,
-      ['rev-parse', '--verify', refName],
-    );
+  for (const refName of await listV18MigrationRefs(scratchPath, `refs/warp/${graph}/`)) {
+    desired[refName] = await v18MigrationGitText(scratchPath, ['rev-parse', '--verify', refName]);
   }
   return Object.freeze(desired);
+}
+
+async function fetchMigrationRefs(
+  repositoryPath: string,
+  sourcePath: string,
+  refs: readonly string[]
+): Promise<void> {
+  if (refs.length === 0) {
+    return;
+  }
+  await v18MigrationGitText(repositoryPath, [
+    'fetch',
+    '-q',
+    '--no-tags',
+    sourcePath,
+    ...refs.map((refName) => `+${refName}:${refName}`),
+  ]);
+}
+
+async function closeScratchResources(
+  commitWriter: V18MigrationGitCommitWriter | null,
+  objectReader: V18MigrationGitObjectReader,
+  translator: V18PatchTranslator | null
+): Promise<void> {
+  const results = await Promise.allSettled([
+    ...(commitWriter === null ? [] : [commitWriter.close()]),
+    objectReader.close(),
+    ...(translator === null ? [] : [translator.close()]),
+  ]);
+  const failures = results
+    .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+    .map((result) => result.reason);
+  if (failures.length === 1) {
+    throw failures[0];
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(failures, 'v18 scratch resources failed to close');
+  }
 }

--- a/scripts/v18-to-v19/V18MigrationTheme.ts
+++ b/scripts/v18-to-v19/V18MigrationTheme.ts
@@ -1,0 +1,88 @@
+import type { TextModifier, Theme, TokenValue } from '@flyingrobots/bijou';
+
+/**
+ * Reference colors for the migration shell.
+ *
+ * Design Book 0.5.0 selected `paper` through `bestContrastWith(ink, palette)`.
+ * Bijou measures the resulting paper-on-ink pair at 18.94:1.
+ */
+const PALETTE = Object.freeze({
+  accent: '#38bdf8',
+  danger: '#fca5a5',
+  ink: '#07111f',
+  paper: '#ffffff',
+  success: '#86efac',
+  warning: '#fbbf24',
+});
+
+function foreground(hex: string, modifiers?: TextModifier[]): TokenValue {
+  return {
+    hex,
+    ...(modifiers === undefined ? {} : { modifiers }),
+  };
+}
+
+function surface(hex: string, background = PALETTE.ink): TokenValue {
+  return {
+    bg: background,
+    hex,
+  };
+}
+
+/** High-contrast semantic theme for the interactive v18-to-v19 migration shell. */
+export const V18_MIGRATION_THEME: Theme = {
+  name: 'git-warp-v18-to-v19',
+  status: {
+    active: foreground(PALETTE.accent),
+    error: foreground(PALETTE.danger),
+    info: foreground(PALETTE.accent),
+    muted: foreground(PALETTE.paper),
+    pending: foreground(PALETTE.paper),
+    success: foreground(PALETTE.success),
+    warning: foreground(PALETTE.warning),
+  },
+  semantic: {
+    accent: foreground(PALETTE.accent),
+    error: foreground(PALETTE.danger),
+    info: foreground(PALETTE.accent),
+    muted: foreground(PALETTE.paper),
+    primary: foreground(PALETTE.paper, ['bold']),
+    success: foreground(PALETTE.success),
+    warning: foreground(PALETTE.warning),
+  },
+  gradient: {
+    brand: [
+      { color: [56, 189, 248], pos: 0 },
+      { color: [134, 239, 172], pos: 1 },
+    ],
+    progress: [
+      { color: [56, 189, 248], pos: 0 },
+      { color: [134, 239, 172], pos: 1 },
+    ],
+  },
+  border: {
+    error: foreground(PALETTE.danger),
+    muted: foreground(PALETTE.paper),
+    primary: foreground(PALETTE.accent),
+    secondary: foreground(PALETTE.paper),
+    success: foreground(PALETTE.success),
+    warning: foreground(PALETTE.warning),
+  },
+  ui: {
+    cursor: foreground(PALETTE.warning),
+    focusGutter: surface(PALETTE.accent),
+    logo: foreground(PALETTE.accent),
+    scrollThumb: foreground(PALETTE.accent),
+    scrollTrack: foreground(PALETTE.paper),
+    sectionHeader: foreground(PALETTE.paper, ['bold']),
+    tableHeader: foreground(PALETTE.paper, ['bold']),
+    trackEmpty: foreground(PALETTE.paper),
+  },
+  surface: {
+    elevated: surface(PALETTE.paper),
+    muted: surface(PALETTE.paper),
+    overlay: surface(PALETTE.paper),
+    primary: surface(PALETTE.paper),
+    secondary: surface(PALETTE.paper),
+  },
+};

--- a/scripts/v18-to-v19/V18MigrationTheme.ts
+++ b/scripts/v18-to-v19/V18MigrationTheme.ts
@@ -30,7 +30,7 @@ function surface(hex: string, background = PALETTE.ink): TokenValue {
 }
 
 /** High-contrast semantic theme for the interactive v18-to-v19 migration shell. */
-export const V18_MIGRATION_THEME: Theme = {
+const MIGRATION_THEME: Theme = {
   name: 'git-warp-v18-to-v19',
   status: {
     active: foreground(PALETTE.accent),
@@ -86,3 +86,20 @@ export const V18_MIGRATION_THEME: Theme = {
     secondary: surface(PALETTE.paper),
   },
 };
+
+export const V18_MIGRATION_THEME: Theme = deepFreeze(MIGRATION_THEME);
+
+/** Return the mutable copy Bijou enriches while resolving a runtime context. */
+export function createV18MigrationTheme(): Theme {
+  return structuredClone(V18_MIGRATION_THEME);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
+    for (const nested of Object.values(value)) {
+      deepFreeze(nested);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/scripts/v18-to-v19/V18PatchCommit.ts
+++ b/scripts/v18-to-v19/V18PatchCommit.ts
@@ -1,6 +1,7 @@
 import { TrailerCodec, TrailerCodecService } from '@git-stunts/trailer-codec';
 
 import { runV18MigrationGit } from './V18MigrationGit.ts';
+import type { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 
 const OID_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u;
 const codec = new TrailerCodec({ service: new TrailerCodecService() });
@@ -39,11 +40,12 @@ export type V18PatchCommit = Readonly<{
 export async function readV18PatchCommit(
   repositoryPath: string,
   sha: string,
+  objectReader?: V18MigrationGitObjectReader,
 ): Promise<V18PatchCommit> {
-  const raw = Buffer.from(await runV18MigrationGit(
-    repositoryPath,
-    ['cat-file', 'commit', sha],
-  )).toString('utf8');
+  const bytes = objectReader === undefined
+    ? await runV18MigrationGit(repositoryPath, ['cat-file', 'commit', sha])
+    : await objectReader.readObject(sha, 'commit');
+  const raw = Buffer.from(bytes).toString('utf8');
   const commit = parseGitCommit(sha, raw);
   return parsePatchMessage(commit);
 }

--- a/scripts/v18-to-v19/V18PatchTranslator.ts
+++ b/scripts/v18-to-v19/V18PatchTranslator.ts
@@ -14,6 +14,7 @@ import {
 } from '../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts';
 import type { V18PatchCommit } from './V18PatchCommit.ts';
 import { runV18MigrationGit, v18MigrationGitText } from './V18MigrationGit.ts';
+import type { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 
 const OID_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u;
 const messageCodec = new TrailerCommitMessageCodecAdapter();
@@ -31,20 +32,24 @@ export type V18TranslatedPatch = Readonly<{
 export default class V18PatchTranslator {
   readonly #cas: ContentAddressableStore;
   readonly #contentHandles = new Map<string, string>();
+  readonly #objectReader: V18MigrationGitObjectReader;
   readonly #passphrase: string | null;
   readonly #repositoryPath: string;
 
   private constructor(
     repositoryPath: string,
     cas: ContentAddressableStore,
+    objectReader: V18MigrationGitObjectReader,
     passphrase: string | null,
   ) {
     this.#repositoryPath = repositoryPath;
     this.#cas = cas;
+    this.#objectReader = objectReader;
     this.#passphrase = passphrase;
   }
 
   static async open(options: Readonly<{
+    objectReader: V18MigrationGitObjectReader;
     passphrase?: string;
     repositoryPath: string;
   }>): Promise<V18PatchTranslator> {
@@ -56,6 +61,7 @@ export default class V18PatchTranslator {
     return new V18PatchTranslator(
       options.repositoryPath,
       cas,
+      options.objectReader,
       options.passphrase ?? null,
     );
   }
@@ -129,10 +135,7 @@ export default class V18PatchTranslator {
 
   async #readLegacyPatch(patch: V18PatchCommit): Promise<Uint8Array> {
     if (patch.storage.kind === 'legacy-blob') {
-      return await runV18MigrationGit(
-        this.#repositoryPath,
-        ['cat-file', 'blob', patch.storage.oid],
-      );
+      return await this.#objectReader.readObject(patch.storage.oid, 'blob');
     }
     if (patch.storage.kind === 'current') {
       throw new Error(`commit ${patch.commit.sha} is already current`);

--- a/scripts/v18-to-v19/V18PatchTranslator.ts
+++ b/scripts/v18-to-v19/V18PatchTranslator.ts
@@ -5,12 +5,15 @@ import ContentAddressableStore, {
 
 import { hydrateDecodedPatch } from '../../src/domain/services/PatchHydrator.ts';
 import AssetHandle from '../../src/domain/storage/AssetHandle.ts';
-import { createGitCasPatchStorage } from '../../src/ports/CommitMessageCodecPort.ts';
+import {
+  createGitCasPatchStorage,
+} from '../../src/ports/CommitMessageCodecPort.ts';
 import warpCborCodec from '../../src/infrastructure/codecs/CborCodec.ts';
-import { TrailerCommitMessageCodecAdapter } from '../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts';
+import {
+  TrailerCommitMessageCodecAdapter,
+} from '../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts';
 import type { V18PatchCommit } from './V18PatchCommit.ts';
 import { runV18MigrationGit, v18MigrationGitText } from './V18MigrationGit.ts';
-import type { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 
 const OID_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u;
 const messageCodec = new TrailerCommitMessageCodecAdapter();
@@ -28,29 +31,23 @@ export type V18TranslatedPatch = Readonly<{
 export default class V18PatchTranslator {
   readonly #cas: ContentAddressableStore;
   readonly #contentHandles = new Map<string, string>();
-  readonly #objectReader: V18MigrationGitObjectReader;
   readonly #passphrase: string | null;
   readonly #repositoryPath: string;
 
   private constructor(
     repositoryPath: string,
     cas: ContentAddressableStore,
-    objectReader: V18MigrationGitObjectReader,
-    passphrase: string | null
+    passphrase: string | null,
   ) {
     this.#repositoryPath = repositoryPath;
     this.#cas = cas;
-    this.#objectReader = objectReader;
     this.#passphrase = passphrase;
   }
 
-  static async open(
-    options: Readonly<{
-      objectReader: V18MigrationGitObjectReader;
-      passphrase?: string;
-      repositoryPath: string;
-    }>
-  ): Promise<V18PatchTranslator> {
+  static async open(options: Readonly<{
+    passphrase?: string;
+    repositoryPath: string;
+  }>): Promise<V18PatchTranslator> {
     const cas = await ContentAddressableStore.open({
       cwd: options.repositoryPath,
       codec: new GitCasCborCodec(),
@@ -59,8 +56,7 @@ export default class V18PatchTranslator {
     return new V18PatchTranslator(
       options.repositoryPath,
       cas,
-      options.objectReader,
-      options.passphrase ?? null
+      options.passphrase ?? null,
     );
   }
 
@@ -116,44 +112,45 @@ export default class V18PatchTranslator {
     const translated = new Set(
       [false, true]
         .map((encrypted) => this.#contentHandles.get(contentCacheKey(reference, encrypted)))
-        .filter((handle): handle is string => handle !== undefined)
+        .filter((handle): handle is string => handle !== undefined),
     );
     if (translated.size === 0) {
       throw new Error(
-        `legacy checkpoint content ${reference} was not translated from writer history`
+        `legacy checkpoint content ${reference} was not translated from writer history`,
       );
     }
     if (translated.size > 1) {
-      throw new Error(`legacy checkpoint content ${reference} has ambiguous encryption modes`);
+      throw new Error(
+        `legacy checkpoint content ${reference} has ambiguous encryption modes`,
+      );
     }
     return [...translated][0] as string;
   }
 
   async #readLegacyPatch(patch: V18PatchCommit): Promise<Uint8Array> {
     if (patch.storage.kind === 'legacy-blob') {
-      return await this.#objectReader.readObject(patch.storage.oid, 'blob');
+      return await runV18MigrationGit(
+        this.#repositoryPath,
+        ['cat-file', 'blob', patch.storage.oid],
+      );
     }
     if (patch.storage.kind === 'current') {
       throw new Error(`commit ${patch.commit.sha} is already current`);
     }
     const adopted = await this.#cas.assets.adopt({ treeOid: patch.storage.oid });
-    return await collectChunks(
-      this.#cas.assets.open({
-        handle: adopted.handle,
-        ...this.#decryptionOptions(patch.storage.encrypted),
-      })
-    );
+    return await collectChunks(this.#cas.assets.open({
+      handle: adopted.handle,
+      ...this.#decryptionOptions(patch.storage.encrypted),
+    }));
   }
 
   async #rewriteContentHandles(
     patch: DecodedRecord,
-    encrypted: boolean
-  ): Promise<
-    Readonly<{
-      attachmentHandles: ReadonlySet<string>;
-      patch: DecodedRecord;
-    }>
-  > {
+    encrypted: boolean,
+  ): Promise<Readonly<{
+    attachmentHandles: ReadonlySet<string>;
+    patch: DecodedRecord;
+  }>> {
     const ops = requireArray(patch['ops'], 'patch ops');
     const attachmentHandles = new Set<string>();
     const rewrittenOps: DecodedRecord[] = [];
@@ -170,7 +167,7 @@ export default class V18PatchTranslator {
   async #rewriteOperation(
     op: DecodedRecord,
     encrypted: boolean,
-    attachmentHandles: Set<string>
+    attachmentHandles: Set<string>,
   ): Promise<DecodedRecord> {
     const type = op['type'];
     if (op['key'] === '_content') {
@@ -200,31 +197,31 @@ export default class V18PatchTranslator {
     if (existing !== undefined) {
       return existing;
     }
-    const objectType = await v18MigrationGitText(this.#repositoryPath, [
-      'cat-file',
-      '-t',
-      reference,
-    ]);
-    const handle =
-      objectType === 'tree'
-        ? await this.#adoptContentTree(reference, encrypted)
-        : await this.#stageContentBlob(reference, objectType, encrypted);
+    const objectType = await v18MigrationGitText(
+      this.#repositoryPath,
+      ['cat-file', '-t', reference],
+    );
+    const handle = objectType === 'tree'
+      ? await this.#adoptContentTree(reference, encrypted)
+      : await this.#stageContentBlob(reference, objectType, encrypted);
     this.#contentHandles.set(cacheKey, handle);
     return handle;
   }
 
   async #adoptContentTree(treeOid: string, encrypted: boolean): Promise<string> {
     const adopted = await this.#cas.assets.adopt({ treeOid });
-    await drain(
-      this.#cas.assets.open({
-        handle: adopted.handle,
-        ...this.#decryptionOptions(encrypted),
-      })
-    );
+    await drain(this.#cas.assets.open({
+      handle: adopted.handle,
+      ...this.#decryptionOptions(encrypted),
+    }));
     return adopted.handle.toString();
   }
 
-  async #stageContentBlob(oid: string, objectType: string, encrypted: boolean): Promise<string> {
+  async #stageContentBlob(
+    oid: string,
+    objectType: string,
+    encrypted: boolean,
+  ): Promise<string> {
     if (objectType !== 'blob') {
       throw new Error(`legacy content ${oid} has unsupported Git object type ${objectType}`);
     }
@@ -241,7 +238,7 @@ export default class V18PatchTranslator {
   #requirePassphrase(patch: V18PatchCommit): void {
     if (patch.storage.encrypted && this.#passphrase === null) {
       throw new Error(
-        `encrypted commit ${patch.commit.sha} requires GIT_WARP_MIGRATION_PASSPHRASE`
+        `encrypted commit ${patch.commit.sha} requires GIT_WARP_MIGRATION_PASSPHRASE`,
       );
     }
   }

--- a/scripts/v18-to-v19/V18PatchTranslator.ts
+++ b/scripts/v18-to-v19/V18PatchTranslator.ts
@@ -5,15 +5,12 @@ import ContentAddressableStore, {
 
 import { hydrateDecodedPatch } from '../../src/domain/services/PatchHydrator.ts';
 import AssetHandle from '../../src/domain/storage/AssetHandle.ts';
-import {
-  createGitCasPatchStorage,
-} from '../../src/ports/CommitMessageCodecPort.ts';
+import { createGitCasPatchStorage } from '../../src/ports/CommitMessageCodecPort.ts';
 import warpCborCodec from '../../src/infrastructure/codecs/CborCodec.ts';
-import {
-  TrailerCommitMessageCodecAdapter,
-} from '../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts';
+import { TrailerCommitMessageCodecAdapter } from '../../src/infrastructure/adapters/TrailerCommitMessageCodecAdapter.ts';
 import type { V18PatchCommit } from './V18PatchCommit.ts';
 import { runV18MigrationGit, v18MigrationGitText } from './V18MigrationGit.ts';
+import type { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 
 const OID_PATTERN = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/u;
 const messageCodec = new TrailerCommitMessageCodecAdapter();
@@ -31,23 +28,29 @@ export type V18TranslatedPatch = Readonly<{
 export default class V18PatchTranslator {
   readonly #cas: ContentAddressableStore;
   readonly #contentHandles = new Map<string, string>();
+  readonly #objectReader: V18MigrationGitObjectReader;
   readonly #passphrase: string | null;
   readonly #repositoryPath: string;
 
   private constructor(
     repositoryPath: string,
     cas: ContentAddressableStore,
-    passphrase: string | null,
+    objectReader: V18MigrationGitObjectReader,
+    passphrase: string | null
   ) {
     this.#repositoryPath = repositoryPath;
     this.#cas = cas;
+    this.#objectReader = objectReader;
     this.#passphrase = passphrase;
   }
 
-  static async open(options: Readonly<{
-    passphrase?: string;
-    repositoryPath: string;
-  }>): Promise<V18PatchTranslator> {
+  static async open(
+    options: Readonly<{
+      objectReader: V18MigrationGitObjectReader;
+      passphrase?: string;
+      repositoryPath: string;
+    }>
+  ): Promise<V18PatchTranslator> {
     const cas = await ContentAddressableStore.open({
       cwd: options.repositoryPath,
       codec: new GitCasCborCodec(),
@@ -56,7 +59,8 @@ export default class V18PatchTranslator {
     return new V18PatchTranslator(
       options.repositoryPath,
       cas,
-      options.passphrase ?? null,
+      options.objectReader,
+      options.passphrase ?? null
     );
   }
 
@@ -112,45 +116,44 @@ export default class V18PatchTranslator {
     const translated = new Set(
       [false, true]
         .map((encrypted) => this.#contentHandles.get(contentCacheKey(reference, encrypted)))
-        .filter((handle): handle is string => handle !== undefined),
+        .filter((handle): handle is string => handle !== undefined)
     );
     if (translated.size === 0) {
       throw new Error(
-        `legacy checkpoint content ${reference} was not translated from writer history`,
+        `legacy checkpoint content ${reference} was not translated from writer history`
       );
     }
     if (translated.size > 1) {
-      throw new Error(
-        `legacy checkpoint content ${reference} has ambiguous encryption modes`,
-      );
+      throw new Error(`legacy checkpoint content ${reference} has ambiguous encryption modes`);
     }
     return [...translated][0] as string;
   }
 
   async #readLegacyPatch(patch: V18PatchCommit): Promise<Uint8Array> {
     if (patch.storage.kind === 'legacy-blob') {
-      return await runV18MigrationGit(
-        this.#repositoryPath,
-        ['cat-file', 'blob', patch.storage.oid],
-      );
+      return await this.#objectReader.readObject(patch.storage.oid, 'blob');
     }
     if (patch.storage.kind === 'current') {
       throw new Error(`commit ${patch.commit.sha} is already current`);
     }
     const adopted = await this.#cas.assets.adopt({ treeOid: patch.storage.oid });
-    return await collectChunks(this.#cas.assets.open({
-      handle: adopted.handle,
-      ...this.#decryptionOptions(patch.storage.encrypted),
-    }));
+    return await collectChunks(
+      this.#cas.assets.open({
+        handle: adopted.handle,
+        ...this.#decryptionOptions(patch.storage.encrypted),
+      })
+    );
   }
 
   async #rewriteContentHandles(
     patch: DecodedRecord,
-    encrypted: boolean,
-  ): Promise<Readonly<{
-    attachmentHandles: ReadonlySet<string>;
-    patch: DecodedRecord;
-  }>> {
+    encrypted: boolean
+  ): Promise<
+    Readonly<{
+      attachmentHandles: ReadonlySet<string>;
+      patch: DecodedRecord;
+    }>
+  > {
     const ops = requireArray(patch['ops'], 'patch ops');
     const attachmentHandles = new Set<string>();
     const rewrittenOps: DecodedRecord[] = [];
@@ -167,7 +170,7 @@ export default class V18PatchTranslator {
   async #rewriteOperation(
     op: DecodedRecord,
     encrypted: boolean,
-    attachmentHandles: Set<string>,
+    attachmentHandles: Set<string>
   ): Promise<DecodedRecord> {
     const type = op['type'];
     if (op['key'] === '_content') {
@@ -197,31 +200,31 @@ export default class V18PatchTranslator {
     if (existing !== undefined) {
       return existing;
     }
-    const objectType = await v18MigrationGitText(
-      this.#repositoryPath,
-      ['cat-file', '-t', reference],
-    );
-    const handle = objectType === 'tree'
-      ? await this.#adoptContentTree(reference, encrypted)
-      : await this.#stageContentBlob(reference, objectType, encrypted);
+    const objectType = await v18MigrationGitText(this.#repositoryPath, [
+      'cat-file',
+      '-t',
+      reference,
+    ]);
+    const handle =
+      objectType === 'tree'
+        ? await this.#adoptContentTree(reference, encrypted)
+        : await this.#stageContentBlob(reference, objectType, encrypted);
     this.#contentHandles.set(cacheKey, handle);
     return handle;
   }
 
   async #adoptContentTree(treeOid: string, encrypted: boolean): Promise<string> {
     const adopted = await this.#cas.assets.adopt({ treeOid });
-    await drain(this.#cas.assets.open({
-      handle: adopted.handle,
-      ...this.#decryptionOptions(encrypted),
-    }));
+    await drain(
+      this.#cas.assets.open({
+        handle: adopted.handle,
+        ...this.#decryptionOptions(encrypted),
+      })
+    );
     return adopted.handle.toString();
   }
 
-  async #stageContentBlob(
-    oid: string,
-    objectType: string,
-    encrypted: boolean,
-  ): Promise<string> {
+  async #stageContentBlob(oid: string, objectType: string, encrypted: boolean): Promise<string> {
     if (objectType !== 'blob') {
       throw new Error(`legacy content ${oid} has unsupported Git object type ${objectType}`);
     }
@@ -238,7 +241,7 @@ export default class V18PatchTranslator {
   #requirePassphrase(patch: V18PatchCommit): void {
     if (patch.storage.encrypted && this.#passphrase === null) {
       throw new Error(
-        `encrypted commit ${patch.commit.sha} requires GIT_WARP_MIGRATION_PASSPHRASE`,
+        `encrypted commit ${patch.commit.sha} requires GIT_WARP_MIGRATION_PASSPHRASE`
       );
     }
   }

--- a/scripts/v18-to-v19/V18WriterChainRewriter.ts
+++ b/scripts/v18-to-v19/V18WriterChainRewriter.ts
@@ -4,6 +4,7 @@ import {
   readV18MigrationRef,
   v18MigrationGitText,
 } from './V18MigrationGit.ts';
+import type { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 import V18PatchTranslator from './V18PatchTranslator.ts';
 import {
   reportV18MigrationProgress,
@@ -24,6 +25,7 @@ export type V18WriterChainRewrite = Readonly<{
 export async function rewriteV18WriterChain(options: Readonly<{
   commitMap?: Map<string, string>;
   graph: string;
+  objectReader?: V18MigrationGitObjectReader;
   progress?: V18MigrationProgressReporter;
   refName: string;
   repositoryPath: string;
@@ -47,7 +49,11 @@ export async function rewriteV18WriterChain(options: Readonly<{
     writer: options.writer,
   });
   for (const sha of commits) {
-    const patch = await readV18PatchCommit(options.repositoryPath, sha);
+    const patch = await readV18PatchCommit(
+      options.repositoryPath,
+      sha,
+      options.objectReader,
+    );
     requirePatchIdentity(patch, options.graph, options.writer);
     requireLinearParent(patch, previousOld);
     const translated = patch.storage.kind === 'current'

--- a/scripts/v18-to-v19/V18WriterChainRewriter.ts
+++ b/scripts/v18-to-v19/V18WriterChainRewriter.ts
@@ -4,6 +4,7 @@ import {
   readV18MigrationRef,
   v18MigrationGitText,
 } from './V18MigrationGit.ts';
+import type { V18MigrationGitCommitWriter } from './V18MigrationGitCommitWriter.ts';
 import type { V18MigrationGitObjectReader } from './V18MigrationGitObjectReader.ts';
 import V18PatchTranslator from './V18PatchTranslator.ts';
 import {
@@ -23,6 +24,7 @@ export type V18WriterChainRewrite = Readonly<{
 
 /** Recreates one writer chain in order, translating only legacy patch payloads. */
 export async function rewriteV18WriterChain(options: Readonly<{
+  commitWriter?: V18MigrationGitCommitWriter;
   commitMap?: Map<string, string>;
   graph: string;
   objectReader?: V18MigrationGitObjectReader;
@@ -68,6 +70,7 @@ export async function rewriteV18WriterChain(options: Readonly<{
       translated.tree,
       translated.message,
       previousNew,
+      options.commitWriter,
     );
     if (patch.storage.kind === 'current' && previousNew === previousOld && newSha !== sha) {
       throw new Error(`current commit ${sha} was not recreated byte-identically`);
@@ -144,7 +147,17 @@ async function createCommit(
   tree: string,
   message: string,
   parent: string | null,
+  commitWriter?: V18MigrationGitCommitWriter,
 ): Promise<string> {
+  if (commitWriter !== undefined) {
+    return await commitWriter.writeCommit({
+      author: patch.commit.author,
+      committer: patch.commit.committer,
+      message,
+      parent,
+      tree,
+    });
+  }
   const args = ['commit-tree', tree, '-F', '-'];
   if (parent !== null) {
     args.push('-p', parent);

--- a/scripts/v18-to-v19/migrate.ts
+++ b/scripts/v18-to-v19/migrate.ts
@@ -1,31 +1,71 @@
 #!/usr/bin/env node
 
-import { runV18ToV19Migration } from './V18MigrationCommand.ts';
-import type { V18MigrationProgress } from './V18MigrationProgress.ts';
+import { progressBar, type BijouContext } from '@flyingrobots/bijou';
+import { createNodeContext } from '@flyingrobots/bijou-node';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-type CliOptions = Readonly<{
-  apply: boolean;
+import { runV18MigrationApp } from './V18MigrationApp.ts';
+import { runV18ToV19Migration, type V18MigrationCommandReport } from './V18MigrationCommand.ts';
+import V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
+import V18MigrationGraphCatalog from './V18MigrationGraphCatalog.ts';
+import type { V18MigrationProgress } from './V18MigrationProgress.ts';
+import { V18_MIGRATION_THEME } from './V18MigrationTheme.ts';
+
+export type V18MigrationCliOptions = Readonly<{
+  assumeYes: boolean;
   graph: string;
   json: boolean;
+  mode: V18MigrationExecutionMode;
   recoveryId?: string;
   repositoryPath: string;
   scratchRoot?: string;
 }>;
 
 async function main(): Promise<void> {
-  const options = parseArgs(process.argv.slice(2));
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    process.stdout.write(usage());
+    return;
+  }
+  const options = parseV18MigrationCliOptions(process.argv.slice(2));
+  const repositoryPath = resolve(options.repositoryPath);
+  const catalog = await V18MigrationGraphCatalog.discover(repositoryPath);
+  const graph = catalog.require(options.graph);
+  const ctx = migrationContext();
   const passphrase = process.env['GIT_WARP_MIGRATION_PASSPHRASE'];
-  const report = await runV18ToV19Migration({
-    apply: options.apply,
-    graph: options.graph,
-    progress: (progress) => {
-      process.stderr.write(formatProgress(progress));
-    },
-    repositoryPath: options.repositoryPath,
+  const sharedOptions = {
+    mode: options.mode,
+    repositoryPath,
     ...(passphrase === undefined ? {} : { passphrase }),
     ...(options.recoveryId === undefined ? {} : { recoveryId: options.recoveryId }),
     ...(options.scratchRoot === undefined ? {} : { scratchRoot: options.scratchRoot }),
-  });
+  };
+  let report: V18MigrationCommandReport;
+  if (!options.assumeYes) {
+    requireInteractiveConfirmation(catalog.summary());
+    const result = await runV18MigrationApp({
+      context: ctx,
+      graph,
+      ...sharedOptions,
+    });
+    if (result.status === 'cancelled') {
+      process.stdout.write('v18-to-v19 migration cancelled; no refs changed\n');
+      return;
+    }
+    if (result.status === 'failed') {
+      throw result.error;
+    }
+    report = result.report;
+  } else {
+    process.stderr.write(`${catalog.summary()}\n`);
+    report = await runV18ToV19Migration({
+      ...sharedOptions,
+      graph: options.graph,
+      progress: (progress) => {
+        process.stderr.write(formatProgress(progress, ctx));
+      },
+    });
+  }
   if (options.json) {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     return;
@@ -33,38 +73,74 @@ async function main(): Promise<void> {
   process.stdout.write(formatReport(report));
 }
 
-function formatProgress(progress: V18MigrationProgress): string {
-  const writer = progress.writer === undefined ? '' : ` ${progress.writer}`;
-  const count = progress.completed === undefined || progress.total === undefined
-    ? ''
-    : ` ${String(progress.completed)}/${String(progress.total)}`;
-  return `v18-to-v19 [${progress.phase}]${writer}${count}: ${progress.message}\n`;
+function migrationContext(): BijouContext {
+  return createNodeContext({
+    nodeIO: {
+      stderr: process.stderr,
+      stdout: process.stderr,
+    },
+    theme: V18_MIGRATION_THEME,
+  });
 }
 
-function parseArgs(args: readonly string[]): CliOptions {
-  let apply = false;
+function requireInteractiveConfirmation(catalogSummary: string): void {
+  if (!process.stdin.isTTY || !process.stderr.isTTY) {
+    process.stderr.write(`${catalogSummary}\n`);
+    throw new Error(
+      'confirmation requires an interactive terminal; inspect the graph list and rerun with --yes'
+    );
+  }
+}
+
+function formatProgress(progress: V18MigrationProgress, ctx: BijouContext): string {
+  const writer = progress.writer === undefined ? '' : ` ${progress.writer}`;
+  const count =
+    progress.completed === undefined || progress.total === undefined
+      ? ''
+      : ` ${String(progress.completed)}/${String(progress.total)}`;
+  const bar =
+    progress.completed === undefined || progress.total === undefined
+      ? ''
+      : `\n  ${progressBar(progressPercent(progress.completed, progress.total), {
+          ctx,
+          width: 28,
+        })}`;
+  return `v18-to-v19 [${progress.phase}]${writer}${count}: ${progress.message}${bar}\n`;
+}
+
+function progressPercent(completed: number, total: number): number {
+  return total === 0 ? 100 : (completed / total) * 100;
+}
+
+export function parseV18MigrationCliOptions(args: readonly string[]): V18MigrationCliOptions {
+  let applySeen = false;
+  let assumeYes = false;
+  let dryRunSeen = false;
   let graph: string | null = null;
   let json = false;
+  let mode = V18MigrationExecutionMode.promote();
   let recoveryId: string | undefined;
   let repositoryPath: string | null = null;
   let scratchRoot: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === '--apply') {
-      apply = true;
+      applySeen = true;
+    } else if (arg === '--dry-run') {
+      dryRunSeen = true;
+      mode = V18MigrationExecutionMode.rehearse();
+    } else if (arg === '--yes') {
+      assumeYes = true;
     } else if (arg === '--json') {
       json = true;
     } else if (arg === '--graph') {
-      graph = requireValue(args, index += 1, '--graph');
+      graph = requireValue(args, (index += 1), '--graph');
     } else if (arg === '--repo') {
-      repositoryPath = requireValue(args, index += 1, '--repo');
+      repositoryPath = requireValue(args, (index += 1), '--repo');
     } else if (arg === '--recovery-id') {
-      recoveryId = requireValue(args, index += 1, '--recovery-id');
+      recoveryId = requireValue(args, (index += 1), '--recovery-id');
     } else if (arg === '--scratch-root') {
-      scratchRoot = requireValue(args, index += 1, '--scratch-root');
-    } else if (arg === '--help' || arg === '-h') {
-      process.stdout.write(usage());
-      process.exit(0);
+      scratchRoot = requireValue(args, (index += 1), '--scratch-root');
     } else {
       throw new Error(`unknown argument: ${String(arg)}`);
     }
@@ -72,21 +148,21 @@ function parseArgs(args: readonly string[]): CliOptions {
   if (graph === null || repositoryPath === null) {
     throw new Error(`--repo and --graph are required\n\n${usage()}`);
   }
+  if (applySeen && dryRunSeen) {
+    throw new Error('--apply cannot be combined with --dry-run');
+  }
   return Object.freeze({
-    apply,
+    assumeYes,
     graph,
     json,
+    mode,
     repositoryPath,
     ...(recoveryId === undefined ? {} : { recoveryId }),
     ...(scratchRoot === undefined ? {} : { scratchRoot }),
   });
 }
 
-function requireValue(
-  args: readonly string[],
-  index: number,
-  option: string,
-): string {
+function requireValue(args: readonly string[], index: number, option: string): string {
   const value = args[index];
   if (value === undefined || value.startsWith('--')) {
     throw new Error(`${option} requires a value`);
@@ -94,9 +170,7 @@ function requireValue(
   return value;
 }
 
-function formatReport(
-  report: Awaited<ReturnType<typeof runV18ToV19Migration>>,
-): string {
+function formatReport(report: Awaited<ReturnType<typeof runV18ToV19Migration>>): string {
   const lines = [
     `v18-to-v19 retained-substrate migration: ${report.status}`,
     `repository: ${report.plan.repositoryPath}`,
@@ -108,7 +182,7 @@ function formatReport(
     lines.push(`recovery refs: ${report.finalization.recoveryPrefix}`);
   }
   if (report.status === 'verified-dry-run') {
-    lines.push('no authoritative refs changed; rerun with --apply to promote');
+    lines.push('no authoritative refs changed; a later promotion reruns the migration');
   }
   return `${lines.join('\n')}\n`;
 }
@@ -118,22 +192,33 @@ function usage(): string {
     'Usage: git-warp-v18-to-v19 --repo <path> --graph <name> [options]',
     '',
     'Options:',
-    '  --apply                 Atomically promote the scratch-verified migration.',
+    '  --dry-run               Rehearse fully, then discard the verified scratch repo.',
+    '  --yes                   Skip the interactive confirmation for automation.',
+    '  --apply                 Compatibility alias for the default promotion mode.',
     '  --json                  Print the machine-readable report.',
     '  --recovery-id <token>   Stable recovery-ref suffix for operator tracking.',
     '  --scratch-root <path>    Place disposable repositories on this volume.',
     '  -h, --help              Show this help.',
     '',
-    'Without --apply, the command performs the complete disposable proof only.',
+    'The default is one pass: discover, confirm, rehearse, promote, and verify.',
+    'Discovery lists every graph and whether it is current or needs an upgrade.',
+    'A separate --dry-run is intentionally disposable and cannot be reused.',
     'For encrypted stores, set GIT_WARP_MIGRATION_PASSPHRASE in the environment.',
     '',
   ].join('\n');
 }
 
-main().catch((error: unknown) => {
-  process.stderr.write(`git-warp-v18-to-v19: ${formatFailure(error)}\n`);
-  process.exitCode = 1;
-});
+if (isMainModule()) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`git-warp-v18-to-v19: ${formatFailure(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+function isMainModule(): boolean {
+  const invokedPath = process.argv[1];
+  return invokedPath !== undefined && import.meta.url === pathToFileURL(resolve(invokedPath)).href;
+}
 
 function formatFailure(error: unknown, seen = new Set<unknown>()): string {
   if (seen.has(error)) {

--- a/scripts/v18-to-v19/migrate.ts
+++ b/scripts/v18-to-v19/migrate.ts
@@ -9,6 +9,10 @@ import { runV18MigrationApp } from './V18MigrationApp.ts';
 import { runV18ToV19Migration, type V18MigrationCommandReport } from './V18MigrationCommand.ts';
 import V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
 import V18MigrationGraphCatalog from './V18MigrationGraphCatalog.ts';
+import {
+  formatV18MigrationPreflight,
+  inspectV18MigrationPreflight,
+} from './V18MigrationPreflight.ts';
 import type { V18MigrationProgress } from './V18MigrationProgress.ts';
 import { V18_MIGRATION_THEME } from './V18MigrationTheme.ts';
 
@@ -31,6 +35,10 @@ async function main(): Promise<void> {
   const repositoryPath = resolve(options.repositoryPath);
   const catalog = await V18MigrationGraphCatalog.discover(repositoryPath);
   const graph = catalog.require(options.graph);
+  const preflight = await inspectV18MigrationPreflight({
+    repositoryPath,
+    ...(options.scratchRoot === undefined ? {} : { scratchRoot: options.scratchRoot }),
+  });
   const ctx = migrationContext();
   const passphrase = process.env['GIT_WARP_MIGRATION_PASSPHRASE'];
   const sharedOptions = {
@@ -46,6 +54,7 @@ async function main(): Promise<void> {
     const result = await runV18MigrationApp({
       context: ctx,
       graph,
+      preflight,
       ...sharedOptions,
     });
     if (result.status === 'cancelled') {
@@ -57,7 +66,7 @@ async function main(): Promise<void> {
     }
     report = result.report;
   } else {
-    process.stderr.write(`${catalog.summary()}\n`);
+    process.stderr.write(`${catalog.summary()}\n${formatV18MigrationPreflight(preflight)}\n`);
     report = await runV18ToV19Migration({
       ...sharedOptions,
       graph: options.graph,

--- a/scripts/v18-to-v19/migrate.ts
+++ b/scripts/v18-to-v19/migrate.ts
@@ -2,9 +2,11 @@
 
 import { progressBar, type BijouContext } from '@flyingrobots/bijou';
 import { createNodeContext } from '@flyingrobots/bijou-node';
+import { realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { formatFailure } from '../formatFailure.ts';
 import { runV18MigrationApp } from './V18MigrationApp.ts';
 import { runV18ToV19Migration, type V18MigrationCommandReport } from './V18MigrationCommand.ts';
 import V18MigrationExecutionMode from './V18MigrationExecutionMode.ts';
@@ -13,8 +15,8 @@ import {
   formatV18MigrationPreflight,
   inspectV18MigrationPreflight,
 } from './V18MigrationPreflight.ts';
-import type { V18MigrationProgress } from './V18MigrationProgress.ts';
-import { V18_MIGRATION_THEME } from './V18MigrationTheme.ts';
+import { type V18MigrationProgress, v18MigrationProgressPercent } from './V18MigrationProgress.ts';
+import { createV18MigrationTheme } from './V18MigrationTheme.ts';
 
 export type V18MigrationCliOptions = Readonly<{
   assumeYes: boolean;
@@ -88,7 +90,7 @@ function migrationContext(): BijouContext {
       stderr: process.stderr,
       stdout: process.stderr,
     },
-    theme: V18_MIGRATION_THEME,
+    theme: createV18MigrationTheme(),
   });
 }
 
@@ -110,15 +112,11 @@ function formatProgress(progress: V18MigrationProgress, ctx: BijouContext): stri
   const bar =
     progress.completed === undefined || progress.total === undefined
       ? ''
-      : `\n  ${progressBar(progressPercent(progress.completed, progress.total), {
+      : `\n  ${progressBar(v18MigrationProgressPercent(progress.completed, progress.total), {
           ctx,
           width: 28,
         })}`;
   return `v18-to-v19 [${progress.phase}]${writer}${count}: ${progress.message}${bar}\n`;
-}
-
-function progressPercent(completed: number, total: number): number {
-  return total === 0 ? 100 : (completed / total) * 100;
 }
 
 export function parseV18MigrationCliOptions(args: readonly string[]): V18MigrationCliOptions {
@@ -226,23 +224,13 @@ if (isMainModule()) {
 
 function isMainModule(): boolean {
   const invokedPath = process.argv[1];
-  return invokedPath !== undefined && import.meta.url === pathToFileURL(resolve(invokedPath)).href;
-}
-
-function formatFailure(error: unknown, seen = new Set<unknown>()): string {
-  if (seen.has(error)) {
-    return '[circular failure]';
+  if (invokedPath === undefined) {
+    return false;
   }
-  seen.add(error);
-  const message = error instanceof Error ? error.message : String(error);
-  const nested: string[] = [];
-  if (error instanceof AggregateError) {
-    error.errors.forEach((entry, index) => {
-      nested.push(`failure ${String(index + 1)}: ${formatFailure(entry, seen)}`);
-    });
+  const resolvedPath = resolve(invokedPath);
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(resolvedPath)).href;
+  } catch {
+    return import.meta.url === pathToFileURL(resolvedPath).href;
   }
-  if (error instanceof Error && error.cause !== undefined) {
-    nested.push(`cause: ${formatFailure(error.cause, seen)}`);
-  }
-  return nested.length === 0 ? message : `${message}\n${nested.join('\n')}`;
 }

--- a/scripts/v18-to-v19/performance/MigratedReadPerformanceFixture.ts
+++ b/scripts/v18-to-v19/performance/MigratedReadPerformanceFixture.ts
@@ -2,10 +2,9 @@ import { execFileSync } from 'node:child_process';
 import { readFile, stat } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { performance } from 'node:perf_hooks';
-import {
-  restoreV18RetainedSubstrateFixture,
-} from '../V18RetainedSubstrateFixtureRestore.ts';
+import { restoreV18RetainedSubstrateFixture } from '../V18RetainedSubstrateFixtureRestore.ts';
 import { runV18ToV19Migration } from '../V18MigrationCommand.ts';
+import V18MigrationExecutionMode from '../V18MigrationExecutionMode.ts';
 
 export type MigratedReadSeeds = Readonly<{
   bundleBytes: number;
@@ -16,10 +15,12 @@ export type MigratedReadSeeds = Readonly<{
   v19Repository: string;
 }>;
 
-export async function prepareMigratedReadSeeds(options: Readonly<{
-  manifestPath: string;
-  root: string;
-}>): Promise<MigratedReadSeeds> {
+export async function prepareMigratedReadSeeds(
+  options: Readonly<{
+    manifestPath: string;
+    root: string;
+  }>
+): Promise<MigratedReadSeeds> {
   const v18 = await restoreV18RetainedSubstrateFixture({
     manifestPath: options.manifestPath,
     targetDirectory: join(options.root, 'v18-seed'),
@@ -30,8 +31,8 @@ export async function prepareMigratedReadSeeds(options: Readonly<{
   });
   const migrationStarted = performance.now();
   const report = await runV18ToV19Migration({
-    apply: true,
     graph: v19.manifest.graphId,
+    mode: V18MigrationExecutionMode.promote(),
     repositoryPath: v19.repositoryPath,
   });
   const migrationWallMs = performance.now() - migrationStarted;
@@ -42,16 +43,13 @@ export async function prepareMigratedReadSeeds(options: Readonly<{
     .filter((ref) => ref.kind === 'writer')
     .reduce((total, ref) => total + (ref.patchCount ?? 0), 0);
   if (
-    v18.manifest.fixtureId !== 'v18-retained-substrate-medium-001'
-    || v18.manifest.graphId !== 'v18-medium-retained-substrate'
-    || writerPatchCount !== 18
+    v18.manifest.fixtureId !== 'v18-retained-substrate-medium-001' ||
+    v18.manifest.graphId !== 'v18-medium-retained-substrate' ||
+    writerPatchCount !== 18
   ) {
     throw new Error('medium retained-substrate fixture identity drifted');
   }
-  const bundlePath = resolve(
-    dirname(options.manifestPath),
-    v18.manifest.bundlePath,
-  );
+  const bundlePath = resolve(dirname(options.manifestPath), v18.manifest.bundlePath);
   return Object.freeze({
     bundleBytes: (await stat(bundlePath)).size,
     graph: v18.manifest.graphId,
@@ -62,30 +60,33 @@ export async function prepareMigratedReadSeeds(options: Readonly<{
   });
 }
 
-export async function migratedReadEnvironment(options: Readonly<{
-  fixturePackage: string;
-  projectRoot: string;
-}>): Promise<Readonly<{
-  architecture: string;
-  git: string;
-  node: string;
-  platform: string;
-  v18GitCas: '6.0.0';
-  v18GitWarp: '18.2.1';
-  v19Commit: string;
-  v19GitCas: string;
-  v19PackageVersion: string;
-}>> {
+export async function migratedReadEnvironment(
+  options: Readonly<{
+    fixturePackage: string;
+    projectRoot: string;
+  }>
+): Promise<
+  Readonly<{
+    architecture: string;
+    git: string;
+    node: string;
+    platform: string;
+    v18GitCas: '6.0.0';
+    v18GitWarp: '18.2.1';
+    v19Commit: string;
+    v19GitCas: string;
+    v19PackageVersion: string;
+  }>
+> {
   const v18GitWarp = await packageVersion(
-    join(options.fixturePackage, 'node_modules/@git-stunts/git-warp'),
+    join(options.fixturePackage, 'node_modules/@git-stunts/git-warp')
   );
   const v18GitCas = await packageVersion(
-    join(options.fixturePackage, 'node_modules/@git-stunts/git-cas'),
+    join(options.fixturePackage, 'node_modules/@git-stunts/git-cas')
   );
   if (v18GitWarp !== '18.2.1' || v18GitCas !== '6.0.0') {
     throw new Error(
-      `v18 fixture dependencies drifted: git-warp ${v18GitWarp}, `
-        + `git-cas ${v18GitCas}`,
+      `v18 fixture dependencies drifted: git-warp ${v18GitWarp}, ` + `git-cas ${v18GitCas}`
     );
   }
   return Object.freeze({
@@ -99,22 +100,18 @@ export async function migratedReadEnvironment(options: Readonly<{
       cwd: options.projectRoot,
       encoding: 'utf8',
     }).trim(),
-    v19GitCas: await packageVersion(
-      join(options.projectRoot, 'node_modules/@git-stunts/git-cas'),
-    ),
+    v19GitCas: await packageVersion(join(options.projectRoot, 'node_modules/@git-stunts/git-cas')),
     v19PackageVersion: await packageVersion(options.projectRoot),
   });
 }
 
 async function packageVersion(packageRoot: string): Promise<string> {
-  const manifest = JSON.parse(
-    await readFile(join(packageRoot, 'package.json'), 'utf8'),
-  ) as unknown;
+  const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8')) as unknown;
   if (
-    typeof manifest !== 'object'
-    || manifest === null
-    || !('version' in manifest)
-    || typeof manifest.version !== 'string'
+    typeof manifest !== 'object' ||
+    manifest === null ||
+    !('version' in manifest) ||
+    typeof manifest.version !== 'string'
   ) {
     throw new Error(`${packageRoot} has no package version`);
   }

--- a/scripts/validate-mermaid.ts
+++ b/scripts/validate-mermaid.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { extname, join, relative, resolve } from 'node:path';
+
+import { run } from '@mermaid-js/mermaid-cli';
+
+const ROOT = resolve('.');
+const SKIPPED_DIRECTORIES = new Set(['.git', 'coverage', 'dist', 'node_modules']);
+const OPENING_FENCE = /^```mermaid[ \t]*$/u;
+const CLOSING_FENCE = /^```[ \t]*$/u;
+
+type MermaidBlock = Readonly<{
+  line: number;
+  source: string;
+}>;
+
+async function main(): Promise<void> {
+  const markdownFiles = await listMarkdownFiles(ROOT);
+  let diagramCount = 0;
+  let fileCount = 0;
+  const renderInput: string[] = [];
+  for (const path of markdownFiles) {
+    const blocks = extractMermaidBlocks(await readFile(path, 'utf8'), path);
+    if (blocks.length > 0) {
+      fileCount += 1;
+    }
+    for (const block of blocks) {
+      diagramCount += 1;
+      renderInput.push(
+        `<!-- ${relative(ROOT, path)}:${String(block.line)} -->`,
+        '```mermaid',
+        block.source,
+        '```',
+        ''
+      );
+    }
+  }
+  if (diagramCount === 0) {
+    throw new Error('Mermaid validation found no diagrams');
+  }
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'git-warp-mermaid-validation-'));
+  try {
+    const inputPath = join(temporaryDirectory, 'diagrams.md');
+    const outputPath = join(temporaryDirectory, 'rendered.md') as `${string}.md`;
+    await writeFile(inputPath, renderInput.join('\n'), 'utf8');
+    try {
+      await run(inputPath, outputPath, {
+        artefacts: temporaryDirectory,
+        quiet: true,
+      });
+    } catch (error: unknown) {
+      throw new Error(`Mermaid render failed: ${formatFailure(error)}`, {
+        cause: error,
+      });
+    }
+    process.stdout.write(
+      `Mermaid render valid: ${String(diagramCount)} diagrams in ${String(fileCount)} files.\n`
+    );
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+}
+
+function extractMermaidBlocks(markdown: string, path: string): MermaidBlock[] {
+  const lines = markdown.split('\n');
+  const blocks: MermaidBlock[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!OPENING_FENCE.test(lines[index] ?? '')) {
+      continue;
+    }
+    const start = index + 2;
+    const source: string[] = [];
+    index += 1;
+    while (index < lines.length && !CLOSING_FENCE.test(lines[index] ?? '')) {
+      source.push(lines[index] ?? '');
+      index += 1;
+    }
+    if (index >= lines.length) {
+      throw new Error(`${relative(ROOT, path)}:${String(start - 1)}: unclosed Mermaid fence`);
+    }
+    blocks.push(Object.freeze({ line: start, source: source.join('\n') }));
+  }
+  return blocks;
+}
+
+async function listMarkdownFiles(directory: string): Promise<readonly string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const paths: string[] = [];
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRECTORIES.has(entry.name)) {
+        paths.push(...(await listMarkdownFiles(path)));
+      }
+    } else if (entry.isFile() && extname(entry.name) === '.md') {
+      paths.push(path);
+    }
+  }
+  return Object.freeze(paths.sort());
+}
+
+function formatFailure(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message.replaceAll('\n', ' ');
+  }
+  return String(error);
+}
+
+await main();

--- a/scripts/validate-mermaid.ts
+++ b/scripts/validate-mermaid.ts
@@ -4,10 +4,12 @@ import { extname, join, relative, resolve } from 'node:path';
 
 import { run } from '@mermaid-js/mermaid-cli';
 
+import { formatFailure } from './formatFailure.ts';
+
 const ROOT = resolve('.');
 const SKIPPED_DIRECTORIES = new Set(['.git', 'coverage', 'dist', 'node_modules']);
-const OPENING_FENCE = /^```mermaid[ \t]*$/u;
-const CLOSING_FENCE = /^```[ \t]*$/u;
+const OPENING_FENCE = /^( {0,3})```mermaid[ \t]*$/u;
+const CLOSING_FENCE = /^ {0,3}```[ \t]*$/u;
 
 type MermaidBlock = Readonly<{
   line: number;
@@ -46,9 +48,7 @@ async function main(): Promise<void> {
     try {
       await run(inputPath, outputPath, {
         artefacts: temporaryDirectory,
-        puppeteerConfig: {
-          args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        },
+        puppeteerConfig: mermaidPuppeteerConfig(),
         quiet: true,
       });
     } catch (error: unknown) {
@@ -68,14 +68,16 @@ function extractMermaidBlocks(markdown: string, path: string): MermaidBlock[] {
   const lines = markdown.split('\n');
   const blocks: MermaidBlock[] = [];
   for (let index = 0; index < lines.length; index += 1) {
-    if (!OPENING_FENCE.test(lines[index] ?? '')) {
+    const opening = (lines[index] ?? '').match(OPENING_FENCE);
+    if (opening === null) {
       continue;
     }
+    const indentation = opening[1]?.length ?? 0;
     const start = index + 2;
     const source: string[] = [];
     index += 1;
     while (index < lines.length && !CLOSING_FENCE.test(lines[index] ?? '')) {
-      source.push(lines[index] ?? '');
+      source.push(removeSupportedIndent(lines[index] ?? '', indentation));
       index += 1;
     }
     if (index >= lines.length) {
@@ -102,11 +104,18 @@ async function listMarkdownFiles(directory: string): Promise<readonly string[]> 
   return Object.freeze(paths.sort());
 }
 
-function formatFailure(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message.replaceAll('\n', ' ');
+function mermaidPuppeteerConfig(): { args?: string[] } {
+  return process.env['GIT_WARP_MERMAID_DISABLE_SANDBOX'] === '1'
+    ? { args: ['--no-sandbox', '--disable-setuid-sandbox'] }
+    : {};
+}
+
+function removeSupportedIndent(line: string, indentation: number): string {
+  let offset = 0;
+  while (offset < indentation && line[offset] === ' ') {
+    offset += 1;
   }
-  return String(error);
+  return line.slice(offset);
 }
 
 await main();

--- a/scripts/validate-mermaid.ts
+++ b/scripts/validate-mermaid.ts
@@ -46,6 +46,9 @@ async function main(): Promise<void> {
     try {
       await run(inputPath, outputPath, {
         artefacts: temporaryDirectory,
+        puppeteerConfig: {
+          args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        },
         quiet: true,
       });
     } catch (error: unknown) {

--- a/test/integration/scripts/v18-to-v19-medium-fixture.test.ts
+++ b/test/integration/scripts/v18-to-v19-medium-fixture.test.ts
@@ -8,9 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { restoreV18RetainedSubstrateFixture } from '../../../scripts/v18-to-v19/V18RetainedSubstrateFixtureRestore.ts';
 import { readV18MigrationRefMap } from '../../helpers/V18MigrationRefMap.ts';
 
-const MANIFEST_PATH = resolve(
-  'fixtures/v18/retained-substrate-medium/manifest.json',
-);
+const MANIFEST_PATH = resolve('fixtures/v18/retained-substrate-medium/manifest.json');
 
 describe('v18-to-v19 medium standalone migration', () => {
   const temporaryDirectories: string[] = [];
@@ -19,7 +17,7 @@ describe('v18-to-v19 medium standalone migration', () => {
     await Promise.all(
       temporaryDirectories.splice(0).map(async (directory) => {
         await rm(directory, { recursive: true, force: true });
-      }),
+      })
     );
   });
 
@@ -43,22 +41,21 @@ describe('v18-to-v19 medium standalone migration', () => {
       scratchVerified: true,
       status: 'verified-dry-run',
     });
-    expect(report.plan.writers).toEqual(expect.arrayContaining([
-      expect.objectContaining({ commitCount: 16, writer: 'medium-alice' }),
-      expect.objectContaining({ commitCount: 2, writer: 'medium-bob' }),
-    ]));
+    expect(report.plan.writers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ commitCount: 16, writer: 'medium-alice' }),
+        expect.objectContaining({ commitCount: 2, writer: 'medium-bob' }),
+      ])
+    );
     expect(execution.stderr).toMatch(/\[inventory\].*medium-alice 16\/16/u);
     expect(execution.stderr).toMatch(/\[rewrite\].*medium-alice 16\/16/u);
     expect(execution.stderr).toContain('loading retained v18 checkpoint state');
     expect(execution.stderr).toContain('building current bounded checkpoint indexes');
     expect(execution.stderr).not.toContain(
-      'materializing writer history without a checkpoint seed',
+      'materializing writer history without a checkpoint seed'
     );
     expect(execution.stderr).toContain('[verify]');
-    expect(await readV18MigrationRefMap(
-      restored.repositoryPath,
-      refNames,
-    )).toEqual(before);
+    expect(await readV18MigrationRefMap(restored.repositoryPath, refNames)).toEqual(before);
   }, 120_000);
 });
 
@@ -70,16 +67,20 @@ type StandaloneReport = Readonly<{
   status: string;
 }>;
 
-async function runStandaloneMigration(options: Readonly<{
-  graph: string;
-  repositoryPath: string;
-}>): Promise<Readonly<{ report: StandaloneReport; stderr: string }>> {
+async function runStandaloneMigration(
+  options: Readonly<{
+    graph: string;
+    repositoryPath: string;
+  }>
+): Promise<Readonly<{ report: StandaloneReport; stderr: string }>> {
   const result = await runProcess(process.execPath, [
     'scripts/v18-to-v19/migrate.ts',
     '--repo',
     options.repositoryPath,
     '--graph',
     options.graph,
+    '--dry-run',
+    '--yes',
     '--json',
   ]);
   if (result.exitCode !== 0) {
@@ -93,7 +94,7 @@ async function runStandaloneMigration(options: Readonly<{
 
 async function runProcess(
   command: string,
-  args: readonly string[],
+  args: readonly string[]
 ): Promise<Readonly<{ exitCode: number | null; stderr: string; stdout: string }>> {
   return await new Promise((complete, reject) => {
     const child = spawn(command, args, { cwd: resolve('.') });
@@ -102,10 +103,14 @@ async function runProcess(
     child.stdout.on('data', (chunk: Uint8Array) => stdout.push(chunk));
     child.stderr.on('data', (chunk: Uint8Array) => stderr.push(chunk));
     child.on('error', reject);
-    child.on('close', (exitCode) => complete(Object.freeze({
-      exitCode,
-      stderr: Buffer.concat(stderr).toString('utf8'),
-      stdout: Buffer.concat(stdout).toString('utf8'),
-    })));
+    child.on('close', (exitCode) =>
+      complete(
+        Object.freeze({
+          exitCode,
+          stderr: Buffer.concat(stderr).toString('utf8'),
+          stdout: Buffer.concat(stdout).toString('utf8'),
+        })
+      )
+    );
   });
 }

--- a/test/unit/scripts/v18-migration-app.test.ts
+++ b/test/unit/scripts/v18-migration-app.test.ts
@@ -4,7 +4,18 @@ import { describe, expect, it } from 'vitest';
 import { renderV18MigrationApp } from '../../../scripts/v18-to-v19/V18MigrationAppSurface.ts';
 import V18MigrationExecutionMode from '../../../scripts/v18-to-v19/V18MigrationExecutionMode.ts';
 import V18MigrationGraph from '../../../scripts/v18-to-v19/V18MigrationGraph.ts';
+import type { V18MigrationPreflight } from '../../../scripts/v18-to-v19/V18MigrationPreflight.ts';
 import { V18_MIGRATION_THEME } from '../../../scripts/v18-to-v19/V18MigrationTheme.ts';
+
+const PREFLIGHT: V18MigrationPreflight = Object.freeze({
+  repositoryObjectBytes: 80n * 1_048_576n,
+  scratchAvailableBytes: 400n * 1_048_576n,
+  scratchMinimumBytes: 160n * 1_048_576n,
+  scratchPath: '/tmp',
+  scratchSufficient: true,
+  sourceAvailableBytes: 500n * 1_048_576n,
+  sourceGitDirectory: '/tmp/think/.git',
+});
 
 describe('v18 migration framed app', () => {
   it('keeps every surface text pair above WCAG AAA contrast', () => {
@@ -24,6 +35,7 @@ describe('v18 migration framed app', () => {
           writerCount: 2,
         }),
         mode: V18MigrationExecutionMode.promote(),
+        preflight: PREFLIGHT,
         repositoryPath: '/tmp/think',
       },
       { phase: 'confirm' },
@@ -33,6 +45,8 @@ describe('v18 migration framed app', () => {
 
     const text = surfaceText(surface);
     expect(text).toContain('Nothing changes before you confirm.');
+    expect(text).toContain('Git object storage: 80.0 MiB');
+    expect(text).toContain('Scratch capacity check: sufficient.');
     expect(text).toContain('Press Y or Enter to continue.');
     expect(text).not.toContain('Starting migration');
   });
@@ -47,6 +61,7 @@ describe('v18 migration framed app', () => {
           writerCount: 2,
         }),
         mode: V18MigrationExecutionMode.promote(),
+        preflight: PREFLIGHT,
         repositoryPath: '/tmp/think',
       },
       {

--- a/test/unit/scripts/v18-migration-app.test.ts
+++ b/test/unit/scripts/v18-migration-app.test.ts
@@ -1,0 +1,81 @@
+import { themeContrastRatio } from '@flyingrobots/bijou';
+import { describe, expect, it } from 'vitest';
+
+import { renderV18MigrationApp } from '../../../scripts/v18-to-v19/V18MigrationAppSurface.ts';
+import V18MigrationExecutionMode from '../../../scripts/v18-to-v19/V18MigrationExecutionMode.ts';
+import V18MigrationGraph from '../../../scripts/v18-to-v19/V18MigrationGraph.ts';
+import { V18_MIGRATION_THEME } from '../../../scripts/v18-to-v19/V18MigrationTheme.ts';
+
+describe('v18 migration framed app', () => {
+  it('keeps every surface text pair above WCAG AAA contrast', () => {
+    for (const [name, token] of Object.entries(V18_MIGRATION_THEME.surface)) {
+      expect(token.bg, name).toBeDefined();
+      expect(themeContrastRatio(token.hex, token.bg!), name).toBeGreaterThanOrEqual(7);
+    }
+  });
+
+  it('renders confirmation before any migration progress', () => {
+    const surface = renderV18MigrationApp(
+      {
+        graph: new V18MigrationGraph({
+          name: 'think',
+          refCount: 4,
+          version: 'upgrade required (legacy unmarked substrate)',
+          writerCount: 2,
+        }),
+        mode: V18MigrationExecutionMode.promote(),
+        repositoryPath: '/tmp/think',
+      },
+      { phase: 'confirm' },
+      100,
+      24
+    );
+
+    const text = surfaceText(surface);
+    expect(text).toContain('Nothing changes before you confirm.');
+    expect(text).toContain('Press Y or Enter to continue.');
+    expect(text).not.toContain('Starting migration');
+  });
+
+  it('renders bounded writer progress inside the frame', () => {
+    const surface = renderV18MigrationApp(
+      {
+        graph: new V18MigrationGraph({
+          name: 'think',
+          refCount: 4,
+          version: 'upgrade required (legacy unmarked substrate)',
+          writerCount: 2,
+        }),
+        mode: V18MigrationExecutionMode.promote(),
+        repositoryPath: '/tmp/think',
+      },
+      {
+        phase: 'running',
+        progress: {
+          completed: 250,
+          message: 'translating writer chain',
+          phase: 'rewrite',
+          total: 1_000,
+          writer: 'local.cli',
+        },
+      },
+      100,
+      24
+    );
+
+    const text = surfaceText(surface);
+    expect(text).toContain('[rewrite] local.cli');
+    expect(text).toContain('250/1000 25.0%');
+    expect(text).toContain('███████████');
+  });
+});
+
+function surfaceText(surface: ReturnType<typeof renderV18MigrationApp>): string {
+  return Array.from({ length: surface.height }, (_, row) =>
+    surface
+      .getRow(row)
+      .map((cell) => cell.char)
+      .join('')
+      .trimEnd()
+  ).join('\n');
+}

--- a/test/unit/scripts/v18-migration-app.test.ts
+++ b/test/unit/scripts/v18-migration-app.test.ts
@@ -1,11 +1,15 @@
 import { themeContrastRatio } from '@flyingrobots/bijou';
+import { createTestContext } from '@flyingrobots/bijou/adapters/test';
 import { describe, expect, it } from 'vitest';
 
 import { renderV18MigrationApp } from '../../../scripts/v18-to-v19/V18MigrationAppSurface.ts';
 import V18MigrationExecutionMode from '../../../scripts/v18-to-v19/V18MigrationExecutionMode.ts';
 import V18MigrationGraph from '../../../scripts/v18-to-v19/V18MigrationGraph.ts';
 import type { V18MigrationPreflight } from '../../../scripts/v18-to-v19/V18MigrationPreflight.ts';
-import { V18_MIGRATION_THEME } from '../../../scripts/v18-to-v19/V18MigrationTheme.ts';
+import {
+  createV18MigrationTheme,
+  V18_MIGRATION_THEME,
+} from '../../../scripts/v18-to-v19/V18MigrationTheme.ts';
 
 const PREFLIGHT: V18MigrationPreflight = Object.freeze({
   repositoryObjectBytes: 80n * 1_048_576n,
@@ -17,18 +21,44 @@ const PREFLIGHT: V18MigrationPreflight = Object.freeze({
   sourceAvailableBytes: 500n * 1_048_576n,
   sourceGitDirectory: '/tmp/think/.git',
 });
+const CONTEXT = createTestContext({
+  mode: 'interactive',
+  noColor: true,
+  theme: createV18MigrationTheme(),
+});
 
 describe('v18 migration framed app', () => {
-  it('keeps every surface text pair above WCAG AAA contrast', () => {
+  it('keeps every rendered foreground above WCAG AAA on the primary surface', () => {
+    const background = V18_MIGRATION_THEME.surface.primary.bg;
+    expect(background).toBeDefined();
+    for (const group of [
+      V18_MIGRATION_THEME.semantic,
+      V18_MIGRATION_THEME.status,
+      V18_MIGRATION_THEME.border,
+      V18_MIGRATION_THEME.ui,
+    ]) {
+      for (const [name, token] of Object.entries(group)) {
+        expect(themeContrastRatio(token.hex, background!), name).toBeGreaterThanOrEqual(7);
+      }
+    }
     for (const [name, token] of Object.entries(V18_MIGRATION_THEME.surface)) {
       expect(token.bg, name).toBeDefined();
       expect(themeContrastRatio(token.hex, token.bg!), name).toBeGreaterThanOrEqual(7);
     }
   });
 
+  it('deep-freezes the migration theme token graph', () => {
+    expect(Object.isFrozen(V18_MIGRATION_THEME)).toBe(true);
+    expect(Object.isFrozen(V18_MIGRATION_THEME.semantic)).toBe(true);
+    expect(Object.isFrozen(V18_MIGRATION_THEME.semantic.primary)).toBe(true);
+    expect(Object.isFrozen(V18_MIGRATION_THEME.gradient.progress)).toBe(true);
+    expect(Object.isFrozen(V18_MIGRATION_THEME.gradient.progress[0])).toBe(true);
+  });
+
   it('renders confirmation before any migration progress', () => {
     const surface = renderV18MigrationApp(
       {
+        context: CONTEXT,
         graph: new V18MigrationGraph({
           name: 'think',
           refCount: 4,
@@ -52,9 +82,66 @@ describe('v18 migration framed app', () => {
     expect(text).not.toContain('Starting migration');
   });
 
+  it('keeps the confirmation prompt visible in a short frame', () => {
+    const surface = renderV18MigrationApp(
+      {
+        context: CONTEXT,
+        graph: new V18MigrationGraph({
+          name: 'think',
+          refCount: 4,
+          version: 'upgrade required (legacy unmarked substrate)',
+          writerCount: 2,
+        }),
+        mode: V18MigrationExecutionMode.promote(),
+        preflight: PREFLIGHT,
+        repositoryPath: '/tmp/think',
+      },
+      { phase: 'confirm' },
+      100,
+      4
+    );
+
+    expect(surfaceRowText(surface, 3)).toContain('Press Y or Enter to continue.');
+  });
+
+  it('renders an insufficient scratch budget as a warning', () => {
+    const surface = renderV18MigrationApp(
+      {
+        context: CONTEXT,
+        graph: new V18MigrationGraph({
+          name: 'think',
+          refCount: 4,
+          version: 'upgrade required (legacy unmarked substrate)',
+          writerCount: 2,
+        }),
+        mode: V18MigrationExecutionMode.promote(),
+        preflight: Object.freeze({
+          ...PREFLIGHT,
+          scratchAvailableBytes: 40n * 1_048_576n,
+          scratchSufficient: false,
+        }),
+        repositoryPath: '/tmp/think',
+      },
+      { phase: 'confirm' },
+      100,
+      24
+    );
+
+    const rows = Array.from({ length: surface.height }, (_, row) => surfaceRowText(surface, row));
+    const warningRow = rows.findIndex((line) => line.includes('BELOW OPERATING BUDGET'));
+    expect(warningRow).toBeGreaterThanOrEqual(0);
+    expect(
+      surface
+        .getRow(warningRow)
+        .filter((cell) => cell.char !== ' ')
+        .every((cell) => cell.fg === V18_MIGRATION_THEME.semantic.warning.hex)
+    ).toBe(true);
+  });
+
   it('renders bounded writer progress inside the frame', () => {
     const surface = renderV18MigrationApp(
       {
+        context: CONTEXT,
         graph: new V18MigrationGraph({
           name: 'think',
           refCount: 4,
@@ -84,6 +171,30 @@ describe('v18 migration framed app', () => {
     expect(text).toContain('250/1000 25.0%');
     expect(text).toContain('███████████');
   });
+
+  it('does not describe an incomplete success model as a migration failure', () => {
+    const surface = renderV18MigrationApp(
+      {
+        context: CONTEXT,
+        graph: new V18MigrationGraph({
+          name: 'think',
+          refCount: 4,
+          version: 'upgrade required (legacy unmarked substrate)',
+          writerCount: 2,
+        }),
+        mode: V18MigrationExecutionMode.promote(),
+        preflight: PREFLIGHT,
+        repositoryPath: '/tmp/think',
+      },
+      { phase: 'succeeded' },
+      100,
+      24
+    );
+
+    const text = surfaceText(surface);
+    expect(text).toContain('Internal migration UI state is incomplete.');
+    expect(text).not.toContain('Migration failed.');
+  });
 });
 
 function surfaceText(surface: ReturnType<typeof renderV18MigrationApp>): string {
@@ -94,4 +205,12 @@ function surfaceText(surface: ReturnType<typeof renderV18MigrationApp>): string 
       .join('')
       .trimEnd()
   ).join('\n');
+}
+
+function surfaceRowText(surface: ReturnType<typeof renderV18MigrationApp>, row: number): string {
+  return surface
+    .getRow(row)
+    .map((cell) => cell.char)
+    .join('')
+    .trimEnd();
 }

--- a/test/unit/scripts/v18-migration-app.test.ts
+++ b/test/unit/scripts/v18-migration-app.test.ts
@@ -9,6 +9,7 @@ import { V18_MIGRATION_THEME } from '../../../scripts/v18-to-v19/V18MigrationThe
 
 const PREFLIGHT: V18MigrationPreflight = Object.freeze({
   repositoryObjectBytes: 80n * 1_048_576n,
+  repositoryObjectCount: 2_000n,
   scratchAvailableBytes: 400n * 1_048_576n,
   scratchMinimumBytes: 160n * 1_048_576n,
   scratchPath: '/tmp',

--- a/test/unit/scripts/v18-migration-cli.test.ts
+++ b/test/unit/scripts/v18-migration-cli.test.ts
@@ -1,0 +1,94 @@
+import { spawn } from 'node:child_process';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import V18MigrationExecutionMode from '../../../scripts/v18-to-v19/V18MigrationExecutionMode.ts';
+import { parseV18MigrationCliOptions } from '../../../scripts/v18-to-v19/migrate.ts';
+import { gitOk, MigrationTestDirectories } from './migrationTestEnvironment.ts';
+
+describe('v18 migration CLI', () => {
+  const directories = new MigrationTestDirectories();
+
+  afterEach(async () => {
+    await directories.cleanup();
+  });
+
+  it('promotes by default and reserves rehearsal for explicit --dry-run', () => {
+    const required = ['--repo', '/tmp/repo', '--graph', 'think'];
+    const normal = parseV18MigrationCliOptions(required);
+    const compatibility = parseV18MigrationCliOptions([...required, '--apply']);
+    const rehearsal = parseV18MigrationCliOptions([...required, '--dry-run']);
+
+    expect(normal.mode).toBe(V18MigrationExecutionMode.promote());
+    expect(compatibility.mode).toBe(V18MigrationExecutionMode.promote());
+    expect(rehearsal.mode).toBe(V18MigrationExecutionMode.rehearse());
+    expect(() => parseV18MigrationCliOptions([...required, '--apply', '--dry-run'])).toThrow(
+      '--apply cannot be combined with --dry-run'
+    );
+  });
+
+  it('reports Graph not found and the graphs that are present', async () => {
+    const repositoryPath = await repositoryWithGraph(directories, 'think');
+    const execution = await runMigrationProcess([
+      '--repo',
+      repositoryPath,
+      '--graph',
+      'events',
+      '--yes',
+    ]);
+
+    expect(execution.exitCode).toBe(1);
+    expect(execution.stderr).toContain('Graph not found: events');
+    expect(execution.stderr).toContain('think — upgrade required (legacy unmarked substrate)');
+    expect(execution.stderr).not.toContain('migration: empty');
+  });
+
+  it('requires explicit --yes before noninteractive inventory', async () => {
+    const repositoryPath = await repositoryWithGraph(directories, 'think');
+    const writerRef = 'refs/warp/think/writers/local';
+    const before = await gitOk(repositoryPath, ['rev-parse', writerRef]);
+    const execution = await runMigrationProcess(['--repo', repositoryPath, '--graph', 'think']);
+
+    expect(execution.exitCode).toBe(1);
+    expect(execution.stderr).toContain('Graphs found:');
+    expect(execution.stderr).toContain('confirmation requires an interactive terminal');
+    expect(execution.stderr).not.toContain('[inventory]');
+    expect(await gitOk(repositoryPath, ['rev-parse', writerRef])).toBe(before);
+  });
+});
+
+async function repositoryWithGraph(
+  directories: MigrationTestDirectories,
+  graph: string
+): Promise<string> {
+  const repositoryPath = await directories.create('git-warp-migration-cli-');
+  await gitOk(repositoryPath, ['init', '--bare']);
+  const oid = await gitOk(repositoryPath, ['hash-object', '-w', '--stdin'], 'legacy');
+  await gitOk(repositoryPath, ['update-ref', `refs/warp/${graph}/writers/local`, oid]);
+  return repositoryPath;
+}
+
+async function runMigrationProcess(
+  args: readonly string[]
+): Promise<Readonly<{ exitCode: number | null; stderr: string }>> {
+  return await new Promise((complete, reject) => {
+    const child = spawn(process.execPath, ['scripts/v18-to-v19/migrate.ts', ...args], {
+      cwd: resolveProjectRoot(),
+    });
+    const stderr: Uint8Array[] = [];
+    child.stderr.on('data', (chunk: Uint8Array) => stderr.push(chunk));
+    child.on('error', reject);
+    child.on('close', (exitCode) =>
+      complete(
+        Object.freeze({
+          exitCode,
+          stderr: Buffer.concat(stderr).toString('utf8'),
+        })
+      )
+    );
+  });
+}
+
+function resolveProjectRoot(): string {
+  return process.cwd();
+}

--- a/test/unit/scripts/v18-migration-graph-catalog.test.ts
+++ b/test/unit/scripts/v18-migration-graph-catalog.test.ts
@@ -31,9 +31,10 @@ describe('v18 migration graph catalog', () => {
     expect(catalog.graphs.map((graph) => graph.summary())).toEqual([
       'future — unsupported marker (future-marker); 1 writer; 2 refs',
       'notes — upgrade required (legacy unmarked substrate); 1 writer; 1 ref',
-      'team — upgrade required (legacy unmarked substrate); 1 writer; 2 refs',
+      'team — upgrade required (legacy unmarked substrate); 1 writer; 1 ref',
       'team/events — v19 current; 2 writers; 3 refs',
     ]);
+    expect(catalog.require('team').refCount).toBe(1);
     expect(catalog.require('team/events').writerCount).toBe(2);
   });
 

--- a/test/unit/scripts/v18-migration-graph-catalog.test.ts
+++ b/test/unit/scripts/v18-migration-graph-catalog.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import V18MigrationGraphCatalog from '../../../scripts/v18-to-v19/V18MigrationGraphCatalog.ts';
+import { CURRENT_SUBSTRATE_MARKER } from '../../../src/infrastructure/adapters/SubstrateVersionGate.ts';
+import { gitOk, MigrationTestDirectories } from './migrationTestEnvironment.ts';
+
+describe('v18 migration graph catalog', () => {
+  const directories = new MigrationTestDirectories();
+
+  afterEach(async () => {
+    await directories.cleanup();
+  });
+
+  it('discovers multiple and nested graph namespaces with version posture', async () => {
+    const repositoryPath = await initializedRepository(directories);
+    const legacyOid = await writeBlob(repositoryPath, 'legacy');
+    const currentMarkerOid = await writeBlob(repositoryPath, CURRENT_SUBSTRATE_MARKER);
+    const unsupportedMarkerOid = await writeBlob(repositoryPath, 'future-marker');
+
+    await writeRef(repositoryPath, 'refs/warp/notes/writers/local', legacyOid);
+    await writeRef(repositoryPath, 'refs/warp/team/writers/alice', legacyOid);
+    await writeRef(repositoryPath, 'refs/warp/team/recovery/old/refs/writers/ghost', legacyOid);
+    await writeRef(repositoryPath, 'refs/warp/team/events/writers/bob', legacyOid);
+    await writeRef(repositoryPath, 'refs/warp/team/events/writers/charlie', legacyOid);
+    await writeRef(repositoryPath, 'refs/warp/team/events/substrate-version', currentMarkerOid);
+    await writeRef(repositoryPath, 'refs/warp/future/writers/next', legacyOid);
+    await writeRef(repositoryPath, 'refs/warp/future/substrate-version', unsupportedMarkerOid);
+
+    const catalog = await V18MigrationGraphCatalog.discover(repositoryPath);
+
+    expect(catalog.graphs.map((graph) => graph.summary())).toEqual([
+      'future — unsupported marker (future-marker); 1 writer; 2 refs',
+      'notes — upgrade required (legacy unmarked substrate); 1 writer; 1 ref',
+      'team — upgrade required (legacy unmarked substrate); 1 writer; 2 refs',
+      'team/events — v19 current; 2 writers; 3 refs',
+    ]);
+    expect(catalog.require('team/events').writerCount).toBe(2);
+  });
+
+  it('reports Graph not found and lists the namespaces that do exist', async () => {
+    const repositoryPath = await initializedRepository(directories);
+    const oid = await writeBlob(repositoryPath, 'legacy');
+    await writeRef(repositoryPath, 'refs/warp/think/writers/local', oid);
+    await writeRef(repositoryPath, 'refs/warp/archive/writers/local', oid);
+
+    const catalog = await V18MigrationGraphCatalog.discover(repositoryPath);
+
+    expect(() => catalog.require('events')).toThrow(
+      /Graph not found: events[\s\S]*archive — upgrade required[\s\S]*think — upgrade required/u
+    );
+  });
+
+  it('distinguishes an empty repository from an empty named graph', async () => {
+    const repositoryPath = await initializedRepository(directories);
+    const catalog = await V18MigrationGraphCatalog.discover(repositoryPath);
+
+    expect(catalog.summary()).toBe('Graphs found: none');
+    expect(() => catalog.require('events')).toThrow('Graph not found: events\nGraphs found: none');
+  });
+});
+
+async function initializedRepository(directories: MigrationTestDirectories): Promise<string> {
+  const repositoryPath = await directories.create('git-warp-graph-catalog-');
+  await gitOk(repositoryPath, ['init', '--bare']);
+  return repositoryPath;
+}
+
+async function writeBlob(repositoryPath: string, value: string): Promise<string> {
+  return await gitOk(repositoryPath, ['hash-object', '-w', '--stdin'], value);
+}
+
+async function writeRef(repositoryPath: string, refName: string, oid: string): Promise<void> {
+  await gitOk(repositoryPath, ['update-ref', refName, oid]);
+}

--- a/test/unit/scripts/v18-migration-preflight.test.ts
+++ b/test/unit/scripts/v18-migration-preflight.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  estimateV18MigrationScratchBytes,
   formatV18MigrationBytes,
   formatV18MigrationPreflight,
   parseV18MigrationObjectBytes,
+  parseV18MigrationObjectCount,
 } from '../../../scripts/v18-to-v19/V18MigrationPreflight.ts';
 
 describe('v18 migration preflight', () => {
@@ -24,6 +26,33 @@ describe('v18 migration preflight', () => {
     ).toBe(19n * 1_024n);
   });
 
+  it('counts loose and packed objects', () => {
+    expect(
+      parseV18MigrationObjectCount(
+        [
+          'count: 7',
+          'size: 3',
+          'in-pack: 10',
+          'packs: 1',
+          'size-pack: 11',
+          'prune-packable: 0',
+          'garbage: 0',
+          'size-garbage: 0',
+        ].join('\n')
+      )
+    ).toBe(17n);
+  });
+
+  it('budgets for both byte volume and loose-object allocation', () => {
+    expect(
+      estimateV18MigrationScratchBytes({
+        repositoryObjectBytes: 100n,
+        repositoryObjectCount: 17n,
+        scratchBlockBytes: 4_096n,
+      })
+    ).toBe(69_732n);
+  });
+
   it('formats binary byte units without floating point', () => {
     expect(formatV18MigrationBytes(0n)).toBe('0 B');
     expect(formatV18MigrationBytes(1_536n)).toBe('1.5 KiB');
@@ -34,6 +63,7 @@ describe('v18 migration preflight', () => {
     expect(
       formatV18MigrationPreflight({
         repositoryObjectBytes: 100n,
+        repositoryObjectCount: 17n,
         scratchAvailableBytes: 150n,
         scratchMinimumBytes: 200n,
         scratchPath: '/scratch',

--- a/test/unit/scripts/v18-migration-preflight.test.ts
+++ b/test/unit/scripts/v18-migration-preflight.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatV18MigrationBytes,
+  formatV18MigrationPreflight,
+  parseV18MigrationObjectBytes,
+} from '../../../scripts/v18-to-v19/V18MigrationPreflight.ts';
+
+describe('v18 migration preflight', () => {
+  it('counts loose, packed, and garbage object storage', () => {
+    expect(
+      parseV18MigrationObjectBytes(
+        [
+          'count: 7',
+          'size: 3',
+          'in-pack: 10',
+          'packs: 1',
+          'size-pack: 11',
+          'prune-packable: 0',
+          'garbage: 1',
+          'size-garbage: 5',
+        ].join('\n')
+      )
+    ).toBe(19n * 1_024n);
+  });
+
+  it('formats binary byte units without floating point', () => {
+    expect(formatV18MigrationBytes(0n)).toBe('0 B');
+    expect(formatV18MigrationBytes(1_536n)).toBe('1.5 KiB');
+    expect(formatV18MigrationBytes(81n * 1_048_576n)).toBe('81.0 MiB');
+  });
+
+  it('makes an insufficient scratch volume conspicuous', () => {
+    expect(
+      formatV18MigrationPreflight({
+        repositoryObjectBytes: 100n,
+        scratchAvailableBytes: 150n,
+        scratchMinimumBytes: 200n,
+        scratchPath: '/scratch',
+        scratchSufficient: false,
+        sourceAvailableBytes: 300n,
+        sourceGitDirectory: '/repo/.git',
+      })
+    ).toContain('Scratch free: 150 B (BELOW OPERATING BUDGET)');
+  });
+});

--- a/test/unit/scripts/v18-to-v19-command.test.ts
+++ b/test/unit/scripts/v18-to-v19-command.test.ts
@@ -9,6 +9,7 @@ import WarpError from '../../../src/domain/errors/WarpError.ts';
 import { buildCheckpointRef } from '../../../src/domain/utils/RefLayout.ts';
 import { restoreV18RetainedSubstrateFixture } from '../../../scripts/v18-to-v19/V18RetainedSubstrateFixtureRestore.ts';
 import { runV18ToV19Migration } from '../../../scripts/v18-to-v19/V18MigrationCommand.ts';
+import V18MigrationExecutionMode from '../../../scripts/v18-to-v19/V18MigrationExecutionMode.ts';
 import {
   readV18MigrationRef,
   runV18MigrationGit,
@@ -17,9 +18,7 @@ import {
 } from '../../../scripts/v18-to-v19/V18MigrationGit.ts';
 import { readRequiredV18MigrationRefMap } from '../../helpers/V18MigrationRefMap.ts';
 
-const MANIFEST_PATH = resolve(
-  'fixtures/v18/retained-substrate-golden/manifest.json',
-);
+const MANIFEST_PATH = resolve('fixtures/v18/retained-substrate-golden/manifest.json');
 const RECOVERY_ID = 'fixture-proof';
 
 describe('v18-to-v19 migration command', () => {
@@ -29,7 +28,7 @@ describe('v18-to-v19 migration command', () => {
     await Promise.all(
       temporaryDirectories.splice(0).map(async (directory) => {
         await rm(directory, { recursive: true, force: true });
-      }),
+      })
     );
   });
 
@@ -39,14 +38,10 @@ describe('v18-to-v19 migration command', () => {
     temporaryDirectories.push(repositoryPath, nonRepositoryPath);
     await v18MigrationGitText(repositoryPath, ['init', '--bare']);
 
-    await expect(readV18MigrationRef(
-      repositoryPath,
-      'refs/warp/missing',
-    )).resolves.toBeNull();
-    await expect(readV18MigrationRef(
-      nonRepositoryPath,
-      'refs/warp/missing',
-    )).rejects.toThrow(/not a git repository/iu);
+    await expect(readV18MigrationRef(repositoryPath, 'refs/warp/missing')).resolves.toBeNull();
+    await expect(readV18MigrationRef(nonRepositoryPath, 'refs/warp/missing')).rejects.toThrow(
+      /not a git repository/iu
+    );
   });
 
   it('surfaces early-exit stdin failures through the migration Git error', async () => {
@@ -54,11 +49,11 @@ describe('v18-to-v19 migration command', () => {
     temporaryDirectories.push(repositoryPath);
     await v18MigrationGitText(repositoryPath, ['init', '--bare']);
 
-    await expect(runV18MigrationGit(
-      repositoryPath,
-      ['cat-file', 'blob', 'f'.repeat(40)],
-      { input: new Uint8Array(8 * 1024 * 1024) },
-    )).rejects.toBeInstanceOf(V18MigrationGitError);
+    await expect(
+      runV18MigrationGit(repositoryPath, ['cat-file', 'blob', 'f'.repeat(40)], {
+        input: new Uint8Array(8 * 1024 * 1024),
+      })
+    ).rejects.toBeInstanceOf(V18MigrationGitError);
   });
 
   it('atomically promotes verified refs and retains complete recovery roots', async () => {
@@ -68,15 +63,13 @@ describe('v18-to-v19 migration command', () => {
       manifestPath: MANIFEST_PATH,
       targetDirectory,
     });
-    const writerFixtureRef = restored.manifest.refs.find(
-      (ref) => ref.kind === 'writer',
-    );
+    const writerFixtureRef = restored.manifest.refs.find((ref) => ref.kind === 'writer');
     if (writerFixtureRef === undefined) {
       throw new Error('fixture has no writer commit for a historical checkpoint ref');
     }
     const oldCheckpointSha = writerFixtureRef.expectedHead;
-    const historicalCheckpointRef = `refs/warp/${restored.manifest.graphId}`
-      + '/checkpoints/pre-rehearsal';
+    const historicalCheckpointRef =
+      `refs/warp/${restored.manifest.graphId}` + '/checkpoints/pre-rehearsal';
     await v18MigrationGitText(restored.repositoryPath, [
       'update-ref',
       historicalCheckpointRef,
@@ -84,16 +77,14 @@ describe('v18-to-v19 migration command', () => {
     ]);
     const sourceHeads = await readRequiredV18MigrationRefMap(
       restored.repositoryPath,
-      restored.manifest.refs.map((ref) => ref.refName),
+      restored.manifest.refs.map((ref) => ref.refName)
     );
     const runtime = await Runtime.open({
       at: restored.repositoryPath,
       writer: 'preflight-proof',
     });
     try {
-      const error = await runtime
-        .lane(restored.manifest.graphId)
-        .catch((cause: unknown) => cause);
+      const error = await runtime.lane(restored.manifest.graphId).catch((cause: unknown) => cause);
       expect(error).toBeInstanceOf(WarpError);
       if (error instanceof WarpError) {
         expect(error.code).toBe('E_SUBSTRATE_MIGRATION_REQUIRED');
@@ -101,14 +92,16 @@ describe('v18-to-v19 migration command', () => {
     } finally {
       await runtime.close();
     }
-    expect(await readRequiredV18MigrationRefMap(
-      restored.repositoryPath,
-      restored.manifest.refs.map((ref) => ref.refName),
-    )).toEqual(sourceHeads);
+    expect(
+      await readRequiredV18MigrationRefMap(
+        restored.repositoryPath,
+        restored.manifest.refs.map((ref) => ref.refName)
+      )
+    ).toEqual(sourceHeads);
 
     const report = await runV18ToV19Migration({
-      apply: true,
       graph: restored.manifest.graphId,
+      mode: V18MigrationExecutionMode.promote(),
       recoveryId: RECOVERY_ID,
       repositoryPath: restored.repositoryPath,
     });
@@ -116,49 +109,58 @@ describe('v18-to-v19 migration command', () => {
     expect(report.status).toBe('migrated');
     expect(report.scratchVerified).toBe(true);
     expect(report.finalization?.recoveryPrefix).toBe(
-      `refs/warp/${restored.manifest.graphId}/recovery/v18-to-v19/${RECOVERY_ID}`,
+      `refs/warp/${restored.manifest.graphId}/recovery/v18-to-v19/${RECOVERY_ID}`
     );
     for (const ref of restored.manifest.refs) {
       const live = await readV18MigrationRef(restored.repositoryPath, ref.refName);
       if (ref.kind === 'writer') {
         expect(live).not.toBe(ref.expectedHead);
-        expect(await readV18MigrationRef(
-          restored.repositoryPath,
-          `${report.finalization?.recoveryPrefix}/refs/writers/${ref.writerId}`,
-        )).toBe(ref.expectedHead);
+        expect(
+          await readV18MigrationRef(
+            restored.repositoryPath,
+            `${report.finalization?.recoveryPrefix}/refs/writers/${ref.writerId}`
+          )
+        ).toBe(ref.expectedHead);
       } else {
         expect(live).toBeNull();
-        expect(await readV18MigrationRef(
-          restored.repositoryPath,
-          `${report.finalization?.recoveryPrefix}/refs/state-cache`,
-        )).toBe(ref.expectedHead);
+        expect(
+          await readV18MigrationRef(
+            restored.repositoryPath,
+            `${report.finalization?.recoveryPrefix}/refs/state-cache`
+          )
+        ).toBe(ref.expectedHead);
       }
     }
-    expect(await readV18MigrationRef(
-      restored.repositoryPath,
-      `${report.finalization?.recoveryPrefix}/retained-payloads/`
-        + restored.manifest.retainedState.payloadRoot,
-    )).toBe(restored.manifest.retainedState.payloadRoot);
-    expect(await readV18MigrationRef(
-      restored.repositoryPath,
-      `refs/warp/${restored.manifest.graphId}/substrate-version`,
-    )).not.toBeNull();
-    expect(await readV18MigrationRef(
-      restored.repositoryPath,
-      buildCheckpointRef(restored.manifest.graphId),
-    )).not.toBeNull();
-    expect(await readV18MigrationRef(
-      restored.repositoryPath,
-      historicalCheckpointRef,
-    )).toBeNull();
-    expect(await readV18MigrationRef(
-      restored.repositoryPath,
-      `${report.finalization?.recoveryPrefix}/refs/checkpoints/pre-rehearsal`,
-    )).toBe(oldCheckpointSha);
+    expect(
+      await readV18MigrationRef(
+        restored.repositoryPath,
+        `${report.finalization?.recoveryPrefix}/retained-payloads/` +
+          restored.manifest.retainedState.payloadRoot
+      )
+    ).toBe(restored.manifest.retainedState.payloadRoot);
+    expect(
+      await readV18MigrationRef(
+        restored.repositoryPath,
+        `refs/warp/${restored.manifest.graphId}/substrate-version`
+      )
+    ).not.toBeNull();
+    expect(
+      await readV18MigrationRef(
+        restored.repositoryPath,
+        buildCheckpointRef(restored.manifest.graphId)
+      )
+    ).not.toBeNull();
+    expect(await readV18MigrationRef(restored.repositoryPath, historicalCheckpointRef)).toBeNull();
+    expect(
+      await readV18MigrationRef(
+        restored.repositoryPath,
+        `${report.finalization?.recoveryPrefix}/refs/checkpoints/pre-rehearsal`
+      )
+    ).toBe(oldCheckpointSha);
 
     const second = await runV18ToV19Migration({
-      apply: true,
       graph: restored.manifest.graphId,
+      mode: V18MigrationExecutionMode.promote(),
       repositoryPath: restored.repositoryPath,
     });
     expect(second.status).toBe('already-current');

--- a/test/unit/scripts/v18-to-v19-finalization.test.ts
+++ b/test/unit/scripts/v18-to-v19-finalization.test.ts
@@ -20,7 +20,9 @@ import {
 import { openScratchGraph } from '../../../scripts/v18-to-v19/V18MigrationScratchGraph.ts';
 import { restoreV18RetainedSubstrateFixture } from '../../../scripts/v18-to-v19/V18RetainedSubstrateFixtureRestore.ts';
 
-const MANIFEST_PATH = resolve('fixtures/v18/retained-substrate-golden/manifest.json');
+const MANIFEST_PATH = resolve(
+  'fixtures/v18/retained-substrate-golden/manifest.json',
+);
 
 describe('v18-to-v19 finalization boundaries', () => {
   const temporaryDirectories: string[] = [];
@@ -28,12 +30,12 @@ describe('v18-to-v19 finalization boundaries', () => {
 
   afterEach(async () => {
     await Promise.all(
-      preparedMigrations.splice(0).map(async (prepared) => await prepared.cleanup())
+      preparedMigrations.splice(0).map(async (prepared) => await prepared.cleanup()),
     );
     await Promise.all(
       temporaryDirectories.splice(0).map(async (directory) => {
         await rm(directory, { recursive: true, force: true });
-      })
+      }),
     );
   });
 
@@ -49,21 +51,22 @@ describe('v18-to-v19 finalization boundaries', () => {
       '--format=%T',
       writer.head,
     ]);
-    const concurrentHead = await v18MigrationGitText(
-      migration.repositoryPath,
-      ['commit-tree', tree, '-p', writer.head],
-      {
-        env: {
-          GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
-          GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
-          GIT_AUTHOR_NAME: 'Migration Fixture',
-          GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z',
-          GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
-          GIT_COMMITTER_NAME: 'Migration Fixture',
-        },
-        input: 'concurrent v18 writer advance\n',
-      }
-    );
+    const concurrentHead = await v18MigrationGitText(migration.repositoryPath, [
+      'commit-tree',
+      tree,
+      '-p',
+      writer.head,
+    ], {
+      env: {
+        GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
+        GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
+        GIT_AUTHOR_NAME: 'Migration Fixture',
+        GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z',
+        GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
+        GIT_COMMITTER_NAME: 'Migration Fixture',
+      },
+      input: 'concurrent v18 writer advance\n',
+    });
     await v18MigrationGitText(migration.repositoryPath, [
       'update-ref',
       writer.refName,
@@ -71,23 +74,20 @@ describe('v18-to-v19 finalization boundaries', () => {
       writer.head,
     ]);
 
-    await expect(
-      finalizeV18Migration({
-        plan: migration.plan,
-        prepared: migration.prepared,
-        recoveryId: 'concurrent-proof',
-      })
-    ).rejects.toThrow();
+    await expect(finalizeV18Migration({
+      plan: migration.plan,
+      prepared: migration.prepared,
+      recoveryId: 'concurrent-proof',
+    })).rejects.toThrow();
 
-    expect(await readV18MigrationRef(migration.repositoryPath, writer.refName)).toBe(
-      concurrentHead
-    );
-    expect(
-      await listV18MigrationRefs(
-        migration.repositoryPath,
-        `refs/warp/${migration.graph}/recovery/v18-to-v19/concurrent-proof/`
-      )
-    ).toEqual([]);
+    expect(await readV18MigrationRef(
+      migration.repositoryPath,
+      writer.refName,
+    )).toBe(concurrentHead);
+    expect(await listV18MigrationRefs(
+      migration.repositoryPath,
+      `refs/warp/${migration.graph}/recovery/v18-to-v19/concurrent-proof/`,
+    )).toEqual([]);
   });
 
   it('resumes safely after atomic promotion but before command verification', async () => {
@@ -105,9 +105,10 @@ describe('v18-to-v19 finalization boundaries', () => {
     });
 
     expect(resumed.status).toBe('already-current');
-    expect(
-      await listV18MigrationRefs(migration.repositoryPath, `${finalization.recoveryPrefix}/`)
-    ).not.toEqual([]);
+    expect(await listV18MigrationRefs(
+      migration.repositoryPath,
+      `${finalization.recoveryPrefix}/`,
+    )).not.toEqual([]);
   });
 
   it('verifies a promoted repository without decoding its oversized full state', async () => {
@@ -115,18 +116,26 @@ describe('v18-to-v19 finalization boundaries', () => {
     const opened = await openScratchGraph(
       migration.prepared.scratchPath,
       migration.graph,
-      'oversized-state-writer'
+      'oversized-state-writer',
     );
     try {
       await opened.graph.patch((patch) => {
         patch
           .addNode('oversized-state-node-a')
-          .setProperty('oversized-state-node-a', 'payload', 'a'.repeat(3 * 1024 * 1024));
+          .setProperty(
+            'oversized-state-node-a',
+            'payload',
+            'a'.repeat(3 * 1024 * 1024),
+          );
       });
       await opened.graph.patch((patch) => {
         patch
           .addNode('oversized-state-node-b')
-          .setProperty('oversized-state-node-b', 'payload', 'b'.repeat(3 * 1024 * 1024));
+          .setProperty(
+            'oversized-state-node-b',
+            'payload',
+            'b'.repeat(3 * 1024 * 1024),
+          );
       });
       await opened.graph.materialize();
       await opened.graph.createCheckpoint();
@@ -137,7 +146,7 @@ describe('v18-to-v19 finalization boundaries', () => {
     const eagerControl = await openScratchGraph(
       migration.prepared.scratchPath,
       migration.graph,
-      'oversized-state-eager-control'
+      'oversized-state-eager-control',
     );
     try {
       await expect(eagerControl.graph.materialize()).rejects.toMatchObject({
@@ -147,19 +156,18 @@ describe('v18-to-v19 finalization boundaries', () => {
       await eagerControl.close();
     }
 
-    await expect(
-      verifyPromotedV19Repository(migration.prepared.scratchPath, migration.graph)
-    ).resolves.toBeUndefined();
+    await expect(verifyPromotedV19Repository(
+      migration.prepared.scratchPath,
+      migration.graph,
+    )).resolves.toBeUndefined();
   });
 
-  async function prepareFixtureMigration(): Promise<
-    Readonly<{
-      graph: string;
-      plan: Awaited<ReturnType<typeof planV18ToV19Migration>>;
-      prepared: V18PreparedMigration;
-      repositoryPath: string;
-    }>
-  > {
+  async function prepareFixtureMigration(): Promise<Readonly<{
+    graph: string;
+    plan: Awaited<ReturnType<typeof planV18ToV19Migration>>;
+    prepared: V18PreparedMigration;
+    repositoryPath: string;
+  }>> {
     const targetDirectory = await mkdtemp(join(tmpdir(), 'git-warp-v18-finalize-'));
     temporaryDirectories.push(targetDirectory);
     const restored = await restoreV18RetainedSubstrateFixture({

--- a/test/unit/scripts/v18-to-v19-finalization.test.ts
+++ b/test/unit/scripts/v18-to-v19-finalization.test.ts
@@ -15,12 +15,12 @@ import { planV18ToV19Migration } from '../../../scripts/v18-to-v19/V18MigrationP
 import {
   prepareV18MigrationScratch,
   type V18PreparedMigration,
+  verifyPromotedV19Repository,
 } from '../../../scripts/v18-to-v19/V18MigrationScratch.ts';
+import { openScratchGraph } from '../../../scripts/v18-to-v19/V18MigrationScratchGraph.ts';
 import { restoreV18RetainedSubstrateFixture } from '../../../scripts/v18-to-v19/V18RetainedSubstrateFixtureRestore.ts';
 
-const MANIFEST_PATH = resolve(
-  'fixtures/v18/retained-substrate-golden/manifest.json',
-);
+const MANIFEST_PATH = resolve('fixtures/v18/retained-substrate-golden/manifest.json');
 
 describe('v18-to-v19 finalization boundaries', () => {
   const temporaryDirectories: string[] = [];
@@ -28,12 +28,12 @@ describe('v18-to-v19 finalization boundaries', () => {
 
   afterEach(async () => {
     await Promise.all(
-      preparedMigrations.splice(0).map(async (prepared) => await prepared.cleanup()),
+      preparedMigrations.splice(0).map(async (prepared) => await prepared.cleanup())
     );
     await Promise.all(
       temporaryDirectories.splice(0).map(async (directory) => {
         await rm(directory, { recursive: true, force: true });
-      }),
+      })
     );
   });
 
@@ -49,22 +49,21 @@ describe('v18-to-v19 finalization boundaries', () => {
       '--format=%T',
       writer.head,
     ]);
-    const concurrentHead = await v18MigrationGitText(migration.repositoryPath, [
-      'commit-tree',
-      tree,
-      '-p',
-      writer.head,
-    ], {
-      env: {
-        GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
-        GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
-        GIT_AUTHOR_NAME: 'Migration Fixture',
-        GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z',
-        GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
-        GIT_COMMITTER_NAME: 'Migration Fixture',
-      },
-      input: 'concurrent v18 writer advance\n',
-    });
+    const concurrentHead = await v18MigrationGitText(
+      migration.repositoryPath,
+      ['commit-tree', tree, '-p', writer.head],
+      {
+        env: {
+          GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
+          GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
+          GIT_AUTHOR_NAME: 'Migration Fixture',
+          GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z',
+          GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
+          GIT_COMMITTER_NAME: 'Migration Fixture',
+        },
+        input: 'concurrent v18 writer advance\n',
+      }
+    );
     await v18MigrationGitText(migration.repositoryPath, [
       'update-ref',
       writer.refName,
@@ -72,20 +71,23 @@ describe('v18-to-v19 finalization boundaries', () => {
       writer.head,
     ]);
 
-    await expect(finalizeV18Migration({
-      plan: migration.plan,
-      prepared: migration.prepared,
-      recoveryId: 'concurrent-proof',
-    })).rejects.toThrow();
+    await expect(
+      finalizeV18Migration({
+        plan: migration.plan,
+        prepared: migration.prepared,
+        recoveryId: 'concurrent-proof',
+      })
+    ).rejects.toThrow();
 
-    expect(await readV18MigrationRef(
-      migration.repositoryPath,
-      writer.refName,
-    )).toBe(concurrentHead);
-    expect(await listV18MigrationRefs(
-      migration.repositoryPath,
-      `refs/warp/${migration.graph}/recovery/v18-to-v19/concurrent-proof/`,
-    )).toEqual([]);
+    expect(await readV18MigrationRef(migration.repositoryPath, writer.refName)).toBe(
+      concurrentHead
+    );
+    expect(
+      await listV18MigrationRefs(
+        migration.repositoryPath,
+        `refs/warp/${migration.graph}/recovery/v18-to-v19/concurrent-proof/`
+      )
+    ).toEqual([]);
   });
 
   it('resumes safely after atomic promotion but before command verification', async () => {
@@ -103,18 +105,61 @@ describe('v18-to-v19 finalization boundaries', () => {
     });
 
     expect(resumed.status).toBe('already-current');
-    expect(await listV18MigrationRefs(
-      migration.repositoryPath,
-      `${finalization.recoveryPrefix}/`,
-    )).not.toEqual([]);
+    expect(
+      await listV18MigrationRefs(migration.repositoryPath, `${finalization.recoveryPrefix}/`)
+    ).not.toEqual([]);
   });
 
-  async function prepareFixtureMigration(): Promise<Readonly<{
-    graph: string;
-    plan: Awaited<ReturnType<typeof planV18ToV19Migration>>;
-    prepared: V18PreparedMigration;
-    repositoryPath: string;
-  }>> {
+  it('verifies a promoted repository without decoding its oversized full state', async () => {
+    const migration = await prepareFixtureMigration();
+    const opened = await openScratchGraph(
+      migration.prepared.scratchPath,
+      migration.graph,
+      'oversized-state-writer'
+    );
+    try {
+      await opened.graph.patch((patch) => {
+        patch
+          .addNode('oversized-state-node-a')
+          .setProperty('oversized-state-node-a', 'payload', 'a'.repeat(3 * 1024 * 1024));
+      });
+      await opened.graph.patch((patch) => {
+        patch
+          .addNode('oversized-state-node-b')
+          .setProperty('oversized-state-node-b', 'payload', 'b'.repeat(3 * 1024 * 1024));
+      });
+      await opened.graph.materialize();
+      await opened.graph.createCheckpoint();
+    } finally {
+      await opened.close();
+    }
+
+    const eagerControl = await openScratchGraph(
+      migration.prepared.scratchPath,
+      migration.graph,
+      'oversized-state-eager-control'
+    );
+    try {
+      await expect(eagerControl.graph.materialize()).rejects.toMatchObject({
+        code: 'E_CBOR_DECODE_BOUNDS',
+      });
+    } finally {
+      await eagerControl.close();
+    }
+
+    await expect(
+      verifyPromotedV19Repository(migration.prepared.scratchPath, migration.graph)
+    ).resolves.toBeUndefined();
+  });
+
+  async function prepareFixtureMigration(): Promise<
+    Readonly<{
+      graph: string;
+      plan: Awaited<ReturnType<typeof planV18ToV19Migration>>;
+      prepared: V18PreparedMigration;
+      repositoryPath: string;
+    }>
+  > {
     const targetDirectory = await mkdtemp(join(tmpdir(), 'git-warp-v18-finalize-'));
     temporaryDirectories.push(targetDirectory);
     const restored = await restoreV18RetainedSubstrateFixture({

--- a/test/unit/scripts/v18-to-v19-finalization.test.ts
+++ b/test/unit/scripts/v18-to-v19-finalization.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { runV18ToV19Migration } from '../../../scripts/v18-to-v19/V18MigrationCommand.ts';
+import V18MigrationExecutionMode from '../../../scripts/v18-to-v19/V18MigrationExecutionMode.ts';
 import { finalizeV18Migration } from '../../../scripts/v18-to-v19/V18MigrationFinalizer.ts';
 import {
   listV18MigrationRefs,
@@ -18,9 +19,7 @@ import {
 } from '../../../scripts/v18-to-v19/V18MigrationScratch.ts';
 import { restoreV18RetainedSubstrateFixture } from '../../../scripts/v18-to-v19/V18RetainedSubstrateFixtureRestore.ts';
 
-const MANIFEST_PATH = resolve(
-  'fixtures/v18/retained-substrate-golden/manifest.json',
-);
+const MANIFEST_PATH = resolve('fixtures/v18/retained-substrate-golden/manifest.json');
 
 describe('v18-to-v19 finalization boundaries', () => {
   const temporaryDirectories: string[] = [];
@@ -28,12 +27,12 @@ describe('v18-to-v19 finalization boundaries', () => {
 
   afterEach(async () => {
     await Promise.all(
-      preparedMigrations.splice(0).map(async (prepared) => await prepared.cleanup()),
+      preparedMigrations.splice(0).map(async (prepared) => await prepared.cleanup())
     );
     await Promise.all(
       temporaryDirectories.splice(0).map(async (directory) => {
         await rm(directory, { recursive: true, force: true });
-      }),
+      })
     );
   });
 
@@ -49,22 +48,21 @@ describe('v18-to-v19 finalization boundaries', () => {
       '--format=%T',
       writer.head,
     ]);
-    const concurrentHead = await v18MigrationGitText(migration.repositoryPath, [
-      'commit-tree',
-      tree,
-      '-p',
-      writer.head,
-    ], {
-      env: {
-        GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
-        GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
-        GIT_AUTHOR_NAME: 'Migration Fixture',
-        GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z',
-        GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
-        GIT_COMMITTER_NAME: 'Migration Fixture',
-      },
-      input: 'concurrent v18 writer advance\n',
-    });
+    const concurrentHead = await v18MigrationGitText(
+      migration.repositoryPath,
+      ['commit-tree', tree, '-p', writer.head],
+      {
+        env: {
+          GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
+          GIT_AUTHOR_EMAIL: 'fixture@example.invalid',
+          GIT_AUTHOR_NAME: 'Migration Fixture',
+          GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z',
+          GIT_COMMITTER_EMAIL: 'fixture@example.invalid',
+          GIT_COMMITTER_NAME: 'Migration Fixture',
+        },
+        input: 'concurrent v18 writer advance\n',
+      }
+    );
     await v18MigrationGitText(migration.repositoryPath, [
       'update-ref',
       writer.refName,
@@ -72,20 +70,23 @@ describe('v18-to-v19 finalization boundaries', () => {
       writer.head,
     ]);
 
-    await expect(finalizeV18Migration({
-      plan: migration.plan,
-      prepared: migration.prepared,
-      recoveryId: 'concurrent-proof',
-    })).rejects.toThrow();
+    await expect(
+      finalizeV18Migration({
+        plan: migration.plan,
+        prepared: migration.prepared,
+        recoveryId: 'concurrent-proof',
+      })
+    ).rejects.toThrow();
 
-    expect(await readV18MigrationRef(
-      migration.repositoryPath,
-      writer.refName,
-    )).toBe(concurrentHead);
-    expect(await listV18MigrationRefs(
-      migration.repositoryPath,
-      `refs/warp/${migration.graph}/recovery/v18-to-v19/concurrent-proof/`,
-    )).toEqual([]);
+    expect(await readV18MigrationRef(migration.repositoryPath, writer.refName)).toBe(
+      concurrentHead
+    );
+    expect(
+      await listV18MigrationRefs(
+        migration.repositoryPath,
+        `refs/warp/${migration.graph}/recovery/v18-to-v19/concurrent-proof/`
+      )
+    ).toEqual([]);
   });
 
   it('resumes safely after atomic promotion but before command verification', async () => {
@@ -97,24 +98,25 @@ describe('v18-to-v19 finalization boundaries', () => {
     });
 
     const resumed = await runV18ToV19Migration({
-      apply: true,
       graph: migration.graph,
+      mode: V18MigrationExecutionMode.promote(),
       repositoryPath: migration.repositoryPath,
     });
 
     expect(resumed.status).toBe('already-current');
-    expect(await listV18MigrationRefs(
-      migration.repositoryPath,
-      `${finalization.recoveryPrefix}/`,
-    )).not.toEqual([]);
+    expect(
+      await listV18MigrationRefs(migration.repositoryPath, `${finalization.recoveryPrefix}/`)
+    ).not.toEqual([]);
   });
 
-  async function prepareFixtureMigration(): Promise<Readonly<{
-    graph: string;
-    plan: Awaited<ReturnType<typeof planV18ToV19Migration>>;
-    prepared: V18PreparedMigration;
-    repositoryPath: string;
-  }>> {
+  async function prepareFixtureMigration(): Promise<
+    Readonly<{
+      graph: string;
+      plan: Awaited<ReturnType<typeof planV18ToV19Migration>>;
+      prepared: V18PreparedMigration;
+      repositoryPath: string;
+    }>
+  > {
     const targetDirectory = await mkdtemp(join(tmpdir(), 'git-warp-v18-finalize-'));
     temporaryDirectories.push(targetDirectory);
     const restored = await restoreV18RetainedSubstrateFixture({

--- a/test/unit/scripts/v18-to-v19-finalization.test.ts
+++ b/test/unit/scripts/v18-to-v19-finalization.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -148,9 +148,12 @@ describe('v18-to-v19 finalization boundaries', () => {
       await eagerControl.close();
     }
 
+    const verificationRoot = await mkdtemp(join(tmpdir(), 'git-warp-v18-verify-root-'));
+    temporaryDirectories.push(verificationRoot);
     await expect(
-      verifyPromotedV19Repository(migration.prepared.scratchPath, migration.graph)
+      verifyPromotedV19Repository(migration.prepared.scratchPath, migration.graph, verificationRoot)
     ).resolves.toBeUndefined();
+    expect(await readdir(verificationRoot)).toEqual([]);
   });
 
   async function prepareFixtureMigration(): Promise<

--- a/test/unit/scripts/v18-to-v19-git-commit-writer.test.ts
+++ b/test/unit/scripts/v18-to-v19-git-commit-writer.test.ts
@@ -1,0 +1,127 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { V18CommitIdentity } from '../../../scripts/v18-to-v19/V18PatchCommit.ts';
+import { V18MigrationGitCommitWriter } from '../../../scripts/v18-to-v19/V18MigrationGitCommitWriter.ts';
+import { v18MigrationGitText } from '../../../scripts/v18-to-v19/V18MigrationGit.ts';
+
+const IDENTITY: V18CommitIdentity = Object.freeze({
+  email: 'migration@example.invalid',
+  name: 'Migration Test',
+  timestamp: '1700000000',
+  timezone: '-0700',
+});
+
+describe('v18-to-v19 Git commit writer', () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      temporaryDirectories.splice(0).map(async (directory) => {
+        await rm(directory, { recursive: true, force: true });
+      }),
+    );
+  });
+
+  it('matches commit-tree OIDs for an ordered parent chain', async () => {
+    const repositoryPath = await createRepository(temporaryDirectories);
+    const tree = await v18MigrationGitText(
+      repositoryPath,
+      ['mktree'],
+      { input: '' },
+    );
+    const expectedRoot = await commitTree(repositoryPath, tree, null, 'root commit');
+    const expectedChild = await commitTree(
+      repositoryPath,
+      tree,
+      expectedRoot,
+      'child commit\n',
+    );
+    const writer = new V18MigrationGitCommitWriter(repositoryPath);
+    try {
+      const root = await writer.writeCommit({
+        author: IDENTITY,
+        committer: IDENTITY,
+        message: 'root commit',
+        parent: null,
+        tree,
+      });
+      const child = await writer.writeCommit({
+        author: IDENTITY,
+        committer: IDENTITY,
+        message: 'child commit\n',
+        parent: root,
+        tree,
+      });
+      expect(root).toBe(expectedRoot);
+      expect(child).toBe(expectedChild);
+    } finally {
+      await writer.close();
+    }
+  });
+
+  it('serializes concurrently queued independent commits in request order', async () => {
+    const repositoryPath = await createRepository(temporaryDirectories);
+    const tree = await v18MigrationGitText(
+      repositoryPath,
+      ['mktree'],
+      { input: '' },
+    );
+    const writer = new V18MigrationGitCommitWriter(repositoryPath);
+    try {
+      const messages = ['first\n', 'second\n', 'third\n'];
+      const commits = await Promise.all(messages.map(async (message) => {
+        return await writer.writeCommit({
+          author: IDENTITY,
+          committer: IDENTITY,
+          message,
+          parent: null,
+          tree,
+        });
+      }));
+      await expect(Promise.all(commits.map(async (commit, index) => {
+        const raw = await v18MigrationGitText(repositoryPath, [
+          'cat-file',
+          'commit',
+          commit,
+        ]);
+        expect(raw).toContain(messages[index]?.trim());
+      }))).resolves.toBeDefined();
+    } finally {
+      await writer.close();
+    }
+  });
+});
+
+async function createRepository(temporaryDirectories: string[]): Promise<string> {
+  const repositoryPath = await mkdtemp(join(tmpdir(), 'git-warp-commit-writer-'));
+  temporaryDirectories.push(repositoryPath);
+  await v18MigrationGitText(repositoryPath, ['init', '-q']);
+  return repositoryPath;
+}
+
+async function commitTree(
+  repositoryPath: string,
+  tree: string,
+  parent: string | null,
+  message: string,
+): Promise<string> {
+  const args = ['commit-tree', tree, '-F', '-'];
+  if (parent !== null) {
+    args.push('-p', parent);
+  }
+  return await v18MigrationGitText(repositoryPath, args, {
+    env: {
+      GIT_AUTHOR_DATE: `${IDENTITY.timestamp} ${IDENTITY.timezone}`,
+      GIT_AUTHOR_EMAIL: IDENTITY.email,
+      GIT_AUTHOR_NAME: IDENTITY.name,
+      GIT_COMMITTER_DATE: `${IDENTITY.timestamp} ${IDENTITY.timezone}`,
+      GIT_COMMITTER_EMAIL: IDENTITY.email,
+      GIT_COMMITTER_NAME: IDENTITY.name,
+    },
+    input: message,
+  });
+}

--- a/test/unit/scripts/v18-to-v19-git-object-reader.test.ts
+++ b/test/unit/scripts/v18-to-v19-git-object-reader.test.ts
@@ -1,0 +1,79 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { v18MigrationGitText } from '../../../scripts/v18-to-v19/V18MigrationGit.ts';
+import { V18MigrationGitObjectReader } from '../../../scripts/v18-to-v19/V18MigrationGitObjectReader.ts';
+
+describe('v18-to-v19 Git object reader', () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      temporaryDirectories.splice(0).map(async (directory) => {
+        await rm(directory, { recursive: true, force: true });
+      })
+    );
+  });
+
+  it('reads multiple exact objects through one ordered batch session', async () => {
+    const repositoryPath = await createRepository(temporaryDirectories);
+    const tree = await v18MigrationGitText(repositoryPath, ['mktree'], { input: '' });
+    const first = await v18MigrationGitText(repositoryPath, ['commit-tree', tree, '-F', '-'], {
+      input: 'first batch commit\n',
+    });
+    const second = await v18MigrationGitText(
+      repositoryPath,
+      ['commit-tree', tree, '-p', first, '-F', '-'],
+      { input: 'second batch commit\n' }
+    );
+    const reader = new V18MigrationGitObjectReader(repositoryPath);
+    try {
+      const [firstBytes, secondBytes] = await Promise.all([
+        reader.readObject(first, 'commit'),
+        reader.readObject(second, 'commit'),
+      ]);
+      expect(Buffer.from(firstBytes).toString('utf8')).toContain('\n\nfirst batch commit\n');
+      expect(Buffer.from(secondBytes).toString('utf8')).toContain(`parent ${first}\n`);
+      expect(Buffer.from(secondBytes).toString('utf8')).toContain('\n\nsecond batch commit\n');
+    } finally {
+      await reader.close();
+    }
+  });
+
+  it('rejects missing objects and wrong object types without desynchronizing', async () => {
+    const repositoryPath = await createRepository(temporaryDirectories);
+    const blob = await v18MigrationGitText(repositoryPath, ['hash-object', '-w', '--stdin'], {
+      input: 'not a commit\n',
+    });
+    const tree = await v18MigrationGitText(repositoryPath, ['mktree'], { input: '' });
+    const commit = await v18MigrationGitText(repositoryPath, ['commit-tree', tree, '-F', '-'], {
+      input: 'still readable\n',
+    });
+    const reader = new V18MigrationGitObjectReader(repositoryPath);
+    try {
+      await expect(
+        reader.readObject('0000000000000000000000000000000000000000', 'commit')
+      ).rejects.toThrow('is missing');
+      await expect(reader.readObject(blob, 'commit')).rejects.toThrow(
+        'has type blob; expected commit'
+      );
+      expect(Buffer.from(await reader.readObject(commit, 'commit')).toString('utf8')).toContain(
+        '\n\nstill readable\n'
+      );
+    } finally {
+      await reader.close();
+    }
+  });
+});
+
+async function createRepository(temporaryDirectories: string[]): Promise<string> {
+  const repositoryPath = await mkdtemp(join(tmpdir(), 'git-warp-batch-reader-'));
+  temporaryDirectories.push(repositoryPath);
+  await v18MigrationGitText(repositoryPath, ['init', '-q']);
+  await v18MigrationGitText(repositoryPath, ['config', 'user.name', 'migration test']);
+  await v18MigrationGitText(repositoryPath, ['config', 'user.email', 'migration@example.invalid']);
+  return repositoryPath;
+}

--- a/test/unit/scripts/v18-to-v19-git-object-reader.test.ts
+++ b/test/unit/scripts/v18-to-v19-git-object-reader.test.ts
@@ -67,6 +67,29 @@ describe('v18-to-v19 Git object reader', () => {
       await reader.close();
     }
   });
+
+  it('reads a multi-chunk payload and the following object without buffer copying drift', async () => {
+    const repositoryPath = await createRepository(temporaryDirectories);
+    const payload = Buffer.alloc(4 * 1_048_576, 0xa5);
+    const largeBlob = await v18MigrationGitText(repositoryPath, ['hash-object', '-w', '--stdin'], {
+      input: payload,
+    });
+    const smallBlob = await v18MigrationGitText(repositoryPath, ['hash-object', '-w', '--stdin'], {
+      input: 'after-large-object\n',
+    });
+    const reader = new V18MigrationGitObjectReader(repositoryPath);
+    try {
+      const largeBytes = await reader.readObject(largeBlob, 'blob');
+      expect(largeBytes).toHaveLength(payload.length);
+      expect(largeBytes[0]).toBe(0xa5);
+      expect(largeBytes.at(-1)).toBe(0xa5);
+      expect(Buffer.from(await reader.readObject(smallBlob, 'blob')).toString('utf8')).toBe(
+        'after-large-object\n'
+      );
+    } finally {
+      await reader.close();
+    }
+  });
 });
 
 async function createRepository(temporaryDirectories: string[]): Promise<string> {

--- a/test/unit/scripts/v18-to-v19-writer-chain.test.ts
+++ b/test/unit/scripts/v18-to-v19-writer-chain.test.ts
@@ -10,7 +10,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import warpCborCodec from '../../../src/infrastructure/codecs/CborCodec.ts';
 import { restoreV18RetainedSubstrateFixture } from '../../../scripts/v18-to-v19/V18RetainedSubstrateFixtureRestore.ts';
-import { V18MigrationGitObjectReader } from '../../../scripts/v18-to-v19/V18MigrationGitObjectReader.ts';
 import { readV18PatchCommit } from '../../../scripts/v18-to-v19/V18PatchCommit.ts';
 import V18PatchTranslator from '../../../scripts/v18-to-v19/V18PatchTranslator.ts';
 import {
@@ -20,7 +19,9 @@ import {
 import { v18MigrationGitText } from '../../../scripts/v18-to-v19/V18MigrationGit.ts';
 import { collectAsyncBytes } from '../../helpers/collectAsyncBytes.ts';
 
-const MANIFEST_PATH = resolve('fixtures/v18/retained-substrate-golden/manifest.json');
+const MANIFEST_PATH = resolve(
+  'fixtures/v18/retained-substrate-golden/manifest.json',
+);
 
 describe('v18-to-v19 writer chain migration', () => {
   const temporaryDirectories: string[] = [];
@@ -29,7 +30,7 @@ describe('v18-to-v19 writer chain migration', () => {
     await Promise.all(
       temporaryDirectories.splice(0).map(async (directory) => {
         await rm(directory, { recursive: true, force: true });
-      })
+      }),
     );
   });
 
@@ -40,9 +41,7 @@ describe('v18-to-v19 writer chain migration', () => {
       manifestPath: MANIFEST_PATH,
       targetDirectory,
     });
-    const objectReader = new V18MigrationGitObjectReader(restored.repositoryPath);
     const translator = await V18PatchTranslator.open({
-      objectReader,
       repositoryPath: restored.repositoryPath,
     });
     const rewrites: V18WriterChainRewrite[] = [];
@@ -50,20 +49,18 @@ describe('v18-to-v19 writer chain migration', () => {
     try {
       for (const ref of restored.manifest.refs) {
         if (ref.kind === 'writer') {
-          rewrites.push(
-            await rewriteV18WriterChain({
-              commitMap,
-              graph: restored.manifest.graphId,
-              refName: ref.refName,
-              repositoryPath: restored.repositoryPath,
-              translator,
-              writer: ref.writerId,
-            })
-          );
+          rewrites.push(await rewriteV18WriterChain({
+            commitMap,
+            graph: restored.manifest.graphId,
+            refName: ref.refName,
+            repositoryPath: restored.repositoryPath,
+            translator,
+            writer: ref.writerId,
+          }));
         }
       }
     } finally {
-      await Promise.all([objectReader.close(), translator.close()]);
+      await translator.close();
     }
 
     expect(rewrites.map((rewrite) => rewrite.translatedCount)).toEqual([2, 1]);
@@ -76,7 +73,11 @@ describe('v18-to-v19 writer chain migration', () => {
       throw new Error('missing rewritten alice head');
     }
     const firstSha = (
-      await v18MigrationGitText(restored.repositoryPath, ['rev-list', '--reverse', aliceHead])
+      await v18MigrationGitText(restored.repositoryPath, [
+        'rev-list',
+        '--reverse',
+        aliceHead,
+      ])
     ).split('\n')[0];
     expect(firstSha).toBeDefined();
     if (firstSha === undefined) {
@@ -98,7 +99,7 @@ describe('v18-to-v19 writer chain migration', () => {
       const parsed = GitCasAssetHandle.parse(contentHandle);
       const content = await collectAsyncBytes(cas.assets.open({ handle: parsed }));
       expect(Buffer.from(content).toString('utf8')).toBe(
-        'v18 blob-backed content retained for v19 migration proof\n'
+        'v18 blob-backed content retained for v19 migration proof\n',
       );
     } finally {
       await cas.close();
@@ -116,12 +117,12 @@ function findContentHandle(decoded: unknown): string {
   }
   for (const op of ops) {
     if (
-      op !== null &&
-      typeof op === 'object' &&
-      'key' in op &&
-      op.key === '_content' &&
-      'value' in op &&
-      typeof op.value === 'string'
+      op !== null
+      && typeof op === 'object'
+      && 'key' in op
+      && op.key === '_content'
+      && 'value' in op
+      && typeof op.value === 'string'
     ) {
       return op.value;
     }

--- a/test/unit/scripts/v18-to-v19-writer-chain.test.ts
+++ b/test/unit/scripts/v18-to-v19-writer-chain.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import warpCborCodec from '../../../src/infrastructure/codecs/CborCodec.ts';
 import { restoreV18RetainedSubstrateFixture } from '../../../scripts/v18-to-v19/V18RetainedSubstrateFixtureRestore.ts';
+import { V18MigrationGitObjectReader } from '../../../scripts/v18-to-v19/V18MigrationGitObjectReader.ts';
 import { readV18PatchCommit } from '../../../scripts/v18-to-v19/V18PatchCommit.ts';
 import V18PatchTranslator from '../../../scripts/v18-to-v19/V18PatchTranslator.ts';
 import {
@@ -19,9 +20,7 @@ import {
 import { v18MigrationGitText } from '../../../scripts/v18-to-v19/V18MigrationGit.ts';
 import { collectAsyncBytes } from '../../helpers/collectAsyncBytes.ts';
 
-const MANIFEST_PATH = resolve(
-  'fixtures/v18/retained-substrate-golden/manifest.json',
-);
+const MANIFEST_PATH = resolve('fixtures/v18/retained-substrate-golden/manifest.json');
 
 describe('v18-to-v19 writer chain migration', () => {
   const temporaryDirectories: string[] = [];
@@ -30,7 +29,7 @@ describe('v18-to-v19 writer chain migration', () => {
     await Promise.all(
       temporaryDirectories.splice(0).map(async (directory) => {
         await rm(directory, { recursive: true, force: true });
-      }),
+      })
     );
   });
 
@@ -41,7 +40,9 @@ describe('v18-to-v19 writer chain migration', () => {
       manifestPath: MANIFEST_PATH,
       targetDirectory,
     });
+    const objectReader = new V18MigrationGitObjectReader(restored.repositoryPath);
     const translator = await V18PatchTranslator.open({
+      objectReader,
       repositoryPath: restored.repositoryPath,
     });
     const rewrites: V18WriterChainRewrite[] = [];
@@ -49,18 +50,20 @@ describe('v18-to-v19 writer chain migration', () => {
     try {
       for (const ref of restored.manifest.refs) {
         if (ref.kind === 'writer') {
-          rewrites.push(await rewriteV18WriterChain({
-            commitMap,
-            graph: restored.manifest.graphId,
-            refName: ref.refName,
-            repositoryPath: restored.repositoryPath,
-            translator,
-            writer: ref.writerId,
-          }));
+          rewrites.push(
+            await rewriteV18WriterChain({
+              commitMap,
+              graph: restored.manifest.graphId,
+              refName: ref.refName,
+              repositoryPath: restored.repositoryPath,
+              translator,
+              writer: ref.writerId,
+            })
+          );
         }
       }
     } finally {
-      await translator.close();
+      await Promise.all([objectReader.close(), translator.close()]);
     }
 
     expect(rewrites.map((rewrite) => rewrite.translatedCount)).toEqual([2, 1]);
@@ -73,11 +76,7 @@ describe('v18-to-v19 writer chain migration', () => {
       throw new Error('missing rewritten alice head');
     }
     const firstSha = (
-      await v18MigrationGitText(restored.repositoryPath, [
-        'rev-list',
-        '--reverse',
-        aliceHead,
-      ])
+      await v18MigrationGitText(restored.repositoryPath, ['rev-list', '--reverse', aliceHead])
     ).split('\n')[0];
     expect(firstSha).toBeDefined();
     if (firstSha === undefined) {
@@ -99,7 +98,7 @@ describe('v18-to-v19 writer chain migration', () => {
       const parsed = GitCasAssetHandle.parse(contentHandle);
       const content = await collectAsyncBytes(cas.assets.open({ handle: parsed }));
       expect(Buffer.from(content).toString('utf8')).toBe(
-        'v18 blob-backed content retained for v19 migration proof\n',
+        'v18 blob-backed content retained for v19 migration proof\n'
       );
     } finally {
       await cas.close();
@@ -117,12 +116,12 @@ function findContentHandle(decoded: unknown): string {
   }
   for (const op of ops) {
     if (
-      op !== null
-      && typeof op === 'object'
-      && 'key' in op
-      && op.key === '_content'
-      && 'value' in op
-      && typeof op.value === 'string'
+      op !== null &&
+      typeof op === 'object' &&
+      'key' in op &&
+      op.key === '_content' &&
+      'value' in op &&
+      typeof op.value === 'string'
     ) {
       return op.value;
     }

--- a/test/unit/scripts/v18-to-v19-writer-chain.test.ts
+++ b/test/unit/scripts/v18-to-v19-writer-chain.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import warpCborCodec from '../../../src/infrastructure/codecs/CborCodec.ts';
 import { restoreV18RetainedSubstrateFixture } from '../../../scripts/v18-to-v19/V18RetainedSubstrateFixtureRestore.ts';
+import { V18MigrationGitObjectReader } from '../../../scripts/v18-to-v19/V18MigrationGitObjectReader.ts';
 import { readV18PatchCommit } from '../../../scripts/v18-to-v19/V18PatchCommit.ts';
 import V18PatchTranslator from '../../../scripts/v18-to-v19/V18PatchTranslator.ts';
 import {
@@ -41,7 +42,9 @@ describe('v18-to-v19 writer chain migration', () => {
       manifestPath: MANIFEST_PATH,
       targetDirectory,
     });
+    const objectReader = new V18MigrationGitObjectReader(restored.repositoryPath);
     const translator = await V18PatchTranslator.open({
+      objectReader,
       repositoryPath: restored.repositoryPath,
     });
     const rewrites: V18WriterChainRewrite[] = [];
@@ -60,7 +63,7 @@ describe('v18-to-v19 writer chain migration', () => {
         }
       }
     } finally {
-      await translator.close();
+      await Promise.all([objectReader.close(), translator.close()]);
     }
 
     expect(rewrites.map((rewrite) => rewrite.translatedCount)).toEqual([2, 1]);


### PR DESCRIPTION
## Summary

- Makes v18-to-v19 migration one-pass, graph-aware, capacity-visible, bounded during verification, and practical for the real 11,708-commit Think shape.
- The final no-hardlink rehearsal migrated both writer chains and the 23,995,927-byte checkpoint in about 26m50s, retained 36 recovery refs, proved append/read/receipt behavior, and left the live repository untouched.

## Issue

Closes #806
Closes #808
Closes #809
Refs #807
Refs #810
Refs #822

## Test plan

- Full unit corpus: 637 passed files, 7,283 passed tests.
- v19 acceptance: 129 passed tests.
- Authentic medium fixture, 4 MiB batch-object read, package contents, type/publication surfaces, docs/Mermaid rendering, audit, and IRONCLAD pre-push firewall passed.
- Full-size no-hardlink Think rehearsal completed without touching the live repository.

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3.
- [x] Persisted op formats: not applicable; the migration rewrites storage envelopes without changing the canonical operation schema.
- [x] Wire compatibility: not applicable; no wire cutover or canonical-only wire acceptance is introduced.
- [x] Schema constants: patch and checkpoint namespaces remain distinct.