### PR TITLE
Release v19.0.1 with safe migration guidance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,10 +10,11 @@ If you are learning the product for the first time, start with:
 
 ## Release posture
 
-`v19.0.0` is the current release. Applications open a `Runtime`, address
-causal `Lane`s, write validated `Intent`s, consume bounded `Observation`
-streams of `Reading`s, and keep `Receipt`s. Git history and git-cas remain
-separate infrastructure concerns composed behind the Runtime.
+`v19.0.1` is the current release. Applications open a `Runtime`, address causal
+`Lane`s, write validated `Intent`s, consume bounded `Observation` streams of
+`Reading`s, and keep `Receipt`s. The patch adds the safe one-shot retained-v18
+migration without changing the v19 application grammar. Git history and
+git-cas remain separate infrastructure concerns composed behind the Runtime.
 
 The longer release notes live in [CHANGELOG.md](CHANGELOG.md). The runtime
 architecture below describes current implementation boundaries, not aspirational

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [19.0.1] - 2026-07-28
+
+### Release notes
+
+`v19.0.1` replaces the unsafe retained-state migrator published in v19.0.0.
+Do not use the v19.0.0 migrator on an authoritative repository. The corrected
+command discovers every WARP graph, presents version and capacity posture,
+asks for confirmation, translates and verifies in disposable repositories,
+and promotes through one guarded ref transaction in the same invocation.
+
+This patch does not change the v19 application grammar. Applications must
+still replace the removed v18 graph-first API with `Runtime`, `Lane`, generated
+`Intent` and `Observer` builders, bounded `Observation` streams, and retained
+`Receipt`s before cutting over their authoritative data.
+
+### Fixed
+
+- Made `git-warp-v18-to-v19` discover graph namespaces instead of assuming a
+  graph name. A missing selection now reports `Graph not found` and lists every
+  discovered graph with its version posture, writer count, and ref count.
+- Replaced the two-command rehearsal/apply experience with a one-pass default.
+  Interactive execution uses Bijou 7's framed application, displays source and
+  scratch capacity, renders per-writer progress, and requires confirmation
+  before inventory. `--yes` supports automation; `--dry-run` remains an
+  explicitly disposable full rehearsal; `--apply` is only a compatibility
+  alias.
+- Corrected scratch-space preflight to account for both complete object-store
+  bytes and loose-object filesystem allocation. `--scratch-root` places the
+  scratch and disposable verification repositories on an operator-selected
+  volume.
+- Isolated legacy v18 checkpoint decoding behind a migration-only 64 MiB
+  encoded-byte ceiling with depth and item limits. Promoted verification no
+  longer routes the retained full-state checkpoint through the normal 5 MiB
+  application CBOR boundary.
+- Batched v18 commit reads, patch-blob reads, and commit writes through
+  persistent Git plumbing while preserving exact commit metadata and
+  translation order.
+- Bounded promoted-repository verification through reopen, disposable append,
+  public reading, and Receipt evidence. Failed verification rolls authoritative
+  refs back through a guarded transaction while retaining additive recovery
+  refs.
+- Rechecked every inventoried source ref after scratch verification and used
+  compare-and-swap expectations during final promotion so concurrent writer
+  movement aborts the cutover.
+
+### Documentation
+
+- Added the complete Git-level migration flow, scratch capacity formula,
+  measured Think-shaped rehearsal, recovery-ref posture, one-pass semantics,
+  and application-versus-substrate cutover order.
+- Added an executable no-hardlink backup and maintenance-window checklist for
+  operators, including idempotent `already-current` verification.
+- Included the current topic, operation, and v19 migration documentation in npm
+  and JSR publication so installed-package README links resolve locally.
+- Added the public API class diagram and source anchors for Runtime, Lane,
+  Intent, Observer, Observation, Reading, Receipt, and generated SDK ownership.
+- Explained Wesley's domain-free compiler role, application-owned renderer
+  boundary, pinned installation, generated files, executable `users` fixture,
+  and why source generation does not migrate retained Git data.
+- Corrected stale settlement guidance: `Runtime.previewSettlement()` and
+  `Runtime.settle()` are implemented v19 surfaces with immutable,
+  basis-revalidated plans.
+
 ## [19.0.0] - 2026-07-27
 
 ### Release notes

