### PR TITLE
Stream exact-tree path scans with bounded memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   later safe branch tip cannot conceal an earlier leaking blob or commit.
   A dedicated required CI lane independently inspects the exact commit tree
   before merge. Contributor doctrine also forbids publishing machine-local paths
-  in generated evidence, issues, pull requests, comments, or reviews.
+  in generated evidence, issues, pull requests, comments, or reviews. Exact-tree
+  blob inspection now consumes `git cat-file --batch` through a bounded read
+  window instead of materializing the aggregate response, while retaining
+  cross-window token detection and fail-closed protocol validation.
 - Node and edge content attachment share one staging helper, so the asset
   storage precondition is stated once instead of duplicated per target shape.
 - Effect id validation and derivation moved to `PatchBuilderValidation`.

--- a/scripts/GitBatchBlobStreamScanner.ts
+++ b/scripts/GitBatchBlobStreamScanner.ts
@@ -1,14 +1,159 @@
 import { GitBatchReadWindow } from './GitBatchReadWindow.ts';
 import { MachineLocalPathPolicy } from './MachineLocalPathPolicy.ts';
 
-export class GitBatchBlobStreamScanner {
-  constructor(
-    _source: AsyncIterable<Uint8Array>,
-    _policy: MachineLocalPathPolicy,
-    _readWindow: GitBatchReadWindow
-  ) {}
+const BATCH_BLOB_HEADER_PATTERN = /^([0-9a-f]{40}(?:[0-9a-f]{24})?) blob ([0-9]+)$/u;
+const MAX_BATCH_HEADER_BYTES = 128;
 
-  findLeakingBlobIds(_expectedObjectIds: readonly string[]): Promise<Set<string>> {
-    return Promise.reject(new Error('Git batch blob stream scanner is not implemented'));
+export class GitBatchBlobStreamScanner {
+  readonly #iterator: AsyncIterator<Uint8Array>;
+  readonly #policy: MachineLocalPathPolicy;
+  readonly #readWindow: GitBatchReadWindow;
+  readonly #chunks: Buffer[] = [];
+  #bufferedBytes = 0;
+  #ended = false;
+
+  constructor(
+    source: AsyncIterable<Uint8Array>,
+    policy: MachineLocalPathPolicy,
+    readWindow: GitBatchReadWindow
+  ) {
+    this.#iterator = source[Symbol.asyncIterator]();
+    this.#policy = policy;
+    this.#readWindow = readWindow;
+  }
+
+  async findLeakingBlobIds(expectedObjectIds: readonly string[]): Promise<Set<string>> {
+    const offenders = new Set<string>();
+    for (const expectedObjectId of expectedObjectIds) {
+      const header = await this.#readLine();
+      const size = this.#parseBlobSize(header, expectedObjectId);
+      if (await this.#scanBlob(size)) {
+        offenders.add(expectedObjectId);
+      }
+      const delimiter = await this.#readBytes(1, 'Git returned a truncated batch blob');
+      if (delimiter[0] !== 0x0a) {
+        throw new Error('Git returned a malformed batch blob delimiter');
+      }
+    }
+    await this.#assertEnd();
+    return offenders;
+  }
+
+  #parseBlobSize(header: string, expectedObjectId: string): number {
+    const match = header.match(BATCH_BLOB_HEADER_PATTERN);
+    const actualObjectId = match?.[1];
+    const sizeText = match?.[2];
+    const size = Number(sizeText);
+    if (
+      actualObjectId !== expectedObjectId ||
+      sizeText === undefined ||
+      !Number.isSafeInteger(size) ||
+      size < 0
+    ) {
+      throw new Error('Git returned a malformed batch blob header');
+    }
+    return size;
+  }
+
+  async #scanBlob(size: number): Promise<boolean> {
+    const scanner = this.#policy.createStreamScanner();
+    let remaining = size;
+    while (remaining > 0) {
+      const readSize = Math.min(remaining, this.#readWindow.bytes);
+      scanner.write(await this.#readBytes(readSize, 'Git returned a truncated batch blob'));
+      remaining -= readSize;
+    }
+    return scanner.finish();
+  }
+
+  async #readLine(): Promise<string> {
+    while (true) {
+      const newline = this.#newlineOffset();
+      if (newline >= 0) {
+        if (newline > MAX_BATCH_HEADER_BYTES) {
+          throw new Error('Git returned a malformed batch blob header');
+        }
+        const line = this.#consume(newline);
+        this.#consume(1);
+        return line.toString('utf8');
+      }
+      if (this.#bufferedBytes > MAX_BATCH_HEADER_BYTES) {
+        throw new Error('Git returned a malformed batch blob header');
+      }
+      await this.#readMore('Git returned a truncated batch header');
+    }
+  }
+
+  async #readBytes(size: number, truncatedMessage: string): Promise<Buffer> {
+    while (this.#bufferedBytes < size) {
+      await this.#readMore(truncatedMessage);
+    }
+    return this.#consume(size);
+  }
+
+  async #readMore(truncatedMessage: string): Promise<void> {
+    const next = await this.#iterator.next();
+    if (next.done === true) {
+      this.#ended = true;
+      throw new Error(truncatedMessage);
+    }
+    const chunk = Buffer.from(next.value);
+    if (chunk.length > 0) {
+      this.#chunks.push(chunk);
+      this.#bufferedBytes += chunk.length;
+    }
+  }
+
+  #consume(size: number): Buffer {
+    const output = Buffer.allocUnsafe(size);
+    let copied = 0;
+    while (copied < size) {
+      copied += this.#copyNextChunk(output, copied, size - copied);
+    }
+    return output;
+  }
+
+  #copyNextChunk(output: Buffer, offset: number, remaining: number): number {
+    const chunk = this.#chunks[0];
+    // #840: #readBytes proves this invariant; retain a fail-closed corruption panic.
+    /* v8 ignore next 3 */
+    if (chunk === undefined) {
+      throw new Error('Git batch stream buffer accounting failed');
+    }
+    const length = Math.min(chunk.length, remaining);
+    chunk.copy(output, offset, 0, length);
+    this.#bufferedBytes -= length;
+    if (length === chunk.length) {
+      this.#chunks.shift();
+    } else {
+      this.#chunks[0] = chunk.subarray(length);
+    }
+    return length;
+  }
+
+  #newlineOffset(): number {
+    let offset = 0;
+    for (const chunk of this.#chunks) {
+      const index = chunk.indexOf(0x0a);
+      if (index >= 0) {
+        return offset + index;
+      }
+      offset += chunk.length;
+    }
+    return -1;
+  }
+
+  async #assertEnd(): Promise<void> {
+    if (this.#bufferedBytes > 0) {
+      throw new Error('Git returned trailing batch blob data');
+    }
+    while (!this.#ended) {
+      const next = await this.#iterator.next();
+      if (next.done === true) {
+        this.#ended = true;
+      } else if (next.value.length > 0) {
+        throw new Error('Git returned trailing batch blob data');
+      }
+    }
   }
 }

