### PR TITLE
Run artifact uploads on Node 24

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Retain raw samples and environment evidence
         if: ${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: v19-performance-${{ github.sha }}
           path: performance-results

--- a/test/unit/scripts/performance-workflow.test.ts
+++ b/test/unit/scripts/performance-workflow.test.ts
@@ -60,7 +60,7 @@ describe('v19 performance workflow', () => {
     expect(workflow).toContain('if [[ -f performance-results/summary.md ]]');
     expect(workflow).toContain('cat performance-results/summary.md >> "$GITHUB_STEP_SUMMARY"');
     expect(workflow).toContain(
-      'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02',
+      'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
     );
     expect(workflow).toContain('name: v19-performance-${{ github.sha }}');
     expect(workflow).toContain('retention-days: 90');


### PR DESCRIPTION
## Summary

- pin `actions/upload-artifact` to the immutable commit for official release `v7.0.1`, which declares a Node 24 runtime
- update the Performance workflow's exact-pin regression contract
- preserve artifact naming, source path, missing-file behavior, archive behavior, and 90-day retention

## Issue

Closes #845

## Test plan

- focused Performance workflow tests: 5 passed
- stable unit suite: 7,265 passed; 2 skipped
- `actionlint .github/workflows/performance.yml`
- `npm run lint`
- `npm run typecheck`
- anti-sludge, Semgrep, type-policy, quarantine-graduation, and commit/push hooks

## ADR checks

- [x] This PR does **not** implement ADR 2 without satisfying ADR 3
- [x] This PR does not touch persisted op formats
- [x] This PR does not touch wire compatibility
- [x] This PR does not touch schema constants