--- a/README.md
+++ b/README.md
@@ -46,12 +46,13 @@ It lets you:
 
 ## Latest release
 
-`v19.0.0` replaces the graph-first application API with one public runtime
-boundary: open `Runtime`, address causal `Lane`s, write validated `Intent`s,
-consume bounded `Observation` streams of `Reading`s, and retain `Receipt`s.
-Existing repositories with retained v18 state require the corrected v19.0.1
-one-shot migration below before any v19 process opens them. Do not use the
-v19.0.0 migrator on an authoritative repository.
+`v19.0.1` is the current release. It keeps the public runtime boundary
+introduced in v19.0.0—open `Runtime`, address causal `Lane`s, write validated
+`Intent`s, consume bounded `Observation` streams of `Reading`s, and retain
+`Receipt`s—and replaces the unsafe v19.0.0 retained-state migrator. Existing
+repositories with retained v18 state require the v19.0.1 one-shot migration
+below before any v19 process opens them. Do not use the v19.0.0 migrator on an
+authoritative repository.
 
 The exact merged-main release gate's representative migrated-v18 retained scan
 was 31.1% faster cold, 32.1% faster warm, used 20.1–21.3% less operation CPU,

--- a/docs/migrations/v19/README.md
+++ b/docs/migrations/v19/README.md
@@ -2,8 +2,9 @@
 
 > **Status:** The public grammar shipped in `v19.0.0`. The retained-state
 > migration described below requires `v19.0.1`; do not use the `v19.0.0`
-> migrator on an authoritative repository. General generated-SDK publication
-> remains future work.
+> migrator on an authoritative repository. v19.0.1 ships the generic
+> constructors and an executable generated-SDK reference; each application
+> still owns the renderer that assigns domain meaning.
 
 v19 replaces the transitional storage- and timeline-shaped facade with one
 application grammar:
@@ -43,9 +44,57 @@ final report. Before confirmation, the summary also reports current Git object
 storage, the scratch path, free space on the scratch and source Git volumes,
 and whether scratch free space meets the operating budget.
 
+### Maintenance-window checklist
+
+Prepare the v19 application before this window. Do not let either a v18 or v19
+application open the authoritative repository while the retained substrate is
+being migrated.
+
+1. Stop and disable every process that can write to any graph in the
+   repository.
+2. Create an independent mirror backup. `--no-hardlinks` matters for a local
+   source: it prevents the backup and source from sharing loose-object files.
+
+   ```bash
+   REPOSITORY=/path/to/repository
+   BACKUP=/path/to/git-warp-backup.git
+
+   git clone --mirror --no-hardlinks "$REPOSITORY" "$BACKUP"
+   git -C "$BACKUP" fsck --full
+   ```
+
+3. Record the selected graph's starting refs somewhere outside the repository.
+
+   ```bash
+   GRAPH_NAME=your-graph-name
+   REF_SNAPSHOT=/path/to/warp-refs.before.txt
+
+   git -C "$REPOSITORY" for-each-ref \
+     --format='%(refname) %(objectname)' \
+     "refs/warp/${GRAPH_NAME}/" > "$REF_SNAPSHOT"
+   ```
+
+4. Choose a scratch volume with at least the displayed operating budget. Pass
+   `--scratch-root <path>` when the system temporary volume is not suitable.
+5. Run the normal command without `--dry-run`, inspect the graph and capacity
+   summary, and confirm once.
+6. Save the final report and its recovery-ref prefix. A successful report says
+   `migrated` and `scratch verified: yes`.
+7. Rerun with `--yes --json`. It must verify the promoted repository and
+   report `already-current`; it must not move the promoted refs.
+8. Start only the already-tested v19 application. Verify a bounded read, one
+   application write, its Receipt, restart behavior, and the next backup.
+9. Keep the recovery refs until those checks and the application's retention
+   policy have been independently reviewed. Do not run Git garbage collection
+   as part of the cutover.
+
 ### What the command does
 