--- a/scripts/GitBatchBlobStreamScanner.ts
+++ b/scripts/GitBatchBlobStreamScanner.ts
@@ -1,0 +1,14 @@
+import { GitBatchReadWindow } from './GitBatchReadWindow.ts';
+import { MachineLocalPathPolicy } from './MachineLocalPathPolicy.ts';
+
+export class GitBatchBlobStreamScanner {
+  constructor(
+    _source: AsyncIterable<Uint8Array>,
+    _policy: MachineLocalPathPolicy,
+    _readWindow: GitBatchReadWindow
+  ) {}
+
+  findLeakingBlobIds(_expectedObjectIds: readonly string[]): Promise<Set<string>> {
+    return Promise.reject(new Error('Git batch blob stream scanner is not implemented'));
+  }
+}

--- a/scripts/GitBatchReadWindow.ts
+++ b/scripts/GitBatchReadWindow.ts
@@ -1,0 +1,17 @@
+const DEFAULT_GIT_BATCH_READ_WINDOW_BYTES = 64 * 1024;
+
+export class GitBatchReadWindow {
+  readonly bytes: number;
+
+  constructor(bytes: number) {
+    if (!Number.isSafeInteger(bytes) || bytes < 1) {
+      throw new RangeError('Git batch read window must be a positive safe integer');
+    }
+    this.bytes = bytes;
+    Object.freeze(this);
+  }
+
+  static standard(): GitBatchReadWindow {
+    return new GitBatchReadWindow(DEFAULT_GIT_BATCH_READ_WINDOW_BYTES);
+  }
+}

--- a/scripts/GitBatchScanDeadline.ts
+++ b/scripts/GitBatchScanDeadline.ts
@@ -1,0 +1,17 @@
+const DEFAULT_GIT_BATCH_SCAN_DEADLINE_MILLISECONDS = 120_000;
+
+export class GitBatchScanDeadline {
+  readonly milliseconds: number;
+
+  constructor(milliseconds: number) {
+    if (!Number.isSafeInteger(milliseconds) || milliseconds < 1) {
+      throw new RangeError('Git batch scan deadline must be a positive safe integer');
+    }
+    this.milliseconds = milliseconds;
+    Object.freeze(this);
+  }
+
+  static standard(): GitBatchScanDeadline {
+    return new GitBatchScanDeadline(DEFAULT_GIT_BATCH_SCAN_DEADLINE_MILLISECONDS);
+  }
+}

--- a/scripts/GitMachineLocalPathGuard.ts
+++ b/scripts/GitMachineLocalPathGuard.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import { GitBatchBlobStreamScanner } from './GitBatchBlobStreamScanner.ts';
 import { GitBatchReadWindow } from './GitBatchReadWindow.ts';
+import { GitBatchScanDeadline } from './GitBatchScanDeadline.ts';
 import { MachineLocalPathPolicy } from './MachineLocalPathPolicy.ts';
 
 const MAX_INSPECTED_BLOB_BYTES = 512 * 1024 * 1024;