-The source repository is read-only until the final ref transaction:
+Discovery, preflight, inventory, scratch translation, and scratch verification
+do not change the source graph. After that proof, the source object database
+receives verified objects under temporary private import refs.
+**Authoritative WARP refs remain unchanged until the final compare-and-swap
+transaction.**
 
 ```mermaid
 flowchart LR
@@ -54,6 +103,7 @@ flowchart LR
   scratch["Scratch repository<br/>translated objects"]
   verify["Scratch verification<br/>reopen + append + read"]
   compare["Recheck source heads"]
+  import["Private import refs<br/>verified objects"]
   promote["Atomic ref transaction"]
   recovery["Recovery refs<br/>old objects retained"]
 
@@ -61,7 +111,8 @@ flowchart LR
   inventory --> scratch
   scratch --> verify
   verify --> compare
-  compare -->|all OIDs unchanged| promote
+  compare -->|all OIDs unchanged| import
+  import --> promote
   compare -->|any OID changed| abort["Abort without cutover"]
   promote --> source
   promote --> recovery
@@ -80,14 +131,22 @@ immutable:
    repository.
 5. It proves that the scratch graph can reopen, accept a disposable append,
    return a bounded public reading, and produce a valid receipt.
-6. It fetches the verified scratch objects into private import refs in the
-   source repository.
-7. One `git update-ref --stdin` transaction compares every original ref with
+6. It re-inventories the source refs and aborts if anything changed during the
+   scratch proof.
+7. It fetches verified scratch objects under temporary
+   `refs/warp-migration-import/v18-to-v19/` refs in the source repository.
+8. One `git update-ref --stdin` transaction compares every original ref with
    its inventoried OID, archives the original refs, and promotes the verified
    refs. If any expected OID moved, the transaction fails as a unit.
-8. It verifies the promoted graph. If that proof fails, another guarded ref
-   transaction restores the original authoritative refs while retaining
-   recovery refs for diagnosis.
+9. It deletes the temporary private import refs. Imported objects may remain
+   physically present, but no import ref remains part of the repository's
+   public or recovery topology.
+10. It verifies the promoted graph. If that proof fails, another guarded ref
+    transaction restores the original authoritative refs while retaining
+    recovery refs for diagnosis.
+
+After finalization, the temporary private import refs are deleted whether the
+promotion succeeds or fails.
 
 Current v18 audit, intent, strand, overlay, braid, and trust publication refs
 are carried through unchanged and included in the compare-and-swap inventory.
@@ -430,18 +489,16 @@ try {
   await lane.write(
     users.intents.registerUser({
       subject: 'user:alice',
-    }),
+    })
   );
   await lane.write(
     users.intents.assignRole({
       subject: 'user:alice',
       role: 'admin',
-    }),
+    })
   );
 
-  const observation = lane.observe(
-    users.observers.roleOf({ subject: 'user:alice' }),
-  );
+  const observation = lane.observe(users.observers.roleOf({ subject: 'user:alice' }));
 
   console.log((await observation.one()).value);
   console.log((await observation.receipt).status);
@@ -526,9 +583,7 @@ remain outside this four-way causal union.
 Before:
 
 ```typescript
-const result = await timeline.read(
-  reading.property({ subject: 'user:alice', key: 'role' })
-);
+const result = await timeline.read(reading.property({ subject: 'user:alice', key: 'role' }));
 
 console.log(result.value);
 console.log(result.receipt);