@@ -14,15 +15,18 @@ export class GitMachineLocalPathGuard {
   readonly #repository: string;
   readonly #policy: MachineLocalPathPolicy;
   readonly #readWindow: GitBatchReadWindow;
+  readonly #scanDeadline: GitBatchScanDeadline;
 
   constructor(
     repository: string,
     policy: MachineLocalPathPolicy,
-    readWindow: GitBatchReadWindow = GitBatchReadWindow.standard()
+    readWindow: GitBatchReadWindow = GitBatchReadWindow.standard(),
+    scanDeadline: GitBatchScanDeadline = GitBatchScanDeadline.standard()
   ) {
     this.#repository = repository;
     this.#policy = policy;
     this.#readWindow = readWindow;
+    this.#scanDeadline = scanDeadline;
   }
 
   findWorkingTreePaths(): string[] {
@@ -179,14 +183,32 @@ export class GitMachineLocalPathGuard {
     });
     child.stdin.end(objectIds.join('\n') + '\n');
     const scanner = new GitBatchBlobStreamScanner(child.stdout, this.#policy, this.#readWindow);
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      deadlineTimer = setTimeout(() => {
+        child.kill();
+        reject(
+          new Error(
+            `git cat-file --batch scan exceeded ${String(this.#scanDeadline.milliseconds)} ms deadline`
+          )
+        );
+      }, this.#scanDeadline.milliseconds);
+      deadlineTimer.unref();
+    });
     try {
-      const offenders = await scanner.findLeakingBlobIds(objectIds);
+      const offenders = await Promise.race([
+        scanner.findLeakingBlobIds(objectIds),
+        deadline,
+      ]);
       const exitCode = await exit;
       if (exitCode !== 0) {
         throw new Error(`git cat-file --batch failed with exit ${String(exitCode)}`);
       }
       return offenders;
     } finally {
+      if (deadlineTimer !== undefined) {
+        clearTimeout(deadlineTimer);
+      }
       if (child.exitCode === null) {
         child.kill();
         await exit;

--- a/scripts/GitMachineLocalPathGuard.ts
+++ b/scripts/GitMachineLocalPathGuard.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, lstatSync, readFileSync, readlinkSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { GitBatchReadWindow } from './GitBatchReadWindow.ts';
 import { MachineLocalPathPolicy } from './MachineLocalPathPolicy.ts';
 
 const MAX_INSPECTED_BLOB_BYTES = 512 * 1024 * 1024;
@@ -12,7 +13,11 @@ export class GitMachineLocalPathGuard {
   readonly #repository: string;
   readonly #policy: MachineLocalPathPolicy;
 
-  constructor(repository: string, policy: MachineLocalPathPolicy) {
+  constructor(
+    repository: string,
+    policy: MachineLocalPathPolicy,
+    _readWindow: GitBatchReadWindow = GitBatchReadWindow.standard()
+  ) {
     this.#repository = repository;
     this.#policy = policy;
   }
@@ -121,7 +126,7 @@ export class GitMachineLocalPathGuard {
     return offenders.sort();
   }
 
-  findTreePaths(revision: string): string[] {
+  async findTreePaths(revision: string): Promise<string[]> {
     if (!OBJECT_ID_PATTERN.test(revision)) {
       throw new Error('Committed-tree scan requires an exact object id');
     }

--- a/scripts/GitMachineLocalPathGuard.ts
+++ b/scripts/GitMachineLocalPathGuard.ts
@@ -1,7 +1,8 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { existsSync, lstatSync, readFileSync, readlinkSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { GitBatchBlobStreamScanner } from './GitBatchBlobStreamScanner.ts';
 import { GitBatchReadWindow } from './GitBatchReadWindow.ts';
 import { MachineLocalPathPolicy } from './MachineLocalPathPolicy.ts';
 
@@ -12,14 +13,16 @@ const ZERO_OBJECT_PATTERN = /^0+$/u;
 export class GitMachineLocalPathGuard {
   readonly #repository: string;
   readonly #policy: MachineLocalPathPolicy;
+  readonly #readWindow: GitBatchReadWindow;
 
   constructor(
     repository: string,
     policy: MachineLocalPathPolicy,
-    _readWindow: GitBatchReadWindow = GitBatchReadWindow.standard()
+    readWindow: GitBatchReadWindow = GitBatchReadWindow.standard()
   ) {
     this.#repository = repository;
     this.#policy = policy;
+    this.#readWindow = readWindow;
   }
 
   findWorkingTreePaths(): string[] {
@@ -157,58 +160,38 @@ export class GitMachineLocalPathGuard {
       pathsByObjectId.set(objectId, paths);
     }
 
-    const leakingObjectIds = this.#findLeakingBlobIds([...pathsByObjectId.keys()]);
+    const leakingObjectIds = await this.#findLeakingBlobIds([...pathsByObjectId.keys()]);
     return [...leakingObjectIds]
       .flatMap((objectId) => pathsByObjectId.get(objectId) ?? [])
       .sort();
   }
 
-  #findLeakingBlobIds(objectIds: readonly string[]): Set<string> {
+  async #findLeakingBlobIds(objectIds: readonly string[]): Promise<Set<string>> {
     if (objectIds.length === 0) {
       return new Set();
     }
-    const batch = execFileSync('git', ['cat-file', '--batch'], {
-      cwd: this.#repository,
-      input: objectIds.join('\n') + '\n',
-      maxBuffer: MAX_INSPECTED_BLOB_BYTES,
+    const child = spawn('git', ['cat-file', '--batch'], { cwd: this.#repository });
+    child.stderr.resume();
+    child.stdin.on('error', child.kill.bind(child));
+    const exit = new Promise<number | null>((resolve) => {
+      child.once('error', () => resolve(null));
+      child.once('close', resolve);
     });
-    const offenders = new Set<string>();
-    let offset = 0;
-
-    for (const expectedObjectId of objectIds) {
-      const headerEnd = batch.indexOf(10, offset);
-      if (headerEnd < 0) {
-        throw new Error('Git returned a truncated batch header');
+    child.stdin.end(objectIds.join('\n') + '\n');
+    const scanner = new GitBatchBlobStreamScanner(child.stdout, this.#policy, this.#readWindow);
+    try {
+      const offenders = await scanner.findLeakingBlobIds(objectIds);
+      const exitCode = await exit;
+      if (exitCode !== 0) {
+        throw new Error(`git cat-file --batch failed with exit ${String(exitCode)}`);
       }
-      const header = batch.subarray(offset, headerEnd).toString('utf8').split(' ');
-      const actualObjectId = header[0];
-      const objectType = header[1];
-      const sizeText = header[2];
-      const size = Number(sizeText);
-      if (
-        actualObjectId !== expectedObjectId ||
-        objectType !== 'blob' ||
-        sizeText === undefined ||
-        !Number.isSafeInteger(size) ||
-        size < 0
-      ) {
-        throw new Error('Git returned a malformed batch blob header');
+      return offenders;
+    } finally {
+      if (child.exitCode === null) {
+        child.kill();
+        await exit;
       }
-      const contentStart = headerEnd + 1;
-      const contentEnd = contentStart + size;
-      if (contentEnd >= batch.length || batch[contentEnd] !== 10) {
-        throw new Error('Git returned a truncated batch blob');
-      }
-      if (this.#containsMachineLocalPath(batch.subarray(contentStart, contentEnd))) {
-        offenders.add(expectedObjectId);
-      }
-      offset = contentEnd + 1;
     }
-
-    if (offset !== batch.length) {
-      throw new Error('Git returned trailing batch blob data');
-    }
-    return offenders;
   }
 
   #findRemoteTips(remoteName: string): string[] {

--- a/scripts/MachineLocalPathPolicy.ts
+++ b/scripts/MachineLocalPathPolicy.ts
@@ -1,23 +1,13 @@
-const POSIX_HOME_PATTERN = [
-  ['', 'Users', String.raw`[^/\s]+`].join('/') + String.raw`(?:/|$)`,
-  ['', 'home', String.raw`[^/\s]+`].join('/') + String.raw`(?:/|$)`,
-];
-const DARWIN_TEMP_PATTERN = [
-  ['', 'private', 'var', 'folders', String.raw`[^/\s]+`].join('/') + String.raw`(?:/|$)`,
-  ['', 'var', 'folders', String.raw`[^/\s]+`].join('/') + String.raw`(?:/|$)`,
-];
-const WINDOWS_HOME_PATTERN = String.raw`[A-Za-z]:\\` + 'Users' + String.raw`\\[^\\\s]+(?:\\|$)`;
-
-const MACHINE_LOCAL_PATH_PATTERN = new RegExp(
-  [...POSIX_HOME_PATTERN, ...DARWIN_TEMP_PATTERN].join('|'),
-  'u'
-);
-const WINDOWS_MACHINE_LOCAL_PATH_PATTERN = new RegExp(WINDOWS_HOME_PATTERN, 'iu');
+import { MachineLocalPathStreamScanner } from './MachineLocalPathStreamScanner.ts';
 
 export class MachineLocalPathPolicy {
   containsMachineLocalPath(content: string): boolean {
-    return (
-      MACHINE_LOCAL_PATH_PATTERN.test(content) || WINDOWS_MACHINE_LOCAL_PATH_PATTERN.test(content)
-    );
+    const scanner = this.createStreamScanner();
+    scanner.write(new TextEncoder().encode(content));
+    return scanner.finish();
+  }
+
+  createStreamScanner(): MachineLocalPathStreamScanner {
+    return new MachineLocalPathStreamScanner();
   }
 }

--- a/scripts/MachineLocalPathStreamScanner.ts
+++ b/scripts/MachineLocalPathStreamScanner.ts
@@ -1,8 +1,8 @@
 const POSIX_PATH_PREFIXES = Object.freeze([
-  '/Users/',
-  '/home/',
-  '/private/var/folders/',
-  '/var/folders/',
+  ['', 'Users', ''].join('/'),
+  ['', 'home', ''].join('/'),
+  ['', 'private', 'var', 'folders', ''].join('/'),
+  ['', 'var', 'folders', ''].join('/'),
 ]);
 const WINDOWS_PATH_PREFIX_PATTERN = /[a-z]:\\users\\$/iu;
 const WHITESPACE_PATTERN = /\s/u;
@@ -76,6 +76,7 @@ export class MachineLocalPathStreamScanner {
       return null;
     }
     if (WHITESPACE_PATTERN.test(character)) {
+      this.#matched ||= length > 0;
       return null;
     }
     return length + 1;

--- a/scripts/MachineLocalPathStreamScanner.ts
+++ b/scripts/MachineLocalPathStreamScanner.ts
@@ -1,0 +1,87 @@
+const POSIX_PATH_PREFIXES = Object.freeze([
+  '/Users/',
+  '/home/',
+  '/private/var/folders/',
+  '/var/folders/',
+]);
+const WINDOWS_PATH_PREFIX_PATTERN = /[a-z]:\\users\\$/iu;
+const WHITESPACE_PATTERN = /\s/u;
+const MAX_PREFIX_CHARACTERS = Math.max(
+  ...POSIX_PATH_PREFIXES.map((prefix) => prefix.length),
+  'C:\\Users\\'.length
+);
+
+export class MachineLocalPathStreamScanner {
+  readonly #decoder = new TextDecoder();
+  #suffix = '';
+  #posixSegmentLength: number | null = null;
+  #windowsSegmentLength: number | null = null;
+  #matched = false;
+  #finished = false;
+
+  write(bytes: Uint8Array): boolean {
+    if (this.#finished) {
+      throw new Error('Machine-local path stream scanner is already finished');
+    }
+    this.#scan(this.#decoder.decode(bytes, { stream: true }));
+    return this.#matched;
+  }
+
+  finish(): boolean {
+    if (!this.#finished) {
+      this.#scan(this.#decoder.decode());
+      this.#matched ||=
+        this.#hasCompleteSegment(this.#posixSegmentLength) ||
+        this.#hasCompleteSegment(this.#windowsSegmentLength);
+      this.#finished = true;
+    }
+    return this.#matched;
+  }
+
+  #scan(content: string): void {
+    for (const character of content) {
+      this.#advanceCandidates(character);
+      if (this.#matched) {
+        return;
+      }
+      this.#suffix = (this.#suffix + character).slice(-MAX_PREFIX_CHARACTERS);
+      if (POSIX_PATH_PREFIXES.some((prefix) => this.#suffix.endsWith(prefix))) {
+        this.#posixSegmentLength = 0;
+      }
+      if (WINDOWS_PATH_PREFIX_PATTERN.test(this.#suffix)) {
+        this.#windowsSegmentLength = 0;
+      }
+    }
+  }
+
+  #advanceCandidates(character: string): void {
+    this.#posixSegmentLength = this.#advanceCandidate(
+      this.#posixSegmentLength,
+      character,
+      '/'
+    );
+    this.#windowsSegmentLength = this.#advanceCandidate(
+      this.#windowsSegmentLength,
+      character,
+      '\\'
+    );
+  }
+
+  #advanceCandidate(length: number | null, character: string, delimiter: string): number | null {
+    if (length === null) {
+      return null;
+    }
+    if (character === delimiter) {
+      this.#matched ||= length > 0;
+      return null;
+    }
+    if (WHITESPACE_PATTERN.test(character)) {
+      return null;
+    }
+    return length + 1;
+  }
+
+  #hasCompleteSegment(length: number | null): boolean {
+    return length !== null && length > 0;
+  }
+}

--- a/scripts/check-machine-local-paths.ts
+++ b/scripts/check-machine-local-paths.ts
@@ -17,7 +17,7 @@ if (mode === '--working-tree') {
 } else if (mode === '--pre-push') {
   offenders = guard.findOutgoingObjects(readFileSync(0, 'utf8'), process.argv[3] ?? '');
 } else if (mode === '--tree') {
-  offenders = guard.findTreePaths(process.argv[3] ?? '');
+  offenders = await guard.findTreePaths(process.argv[3] ?? '');
 } else {
   process.stderr.write(`Unknown machine-local path scan mode: ${mode}\n`);
   process.exit(2);

--- a/test/unit/scripts/git-batch-blob-stream-scanner.test.ts
+++ b/test/unit/scripts/git-batch-blob-stream-scanner.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { GitBatchBlobStreamScanner }
+  from '../../../scripts/GitBatchBlobStreamScanner.ts';
+import { GitBatchReadWindow } from '../../../scripts/GitBatchReadWindow.ts';
+import { MachineLocalPathPolicy } from '../../../scripts/MachineLocalPathPolicy.ts';
+
+const FIRST_OBJECT_ID = '1'.repeat(40);
+const SECOND_OBJECT_ID = '2'.repeat(40);
+
+function personalHome(...segments: readonly string[]): string {
+  return ['', 'Users', 'example', ...segments].join('/');
+}
+
+function batchRecord(objectId: string, payload: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from(`${objectId} blob ${String(payload.length)}\n`, 'utf8'),
+    payload,
+    Buffer.from('\n', 'utf8'),
+  ]);
+}
+
+async function* bytesSource(bytes: Buffer): AsyncGenerator<Uint8Array> {
+  yield bytes;
+}
+
+function scanner(bytes: Buffer, windowBytes: number): GitBatchBlobStreamScanner {
+  return new GitBatchBlobStreamScanner(
+    bytesSource(bytes),
+    new MachineLocalPathPolicy(),
+    new GitBatchReadWindow(windowBytes)
+  );
+}
+
+describe('Git batch blob stream scanner', () => {
+  it('scans an aggregate larger than its bounded read window', async () => {
+    const batch = Buffer.concat([
+      batchRecord(FIRST_OBJECT_ID, Buffer.from('portable first payload', 'utf8')),
+      batchRecord(SECOND_OBJECT_ID, Buffer.from('portable second payload', 'utf8')),
+    ]);
+
+    await expect(scanner(batch, 5).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+      SECOND_OBJECT_ID,
+    ])).resolves.toEqual(new Set());
+  });
+
+  it('detects a forbidden token split across bounded reads', async () => {
+    const batch = batchRecord(
+      FIRST_OBJECT_ID,
+      Buffer.from(personalHome('build', 'artifact'), 'utf8')
+    );
+
+    await expect(scanner(batch, 3).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).resolves.toEqual(new Set([FIRST_OBJECT_ID]));
+  });
+
+  it('fails closed on a malformed blob header', async () => {
+    const malformed = Buffer.from(`${FIRST_OBJECT_ID} tree 0\n\n`, 'utf8');
+
+    await expect(scanner(malformed, 7).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('malformed batch blob header');
+  });
+
+  it('fails closed on a truncated blob payload', async () => {
+    const truncated = Buffer.from(`${FIRST_OBJECT_ID} blob 5\nabc`, 'utf8');
+
+    await expect(scanner(truncated, 2).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('truncated batch blob');
+  });
+
+  it('fails closed on trailing batch data', async () => {
+    const trailing = Buffer.concat([
+      batchRecord(FIRST_OBJECT_ID, Buffer.from('portable', 'utf8')),
+      Buffer.from('trailing', 'utf8'),
+    ]);
+
+    await expect(scanner(trailing, 4).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('trailing batch blob data');
+  });
+});

--- a/test/unit/scripts/git-batch-blob-stream-scanner.test.ts
+++ b/test/unit/scripts/git-batch-blob-stream-scanner.test.ts
@@ -24,6 +24,12 @@ async function* bytesSource(bytes: Buffer): AsyncGenerator<Uint8Array> {
   yield bytes;
 }
 
+async function* chunkSource(chunks: readonly Buffer[]): AsyncGenerator<Uint8Array> {
+  for (const chunk of chunks) {
+    yield chunk;
+  }
+}
+
 function scanner(bytes: Buffer, windowBytes: number): GitBatchBlobStreamScanner {
   return new GitBatchBlobStreamScanner(
     bytesSource(bytes),
@@ -56,6 +62,19 @@ describe('Git batch blob stream scanner', () => {
     ])).resolves.toEqual(new Set([FIRST_OBJECT_ID]));
   });
 
+  it('ignores empty source chunks without stalling payload consumption', async () => {
+    const record = batchRecord(FIRST_OBJECT_ID, Buffer.from('portable', 'utf8'));
+    const streamScanner = new GitBatchBlobStreamScanner(
+      chunkSource([Buffer.alloc(0), record.subarray(0, 8), Buffer.alloc(0), record.subarray(8)]),
+      new MachineLocalPathPolicy(),
+      new GitBatchReadWindow(3)
+    );
+
+    await expect(streamScanner.findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).resolves.toEqual(new Set());
+  });
+
   it('fails closed on a malformed blob header', async () => {
     const malformed = Buffer.from(`${FIRST_OBJECT_ID} tree 0\n\n`, 'utf8');
 
@@ -64,12 +83,74 @@ describe('Git batch blob stream scanner', () => {
     ])).rejects.toThrow('malformed batch blob header');
   });
 
+  it('fails closed on an oversized blob header before buffering payload bytes', async () => {
+    const oversized = Buffer.from('x'.repeat(129), 'utf8');
+
+    await expect(scanner(oversized, 7).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('malformed batch blob header');
+  });
+
+  it('fails closed when an oversized blob header eventually terminates', async () => {
+    const oversized = Buffer.from(`${'x'.repeat(129)}\n`, 'utf8');
+
+    await expect(scanner(oversized, 7).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('malformed batch blob header');
+  });
+
+  it('fails closed on an unsafe blob size', async () => {
+    const unsafeSize = Buffer.from(
+      `${FIRST_OBJECT_ID} blob ${String(Number.MAX_SAFE_INTEGER + 1)}\n`,
+      'utf8'
+    );
+
+    await expect(scanner(unsafeSize, 7).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('malformed batch blob header');
+  });
+
+  it('fails closed when Git returns a different object identity', async () => {
+    const mismatched = batchRecord(SECOND_OBJECT_ID, Buffer.from('portable', 'utf8'));
+
+    await expect(scanner(mismatched, 7).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('malformed batch blob header');
+  });
+
+  it('fails closed on a truncated blob header', async () => {
+    const truncated = Buffer.from(`${FIRST_OBJECT_ID} blob`, 'utf8');
+
+    await expect(scanner(truncated, 7).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('truncated batch header');
+  });
+
   it('fails closed on a truncated blob payload', async () => {
     const truncated = Buffer.from(`${FIRST_OBJECT_ID} blob 5\nabc`, 'utf8');
 
     await expect(scanner(truncated, 2).findLeakingBlobIds([
       FIRST_OBJECT_ID,
     ])).rejects.toThrow('truncated batch blob');
+  });
+
+  it('fails closed on a malformed blob delimiter', async () => {
+    const malformed = Buffer.concat([
+      Buffer.from(`${FIRST_OBJECT_ID} blob 3\nabc`, 'utf8'),
+      Buffer.from('x', 'utf8'),
+    ]);
+
+    await expect(scanner(malformed, 2).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('malformed batch blob delimiter');
+  });
+
+  it('accepts an empty blob without inventing a match', async () => {
+    const empty = batchRecord(FIRST_OBJECT_ID, Buffer.alloc(0));
+
+    await expect(scanner(empty, 2).findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).resolves.toEqual(new Set());
   });
 
   it('fails closed on trailing batch data', async () => {
@@ -81,5 +162,23 @@ describe('Git batch blob stream scanner', () => {
     await expect(scanner(trailing, 4).findLeakingBlobIds([
       FIRST_OBJECT_ID,
     ])).rejects.toThrow('trailing batch blob data');
+  });
+
+  it('fails closed on trailing data delivered after empty stream chunks', async () => {
+    const record = batchRecord(FIRST_OBJECT_ID, Buffer.from('portable', 'utf8'));
+    const streamScanner = new GitBatchBlobStreamScanner(
+      chunkSource([record, Buffer.alloc(0), Buffer.from('trailing', 'utf8')]),
+      new MachineLocalPathPolicy(),
+      new GitBatchReadWindow(4)
+    );
+
+    await expect(streamScanner.findLeakingBlobIds([
+      FIRST_OBJECT_ID,
+    ])).rejects.toThrow('trailing batch blob data');
+  });
+
+  it('rejects invalid read windows at construction', () => {
+    expect(() => new GitBatchReadWindow(0)).toThrow('positive safe integer');
+    expect(() => new GitBatchReadWindow(Number.NaN)).toThrow('positive safe integer');
   });
 });

--- a/test/unit/scripts/git-machine-local-path-guard-process.test.ts
+++ b/test/unit/scripts/git-machine-local-path-guard-process.test.ts
@@ -26,7 +26,14 @@ vi.mock('node:child_process', async (importOriginal) => {
             '  });',
             '});',
           ].join('\n')
-        : [
+        : spawnBehavior.current === 'silent-hanging'
+          ? [
+              "process.stdin.on('end', () => {",
+              '  setInterval(() => undefined, 1_000);',
+              '});',
+              'process.stdin.resume();',
+            ].join('\n')
+          : [
             "process.stdin.on('end', () => {",
             "  process.stdout.write('malformed\\n');",
             '  setInterval(() => undefined, 1_000);',
@@ -38,6 +45,8 @@ vi.mock('node:child_process', async (importOriginal) => {
   };
 });
 
+import { GitBatchReadWindow } from '../../../scripts/GitBatchReadWindow.ts';
+import { GitBatchScanDeadline } from '../../../scripts/GitBatchScanDeadline.ts';
 import { GitMachineLocalPathGuard } from '../../../scripts/GitMachineLocalPathGuard.ts';
 import { MachineLocalPathPolicy } from '../../../scripts/MachineLocalPathPolicy.ts';
 
@@ -98,5 +107,26 @@ describe('Git machine-local path guard batch process', () => {
     const guard = new GitMachineLocalPathGuard(repository, new MachineLocalPathPolicy());
 
     await expect(guard.findTreePaths(revision)).rejects.toThrow();
+  });
+
+  it('terminates a silent batch producer at the configured deadline', async () => {
+    spawnBehavior.current = 'silent-hanging';
+    const repository = createCommittedRepository();
+    const revision = gitText(repository, 'rev-parse', 'HEAD');
+    const guard = new GitMachineLocalPathGuard(
+      repository,
+      new MachineLocalPathPolicy(),
+      GitBatchReadWindow.standard(),
+      new GitBatchScanDeadline(100)
+    );
+
+    await expect(guard.findTreePaths(revision)).rejects.toThrow(
+      'git cat-file --batch scan exceeded 100 ms deadline'
+    );
+  });
+
+  it('rejects invalid batch scan deadlines', () => {
+    expect(() => new GitBatchScanDeadline(0)).toThrow('positive safe integer');
+    expect(() => new GitBatchScanDeadline(Number.NaN)).toThrow('positive safe integer');
   });
 });

--- a/test/unit/scripts/git-machine-local-path-guard-process.test.ts
+++ b/test/unit/scripts/git-machine-local-path-guard-process.test.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const spawnBehavior = vi.hoisted(() => ({ current: 'nonzero-exit' }));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: () => {
+      if (spawnBehavior.current === 'spawn-error') {
+        return actual.spawn('git-warp-deliberately-missing-executable');
+      }
+      const script = spawnBehavior.current === 'nonzero-exit'
+        ? [
+            "let input = '';",
+            "process.stdin.setEncoding('utf8');",
+            "process.stdin.on('data', (chunk) => { input += chunk; });",
+            "process.stdin.on('end', () => {",
+            "  const objectId = input.trim().split('\\n')[0];",
+            "  process.stdout.write(`${objectId} blob 8\\nportable\\n`, () => {",
+            '    process.exitCode = 7;',
+            '  });',
+            '});',
+          ].join('\n')
+        : [
+            "process.stdin.on('end', () => {",
+            "  process.stdout.write('malformed\\n');",
+            '  setInterval(() => undefined, 1_000);',
+            '});',
+            'process.stdin.resume();',
+          ].join('\n');
+      return actual.spawn(process.execPath, ['-e', script]);
+    },
+  };
+});
+
+import { GitMachineLocalPathGuard } from '../../../scripts/GitMachineLocalPathGuard.ts';
+import { MachineLocalPathPolicy } from '../../../scripts/MachineLocalPathPolicy.ts';
+
+const tempDirs: string[] = [];
+
+function gitText(repository: string, ...args: readonly string[]): string {
+  return execFileSync('git', args, { cwd: repository, encoding: 'utf8' }).trim();
+}
+
+function createCommittedRepository(): string {
+  const repository = mkdtempSync(join(tmpdir(), 'git-warp-batch-process-'));
+  tempDirs.push(repository);
+  execFileSync('git', ['init', '--quiet'], { cwd: repository });
+  execFileSync('git', ['config', 'user.name', 'Batch Process Test'], { cwd: repository });
+  execFileSync('git', ['config', 'user.email', 'batch-process@example.invalid'], {
+    cwd: repository,
+  });
+  writeFileSync(join(repository, 'fixture.txt'), 'portable', 'utf8');
+  execFileSync('git', ['add', 'fixture.txt'], { cwd: repository });
+  execFileSync('git', ['commit', '--quiet', '-m', 'portable fixture'], { cwd: repository });
+  return repository;
+}
+
+afterEach(() => {
+  spawnBehavior.current = 'nonzero-exit';
+  while (tempDirs.length > 0) {
+    const directory = tempDirs.pop();
+    if (directory !== undefined) {
+      rmSync(directory, { force: true, recursive: true });
+    }
+  }
+});
+
+describe('Git machine-local path guard batch process', () => {
+  it('fails closed when a complete batch exits nonzero', async () => {
+    const repository = createCommittedRepository();
+    const revision = gitText(repository, 'rev-parse', 'HEAD');
+    const guard = new GitMachineLocalPathGuard(repository, new MachineLocalPathPolicy());
+
+    await expect(guard.findTreePaths(revision)).rejects.toThrow(
+      'git cat-file --batch failed with exit 7'
+    );
+  });
+
+  it('kills a still-running batch producer after malformed output', async () => {
+    spawnBehavior.current = 'malformed-hanging';
+    const repository = createCommittedRepository();
+    const revision = gitText(repository, 'rev-parse', 'HEAD');
+    const guard = new GitMachineLocalPathGuard(repository, new MachineLocalPathPolicy());
+
+    await expect(guard.findTreePaths(revision)).rejects.toThrow('malformed batch blob header');
+  });
+
+  it('contains a spawn error while the stream parser fails closed', async () => {
+    spawnBehavior.current = 'spawn-error';
+    const repository = createCommittedRepository();
+    const revision = gitText(repository, 'rev-parse', 'HEAD');
+    const guard = new GitMachineLocalPathGuard(repository, new MachineLocalPathPolicy());
+
+    await expect(guard.findTreePaths(revision)).rejects.toThrow();
+  });
+});

--- a/test/unit/scripts/git-machine-local-path-guard.test.ts
+++ b/test/unit/scripts/git-machine-local-path-guard.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { GitBatchReadWindow } from '../../../scripts/GitBatchReadWindow.ts';
 import { GitMachineLocalPathGuard } from '../../../scripts/GitMachineLocalPathGuard.ts';
 import { MachineLocalPathPolicy } from '../../../scripts/MachineLocalPathPolicy.ts';
 
@@ -109,7 +110,7 @@ describe('Git machine-local path guard', () => {
     expect(hook).toContain('node scripts/check-machine-local-paths.ts --pre-push "$REMOTE_NAME"');
   });
 
-  it('scans an exact committed tree instead of mutable working-tree bytes', () => {
+  it('scans an exact committed tree instead of mutable working-tree bytes', async () => {
     const repository = createRepository();
     const fixturePath = join(repository, 'fixture.txt');
     writeFileSync(fixturePath, personalHome('git', 'project'), 'utf8');
@@ -120,8 +121,39 @@ describe('Git machine-local path guard', () => {
 
     const guard = new GitMachineLocalPathGuard(repository, new MachineLocalPathPolicy());
 
-    expect(guard.findTreePaths(committedObject)).toEqual(['fixture.txt']);
+    await expect(guard.findTreePaths(committedObject)).resolves.toEqual(['fixture.txt']);
     expect(guard.findWorkingTreePaths()).toEqual([]);
+  });
+
+  it('bounds exact-tree scan memory independently of aggregate blob bytes', async () => {
+    const repository = createRepository();
+    writeFileSync(join(repository, 'first.txt'), 'portable first payload', 'utf8');
+    writeFileSync(join(repository, 'second.txt'), 'portable second payload', 'utf8');
+    git(repository, 'add', 'first.txt', 'second.txt');
+    git(repository, 'commit', '--quiet', '-m', 'clean aggregate');
+    const committedObject = gitText(repository, 'rev-parse', 'HEAD');
+    const guard = new GitMachineLocalPathGuard(
+      repository,
+      new MachineLocalPathPolicy(),
+      new GitBatchReadWindow(5)
+    );
+
+    await expect(guard.findTreePaths(committedObject)).resolves.toEqual([]);
+  });
+
+  it('detects a machine-local path split across exact-tree read windows', async () => {
+    const repository = createRepository();
+    writeFileSync(join(repository, 'fixture.txt'), personalHome('build', 'artifact'), 'utf8');
+    git(repository, 'add', 'fixture.txt');
+    git(repository, 'commit', '--quiet', '-m', 'split leak');
+    const committedObject = gitText(repository, 'rev-parse', 'HEAD');
+    const guard = new GitMachineLocalPathGuard(
+      repository,
+      new MachineLocalPathPolicy(),
+      new GitBatchReadWindow(3)
+    );
+
+    await expect(guard.findTreePaths(committedObject)).resolves.toEqual(['fixture.txt']);
   });
 
   it('makes exact-tree path hygiene a dedicated required CI lane', () => {

--- a/test/unit/scripts/git-machine-local-path-guard.test.ts
+++ b/test/unit/scripts/git-machine-local-path-guard.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -141,6 +141,15 @@ describe('Git machine-local path guard', () => {
     await expect(guard.findTreePaths(committedObject)).resolves.toEqual([]);
   });
 
+  it('accepts an exact empty tree without spawning a blob batch', async () => {
+    const repository = createRepository();
+    git(repository, 'commit', '--allow-empty', '--quiet', '-m', 'empty tree');
+    const committedObject = gitText(repository, 'rev-parse', 'HEAD');
+    const guard = new GitMachineLocalPathGuard(repository, new MachineLocalPathPolicy());
+
+    await expect(guard.findTreePaths(committedObject)).resolves.toEqual([]);
+  });
+
   it('detects a machine-local path split across exact-tree read windows', async () => {
     const repository = createRepository();
     writeFileSync(join(repository, 'fixture.txt'), personalHome('build', 'artifact'), 'utf8');
@@ -154,6 +163,26 @@ describe('Git machine-local path guard', () => {
     );
 
     await expect(guard.findTreePaths(committedObject)).resolves.toEqual(['fixture.txt']);
+  });
+
+  it('preserves binary blob and symlink target inspection for exact trees', async () => {
+    const repository = createRepository();
+    const binary = Buffer.concat([
+      Buffer.from([0xff, 0]),
+      Buffer.from(personalHome('build', 'artifact'), 'utf8'),
+      Buffer.from([0]),
+    ]);
+    writeFileSync(join(repository, 'fixture.bin'), binary);
+    symlinkSync(personalHome('git', 'project'), join(repository, 'fixture.link'));
+    git(repository, 'add', 'fixture.bin', 'fixture.link');
+    git(repository, 'commit', '--quiet', '-m', 'binary and symlink leaks');
+    const committedObject = gitText(repository, 'rev-parse', 'HEAD');
+    const guard = new GitMachineLocalPathGuard(repository, new MachineLocalPathPolicy());
+
+    await expect(guard.findTreePaths(committedObject)).resolves.toEqual([
+      'fixture.bin',
+      'fixture.link',
+    ]);
   });
 
   it('makes exact-tree path hygiene a dedicated required CI lane', () => {

--- a/test/unit/scripts/machine-local-path-policy.test.ts
+++ b/test/unit/scripts/machine-local-path-policy.test.ts
@@ -60,7 +60,7 @@ describe('machine-local path policy', () => {
     expect(policy.containsMachineLocalPath(posixPath('Users', 'example'))).toBe(true);
     expect(policy.containsMachineLocalPath(windowsPath('Users', 'example'))).toBe(true);
     expect(policy.containsMachineLocalPath(`${posixPath('Users', 'example')} portable`)).toBe(
-      false
+      true
     );
     expect(policy.containsMachineLocalPath(posixPath('Users', ''))).toBe(false);
   });

--- a/test/unit/scripts/machine-local-path-policy.test.ts
+++ b/test/unit/scripts/machine-local-path-policy.test.ts
@@ -54,6 +54,26 @@ describe('machine-local path policy', () => {
     expect(policy.containsMachineLocalPath('/tmp/project')).toBe(false);
   });
 
+  it('preserves segment semantics at stream completion and whitespace boundaries', () => {
+    const policy = new MachineLocalPathPolicy();
+
+    expect(policy.containsMachineLocalPath(posixPath('Users', 'example'))).toBe(true);
+    expect(policy.containsMachineLocalPath(windowsPath('Users', 'example'))).toBe(true);
+    expect(policy.containsMachineLocalPath(`${posixPath('Users', 'example')} portable`)).toBe(
+      false
+    );
+    expect(policy.containsMachineLocalPath(posixPath('Users', ''))).toBe(false);
+  });
+
+  it('makes stream completion idempotent and rejects writes after completion', () => {
+    const scanner = new MachineLocalPathPolicy().createStreamScanner();
+    scanner.write(new TextEncoder().encode('portable'));
+
+    expect(scanner.finish()).toBe(false);
+    expect(scanner.finish()).toBe(false);
+    expect(() => scanner.write(new Uint8Array())).toThrow('already finished');
+  });
+
   it('passes the current tracked and unignored repository inventory', () => {
     expect(() =>
       execFileSync(process.execPath, [join(ROOT, 'scripts/check-machine-local-paths.ts')], {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/ports/**/*.ts', 'src/**/*.d.ts'],
       thresholds: {
-        lines: 92.99,
+        lines: 93.02,
         autoUpdate: shouldAutoUpdateCoverageRatchet(),
       },
     },


### PR DESCRIPTION
## Summary

- stream exact-tree `git cat-file --batch` output instead of materializing the aggregate response;
- detect machine-local path tokens across bounded byte reads, UTF-8 decoder boundaries, and whitespace token boundaries;
- preserve exact object identity, binary and symlink inspection, duplicate-object path expansion, and deterministic ordering;
- fail closed on malformed headers, unsafe sizes, truncation, trailing data, spawn failure, nonzero Git exit, and a validated 120-second batch deadline;
- raise the coverage ratchet from 92.99% to 93.02% through the owning coverage command.

Closes #840.

## Validation

- Hosted Node 22, Bun, Deno, coverage-threshold, performance, release-preflight, link, audit-advisory, generated-SDK, and all type-firewall lanes pass on `a75e0ea3e`.
- The complete local stable suite passes 7,291 tests with 2 intentional skips.
- Four focused test files pass 37 tests.
- New scanner and deadline modules have 100% statement, branch, function, and line coverage; changed guard lines have 100% coverage.
- Local lint, typecheck, policy, documentation, quarantine-graduation, link, and publication-surface gates pass.
- Both actionable CodeRabbit threads are fixed and resolved; the follow-up review status is rate limited.

## Architecture scorecard

- Runtime-backed concepts: validated and frozen `GitBatchReadWindow` and `GitBatchScanDeadline`; stateful streaming scanner classes.
- Boundary validation: exact Git batch framing, object identity, type, size, delimiter, terminal-state, and process-deadline checks.
- Behavior ownership: byte protocol and path-token state machines own their transitions.
- Ambient capabilities: no wall clock, entropy, network, or persistence construction enters domain code.
- Type integrity: no `any`, `unknown`, assertions, placeholder `*Like` shapes, or suppression expansion.