@@ -537,9 +592,7 @@ console.log(result.receipt);
 After:
 
 ```typescript
-const observation = events.observe(
-  users.observers.roleOf({ subject: 'user:alice' })
-);
+const observation = events.observe(users.observers.roleOf({ subject: 'user:alice' }));
 
 for await (const reading of observation) {
   console.log(reading.value);
@@ -594,7 +647,7 @@ derived | plural | conflict | obstruction
 Settlement is a later cross-lane operation. It is not another spelling of
 admission and it does not automatically linearize lawful plurality.
 
-The final v19 settlement contract is:
+The implemented v19 settlement contract is:
 
 ```typescript
 const preview = await runtime.previewSettlement({
@@ -610,13 +663,14 @@ The preview is non-authoritative. Its immutable plan is bound to exact source
 and target frontiers, proposal, law, and policy. `settle()` revalidates those
 bindings and must obstruct or reclassify a stale plan.
 
-This settlement surface is still open implementation work. Do not ship code
-that calls it until the corresponding v19 source and conformance evidence has
-landed.
+`Runtime.previewSettlement()` and `Runtime.settle()` are implemented, exported,
+type-checked public surfaces. Preview does not mutate the destination. Settle
+accepts only the immutable plan issued by preview, revalidates its bound basis,
+and returns a settlement Receipt.
 
 ## Expert Subpaths
 
-The intended v19 expert surfaces are:
+The shipped v19 expert surfaces are:
 
 ```text
 @git-stunts/git-warp/advanced
@@ -636,23 +690,23 @@ explicit `/testing` harness.
 
 ## Symbol Map
 
-| Before                         | v19 replacement                         |
-| ------------------------------ | --------------------------------------- |
-| `openWarp(options)`            | `Runtime.open({ at, writer })`          |
-| `warp.timeline(name)`          | `runtime.lane(name)`                    |
-| `timeline.write(intent.*)`     | `lane.write(generated.intents.*)`       |
-| `timeline.read(reading.*)`     | `lane.observe(generated.observers.*)`   |
-| `ReadingResult.value`          | streamed `Reading.value`                |
-| `ReadingResult.receipt`        | `await Observation.receipt`             |
-| `timeline.draft(name)`         | `runtime.fork(lane, { name })`          |
-| `timeline.previewJoin(draft)`  | `runtime.previewSettlement(...)`        |
-| `timeline.join(draft)`         | `runtime.settle(preview.plan)`           |
-| `GitStorage.open({ cwd })`     | internal to `Runtime.open({ at })`       |
-| `storage.close()`              | `runtime.close()`                        |
-| `accepted` write status        | `derived` or `plural` admission          |
-| `conflicted` write status      | `conflict` admission with witness        |
-| `obstructed`/`rejected` write  | `obstruction` admission with reason      |
-| root graph/query builders      | generated SDK or `/charts` observer      |
+| Before                        | v19 replacement                       |
+| ----------------------------- | ------------------------------------- |
+| `openWarp(options)`           | `Runtime.open({ at, writer })`        |
+| `warp.timeline(name)`         | `runtime.lane(name)`                  |
+| `timeline.write(intent.*)`    | `lane.write(generated.intents.*)`     |
+| `timeline.read(reading.*)`    | `lane.observe(generated.observers.*)` |
+| `ReadingResult.value`         | streamed `Reading.value`              |
+| `ReadingResult.receipt`       | `await Observation.receipt`           |
+| `timeline.draft(name)`        | `runtime.fork(lane, { name })`        |
+| `timeline.previewJoin(draft)` | `runtime.previewSettlement(...)`      |
+| `timeline.join(draft)`        | `runtime.settle(preview.plan)`        |
+| `GitStorage.open({ cwd })`    | internal to `Runtime.open({ at })`    |
+| `storage.close()`             | `runtime.close()`                     |
+| `accepted` write status       | `derived` or `plural` admission       |
+| `conflicted` write status     | `conflict` admission with witness     |
+| `obstructed`/`rejected` write | `obstruction` admission with reason   |
+| root graph/query builders     | generated SDK or `/charts` observer   |
 
 ## Upgrade Sequence
 
@@ -663,7 +717,8 @@ explicit `/testing` harness.
 5. Replace eager `read()` calls with streaming `observe()` consumption.
 6. Move receipt handling from each Reading to the Observation terminal path.
 7. Match all four admission variants exhaustively.
-8. Keep existing cross-lane join code isolated until settlement plans land.
+8. Replace cross-lane join code with `Runtime.previewSettlement()` followed by
+   `Runtime.settle(preview.plan)`.
 9. Replace graph-shaped reads with bounded `/charts` observers.
 10. Verify that no import from the removed `/storage` subpath remains.
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -14,6 +14,47 @@ git warp doctor --repo ./team-repo --lane users
 Doctor reports structural, audit, hook, and retained-materialization findings.
 It does not mutate authoritative history or silently repair git-cas.
 
+## Migrate retained v18 state
+
+Use only the v19.0.1 migrator on an authoritative repository. The v19.0.0
+migrator is unsafe for retained v18 state.
+
+Prepare and test the v19 application without opening the authoritative
+repository. During the maintenance window, stop every writer and make an
+independent mirror backup:
+
+```bash
+REPOSITORY=/path/to/repository
+BACKUP=/path/to/git-warp-backup.git
+
+git clone --mirror --no-hardlinks "$REPOSITORY" "$BACKUP"
+git -C "$BACKUP" fsck --full
+```
+
+Run the migration without `--dry-run`; the framed application discovers graph
+names, reports source and scratch capacity, and asks for confirmation:
+
+```bash
+GRAPH_NAME=your-graph-name
+
+npm exec --package=@git-stunts/git-warp@19.0.1 -- \
+  git-warp-v18-to-v19 \
+  --repo "$REPOSITORY" \
+  --graph "$GRAPH_NAME"
+```
+
+After a successful cutover, rerun with `--yes --json`. The idempotent
+verification must report `already-current`. Then start the already-tested v19
+application and verify a bounded read, one write, its Receipt, restart
+behavior, and the next backup.
+
+Keep the recovery refs reported by the command until those checks and a
+separate retention decision are complete. Do not move writer refs backward or
+run garbage collection as part of the migration window. The
+[complete migration guide](../migrations/v19/README.md) explains the Git object
+rewrite, capacity formula, compare-and-swap promotion, automatic rollback, and
+recovery topology.
+
 ## Prepare a bounded basis
 
 When an Observation reports that no bounded basis is available:

--- a/docs/topics/README.md
+++ b/docs/topics/README.md
@@ -5,11 +5,13 @@ specific task.
 
 ## Current release
 
-`v19.0.0` ships the Runtime, Lane, Intent, Observer, Observation, Reading, and
-Receipt application vocabulary, bounded retained reads, and the one-shot
-v18-to-v19 substrate migration. Operator workflows live outside the topic
-shelf in [Operations](../operations/). The full breaking-change, migration,
-and performance narrative lives in the root [CHANGELOG](../../CHANGELOG.md).
+`v19.0.1` is the current release. It ships the Runtime, Lane, Intent, Observer,
+Observation, Reading, and Receipt application vocabulary, bounded retained
+reads, and the safe one-shot v18-to-v19 substrate migration. Do not use the
+v19.0.0 migrator on an authoritative repository. Operator workflows live
+outside the topic shelf in [Operations](../operations/). The full
+breaking-change, migration, and performance narrative lives in the root
+[CHANGELOG](../../CHANGELOG.md).
 
 ## Start here
 

--- a/docs/topics/api/README.md
+++ b/docs/topics/api/README.md
@@ -1,13 +1,12 @@
 # v19 Public Vocabulary Checkpoint
 
-> **Status:** Implemented checkpoint for `v19.0.0`.
+> **Status:** Current in `v19.0.1`; introduced in `v19.0.0`.
 >
 > This document is the normative product vocabulary and public-surface design.
 > The Runtime, Lane, Intent, Observer, streaming Observation, Reading, Receipt,
 > settlement, charts, generated SDK, CLI, and MCP surfaces are implemented.
 > One generated contract drives their public vocabulary and all twelve
-> acceptance gates execute in CI. The release witness remains the final
-> publication evidence.
+> acceptance gates execute in CI and release preflight.
 
 The product doctrine is:
 
@@ -34,12 +33,12 @@ An Observation emits Readings and leaves a Receipt.
 
 The four observation nouns are not aliases:
 
-| Noun | Responsibility |
-| --- | --- |
-| `Observer` | Reusable immutable executable observation plan |
+| Noun          | Responsibility                                               |
+| ------------- | ------------------------------------------------------------ |
+| `Observer`    | Reusable immutable executable observation plan               |
 | `Observation` | One resource-bounded execution of an Observer against a Lane |
-| `Reading` | One bounded semantic result emitted by an Observation |
-| `Receipt` | Durable terminal record of an operation |
+| `Reading`     | One bounded semantic result emitted by an Observation        |
+| `Receipt`     | Durable terminal record of an operation                      |
 
 The canonical sentence is:
 
@@ -638,15 +637,15 @@ actually need graph-shaped correlation and coordination.
 
 ## Supported Package Surfaces
 
-The intended package families are:
+The shipped package families are:
 
-| Surface | Role |
-| --- | --- |
-| root | `Runtime` plus type-only core contracts |
-| `/charts` | Derived graph-shaped Observers and Readings |
-| `/diagnostics` | `doctor`, repair planning, audit, and Receipt inspection |
-| `/advanced` | Formal reads and generic constructors for generated SDK infrastructure |
-| `/testing` | Explicit fake ports, fixtures, and Runtime harnesses |
+| Surface        | Role                                                                   |
+| -------------- | ---------------------------------------------------------------------- |
+| root           | `Runtime` plus type-only core contracts                                |
+| `/charts`      | Derived graph-shaped Observers and Readings                            |
+| `/diagnostics` | `doctor`, repair planning, audit, and Receipt inspection               |
+| `/advanced`    | Formal reads and generic constructors for generated SDK infrastructure |
+| `/testing`     | Explicit fake ports, fixtures, and Runtime harnesses                   |
 
 `/advanced` is not a holding area for everything removed from root. Legacy
 graph-first APIs are removed rather than hidden under a new public contract.
@@ -699,7 +698,7 @@ renaming transport batches as pages.
 ## MCP Grammar
 
 MCP exposes the same model through tools and resources rather than inventing a
-second ontology. The target capability families are:
+second ontology. The shipped capability families are:
 
 ```text
 warp_lane_describe
@@ -767,19 +766,19 @@ formal explanations.
 
 The superseded pre-checkpoint v19 facade has these dispositions:
 
-| Transitional v19 symbol | Canonical disposition |
-| --- | --- |
-| `openWarp()` | `Runtime.open()` |
-| `Warp` | `Runtime` |
-| `Timeline` | `Lane` |
-| `DraftTimeline` | `Lane` with `kind: 'strand'` |
-| `timeline.read(reading)` | `lane.observe(observer)` |
-| root `reading` builders | Wesley-generated `*.observers` or `/charts` |
-| root `intent` builders | Wesley-generated `*.intents` |
-| `previewJoin()` | `Runtime.previewSettlement()` |
-| `join()` | `Runtime.settle(plan)` |
-| `/storage` constructors | internal Runtime composition; testing injection under `/testing` |
-| graph package proposals | `/charts` |
+| Transitional v19 symbol  | Canonical disposition                                            |
+| ------------------------ | ---------------------------------------------------------------- |
+| `openWarp()`             | `Runtime.open()`                                                 |
+| `Warp`                   | `Runtime`                                                        |
+| `Timeline`               | `Lane`                                                           |
+| `DraftTimeline`          | `Lane` with `kind: 'strand'`                                     |
+| `timeline.read(reading)` | `lane.observe(observer)`                                         |
+| root `reading` builders  | Wesley-generated `*.observers` or `/charts`                      |
+| root `intent` builders   | Wesley-generated `*.intents`                                     |
+| `previewJoin()`          | `Runtime.previewSettlement()`                                    |
+| `join()`                 | `Runtime.settle(plan)`                                           |
+| `/storage` constructors  | internal Runtime composition; testing injection under `/testing` |
+| graph package proposals  | `/charts`                                                        |
 
 The v18 graph-first API remains removed. This checkpoint does not revive
 `browser`, `legacy`, `openWarpGraph`, `WarpApp`, `WarpCore`, patch builders, or
@@ -807,5 +806,5 @@ following:
     and substrate exceptions.
 
 The executable mapping for these gates lives in
-`scripts/RunV19AcceptanceGates.ts`; CI and the release witness must run the
-mapping without omissions before v19 publication.
+`scripts/RunV19AcceptanceGates.ts`; CI and release preflight run the mapping
+without omissions.

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/git-warp",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "imports": {
     "roaring": "npm:roaring@^2.7.0"
   },
@@ -20,6 +20,7 @@
       "testing.ts",
       "src/**/*.ts",
       "src/**/*.d.ts",
+      "docs/**/*.md",
       "README.md",
       "CHANGELOG.md",
       "LICENSE",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@git-stunts/git-warp",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@git-stunts/git-warp",
-      "version": "19.0.0",
+      "version": "19.0.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -8005,7 +8005,7 @@
     },
     "packages/warp-adapters": {
       "name": "@git-stunts/warp-adapters",
-      "version": "19.0.0",
+      "version": "19.0.1",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -8013,7 +8013,7 @@
     },
     "packages/warp-kernel": {
       "name": "@git-stunts/warp-kernel",
-      "version": "19.0.0",
+      "version": "19.0.1",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
@@ -8021,7 +8021,7 @@
     },
     "packages/warp-orset": {
       "name": "@git-stunts/warp-orset",
-      "version": "19.0.0",
+      "version": "19.0.1",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/git-warp",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "description": "Git-native causal history runtime for intent writes, timeline reads, and receipts.",
   "type": "module",
   "license": "Apache-2.0",
@@ -54,6 +54,7 @@
   "files": [
     "dist",
     "bin/git-warp",
+    "docs",
     "README.md",
     "CHANGELOG.md",
     "LICENSE",

--- a/packages/warp-adapters/package.json
+++ b/packages/warp-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/warp-adapters",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "description": "Infrastructure adapters: Git/CAS, crypto, and HTTP for git-warp.",
   "private": true,
   "type": "module",

--- a/packages/warp-kernel/package.json
+++ b/packages/warp-kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/warp-kernel",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "description": "Domain engine: services, WarpState, and controllers for git-warp.",
   "private": true,
   "type": "module",

--- a/packages/warp-orset/package.json
+++ b/packages/warp-orset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@git-stunts/warp-orset",
-  "version": "19.0.0",
+  "version": "19.0.1",
   "description": "ORSet engine: trie, cursor, cache, and session primitives for git-warp.",
   "private": true,
   "type": "module",

--- a/test/unit/scripts/release-artifact-command.test.ts
+++ b/test/unit/scripts/release-artifact-command.test.ts
@@ -140,6 +140,11 @@ describe('release artifact command evidence', () => {
     expect(entries.has('bin/git-warp')).toBe(true);
     expect(entries.has('dist/bin/warp-graph.js')).toBe(false);
     expect(entries.has('README.md')).toBe(true);
+    expect(entries.has('docs/migrations/v19/README.md')).toBe(true);
+    expect(entries.has('docs/operations/README.md')).toBe(true);
+    expect(entries.has('docs/topics/README.md')).toBe(true);
+    expect(entries.has('docs/topics/api/README.md')).toBe(true);
+    expect(entries.has('docs/topics/getting-started.md')).toBe(true);
     expect(entries.has('CHANGELOG.md')).toBe(true);
     expect(entries.has('LICENSE')).toBe(true);
     expect(entries.has('docs/GUIDE.md')).toBe(false);

--- a/test/unit/scripts/v19-migration-guidance.test.ts
+++ b/test/unit/scripts/v19-migration-guidance.test.ts
@@ -4,8 +4,12 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+const API_GUIDE = readFileSync(join(ROOT, 'docs/topics/api/README.md'), 'utf8');
+const ARCHITECTURE = readFileSync(join(ROOT, 'ARCHITECTURE.md'), 'utf8');
 const MIGRATION_GUIDE = readFileSync(join(ROOT, 'docs/migrations/v19/README.md'), 'utf8');
+const OPERATIONS_GUIDE = readFileSync(join(ROOT, 'docs/operations/README.md'), 'utf8');
 const ROOT_README = readFileSync(join(ROOT, 'README.md'), 'utf8');
+const TOPICS_INDEX = readFileSync(join(ROOT, 'docs/topics/README.md'), 'utf8');
 
 function generatedSdkSection(): string {
   const start = MIGRATION_GUIDE.indexOf('## Generated Domain SDKs');
@@ -16,6 +20,13 @@ function generatedSdkSection(): string {
 }
 
 describe('v19 migration guidance', () => {
+  it('keeps every public release signpost on v19.0.1', () => {
+    expect(ROOT_README).toContain('`v19.0.1` is the current release');
+    expect(ARCHITECTURE).toContain('`v19.0.1` is the current release');
+    expect(TOPICS_INDEX).toContain('`v19.0.1` is the current release');
+    expect(API_GUIDE).toContain('Current in `v19.0.1`');
+  });
+
   it('keeps the root README on the safe one-pass v19.0.1 migration', () => {
     expect(ROOT_README).toContain('@git-stunts/git-warp@19.0.1');
     expect(ROOT_README).toContain('--repo /path/to/repository');
@@ -31,6 +42,32 @@ describe('v19 migration guidance', () => {
     expect(ROOT_README).toContain('one pass');
   });
 
+  it('states the Git mutation boundary and executable recovery posture precisely', () => {
+    expect(MIGRATION_GUIDE).toContain('git clone --mirror --no-hardlinks');
+    expect(MIGRATION_GUIDE).toContain('Authoritative WARP refs remain unchanged');
+    expect(MIGRATION_GUIDE).toContain('refs/warp-migration-import/v18-to-v19/');
+    expect(MIGRATION_GUIDE).toContain('private import refs are deleted');
+    expect(MIGRATION_GUIDE).not.toContain(
+      'The source repository is read-only until the final ref transaction'
+    );
+  });
+
+  it('gives operators one complete maintenance-window checklist', () => {
+    expect(OPERATIONS_GUIDE).toContain('## Migrate retained v18 state');
+    expect(OPERATIONS_GUIDE).toContain('@git-stunts/git-warp@19.0.1');
+    expect(OPERATIONS_GUIDE).toContain('git clone --mirror --no-hardlinks');
+    expect(OPERATIONS_GUIDE).toContain('already-current');
+    expect(OPERATIONS_GUIDE).toContain('Keep the recovery refs');
+  });
+
+  it('does not describe implemented settlement as future work', () => {
+    expect(MIGRATION_GUIDE).toContain('`Runtime.previewSettlement()`');
+    expect(MIGRATION_GUIDE).toContain('`Runtime.settle()`');
+    expect(MIGRATION_GUIDE).not.toContain(
+      'This settlement surface is still open implementation work'
+    );
+  });
+
   it('gives an adopter a complete generated-user workflow', () => {
     const section = generatedSdkSection();
 
@@ -39,13 +76,13 @@ describe('v19 migration guidance', () => {
     expect(section).toContain('Node.js 22.18 or newer');
     expect(section).toContain('cargo install wesley-cli --version 0.3.0-alpha.1 --locked');
     expect(section).toContain(
-      '"generate:users:wesley": "wesley emit typescript --schema src/warp/users.graphql --out src/generated/users.wesley.generated.ts"',
+      '"generate:users:wesley": "wesley emit typescript --schema src/warp/users.graphql --out src/generated/users.wesley.generated.ts"'
     );
     expect(section).toContain(
-      '"generate:users:sdk": "node scripts/RenderUsersSdk.ts --out src/generated/users.generated.ts"',
+      '"generate:users:sdk": "node scripts/RenderUsersSdk.ts --out src/generated/users.generated.ts"'
     );
     expect(section).toContain(
-      '"check:users": "npm run generate:users && git diff --exit-code -- src/generated"',
+      '"check:users": "npm run generate:users && git diff --exit-code -- src/generated"'
     );
     expect(section).toContain('users.graphql');
     expect(section).toContain('users.wesley.generated.ts');


### PR DESCRIPTION
Tracks #831.

Publishes the corrected one-pass v18-to-v19 migrator with complete public runbooks, synchronized v19.0.1 metadata, and packaged documentation.

Validation: `npm run release:prep`.