### PR TITLE
perf: batch patch-chain reads through one log stream per chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `benchmarks/v19/policy.json` gains `absolute.gitCommandMedian` per scenario and
   `relative.gitCommandRegressionRatio`, and the gate summary reports head and base
   counts. Command counts are structural: they are decided by which code paths run,
-  not by how fast the runner is. Three measured runs of each scenario returned an
-  identical count (MAD 0), so the relative check carries no noise floor and needs
-  no reference recalibration to be actionable — it catches a subprocess-count
-  regression that leaves the CPU envelope untouched on a fast machine.
+  not by how fast the runner is. This is measured rather than assumed: the
+  ubuntu-24.04 reference runner and a local arm64 machine report identical counts
+  per scenario (2758 / 543 / 2788) despite differing in architecture, OS, Node
+  version and Git version, while their CPU medians differ by roughly 2.3x. Three
+  measured runs returned the same count each time (MAD 0). The checks therefore
+  carry no noise floor, and the absolute ceilings sit ~1.15x above the observed
+  count — tight enough to force review of a structural change to the read path,
+  loose enough to absorb a small legitimate addition. Together they catch a
+  subprocess-count regression that leaves the CPU envelope untouched.
   Scope, stated plainly: the current corpus writes each segment as a single
   patch, so every scenario replays a one-patch chain. These counts therefore
   gate object and payload traffic, not chain-traversal depth, and they would not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The v19 performance gate now blocks on Git command counts as well as CPU.
+  `benchmarks/v19/policy.json` gains `absolute.gitCommandMedian` per scenario and
+  `relative.gitCommandRegressionRatio`, and the gate summary reports head and base
+  counts. Command counts are structural: they are decided by which code paths run,
+  not by how fast the runner is. Three measured runs of each scenario returned an
+  identical count (MAD 0), so the relative check carries no noise floor and needs
+  no reference recalibration to be actionable — it catches a subprocess-count
+  regression that leaves the CPU envelope untouched on a fast machine.
+  Scope, stated plainly: the current corpus writes each segment as a single
+  patch, so every scenario replays a one-patch chain. These counts therefore
+  gate object and payload traffic, not chain-traversal depth, and they would not
+  by themselves have caught the per-commit walk fixed above. Giving the fixture a
+  multi-patch chain is tracked separately.
 - `intent.entity.add({ subject, properties })` creates one entity occurrence and
   its initial payload in a single patch. The lowered patch declares an empty
   read set and exactly one subject write. That declaration describes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   caller observes is deterministic. Persistences without a usable bulk log
   surface (or commits missing from the bulk read) fall back to the legacy
   per-commit walk and its error surface, and that fallback is now logged so a
-  silent return to per-commit cost is observable. Measured against a real graph
-  whose largest writer chain holds 705 patch commits: `--recent --count=5` went
-  from 96.0 s to 9.2-9.7 s, and a single capture from 55-69 s to 15.5-15.9 s.
+  silent return to per-commit cost is observable. Measured as an A/B on two
+  fresh copies of one real graph whose largest writer chain holds 745 patch
+  commits, three reads and two captures each: median read time went from
+  80.0 s to 9.3 s, and median capture from 59.0 s to 17.1 s.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than whichever rejected first in wall-clock time, so the failure a
   caller observes is deterministic. Persistences without a usable bulk log
   surface (or commits missing from the bulk read) fall back to the legacy
-  per-commit walk and its error surface. Measured on a real 500-thought
-  graph with ~1,750 patch commits across 7 writer chains: a cold read went from
-  82.9 s (3,505 git subprocesses) to 8.9 s (1,792, now dominated by per-blob
-  payload reads).
+  per-commit walk and its error surface, and that fallback is now logged so a
+  silent return to per-commit cost is observable. Measured against a real graph
+  whose largest writer chain holds 705 patch commits: `--recent --count=5` went
+  from 96.0 s to 9.2-9.7 s, and a single capture from 55-69 s to 15.5-15.9 s.
+
+### Changed
+
+- `LogNodesOptions` gains `firstParent` and `stopAt`. Chain readers advance by
+  first parent and stop at a known boundary, so the history read is now
+  constrained the same way: a merge's side branch is never streamed, and the
+  read is bounded to `stopAt..ref` rather than running to the root of history.
+  Both options are opt-in and default to the previous behaviour.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than whichever rejected first in wall-clock time, so the failure a
   caller observes is deterministic. Persistences without a usable bulk log
   surface (or commits missing from the bulk read) fall back to the legacy
-  per-commit walk and its error surface, and that fallback is now logged so a
-  silent return to per-commit cost is observable. Measured as an A/B on two
+  per-commit walk and its error surface. Both degradations are logged — a bulk
+  read that throws, and a bulk read that succeeds while omitting commits — so a
+  silent return to per-commit cost is observable rather than merely correct. Measured as an A/B on two
   fresh copies of one real graph whose largest writer chain holds 745 patch
   commits, three reads and two captures each: median read time went from
   80.0 s to 9.3 s, and median capture from 59.0 s to 17.1 s.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance
+
+- Patch-chain traversal (`PatchDiscovery.loadPatchChainFromSha`,
+  `PatchDiscovery.discoverTicks`) now reads chain metadata with a single bulk
+  `logNodesStream` history read per chain instead of one `getNodeInfo` call per
+  commit. On the Git adapter every `getNodeInfo` call is a `git show`
+  subprocess, so materializing a graph previously spawned one subprocess per
+  patch commit, serially — O(history × spawn latency) for every read. Patch
+  payload reads now run with bounded concurrency (8) while preserving
+  chronological order and read-error behavior. Persistences without a usable
+  bulk log surface (or commits missing from the bulk read) fall back to the
+  legacy per-commit walk and its error surface. Measured on a real 500-thought
+  graph with ~1,750 patch commits across 7 writer chains: a cold read went from
+  82.9 s (3,505 git subprocesses) to 8.9 s (1,792, now dominated by per-blob
+  payload reads).
+
 ### Added
 
 - `intent.entity.add({ subject, properties })` creates one entity occurrence and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subprocess, so materializing a graph previously spawned one subprocess per
   patch commit, serially — O(history × spawn latency) for every read. Patch
   payload reads now run with bounded concurrency (8) while preserving
-  chronological order and read-error behavior. Persistences without a usable
-  bulk log surface (or commits missing from the bulk read) fall back to the
-  legacy per-commit walk and its error surface. Measured on a real 500-thought
+  chronological order and read-error behavior. When several payload reads fail,
+  the error raised is the one belonging to the earliest patch in chain order
+  rather than whichever rejected first in wall-clock time, so the failure a
+  caller observes is deterministic. Persistences without a usable bulk log
+  surface (or commits missing from the bulk read) fall back to the legacy
+  per-commit walk and its error surface. Measured on a real 500-thought
   graph with ~1,750 patch commits across 7 writer chains: a cold read went from
   82.9 s (3,505 git subprocesses) to 8.9 s (1,792, now dominated by per-blob
   payload reads).

--- a/benchmarks/v19/calibration.json
+++ b/benchmarks/v19/calibration.json
@@ -28,19 +28,25 @@
       "cpuTotalMedianMs": 11440.000000000002,
       "cpuTotalMadMs": 300.0000000000018,
       "maximumRssBytes": 149114880,
-      "maximumHeapUsedBytes": 55814856
+      "maximumHeapUsedBytes": 55814856,
+      "gitCommandMedian": 2758,
+      "gitCommandMadCount": 0
     },
     "warm-materialize": {
       "cpuTotalMedianMs": 2889.9999999999995,
       "cpuTotalMadMs": 90.00000000000045,
       "maximumRssBytes": 129462272,
-      "maximumHeapUsedBytes": 44256456
+      "maximumHeapUsedBytes": 44256456,
+      "gitCommandMedian": 543,
+      "gitCommandMadCount": 0
     },
     "incremental-materialize": {
       "cpuTotalMedianMs": 11240,
       "cpuTotalMadMs": 320,
       "maximumRssBytes": 151187456,
-      "maximumHeapUsedBytes": 57289656
+      "maximumHeapUsedBytes": 57289656,
+      "gitCommandMedian": 2788,
+      "gitCommandMadCount": 0
     },
     "streaming": {
       "generationMaximumRssBytes": 196218880,
@@ -106,10 +112,10 @@
     "note": "CI-runner measurements are primary. Noise floors cover hosted-runner MAD; absolute materialization and streaming ceilings retain reviewed headroom while blocking gross regressions.",
     "gitCommandRegressionRatio": 1.05,
     "gitCommandMedian": {
-      "cold-materialize": 4500,
-      "warm-materialize": 1000,
-      "incremental-materialize": 4500
+      "cold-materialize": 3200,
+      "warm-materialize": 650,
+      "incremental-materialize": 3250
     },
-    "gitCommandNote": "Git command counts are structural, not timing: three measured runs on the local arm64 profile returned an identical count per scenario (MAD 0), so the relative ratio carries no noise floor. The absolute ceilings are provisional. They sit roughly 1.6x above the local observation because no reference-runner count has been recorded yet; retighten them from the first green ubuntu-24.04 performance run. Until then the relative same-runner ratio is the precise instrument and the absolute ceiling is a gross-blowup backstop."
+    "gitCommandNote": "Git command counts are structural, not timing. The reference runner and a local arm64 machine report identical counts per scenario (2758 / 543 / 2788) despite differing in architecture, OS, Node version (v22.23.1 vs v26.0.0) and Git version (2.54.0 vs 2.50.1), while their CPU medians differ by roughly 2.3x. Three measured runs returned the same count each time (MAD 0). Machine independence is therefore measured, not assumed, which is why the relative ratio carries no noise floor. Absolute ceilings sit ~1.15x above the observed count \u2014 tight enough that a structural change to the read path must be reviewed, loose enough to absorb a small legitimate addition. Evidence: https://github.com/git-stunts/git-warp/actions/runs/32493429207"
   }
 }

--- a/benchmarks/v19/calibration.json
+++ b/benchmarks/v19/calibration.json
@@ -64,21 +64,29 @@
         "cpuTotalMedianMs": 3993.154,
         "cpuTotalMadMs": 11.974,
         "maximumRssBytes": 152158208,
-        "maximumHeapUsedBytes": 57703656
+        "maximumHeapUsedBytes": 57703656,
+        "gitCommandMedian": 2758,
+        "gitCommandMadCount": 0
       },
       "warm-materialize": {
         "cpuTotalMedianMs": 834.786,
         "cpuTotalMadMs": 4.831,
         "maximumRssBytes": 120930304,
-        "maximumHeapUsedBytes": 39929144
+        "maximumHeapUsedBytes": 39929144,
+        "gitCommandMedian": 543,
+        "gitCommandMadCount": 0
       },
       "incremental-materialize": {
         "cpuTotalMedianMs": 4276.35,
         "cpuTotalMadMs": 89.092,
         "maximumRssBytes": 152928256,
-        "maximumHeapUsedBytes": 58384360
+        "maximumHeapUsedBytes": 58384360,
+        "gitCommandMedian": 2788,
+        "gitCommandMadCount": 0
       }
-    }
+    },
+    "measuredRuns": 3,
+    "warmupRuns": 1
   },
   "rejectedProfiles": [
     {
@@ -95,6 +103,13 @@
     },
     "streamingMaxRssBytes": 268435456,
     "streamingPeakHeapUsedBytes": 100663296,
-    "note": "CI-runner measurements are primary. Noise floors cover hosted-runner MAD; absolute materialization and streaming ceilings retain reviewed headroom while blocking gross regressions."
+    "note": "CI-runner measurements are primary. Noise floors cover hosted-runner MAD; absolute materialization and streaming ceilings retain reviewed headroom while blocking gross regressions.",
+    "gitCommandRegressionRatio": 1.05,
+    "gitCommandMedian": {
+      "cold-materialize": 4500,
+      "warm-materialize": 1000,
+      "incremental-materialize": 4500
+    },
+    "gitCommandNote": "Git command counts are structural, not timing: three measured runs on the local arm64 profile returned an identical count per scenario (MAD 0), so the relative ratio carries no noise floor. The absolute ceilings are provisional. They sit roughly 1.6x above the local observation because no reference-runner count has been recorded yet; retighten them from the first green ubuntu-24.04 performance run. Until then the relative same-runner ratio is the precise instrument and the absolute ceiling is a gross-blowup backstop."
   }
 }

--- a/benchmarks/v19/policy.json
+++ b/benchmarks/v19/policy.json
@@ -8,9 +8,9 @@
       "incremental-materialize": 30000
     },
     "gitCommandMedian": {
-      "cold-materialize": 4500,
-      "warm-materialize": 1000,
-      "incremental-materialize": 4500
+      "cold-materialize": 3200,
+      "warm-materialize": 650,
+      "incremental-materialize": 3250
     },
     "maxRssBytes": {
       "cold-materialize": 402653184,

--- a/benchmarks/v19/policy.json
+++ b/benchmarks/v19/policy.json
@@ -7,6 +7,11 @@
       "warm-materialize": 10000,
       "incremental-materialize": 30000
     },
+    "gitCommandMedian": {
+      "cold-materialize": 4500,
+      "warm-materialize": 1000,
+      "incremental-materialize": 4500
+    },
     "maxRssBytes": {
       "cold-materialize": 402653184,
       "warm-materialize": 268435456,
@@ -24,7 +29,8 @@
       "warm-materialize": 50,
       "incremental-materialize": 250
     },
-    "cpuRegressionRatio": 1.15
+    "cpuRegressionRatio": 1.15,
+    "gitCommandRegressionRatio": 1.05
   },
   "streaming": {
     "maxRssBytes": 268435456,

--- a/benchmarks/v19/policy.json
+++ b/benchmarks/v19/policy.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "wallTime": "diagnostic",
   "absolute": {
     "cpuTotalMedianMs": {

--- a/scripts/performance/GatePerformance.ts
+++ b/scripts/performance/GatePerformance.ts
@@ -1,45 +1,28 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import z from 'zod';
 import {
   parsePerformanceComparison,
   type PerformanceComparison,
 } from './PerformanceComparisonModel.ts';
 import {
-  PERFORMANCE_SCENARIOS,
   parsePerformanceResult,
   type PerformanceResult,
 } from './PerformanceModel.ts';
-import { comparablePerformanceEnvironment } from './PerformanceEnvironment.ts';
+import {
+  absoluteFailures,
+  relativeFailures,
+  streamingFailures,
+} from './PerformanceGateChecks.ts';
+import {
+  PerformancePolicySchema,
+  type PerformancePolicy,
+} from './PerformancePolicy.ts';
 import { renderPerformanceSummary } from './PerformanceSummary.ts';
 import type { StreamingPerformanceReport } from './StreamingPerformanceReport.ts';
 
-const scenarioThresholds = z.object({
-  'cold-materialize': z.number().finite().nonnegative(),
-  'incremental-materialize': z.number().finite().nonnegative(),
-  'warm-materialize': z.number().finite().nonnegative(),
-}).strict();
+export { PerformancePolicySchema, type PerformancePolicy };
 
-export const PerformancePolicySchema = z.object({
-  absolute: z.object({
-    cpuTotalMedianMs: scenarioThresholds,
-    maxRssBytes: scenarioThresholds,
-    peakHeapUsedBytes: scenarioThresholds,
-  }).strict(),
-  relative: z.object({
-    cpuNoiseFloorMs: scenarioThresholds,
-    cpuRegressionRatio: z.number().finite().gte(1),
-  }).strict(),
-  schemaVersion: z.literal(1),
-  streaming: z.object({
-    maxRssBytes: z.number().finite().positive(),
-    peakHeapUsedBytes: z.number().finite().positive(),
-  }).strict(),
-  wallTime: z.literal('diagnostic'),
-}).strict();
-
-export type PerformancePolicy = Readonly<z.infer<typeof PerformancePolicySchema>>;
 type GateOptions = Readonly<{
   basePath?: string;
   comparisonPath?: string;
@@ -113,108 +96,6 @@ export function evaluatePerformanceGate(
       executionOrder,
     ),
   });
-}
-
-function absoluteFailures(
-  head: PerformanceResult,
-  policy: PerformancePolicy,
-): string[] {
-  const failures: string[] = [];
-  for (const scenario of PERFORMANCE_SCENARIOS) {
-    const actual = head.scenarios[scenario].cpuTotalMs.median;
-    const maximum = policy.absolute.cpuTotalMedianMs[scenario];
-    if (actual > maximum) {
-      failures.push(metricFailure(`${scenario} median CPU`, actual, maximum));
-    }
-    const actualRss = head.scenarios[scenario].maxRssBytes.maximum;
-    const maximumRss = policy.absolute.maxRssBytes[scenario];
-    if (actualRss > maximumRss) {
-      failures.push(byteMetricFailure(
-        `${scenario} maximum RSS`,
-        actualRss,
-        maximumRss,
-      ));
-    }
-    const actualHeap = head.scenarios[scenario].peakHeapUsedBytes.maximum;
-    const maximumHeap = policy.absolute.peakHeapUsedBytes[scenario];
-    if (actualHeap > maximumHeap) {
-      failures.push(byteMetricFailure(
-        `${scenario} peak heap`,
-        actualHeap,
-        maximumHeap,
-      ));
-    }
-  }
-  return failures;
-}
-
-function relativeFailures(
-  base: PerformanceResult,
-  head: PerformanceResult,
-  policy: PerformancePolicy,
-): string[] {
-  requireComparable(base, head);
-  const failures: string[] = [];
-  for (const scenario of PERFORMANCE_SCENARIOS) {
-    const baseCpu = base.scenarios[scenario].cpuTotalMs.median;
-    const headCpu = head.scenarios[scenario].cpuTotalMs.median;
-    const maximum = baseCpu * policy.relative.cpuRegressionRatio
-      + policy.relative.cpuNoiseFloorMs[scenario];
-    if (headCpu > maximum) {
-      failures.push(metricFailure(`${scenario} median CPU regression`, headCpu, maximum));
-    }
-  }
-  return failures;
-}
-
-function streamingFailures(
-  head: StreamingPerformanceReport,
-  policy: PerformancePolicy,
-): string[] {
-  const failures: string[] = [];
-  const metrics = head.streaming.metrics;
-  if (metrics.maxRssBytes > policy.streaming.maxRssBytes) {
-    failures.push(byteMetricFailure(
-      'streaming maximum RSS',
-      metrics.maxRssBytes,
-      policy.streaming.maxRssBytes,
-    ));
-  }
-  if (metrics.peakHeapUsedBytes > policy.streaming.peakHeapUsedBytes) {
-    failures.push(byteMetricFailure(
-      'streaming peak heap',
-      metrics.peakHeapUsedBytes,
-      policy.streaming.peakHeapUsedBytes,
-    ));
-  }
-  return failures;
-}
-
-function requireComparable(base: PerformanceResult, head: PerformanceResult): void {
-  if (
-    JSON.stringify(comparablePerformanceEnvironment(base))
-      !== JSON.stringify(comparablePerformanceEnvironment(head))
-    || JSON.stringify(base.instrumentation) !== JSON.stringify(head.instrumentation)
-  ) {
-    throw new Error('Base and head performance environments are not comparable');
-  }
-  for (const scenario of PERFORMANCE_SCENARIOS) {
-    const baseCorpus = JSON.stringify(base.scenarios[scenario].corpus);
-    const headCorpus = JSON.stringify(head.scenarios[scenario].corpus);
-    if (baseCorpus !== headCorpus) {
-      throw new Error(`Base and head corpora differ: ${scenario}`);
-    }
-  }
-}
-
-function metricFailure(metric: string, actual: number, maximum: number): string {
-  return `${metric}: ${actual.toFixed(1)} ms exceeds ${maximum.toFixed(1)} ms`;
-}
-
-function byteMetricFailure(metric: string, actual: number, maximum: number): string {
-  const mebibyte = 1024 * 1024;
-  return `${metric}: ${(actual / mebibyte).toFixed(1)} MiB exceeds `
-    + `${(maximum / mebibyte).toFixed(1)} MiB`;
 }
 
 async function readResult(path: string): Promise<PerformanceResult> {

--- a/scripts/performance/PerformanceGateChecks.ts
+++ b/scripts/performance/PerformanceGateChecks.ts
@@ -1,0 +1,153 @@
+import {
+  PERFORMANCE_SCENARIOS,
+  type PerformanceResult,
+  type PerformanceScenarioName,
+  type ScenarioResult,
+} from './PerformanceModel.ts';
+import { comparablePerformanceEnvironment } from './PerformanceEnvironment.ts';
+import type { PerformancePolicy } from './PerformancePolicy.ts';
+import type { StreamingPerformanceReport } from './StreamingPerformanceReport.ts';
+
+export function absoluteFailures(
+  head: PerformanceResult,
+  policy: PerformancePolicy,
+): string[] {
+  return PERFORMANCE_SCENARIOS.flatMap((scenario) => scenarioAbsoluteFailures(
+    head.scenarios[scenario],
+    scenario,
+    policy,
+  ));
+}
+
+function scenarioAbsoluteFailures(
+  result: ScenarioResult,
+  scenario: PerformanceScenarioName,
+  policy: PerformancePolicy,
+): string[] {
+  return [
+    ...envelopeFailures(result, scenario, policy),
+    ...structuralFailures(result, scenario, policy),
+  ];
+}
+
+function envelopeFailures(
+  result: ScenarioResult,
+  scenario: PerformanceScenarioName,
+  policy: PerformancePolicy,
+): string[] {
+  const failures: string[] = [];
+  const cpu = result.cpuTotalMs.median;
+  const cpuCeiling = policy.absolute.cpuTotalMedianMs[scenario];
+  if (cpu > cpuCeiling) {
+    failures.push(metricFailure(`${scenario} median CPU`, cpu, cpuCeiling));
+  }
+  const rss = result.maxRssBytes.maximum;
+  const rssCeiling = policy.absolute.maxRssBytes[scenario];
+  if (rss > rssCeiling) {
+    failures.push(byteMetricFailure(`${scenario} maximum RSS`, rss, rssCeiling));
+  }
+  const heap = result.peakHeapUsedBytes.maximum;
+  const heapCeiling = policy.absolute.peakHeapUsedBytes[scenario];
+  if (heap > heapCeiling) {
+    failures.push(byteMetricFailure(`${scenario} peak heap`, heap, heapCeiling));
+  }
+  return failures;
+}
+
+function structuralFailures(
+  result: ScenarioResult,
+  scenario: PerformanceScenarioName,
+  policy: PerformancePolicy,
+): string[] {
+  const commands = result.gitCommandCount.median;
+  const ceiling = policy.absolute.gitCommandMedian[scenario];
+  if (commands <= ceiling) {
+    return [];
+  }
+  return [countMetricFailure(`${scenario} median Git commands`, commands, ceiling)];
+}
+
+export function relativeFailures(
+  base: PerformanceResult,
+  head: PerformanceResult,
+  policy: PerformancePolicy,
+): string[] {
+  requireComparable(base, head);
+  const failures: string[] = [];
+  for (const scenario of PERFORMANCE_SCENARIOS) {
+    const baseCpu = base.scenarios[scenario].cpuTotalMs.median;
+    const headCpu = head.scenarios[scenario].cpuTotalMs.median;
+    const maximum = baseCpu * policy.relative.cpuRegressionRatio
+      + policy.relative.cpuNoiseFloorMs[scenario];
+    if (headCpu > maximum) {
+      failures.push(metricFailure(`${scenario} median CPU regression`, headCpu, maximum));
+    }
+    const baseCommands = base.scenarios[scenario].gitCommandCount.median;
+    const headCommands = head.scenarios[scenario].gitCommandCount.median;
+    const commandCeiling = Math.floor(
+      baseCommands * policy.relative.gitCommandRegressionRatio,
+    );
+    if (headCommands > commandCeiling) {
+      failures.push(countMetricFailure(
+        `${scenario} median Git command regression`,
+        headCommands,
+        commandCeiling,
+      ));
+    }
+  }
+  return failures;
+}
+
+export function streamingFailures(
+  head: StreamingPerformanceReport,
+  policy: PerformancePolicy,
+): string[] {
+  const failures: string[] = [];
+  const metrics = head.streaming.metrics;
+  if (metrics.maxRssBytes > policy.streaming.maxRssBytes) {
+    failures.push(byteMetricFailure(
+      'streaming maximum RSS',
+      metrics.maxRssBytes,
+      policy.streaming.maxRssBytes,
+    ));
+  }
+  if (metrics.peakHeapUsedBytes > policy.streaming.peakHeapUsedBytes) {
+    failures.push(byteMetricFailure(
+      'streaming peak heap',
+      metrics.peakHeapUsedBytes,
+      policy.streaming.peakHeapUsedBytes,
+    ));
+  }
+  return failures;
+}
+
+function requireComparable(base: PerformanceResult, head: PerformanceResult): void {
+  if (
+    JSON.stringify(comparablePerformanceEnvironment(base))
+      !== JSON.stringify(comparablePerformanceEnvironment(head))
+    || JSON.stringify(base.instrumentation) !== JSON.stringify(head.instrumentation)
+  ) {
+    throw new Error('Base and head performance environments are not comparable');
+  }
+  for (const scenario of PERFORMANCE_SCENARIOS) {
+    const baseCorpus = JSON.stringify(base.scenarios[scenario].corpus);
+    const headCorpus = JSON.stringify(head.scenarios[scenario].corpus);
+    if (baseCorpus !== headCorpus) {
+      throw new Error(`Base and head corpora differ: ${scenario}`);
+    }
+  }
+}
+
+function metricFailure(metric: string, actual: number, maximum: number): string {
+  return `${metric}: ${actual.toFixed(1)} ms exceeds ${maximum.toFixed(1)} ms`;
+}
+
+function countMetricFailure(metric: string, actual: number, maximum: number): string {
+  return `${metric}: ${String(actual)} exceeds ${String(maximum)}`;
+}
+
+function byteMetricFailure(metric: string, actual: number, maximum: number): string {
+  const mebibyte = 1024 * 1024;
+  return `${metric}: ${(actual / mebibyte).toFixed(1)} MiB exceeds `
+    + `${(maximum / mebibyte).toFixed(1)} MiB`;
+}

--- a/scripts/performance/PerformancePolicy.ts
+++ b/scripts/performance/PerformancePolicy.ts
@@ -1,5 +1,12 @@
 import z from 'zod';
 
+/**
+ * Version 2 added the structural Git-command thresholds
+ * (`absolute.gitCommandMedian`, `relative.gitCommandRegressionRatio`). Both are
+ * required, so a version-1 policy no longer parses and must not claim to.
+ */
+export const PERFORMANCE_POLICY_SCHEMA_VERSION = 2;
+
 const scenarioThresholds = z.object({
   'cold-materialize': z.number().finite().nonnegative(),
   'incremental-materialize': z.number().finite().nonnegative(),
@@ -24,7 +31,7 @@ export const PerformancePolicySchema = z.object({
     cpuRegressionRatio: z.number().finite().gte(1),
     gitCommandRegressionRatio: z.number().finite().gte(1),
   }).strict(),
-  schemaVersion: z.literal(1),
+  schemaVersion: z.literal(PERFORMANCE_POLICY_SCHEMA_VERSION),
   streaming: z.object({
     maxRssBytes: z.number().finite().positive(),
     peakHeapUsedBytes: z.number().finite().positive(),

--- a/scripts/performance/PerformancePolicy.ts
+++ b/scripts/performance/PerformancePolicy.ts
@@ -1,0 +1,35 @@
+import z from 'zod';
+
+const scenarioThresholds = z.object({
+  'cold-materialize': z.number().finite().nonnegative(),
+  'incremental-materialize': z.number().finite().nonnegative(),
+  'warm-materialize': z.number().finite().nonnegative(),
+}).strict();
+
+const scenarioCountThresholds = z.object({
+  'cold-materialize': z.number().int().nonnegative(),
+  'incremental-materialize': z.number().int().nonnegative(),
+  'warm-materialize': z.number().int().nonnegative(),
+}).strict();
+
+export const PerformancePolicySchema = z.object({
+  absolute: z.object({
+    cpuTotalMedianMs: scenarioThresholds,
+    gitCommandMedian: scenarioCountThresholds,
+    maxRssBytes: scenarioThresholds,
+    peakHeapUsedBytes: scenarioThresholds,
+  }).strict(),
+  relative: z.object({
+    cpuNoiseFloorMs: scenarioThresholds,
+    cpuRegressionRatio: z.number().finite().gte(1),
+    gitCommandRegressionRatio: z.number().finite().gte(1),
+  }).strict(),
+  schemaVersion: z.literal(1),
+  streaming: z.object({
+    maxRssBytes: z.number().finite().positive(),
+    peakHeapUsedBytes: z.number().finite().positive(),
+  }).strict(),
+  wallTime: z.literal('diagnostic'),
+}).strict();
+
+export type PerformancePolicy = Readonly<z.infer<typeof PerformancePolicySchema>>;

--- a/scripts/performance/PerformanceSummary.ts
+++ b/scripts/performance/PerformanceSummary.ts
@@ -22,8 +22,9 @@ export function renderPerformanceSummary(
     '',
     '## Materialization',
     '',
-    '| Scenario | Head CPU | Base CPU | CPU delta | Head wall | Base wall | Head RSS | CPU MAD |',
-    '|---|---:|---:|---:|---:|---:|---:|---:|',
+    '| Scenario | Head CPU | Base CPU | CPU delta | Head Git cmds | Base Git cmds '
+      + '| Head wall | Head RSS | CPU MAD |',
+    '|---|---:|---:|---:|---:|---:|---:|---:|---:|',
   ];
   for (const scenario of PERFORMANCE_SCENARIOS) {
     lines.push(materializationRow(
@@ -35,7 +36,8 @@ export function renderPerformanceSummary(
   lines.push(
     '',
     'CPU is blocking. Wall time remains diagnostic. Peak RSS and heap are '
-      + 'blocking absolute envelopes.',
+      + 'blocking absolute envelopes. Git command counts are structural: they do '
+      + 'not vary with machine speed, so they gate both absolutely and relatively.',
     '',
     base === null
       ? 'Comparison mode: reviewed absolute bootstrap policy.'
@@ -93,8 +95,9 @@ function materializationRow(
   return `| ${scenario} | ${head.cpuTotalMs.median.toFixed(1)} ms | `
     + `${formatMetric(base?.cpuTotalMs.median, 'ms')} | `
     + `${formatDelta(head.cpuTotalMs.median, base?.cpuTotalMs.median)} | `
+    + `${formatCount(head.gitCommandCount.median)} | `
+    + `${formatCount(base?.gitCommandCount.median)} | `
     + `${head.wallMs.median.toFixed(1)} ms | `
-    + `${formatMetric(base?.wallMs.median, 'ms')} | `
     + `${formatMebibytes(head.maxRssBytes.maximum)} | `
     + `${head.cpuTotalMs.mad.toFixed(1)} ms |`;
 }
@@ -117,6 +120,10 @@ function streamingByteRow(
   return `| ${name} | ${formatMebibytes(head)} | `
     + `${base === undefined ? 'n/a' : formatMebibytes(base)} | `
     + `${formatDelta(head, base)} |`;
+}
+
+function formatCount(value: number | undefined): string {
+  return value === undefined ? 'n/a' : String(value);
 }
 
 function formatMetric(value: number | undefined, unit: string): string {

--- a/src/domain/services/controllers/PatchDiscovery.ts
+++ b/src/domain/services/controllers/PatchDiscovery.ts
@@ -10,11 +10,48 @@
 
 import { buildWriterRef, buildWritersPrefix, parseWriterIdFromRef } from '../../utils/RefLayout.ts';
 import PatchError from '../../errors/PatchError.ts';
+import GitLogParser from '../GitLogParser.ts';
 import type Patch from '../../types/Patch.ts';
 import type { CorePersistence } from '../../types/WarpPersistence.ts';
 import type LoggerPort from '../../../ports/LoggerPort.ts';
 import type PatchJournalPort from '../../../ports/PatchJournalPort.ts';
 import type CommitMessageCodecPort from '../../../ports/CommitMessageCodecPort.ts';
+import type { PatchCommitMessage } from '../../../ports/CommitMessageCodecPort.ts';
+
+/** Log format matching GitLogParser's record contract: sha, author, date, parents, message. */
+const CHAIN_LOG_FORMAT = '%H%n%an <%ae>%n%aI%n%P%n%B';
+
+/** Upper bound on concurrent patch payload reads during chain loading. */
+const PATCH_READ_CONCURRENCY = 8;
+
+/** The subset of commit metadata a chain walk consumes. */
+interface ChainNode {
+  sha: string;
+  message: string;
+  parents: readonly string[];
+}
+
+/**
+ * Maps items to results with bounded concurrency, preserving input order.
+ */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await fn(items[index] as T);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
 
 // ── PatchDiscoveryHost ────────────────────────────────────────────────────────
 
@@ -120,6 +157,11 @@ export class PatchDiscovery {
   /**
    * Loads a patch chain walking backwards from a tip SHA.
    * Returns patches in chronological order (oldest first).
+   *
+   * Chain metadata is fetched with a single bulk history read
+   * (`logNodesStream`) instead of one `getNodeInfo` call per commit, so a
+   * Git-backed persistence spawns one subprocess for the whole chain rather
+   * than one per patch. Payload reads run with bounded concurrency.
    */
   async loadPatchChainFromSha(tipSha: string, stopAtSha: string | null = null): Promise<PatchEntry[]> {
     if (typeof tipSha !== 'string' || tipSha.length === 0) {
@@ -127,34 +169,98 @@ export class PatchDiscovery {
     }
 
     const h = this._host;
-    const patches: PatchEntry[] = [];
-    let currentSha: string = tipSha;
+    const pending: Array<{ sha: string; patchMeta: PatchCommitMessage }> = [];
 
-    while (currentSha && currentSha !== stopAtSha) {
-      const nodeInfo = await h._persistence.getNodeInfo(currentSha);
-      const { message } = nodeInfo;
-      const kind = h._commitMessageCodec.detectKind(message);
+    for await (const node of this._chainNodes(tipSha, stopAtSha)) {
+      const kind = h._commitMessageCodec.detectKind(node.message);
       if (kind !== 'patch') {
         break;
       }
+      const patchMeta = h._commitMessageCodec.decodePatch(node.message);
+      this._requireJournal();
+      pending.push({ sha: node.sha, patchMeta });
+    }
 
-      const patchMeta = h._commitMessageCodec.decodePatch(message);
-      const journal = h._patchJournal;
-      if (journal === null || journal === undefined) {
-        throw new PatchError('patchJournal is required for patch discovery', {
-          code: 'E_MISSING_JOURNAL',
-        });
-      }
-      patches.push({ patch: await journal.readPatch(patchMeta), sha: currentSha });
+    if (pending.length === 0) {
+      return [];
+    }
 
-      if (Array.isArray(nodeInfo.parents) && nodeInfo.parents.length > 0) {
-        currentSha = nodeInfo.parents[0] ?? '';
+    const journal = this._requireJournal();
+    const patches = await mapWithConcurrency(pending, PATCH_READ_CONCURRENCY, async ({ sha, patchMeta }) => ({
+      patch: await journal.readPatch(patchMeta),
+      sha,
+    }));
+
+    return patches.reverse();
+  }
+
+  /**
+   * Returns the patch journal or throws the discovery contract error.
+   */
+  private _requireJournal(): PatchJournalPort {
+    const journal = this._host._patchJournal;
+    if (journal === null || journal === undefined) {
+      throw new PatchError('patchJournal is required for patch discovery', {
+        code: 'E_MISSING_JOURNAL',
+      });
+    }
+    return journal;
+  }
+
+  /**
+   * Walks a commit chain from a tip SHA following first parents, yielding
+   * each node until `stopAtSha` or a root commit is reached.
+   *
+   * Prefers one bulk `logNodesStream` read for the whole chain; any commit
+   * missing from the bulk read (or a persistence without a usable bulk
+   * surface) is fetched via per-commit `getNodeInfo`, preserving the legacy
+   * error surface for missing objects.
+   */
+  private async *_chainNodes(tipSha: string, stopAtSha: string | null): AsyncGenerator<ChainNode> {
+    const persistence = this._host._persistence;
+    const chainIndex = await this._loadChainIndex(tipSha, persistence);
+    let currentSha: string = tipSha;
+
+    while (currentSha && currentSha !== stopAtSha) {
+      const node = chainIndex?.get(currentSha) ?? (await persistence.getNodeInfo(currentSha));
+      // Yield the sha we resolved, not node.sha: the legacy walk tracked the
+      // sha itself, and some persistence doubles omit sha from getNodeInfo.
+      yield { sha: currentSha, message: node.message, parents: node.parents };
+
+      const nextSha = node.parents[0];
+      if (typeof nextSha === 'string' && nextSha.length > 0) {
+        currentSha = nextSha;
       } else {
         break;
       }
     }
+  }
 
-    return patches.reverse();
+  /**
+   * Reads the full history reachable from `tipSha` in one bulk read and
+   * indexes it by SHA. Returns null when the persistence does not expose a
+   * bulk log surface (or the bulk read fails), signalling the caller to walk
+   * per-commit instead.
+   */
+  private async _loadChainIndex(
+    tipSha: string,
+    persistence: CorePersistence,
+  ): Promise<Map<string, ChainNode> | null> {
+    const bulk = persistence as Partial<CorePersistence>;
+    if (typeof bulk.logNodesStream !== 'function') {
+      return null;
+    }
+
+    try {
+      const stream = await bulk.logNodesStream({ ref: tipSha, format: CHAIN_LOG_FORMAT });
+      const index = new Map<string, ChainNode>();
+      for await (const node of new GitLogParser().parse(stream)) {
+        index.set(node.sha, { sha: node.sha, message: node.message, parents: node.parents });
+      }
+      return index;
+    } catch {
+      return null;
+    }
   }
 
   /**
@@ -205,20 +311,18 @@ export class PatchDiscovery {
       const tickShas: Record<number, string> = {};
 
       if (typeof tipSha === 'string' && tipSha.length > 0) {
-        let currentSha: string = tipSha;
         let lastLamport = Infinity;
 
-        while (currentSha) {
-          const nodeInfo = await h._persistence.getNodeInfo(currentSha);
-          const kind = h._commitMessageCodec.detectKind(nodeInfo.message);
+        for await (const node of this._chainNodes(tipSha, null)) {
+          const kind = h._commitMessageCodec.detectKind(node.message);
           if (kind !== 'patch') {
             break;
           }
 
-          const patchMeta = h._commitMessageCodec.decodePatch(nodeInfo.message);
+          const patchMeta = h._commitMessageCodec.decodePatch(node.message);
           globalTickSet.add(patchMeta.lamport);
           writerTicks.push(patchMeta.lamport);
-          tickShas[patchMeta.lamport] = currentSha;
+          tickShas[patchMeta.lamport] = node.sha;
 
           if (patchMeta.lamport > lastLamport && h._logger) {
             h._logger.warn(
@@ -226,12 +330,6 @@ export class PatchDiscovery {
             );
           }
           lastLamport = patchMeta.lamport;
-
-          if (Array.isArray(nodeInfo.parents) && nodeInfo.parents.length > 0) {
-            currentSha = nodeInfo.parents[0] ?? '';
-          } else {
-            break;
-          }
         }
       }
 

--- a/src/domain/services/controllers/PatchDiscovery.ts
+++ b/src/domain/services/controllers/PatchDiscovery.ts
@@ -270,8 +270,10 @@ export class PatchDiscovery {
   }
 
   /**
-   * Reads the full history reachable from `tipSha` in one bulk read and
-   * indexes it by SHA. Returns null when the persistence does not expose a
+   * Reads the first-parent history from `tipSha` in one bulk read and
+   * indexes it by SHA. The walk follows first parents, so the bulk read is
+   * constrained the same way: a merge's side branch is neither indexed nor
+   * paid for. Returns null when the persistence does not expose a
    * bulk log surface (or the bulk read fails), signalling the caller to walk
    * per-commit instead.
    */
@@ -280,7 +282,11 @@ export class PatchDiscovery {
     persistence: CorePersistence,
   ): Promise<Map<string, ChainNode> | null> {
     try {
-      const stream = await persistence.logNodesStream({ ref: tipSha, format: CHAIN_LOG_FORMAT });
+      const stream = await persistence.logNodesStream({
+        ref: tipSha,
+        format: CHAIN_LOG_FORMAT,
+        firstParent: true,
+      });
       const index = new Map<string, ChainNode>();
       for await (const node of new GitLogParser().parse(stream)) {
         index.set(node.sha, new ChainNode(node));

--- a/src/domain/services/controllers/PatchDiscovery.ts
+++ b/src/domain/services/controllers/PatchDiscovery.ts
@@ -56,16 +56,14 @@ async function mapWithConcurrency<T, R>(
   fn: (item: T) => Promise<R>,
 ): Promise<R[]> {
   const started = new Array<Promise<R> | null>(items.length).fill(null);
-  let nextIndex = 0;
+  // Workers pull from one shared iterator, so every item is dispatched exactly
+  // once and no result slot is skipped. Indexing `items` directly would widen
+  // each element to `T | undefined` and silently drop a legitimately undefined
+  // item, returning fewer results than inputs.
+  const pending = items.entries();
 
   const drain = async (): Promise<void> => {
-    while (nextIndex < items.length) {
-      const index = nextIndex;
-      nextIndex += 1;
-      const item = items[index];
-      if (item === undefined) {
-        continue;
-      }
+    for (const [index, item] of pending) {
       const inFlight = fn(item);
       started[index] = inFlight;
       // Swallow here so a worker never dies on a rejection; the real error is
@@ -210,7 +208,11 @@ export class PatchDiscovery {
         break;
       }
       const patchMeta = h._commitMessageCodec.decodePatch(node.message);
-      this._requireJournal();
+      if (pending.length === 0) {
+        // Legacy ordering: the contract error surfaces after the first patch
+        // decodes, not after the whole chain is walked. Checking once suffices.
+        this._requireJournal();
+      }
       pending.push({ sha: node.sha, patchMeta });
     }
 
@@ -251,10 +253,17 @@ export class PatchDiscovery {
    */
   private async *_chainNodes(tipSha: string, stopAtSha: string | null): AsyncGenerator<ChainNode> {
     const persistence = this._host._persistence;
-    const chainIndex = await this._loadChainIndex(tipSha, persistence);
+    const chainIndex = await this._loadChainIndex(tipSha, stopAtSha, persistence);
+    const seen = new Set<string>();
     let currentSha: string = tipSha;
 
     while (currentSha && currentSha !== stopAtSha) {
+      if (seen.has(currentSha)) {
+        // A parent cycle is corrupt history. Stopping keeps a malformed chain
+        // from spinning forever now that the walk needs no I/O per step.
+        break;
+      }
+      seen.add(currentSha);
       const node = chainIndex?.get(currentSha) ?? (await persistence.getNodeInfo(currentSha));
       // Yield the sha we resolved, not node.sha: the legacy walk tracked the
       // sha itself, and some persistence doubles omit sha from getNodeInfo.
@@ -270,15 +279,21 @@ export class PatchDiscovery {
   }
 
   /**
-   * Reads the first-parent history from `tipSha` in one bulk read and
-   * indexes it by SHA. The walk follows first parents, so the bulk read is
-   * constrained the same way: a merge's side branch is neither indexed nor
-   * paid for. Returns null when the persistence does not expose a
-   * bulk log surface (or the bulk read fails), signalling the caller to walk
+   * Reads the first-parent history from `tipSha` in one bulk read and indexes
+   * it by SHA.
+   *
+   * The read is bounded exactly as the walk is: `firstParent` keeps a merge's
+   * side branch out, and `stopAtSha` bounds the range so history the walk will
+   * never visit is neither fetched nor held in memory. Parsing also stops at
+   * the boundary, so a persistence that ignores `stopAt` still cannot force an
+   * unbounded index.
+   *
+   * Returns null when the bulk read is unusable, signalling the caller to walk
    * per-commit instead.
    */
   private async _loadChainIndex(
     tipSha: string,
+    stopAtSha: string | null,
     persistence: CorePersistence,
   ): Promise<Map<string, ChainNode> | null> {
     try {
@@ -286,15 +301,24 @@ export class PatchDiscovery {
         ref: tipSha,
         format: CHAIN_LOG_FORMAT,
         firstParent: true,
+        ...(stopAtSha === null ? {} : { stopAt: stopAtSha }),
       });
       const index = new Map<string, ChainNode>();
       for await (const node of new GitLogParser().parse(stream)) {
+        if (node.sha === stopAtSha) {
+          break;
+        }
         index.set(node.sha, new ChainNode(node));
       }
       return index;
-    } catch {
-      // Covers both a persistence that omits the bulk surface entirely and a
-      // bulk read that fails; either way the caller walks per-commit instead.
+    } catch (error) {
+      // Falling back is correct for a persistence with no usable bulk surface,
+      // but it silently restores the per-commit cost this class exists to
+      // avoid — so it must be observable rather than invisible.
+      this._host._logger?.warn(
+        'bulk chain read unavailable; falling back to per-commit walk',
+        { error: error instanceof Error ? error.message : String(error) },
+      );
       return null;
     }
   }

--- a/src/domain/services/controllers/PatchDiscovery.ts
+++ b/src/domain/services/controllers/PatchDiscovery.ts
@@ -19,37 +19,70 @@ import type CommitMessageCodecPort from '../../../ports/CommitMessageCodecPort.t
 import type { PatchCommitMessage } from '../../../ports/CommitMessageCodecPort.ts';
 
 /** Log format matching GitLogParser's record contract: sha, author, date, parents, message. */
-const CHAIN_LOG_FORMAT = '%H%n%an <%ae>%n%aI%n%P%n%B';
+export const CHAIN_LOG_FORMAT = '%H%n%an <%ae>%n%aI%n%P%n%B';
 
 /** Upper bound on concurrent patch payload reads during chain loading. */
 const PATCH_READ_CONCURRENCY = 8;
 
 /** The subset of commit metadata a chain walk consumes. */
-interface ChainNode {
-  sha: string;
-  message: string;
-  parents: readonly string[];
+class ChainNode {
+  readonly sha: string;
+  readonly message: string;
+  readonly parents: readonly string[];
+
+  constructor({ sha, message, parents }: {
+    sha: string;
+    message: string;
+    parents: readonly string[];
+  }) {
+    this.sha = sha;
+    this.message = message;
+    this.parents = parents;
+  }
 }
 
 /**
  * Maps items to results with bounded concurrency, preserving input order.
+ *
+ * Work is dispatched by a bounded worker pool, but results are collected by
+ * awaiting each item's promise in input order. A rejection therefore surfaces
+ * the earliest failing item by index rather than whichever rejected first in
+ * wall-clock time, so callers see a deterministic error regardless of the
+ * relative latency of concurrent reads.
  */
 async function mapWithConcurrency<T, R>(
   items: readonly T[],
   limit: number,
   fn: (item: T) => Promise<R>,
 ): Promise<R[]> {
-  const results = new Array<R>(items.length);
+  const started = new Array<Promise<R> | null>(items.length).fill(null);
   let nextIndex = 0;
-  const workerCount = Math.max(1, Math.min(limit, items.length));
-  const workers = Array.from({ length: workerCount }, async () => {
+
+  const drain = async (): Promise<void> => {
     while (nextIndex < items.length) {
       const index = nextIndex;
       nextIndex += 1;
-      results[index] = await fn(items[index] as T);
+      const item = items[index];
+      if (item === undefined) {
+        continue;
+      }
+      const inFlight = fn(item);
+      started[index] = inFlight;
+      // Swallow here so a worker never dies on a rejection; the real error is
+      // rethrown below in index order, where the caller can observe it.
+      await inFlight.catch(() => undefined);
     }
-  });
-  await Promise.all(workers);
+  };
+
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workerCount }, drain));
+
+  const results: R[] = [];
+  for (const inFlight of started) {
+    if (inFlight !== null) {
+      results.push(await inFlight);
+    }
+  }
   return results;
 }
 
@@ -225,7 +258,7 @@ export class PatchDiscovery {
       const node = chainIndex?.get(currentSha) ?? (await persistence.getNodeInfo(currentSha));
       // Yield the sha we resolved, not node.sha: the legacy walk tracked the
       // sha itself, and some persistence doubles omit sha from getNodeInfo.
-      yield { sha: currentSha, message: node.message, parents: node.parents };
+      yield new ChainNode({ sha: currentSha, message: node.message, parents: node.parents });
 
       const nextSha = node.parents[0];
       if (typeof nextSha === 'string' && nextSha.length > 0) {
@@ -246,19 +279,16 @@ export class PatchDiscovery {
     tipSha: string,
     persistence: CorePersistence,
   ): Promise<Map<string, ChainNode> | null> {
-    const bulk = persistence as Partial<CorePersistence>;
-    if (typeof bulk.logNodesStream !== 'function') {
-      return null;
-    }
-
     try {
-      const stream = await bulk.logNodesStream({ ref: tipSha, format: CHAIN_LOG_FORMAT });
+      const stream = await persistence.logNodesStream({ ref: tipSha, format: CHAIN_LOG_FORMAT });
       const index = new Map<string, ChainNode>();
       for await (const node of new GitLogParser().parse(stream)) {
-        index.set(node.sha, { sha: node.sha, message: node.message, parents: node.parents });
+        index.set(node.sha, new ChainNode(node));
       }
       return index;
     } catch {
+      // Covers both a persistence that omits the bulk surface entirely and a
+      // bulk read that fails; either way the caller walks per-commit instead.
       return null;
     }
   }

--- a/src/domain/services/controllers/PatchDiscovery.ts
+++ b/src/domain/services/controllers/PatchDiscovery.ts
@@ -255,6 +255,7 @@ export class PatchDiscovery {
     const persistence = this._host._persistence;
     const chainIndex = await this._loadChainIndex(tipSha, stopAtSha, persistence);
     const seen = new Set<string>();
+    let gapCount = 0;
     let currentSha: string = tipSha;
 
     while (currentSha && currentSha !== stopAtSha) {
@@ -264,7 +265,12 @@ export class PatchDiscovery {
         break;
       }
       seen.add(currentSha);
-      const node = chainIndex?.get(currentSha) ?? (await persistence.getNodeInfo(currentSha));
+      const indexed = chainIndex?.get(currentSha);
+      if (indexed === undefined) {
+        gapCount += 1;
+        this._warnFirstChainIndexGap(chainIndex, gapCount, tipSha, currentSha);
+      }
+      const node = indexed ?? (await persistence.getNodeInfo(currentSha));
       // Yield the sha we resolved, not node.sha: the legacy walk tracked the
       // sha itself, and some persistence doubles omit sha from getNodeInfo.
       yield new ChainNode({ sha: currentSha, message: node.message, parents: node.parents });
@@ -276,6 +282,29 @@ export class PatchDiscovery {
         break;
       }
     }
+  }
+
+  /**
+   * Warns once when a successful bulk read turns out to be incomplete.
+   *
+   * A bulk read that throws is already reported by `_loadChainIndex`. A bulk
+   * read that succeeds but omits commits is the quieter failure: the walk keeps
+   * working, per-commit `getNodeInfo` covers every gap, and the serial cost this
+   * class exists to remove comes back with nothing in the log to say so.
+   */
+  private _warnFirstChainIndexGap(
+    chainIndex: Map<string, ChainNode> | null,
+    gapCount: number,
+    tipSha: string,
+    missingSha: string,
+  ): void {
+    if (chainIndex === null || gapCount !== 1) {
+      return;
+    }
+    this._host._logger?.warn(
+      'bulk chain read incomplete; falling back to per-commit reads',
+      { tipSha, missingSha },
+    );
   }
 
   /**

--- a/src/infrastructure/adapters/GitLogArgs.ts
+++ b/src/infrastructure/adapters/GitLogArgs.ts
@@ -20,25 +20,46 @@ function stripNulBytes(format: string): string {
  * `firstParent` constrains traversal to first parents so a chain read never
  * pays for a merge's side branch, matching how patch-chain walkers advance.
  *
+ * `stopAt` bounds the read to the range `stopAt..ref`, so a caller that stops
+ * walking at a known boundary does not read history beyond it.
+ *
  * `stripNulFormat` removes NUL bytes from the format AFTER deciding whether a
  * format was supplied at all: a caller-supplied format consisting only of NUL
  * bytes still yields an explicit empty `--format=`, matching Git's own
  * treatment of an empty format.
  */
-export function buildLogArgs({ base, ref, format, firstParent, stripNulFormat }: {
+export function buildLogArgs({ base, ref, format, firstParent, stripNulFormat, stopAt }: {
   base: readonly string[];
   ref: string;
   format: string | undefined;
   firstParent: boolean;
   stripNulFormat: boolean;
+  stopAt: string | undefined;
 }): string[] {
   const args = [...base];
   if (firstParent) {
     args.push('--first-parent');
   }
-  if (typeof format === 'string' && format.length > 0) {
-    args.push(`--format=${stripNulFormat ? stripNulBytes(format) : format}`);
+  const formatArg = resolveFormatArg(format, stripNulFormat);
+  if (formatArg !== null) {
+    args.push(formatArg);
   }
-  args.push(ref);
+  args.push(resolveRevRange(ref, stopAt));
   return args;
+}
+
+/** Renders the `--format=` argument, or null when no format was supplied. */
+function resolveFormatArg(format: string | undefined, stripNulFormat: boolean): string | null {
+  if (typeof format !== 'string' || format.length === 0) {
+    return null;
+  }
+  return `--format=${stripNulFormat ? stripNulBytes(format) : format}`;
+}
+
+/** Renders the revision selector: a `stopAt..ref` range, or the bare ref. */
+function resolveRevRange(ref: string, stopAt: string | undefined): string {
+  if (typeof stopAt !== 'string' || stopAt.length === 0) {
+    return ref;
+  }
+  return `${stopAt}..${ref}`;
 }

--- a/src/infrastructure/adapters/GitLogArgs.ts
+++ b/src/infrastructure/adapters/GitLogArgs.ts
@@ -1,0 +1,44 @@
+/**
+ * Argument assembly for the Git history read commands.
+ *
+ * Extracted from GitTimelineHistoryAdapter so the buffered and streaming
+ * log reads share one definition of how a history query becomes `git log`
+ * arguments.
+ *
+ * @module infrastructure/adapters/GitLogArgs
+ */
+
+/** Git `-z` uses NUL as its record terminator, so a format may not contain one. */
+function stripNulBytes(format: string): string {
+  // eslint-disable-next-line no-control-regex
+  return format.replace(/\x00/gu, '');
+}
+
+/**
+ * Assembles `git log` arguments shared by the buffered and streaming reads.
+ *
+ * `firstParent` constrains traversal to first parents so a chain read never
+ * pays for a merge's side branch, matching how patch-chain walkers advance.
+ *
+ * `stripNulFormat` removes NUL bytes from the format AFTER deciding whether a
+ * format was supplied at all: a caller-supplied format consisting only of NUL
+ * bytes still yields an explicit empty `--format=`, matching Git's own
+ * treatment of an empty format.
+ */
+export function buildLogArgs({ base, ref, format, firstParent, stripNulFormat }: {
+  base: readonly string[];
+  ref: string;
+  format: string | undefined;
+  firstParent: boolean;
+  stripNulFormat: boolean;
+}): string[] {
+  const args = [...base];
+  if (firstParent) {
+    args.push('--first-parent');
+  }
+  if (typeof format === 'string' && format.length > 0) {
+    args.push(`--format=${stripNulFormat ? stripNulBytes(format) : format}`);
+  }
+  args.push(ref);
+  return args;
+}

--- a/src/infrastructure/adapters/GitTimelineHistoryAdapter.ts
+++ b/src/infrastructure/adapters/GitTimelineHistoryAdapter.ts
@@ -13,7 +13,6 @@ import type {
   NodeInfo,
   PingResult,
 } from '../../ports/CommitPort.ts';
-import { buildLogArgs } from './GitLogArgs.ts';
 import type { ListRefsOptions } from '../../ports/RefPort.ts';
 import type TreeEntryLimit from '../../domain/tree/TreeEntryLimit.ts';
 import type TreeEntryPath from '../../domain/tree/TreeEntryPath.ts';
@@ -22,13 +21,14 @@ import type { TreeEntryProbeResult } from '../../domain/tree/TreeEntryProbeResul
 import AdapterValidationError from '../../domain/errors/AdapterValidationError.ts';
 import PersistenceError from '../../domain/errors/PersistenceError.ts';
 import GraphPersistencePort from '../../ports/GraphPersistencePort.ts';
+import { buildLogArgs } from './GitLogArgs.ts';
 import GitCasGraphReaderAdapter from './GitCasGraphReaderAdapter.ts';
 import decodeGitCommitNodeInfo from './GitCommitNodeInfoDecoder.ts';
 import GitRecursiveTreeOidReaderAdapter from './GitRecursiveTreeOidReaderAdapter.ts';
 import AlfredOperationPolicyAdapter from './AlfredOperationPolicyAdapter.ts';
 import WarpStream from '../../domain/stream/WarpStream.ts';
 import { textEncode } from '../../domain/utils/bytes.ts';
-import { validateOid, validateRef, validateLimit, validateConfigKey } from './adapterValidation.ts';
+import { validateOid, validateRef, validateLimit, validateConfigKey, validateLogRequest } from './adapterValidation.ts';
 import {
   type GitPlumbing,
   type GitError,
@@ -239,15 +239,15 @@ export default class GitTimelineHistoryAdapter extends GraphPersistencePort {
     }
   }
 
-  async logNodes({ ref, limit = 50, format, firstParent }: LogNodesOptions): Promise<string> {
-    validateRef(ref);
-    validateLimit(limit);
+  async logNodes({ ref, limit = 50, format, firstParent, stopAt }: LogNodesOptions): Promise<string> {
+    validateLogRequest({ ref, limit, stopAt });
     const args = buildLogArgs({
       base: ['log', `-${limit}`],
       ref,
       format,
-      firstParent: firstParent === true,
+      firstParent: firstParent ?? false,
       stripNulFormat: false,
+      stopAt,
     });
     try {
       return await this._executeWithRetry({ args });
@@ -261,15 +261,16 @@ export default class GitTimelineHistoryAdapter extends GraphPersistencePort {
     limit = 1000000,
     format,
     firstParent,
+    stopAt,
   }: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
-    validateRef(ref);
-    validateLimit(limit);
+    validateLogRequest({ ref, limit, stopAt });
     const args = buildLogArgs({
       base: ['log', '-z', `-${limit}`],
       ref,
       format,
-      firstParent: firstParent === true,
+      firstParent: firstParent ?? false,
       stripNulFormat: true,
+      stopAt,
     });
     const rawStream = await this._policy.stream(
       () => this.plumbing.executeStream({ args }),

--- a/src/infrastructure/adapters/GitTimelineHistoryAdapter.ts
+++ b/src/infrastructure/adapters/GitTimelineHistoryAdapter.ts
@@ -13,6 +13,7 @@ import type {
   NodeInfo,
   PingResult,
 } from '../../ports/CommitPort.ts';
+import { buildLogArgs } from './GitLogArgs.ts';
 import type { ListRefsOptions } from '../../ports/RefPort.ts';
 import type TreeEntryLimit from '../../domain/tree/TreeEntryLimit.ts';
 import type TreeEntryPath from '../../domain/tree/TreeEntryPath.ts';
@@ -238,14 +239,16 @@ export default class GitTimelineHistoryAdapter extends GraphPersistencePort {
     }
   }
 
-  async logNodes({ ref, limit = 50, format }: LogNodesOptions): Promise<string> {
+  async logNodes({ ref, limit = 50, format, firstParent }: LogNodesOptions): Promise<string> {
     validateRef(ref);
     validateLimit(limit);
-    const args = ['log', `-${limit}`];
-    if (typeof format === 'string' && format.length > 0) {
-      args.push(`--format=${format}`);
-    }
-    args.push(ref);
+    const args = buildLogArgs({
+      base: ['log', `-${limit}`],
+      ref,
+      format,
+      firstParent: firstParent === true,
+      stripNulFormat: false,
+    });
     try {
       return await this._executeWithRetry({ args });
     } catch (raw) {
@@ -257,17 +260,17 @@ export default class GitTimelineHistoryAdapter extends GraphPersistencePort {
     ref,
     limit = 1000000,
     format,
+    firstParent,
   }: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
     validateRef(ref);
     validateLimit(limit);
-    const args = ['log', '-z', `-${limit}`];
-    if (typeof format === 'string' && format.length > 0) {
-      // Strip NUL bytes — Git -z uses NUL as record terminator.
-      // eslint-disable-next-line no-control-regex
-      const cleanFormat = format.replace(/\x00/g, '');
-      args.push(`--format=${cleanFormat}`);
-    }
-    args.push(ref);
+    const args = buildLogArgs({
+      base: ['log', '-z', `-${limit}`],
+      ref,
+      format,
+      firstParent: firstParent === true,
+      stripNulFormat: true,
+    });
     const rawStream = await this._policy.stream(
       () => this.plumbing.executeStream({ args }),
       this._retryOptions

--- a/src/infrastructure/adapters/adapterValidation.ts
+++ b/src/infrastructure/adapters/adapterValidation.ts
@@ -71,6 +71,35 @@ export function validateRef(ref: string): void {
   assertRefFormat(ref);
 }
 
+/**
+ * Validates every input a history read puts on the git command line.
+ *
+ * `ref`, `limit` and `stopAt` all reach argv, so they are checked together at
+ * the single point where a log request enters the adapter.
+ */
+export function validateLogRequest({ ref, limit, stopAt }: {
+  ref: string;
+  limit: number;
+  stopAt: string | undefined;
+}): void {
+  validateRef(ref);
+  validateLimit(limit);
+  validateStopAt(stopAt);
+}
+
+/**
+ * Validates an optional exclusive range boundary.
+ *
+ * `stopAt` is interpolated into a `stopAt..ref` rev range, so it must clear the
+ * same checks as a ref; an unvalidated value would reach the git command line.
+ */
+export function validateStopAt(stopAt: string | undefined): void {
+  if (stopAt === undefined) {
+    return;
+  }
+  validateRef(stopAt);
+}
+
 function assertLimitType(limit: number): void {
   if (typeof limit !== 'number' || !Number.isFinite(limit)) {
     throw new AdapterValidationError('Limit must be a finite number');

--- a/src/ports/CommitPort.ts
+++ b/src/ports/CommitPort.ts
@@ -30,6 +30,8 @@ export interface LogNodesOptions {
   ref: string;
   limit?: number;
   format?: string;
+  /** Follow only first parents, excluding side branches of any merge. */
+  firstParent?: boolean;
 }
 
 export interface NodeInfo {

--- a/src/ports/CommitPort.ts
+++ b/src/ports/CommitPort.ts
@@ -32,6 +32,13 @@ export interface LogNodesOptions {
   format?: string;
   /** Follow only first parents, excluding side branches of any merge. */
   firstParent?: boolean;
+  /**
+   * Exclude this commit and everything reachable from it, bounding the read to
+   * the range `stopAt..ref`. A chain reader that stops walking at a known
+   * boundary must also stop *reading* there, or it pays for history it will
+   * never visit.
+   */
+  stopAt?: string;
 }
 
 export interface NodeInfo {

--- a/test/helpers/InMemoryGraphAdapter.ts
+++ b/test/helpers/InMemoryGraphAdapter.ts
@@ -484,7 +484,13 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
     firstParent: boolean;
     stopAt: string | undefined;
   }): (CommitRecord & { sha: string })[] {
-    const excluded = stopAt === undefined ? new Set<string>() : this._reachableFrom(stopAt);
+    // `stopAt` accepts a ref name as well as a SHA, exactly as the Git adapter
+    // does when it builds a `stopAt..ref` range. Resolving first keeps a
+    // boundary ref from silently excluding nothing here but everything there.
+    const excludedTip = stopAt === undefined ? null : this._resolveRef(stopAt);
+    const excluded = excludedTip === null
+      ? new Set<string>()
+      : this._reachableFrom(excludedTip);
     const all: (CommitRecord & { sha: string })[] = [];
     const visited = new Set<string>();
     const queue = [startSha];

--- a/test/helpers/InMemoryGraphAdapter.ts
+++ b/test/helpers/InMemoryGraphAdapter.ts
@@ -278,10 +278,10 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
     return this._countReachable(tip);
   }
 
-  async logNodes({ ref, limit = 50, format: _format }: LogNodesOptions): Promise<string> {
+  async logNodes({ ref, limit = 50, format: _format, firstParent }: LogNodesOptions): Promise<string> {
     validateRef(ref);
     validateLimit(limit);
-    const records = this._walkLog(ref, limit);
+    const records = this._walkLog({ ref, limit, firstParent: firstParent === true });
     if (typeof _format !== 'string' || _format.length === 0) {
       return records.map(c =>
         `commit ${c.sha}\nAuthor: ${c.author}\nDate:   ${c.date}\n\n    ${c.message}\n`,
@@ -290,10 +290,10 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
     return records.map(c => this._formatCommitRecord(c)).join('\0') + (records.length > 0 ? '\0' : '');
   }
 
-  async logNodesStream({ ref, limit = 1000000, format: _format }: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
+  async logNodesStream({ ref, limit = 1000000, format: _format, firstParent }: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
     validateRef(ref);
     validateLimit(limit);
-    const records = this._walkLog(ref, limit);
+    const records = this._walkLog({ ref, limit, firstParent: firstParent === true });
     const formatted = records.map(c => this._formatCommitRecord(c)).join('\0') + (records.length > 0 ? '\0' : '');
     return WarpStream.of<CommitLogChunk>(formatted);
   }
@@ -414,12 +414,16 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
     return null;
   }
 
-  private _walkLog(ref: string, limit: number): (CommitRecord & { sha: string })[] {
+  private _walkLog({ ref, limit, firstParent }: {
+    ref: string;
+    limit: number;
+    firstParent: boolean;
+  }): (CommitRecord & { sha: string })[] {
     const tip = this._resolveRef(ref);
     if (tip === null) {
       return [];
     }
-    const all = this._collectCommits(tip);
+    const all = this._collectCommits({ startSha: tip, firstParent });
     all.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
     return all.slice(0, limit);
   }
@@ -445,7 +449,17 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
     return count;
   }
 
-  private _collectCommits(startSha: string): (CommitRecord & { sha: string })[] {
+  /**
+   * Collects commits reachable from `startSha`.
+   *
+   * With `firstParent`, traversal follows only each commit's first parent, so
+   * a merge's side branch is never collected — matching `git log --first-parent`
+   * and the `LogNodesOptions.firstParent` contract.
+   */
+  private _collectCommits({ startSha, firstParent }: {
+    startSha: string;
+    firstParent: boolean;
+  }): (CommitRecord & { sha: string })[] {
     const all: (CommitRecord & { sha: string })[] = [];
     const visited = new Set<string>();
     const queue = [startSha];
@@ -459,7 +473,8 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
       const commit = this._commits.get(sha);
       if (commit !== undefined) {
         all.push({ sha, ...commit });
-        for (const p of commit.parents) {
+        const parents = firstParent ? commit.parents.slice(0, 1) : commit.parents;
+        for (const p of parents) {
           if (!visited.has(p)) {
             queue.push(p);
           }

--- a/test/helpers/InMemoryGraphAdapter.ts
+++ b/test/helpers/InMemoryGraphAdapter.ts
@@ -278,10 +278,10 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
     return this._countReachable(tip);
   }
 
-  async logNodes({ ref, limit = 50, format: _format, firstParent }: LogNodesOptions): Promise<string> {
+  async logNodes({ ref, limit = 50, format: _format, firstParent, stopAt }: LogNodesOptions): Promise<string> {
     validateRef(ref);
     validateLimit(limit);
-    const records = this._walkLog({ ref, limit, firstParent: firstParent === true });
+    const records = this._walkLog({ ref, limit, firstParent: firstParent ?? false, stopAt });
     if (typeof _format !== 'string' || _format.length === 0) {
       return records.map(c =>
         `commit ${c.sha}\nAuthor: ${c.author}\nDate:   ${c.date}\n\n    ${c.message}\n`,
@@ -290,10 +290,10 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
     return records.map(c => this._formatCommitRecord(c)).join('\0') + (records.length > 0 ? '\0' : '');
   }
 
-  async logNodesStream({ ref, limit = 1000000, format: _format, firstParent }: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
+  async logNodesStream({ ref, limit = 1000000, format: _format, firstParent, stopAt }: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
     validateRef(ref);
     validateLimit(limit);
-    const records = this._walkLog({ ref, limit, firstParent: firstParent === true });
+    const records = this._walkLog({ ref, limit, firstParent: firstParent ?? false, stopAt });
     const formatted = records.map(c => this._formatCommitRecord(c)).join('\0') + (records.length > 0 ? '\0' : '');
     return WarpStream.of<CommitLogChunk>(formatted);
   }
@@ -414,16 +414,17 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
     return null;
   }
 
-  private _walkLog({ ref, limit, firstParent }: {
+  private _walkLog({ ref, limit, firstParent, stopAt }: {
     ref: string;
     limit: number;
     firstParent: boolean;
+    stopAt: string | undefined;
   }): (CommitRecord & { sha: string })[] {
     const tip = this._resolveRef(ref);
     if (tip === null) {
       return [];
     }
-    const all = this._collectCommits({ startSha: tip, firstParent });
+    const all = this._collectCommits({ startSha: tip, firstParent, stopAt });
     all.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
     return all.slice(0, limit);
   }
@@ -449,24 +450,48 @@ export default class InMemoryGraphAdapter extends GraphPersistencePort {
     return count;
   }
 
+  /** Every commit reachable from `sha`, used to exclude a `stopAt` boundary. */
+  private _reachableFrom(sha: string): Set<string> {
+    const seen = new Set<string>();
+    const queue = [sha];
+    let head = 0;
+    while (head < queue.length) {
+      const current = queue[head++]!;
+      if (seen.has(current)) {
+        continue;
+      }
+      seen.add(current);
+      const commit = this._commits.get(current);
+      if (commit !== undefined) {
+        queue.push(...commit.parents);
+      }
+    }
+    return seen;
+  }
+
   /**
    * Collects commits reachable from `startSha`.
    *
    * With `firstParent`, traversal follows only each commit's first parent, so
    * a merge's side branch is never collected — matching `git log --first-parent`
    * and the `LogNodesOptions.firstParent` contract.
+   *
+   * `stopAt` excludes that commit and everything reachable from it, matching
+   * the `stopAt..ref` range semantics of `LogNodesOptions.stopAt`.
    */
-  private _collectCommits({ startSha, firstParent }: {
+  private _collectCommits({ startSha, firstParent, stopAt }: {
     startSha: string;
     firstParent: boolean;
+    stopAt: string | undefined;
   }): (CommitRecord & { sha: string })[] {
+    const excluded = stopAt === undefined ? new Set<string>() : this._reachableFrom(stopAt);
     const all: (CommitRecord & { sha: string })[] = [];
     const visited = new Set<string>();
     const queue = [startSha];
     let head = 0;
     while (head < queue.length) {
       const sha = queue[head++]!;
-      if (visited.has(sha)) {
+      if (visited.has(sha) || excluded.has(sha)) {
         continue;
       }
       visited.add(sha);

--- a/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
+++ b/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
@@ -306,6 +306,38 @@ describe('PatchDiscovery batched chain reads', () => {
     expect(persistence.lastLogOptions?.format).toBe(CHAIN_LOG_FORMAT);
   });
 
+  it('requests first-parent traversal so merge side branches are never read', async () => {
+    const persistence = new FakePersistence({ commits: linearChain(4) });
+    const discovery = new PatchDiscovery(hostWith(persistence));
+
+    await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(persistence.lastLogOptions?.firstParent).toBe(true);
+  });
+
+  it('excludes side-parent commits when a chain commit is a merge', async () => {
+    // shaFor(1) is a merge: first parent shaFor(2) continues the chain, and
+    // sideSha is a patch commit reachable only through the second parent.
+    const sideSha = 'f'.repeat(40);
+    const commits = linearChain(4);
+    const merge = commits[1];
+    if (merge === undefined) {
+      throw new Error('fixture chain too short');
+    }
+    merge.parents = [shaFor(2), sideSha];
+    // A real `git log --first-parent` would not emit the side branch at all;
+    // this double is deliberately laxer and emits it, proving the walk itself
+    // never follows a second parent even when the bulk read is over-broad.
+    commits.push({ sha: sideSha, parents: [], message: 'patch:99' });
+    const persistence = new FakePersistence({ commits });
+    const discovery = new PatchDiscovery(hostWith(persistence));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries.map((entry) => entry.sha)).not.toContain(sideSha);
+    expect(entries.map((entry) => entry.sha)).toEqual([shaFor(3), shaFor(2), shaFor(1), shaFor(0)]);
+  });
+
   it('returns patches in chronological order identical to the per-commit walk', async () => {
     const commits = linearChain(7);
     const batched = new FakePersistence({ commits });

--- a/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
+++ b/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
@@ -568,6 +568,38 @@ describe('PatchDiscovery batched chain reads', () => {
     expect(logger.warnings).toEqual([]);
   });
 
+  it('warns when a successful bulk read turns out to be incomplete', async () => {
+    // The louder failure — a bulk read that throws — is already reported. This
+    // is the quiet one: the read succeeds, omits commits, and the walk silently
+    // pays per-commit for every gap.
+    const logger = new RecordingLogger();
+    const persistence = new FakePersistence({
+      commits: linearChain(6),
+      withholdFromBulk: [shaFor(3)],
+    });
+    const discovery = new PatchDiscovery(hostWith(persistence, new FakeJournal(), logger));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries).toHaveLength(6);
+    expect(logger.warnings).toHaveLength(1);
+    expect(logger.warnings[0]).toMatch(/bulk chain read incomplete/i);
+  });
+
+  it('warns once no matter how many commits the bulk read omitted', async () => {
+    // One line per missing commit would turn a degraded read into a log flood.
+    const logger = new RecordingLogger();
+    const persistence = new FakePersistence({
+      commits: linearChain(6),
+      withholdFromBulk: [shaFor(1), shaFor(2), shaFor(3), shaFor(4)],
+    });
+    const discovery = new PatchDiscovery(hostWith(persistence, new FakeJournal(), logger));
+
+    await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(logger.warnings).toHaveLength(1);
+  });
+
   it('stops instead of spinning when the chain contains a parent cycle', async () => {
     // Corrupt history: the root points back at the tip. The walk needs no I/O
     // per step now, so an unguarded cycle would spin the event loop forever.

--- a/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
+++ b/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
@@ -168,6 +168,7 @@ type FakePersistenceOptions = {
 class FakePersistence implements CorePersistence {
   getNodeInfoCalls = 0;
   logNodesStreamCalls = 0;
+  bulkRecordsEmitted = 0;
   lastLogOptions: LogNodesOptions | null = null;
 
   readonly #commits: FakeCommit[];
@@ -213,7 +214,37 @@ class FakePersistence implements CorePersistence {
     if (this.#logStreamFailure === 'reject') {
       throw new Error('bulk history read failed');
     }
-    return toLogStream(this.#commits.filter((commit) => !this.#withheld.has(commit.sha)));
+    const emitted = this.#visibleCommits(options);
+    this.bulkRecordsEmitted = emitted.length;
+    return toLogStream(emitted);
+  }
+
+  /**
+   * Applies the LogNodesOptions contract this double is asked to honour.
+   *
+   * A double that ignored `stopAt` would let an unbounded read pass review, so
+   * it implements the same range semantics as a conforming persistence.
+   */
+  #visibleCommits(options: LogNodesOptions): FakeCommit[] {
+    const available = this.#commits.filter((commit) => !this.#withheld.has(commit.sha));
+    const stopAt = options.stopAt;
+    if (stopAt === undefined) {
+      return available;
+    }
+    const excluded = new Set<string>();
+    const queue = [stopAt];
+    while (queue.length > 0) {
+      const sha = queue.shift();
+      if (sha === undefined || excluded.has(sha)) {
+        continue;
+      }
+      excluded.add(sha);
+      const commit = available.find((candidate) => candidate.sha === sha);
+      if (commit !== undefined) {
+        queue.push(...commit.parents);
+      }
+    }
+    return available.filter((commit) => !excluded.has(commit.sha));
   }
 
   async readRef(_ref: string): Promise<string | null> {
@@ -356,6 +387,30 @@ describe('PatchDiscovery batched chain reads', () => {
     const entries = await discovery.loadPatchChainFromSha(shaFor(0), shaFor(4));
 
     expect(entries.map((entry) => entry.sha)).toEqual([shaFor(3), shaFor(2), shaFor(1), shaFor(0)]);
+    // The walk stopping is not enough: an unbounded bulk read would fetch and
+    // index all ten commits and still produce these four. Bound the read too.
+    expect(persistence.lastLogOptions?.stopAt).toBe(shaFor(4));
+    expect(persistence.bulkRecordsEmitted).toBe(4);
+  });
+
+  it('bounds the bulk read even when the persistence ignores stopAt', async () => {
+    // A non-conforming persistence emits the whole chain regardless of stopAt.
+    // Parsing must still stop at the boundary, or one bad adapter reinstates
+    // the unbounded read this class exists to avoid.
+    const commits = linearChain(10);
+    const persistence = new (class extends FakePersistence {
+      override async logNodesStream(options: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
+        this.logNodesStreamCalls += 1;
+        this.lastLogOptions = options;
+        return toLogStream(commits);
+      }
+    })({ commits });
+    const discovery = new PatchDiscovery(hostWith(persistence));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0), shaFor(4));
+
+    expect(entries.map((entry) => entry.sha)).toEqual([shaFor(3), shaFor(2), shaFor(1), shaFor(0)]);
+    expect(persistence.getNodeInfoCalls).toBe(0);
   });
 
   it('stops at the first non-patch commit', async () => {

--- a/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
+++ b/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
@@ -1,14 +1,34 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { PatchDiscovery, type PatchDiscoveryHost } from '../../../../../src/domain/services/controllers/PatchDiscovery.ts';
+import {
+  CHAIN_LOG_FORMAT,
+  PatchDiscovery,
+  type PatchDiscoveryHost,
+} from '../../../../../src/domain/services/controllers/PatchDiscovery.ts';
 import WarpStream from '../../../../../src/domain/stream/WarpStream.ts';
 import PatchError from '../../../../../src/domain/errors/PatchError.ts';
+import Patch from '../../../../../src/domain/types/Patch.ts';
+import AssetHandle from '../../../../../src/domain/storage/AssetHandle.ts';
+import CommitMessageCodecPort, {
+  createGitCasPatchStorage,
+  type AnchorCommitMessage,
+  type CheckpointCommitMessage,
+  type CommitMessageKind,
+  type PatchCommitMessage,
+} from '../../../../../src/ports/CommitMessageCodecPort.ts';
+import PatchJournalPort, {
+  type AppendPatchRequest,
+  type PublishedPatch,
+} from '../../../../../src/ports/PatchJournalPort.ts';
+import type PatchEntry from '../../../../../src/domain/artifacts/PatchEntry.ts';
 import type { CorePersistence } from '../../../../../src/domain/types/WarpPersistence.ts';
-import type { CommitLogChunk, LogNodesOptions, NodeInfo } from '../../../../../src/ports/CommitPort.ts';
-import type CommitMessageCodecPort from '../../../../../src/ports/CommitMessageCodecPort.ts';
-import type { PatchCommitMessage } from '../../../../../src/ports/CommitMessageCodecPort.ts';
-import type PatchJournalPort from '../../../../../src/ports/PatchJournalPort.ts';
-import type Patch from '../../../../../src/domain/types/Patch.ts';
+import type {
+  CommitLogChunk,
+  CommitNodeOptions,
+  LogNodesOptions,
+  NodeInfo,
+  PingResult,
+} from '../../../../../src/ports/CommitPort.ts';
 
 /**
  * Spawn-count law for patch-chain traversal.
@@ -19,22 +39,29 @@ import type Patch from '../../../../../src/domain/types/Patch.ts';
  * per-commit walk makes every materialization O(history × spawn latency).
  */
 
-interface FakeCommit {
+const TEST_GRAPH = 'think';
+const TEST_WRITER = 'writer-a';
+const UNIMPLEMENTED = 'not implemented in this test double';
+
+type FakeCommit = {
   sha: string;
   parents: string[];
   message: string;
+};
+
+function shaFor(index: number): string {
+  return index.toString(16).padStart(40, 'a');
 }
 
 /** Builds a linear chain: chain[0] is the tip, last element is the root. */
 function linearChain(length: number, options: { rootKind?: string } = {}): FakeCommit[] {
   const commits: FakeCommit[] = [];
   for (let index = 0; index < length; index += 1) {
-    const sha = shaFor(index);
     const parentSha = index + 1 < length ? shaFor(index + 1) : null;
     const isRoot = index === length - 1;
     const kind = isRoot && options.rootKind !== undefined ? options.rootKind : 'patch';
     commits.push({
-      sha,
+      sha: shaFor(index),
       parents: parentSha === null ? [] : [parentSha],
       message: `${kind}:${length - index}`,
     });
@@ -42,137 +69,257 @@ function linearChain(length: number, options: { rootKind?: string } = {}): FakeC
   return commits;
 }
 
-function shaFor(index: number): string {
-  return index.toString(16).padStart(40, 'a');
-}
-
 /** Formats commits the way GitLogParser expects logNodesStream records. */
 function toLogStream(commits: FakeCommit[]): WarpStream<CommitLogChunk> {
   const records = commits.map(
-    (commit) => `${commit.sha}\nAuthor <author@test>\n2026-08-15T00:00:00Z\n${commit.parents.join(' ')}\n${commit.message}`,
+    (commit) =>
+      `${commit.sha}\nAuthor <author@test>\n2026-08-15T00:00:00Z\n${commit.parents.join(' ')}\n${commit.message}`,
   );
   const joined = records.join('\0') + (records.length > 0 ? '\0' : '');
   return WarpStream.of<CommitLogChunk>(joined);
 }
 
-interface CountingPersistenceOptions {
-  commits: FakeCommit[];
-  omitLogNodesStream?: boolean;
-}
-
-interface CountingPersistence {
-  persistence: CorePersistence;
-  getNodeInfoCalls: () => number;
-  logNodesStreamCalls: () => number;
-}
-
-function countingPersistence({ commits, omitLogNodesStream = false }: CountingPersistenceOptions): CountingPersistence {
-  const bySha = new Map(commits.map((commit) => [commit.sha, commit]));
-  let getNodeInfoCount = 0;
-  let logNodesStreamCount = 0;
-
-  const base = {
-    async getNodeInfo(sha: string): Promise<NodeInfo> {
-      getNodeInfoCount += 1;
-      const commit = bySha.get(sha);
-      if (commit === undefined) {
-        throw new Error(`missing commit: ${sha}`);
-      }
-      return {
-        sha: commit.sha,
-        message: commit.message,
-        author: 'Author <author@test>',
-        date: '2026-08-15T00:00:00Z',
-        parents: [...commit.parents],
-      };
-    },
-    async readRef(_ref: string): Promise<string | null> {
-      return commits[0]?.sha ?? null;
-    },
-    async listRefs(_prefix: string): Promise<string[]> {
-      return [];
-    },
-  };
-
-  const withStream = omitLogNodesStream
-    ? base
-    : {
-        ...base,
-        async logNodesStream(_options: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
-          logNodesStreamCount += 1;
-          return toLogStream(commits);
-        },
-      };
-
+function patchMessageFor(lamport: number): PatchCommitMessage {
   return {
-    persistence: withStream as unknown as CorePersistence,
-    getNodeInfoCalls: () => getNodeInfoCount,
-    logNodesStreamCalls: () => logNodesStreamCount,
+    kind: 'patch',
+    graph: TEST_GRAPH,
+    writer: TEST_WRITER,
+    lamport,
+    schema: 2,
+    patchHandle: new AssetHandle(`asset-${lamport}`),
+    storage: createGitCasPatchStorage({ encrypted: false }),
   };
+}
+
+function patchFor(lamport: number): Patch {
+  return new Patch({ writer: TEST_WRITER, lamport, context: {}, ops: [] });
 }
 
 /** Codec for `<kind>:<lamport>` fake messages. */
-const fakeCodec = {
-  detectKind(message: string): string {
-    const kind = message.split(':')[0];
-    return kind === 'patch' ? 'patch' : 'other';
-  },
-  decodePatch(message: string): PatchCommitMessage {
-    const lamport = Number(message.split(':')[1]);
-    return { kind: 'patch', lamport } as unknown as PatchCommitMessage;
-  },
-} as unknown as CommitMessageCodecPort;
+class FakeCodec extends CommitMessageCodecPort {
+  detectKind(message: string): CommitMessageKind | null {
+    return message.split(':')[0] === 'patch' ? 'patch' : 'checkpoint';
+  }
 
-function fakeJournal(): PatchJournalPort {
-  return {
-    async readPatch(message: PatchCommitMessage): Promise<Patch> {
-      return { lamport: message.lamport, ops: [] } as unknown as Patch;
-    },
-  } as unknown as PatchJournalPort;
+  decodePatch(message: string): PatchCommitMessage {
+    return patchMessageFor(Number(message.split(':')[1]));
+  }
+
+  encodePatch(_message: PatchCommitMessage): string {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  encodeCheckpoint(_message: CheckpointCommitMessage): string {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  decodeCheckpoint(_message: string): CheckpointCommitMessage {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  encodeAnchor(_message: AnchorCommitMessage): string {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  decodeAnchor(_message: string): AnchorCommitMessage {
+    throw new Error(UNIMPLEMENTED);
+  }
 }
 
-function hostWith(persistence: CorePersistence, journal: PatchJournalPort | null = fakeJournal()): PatchDiscoveryHost {
+type ReadPatchHook = (message: PatchCommitMessage) => Promise<Patch>;
+
+class FakeJournal extends PatchJournalPort {
+  readonly reads: number[] = [];
+  readonly #hook: ReadPatchHook | null;
+
+  constructor(hook: ReadPatchHook | null = null) {
+    super();
+    this.#hook = hook;
+  }
+
+  async readPatch(message: PatchCommitMessage): Promise<Patch> {
+    if (this.#hook !== null) {
+      const patch = await this.#hook(message);
+      this.reads.push(message.lamport);
+      return patch;
+    }
+    this.reads.push(message.lamport);
+    return patchFor(message.lamport);
+  }
+
+  appendPatch(_request: AppendPatchRequest): Promise<PublishedPatch> {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  scanPatchRange(_writerId: string, _fromSha: string | null, _toSha: string): WarpStream<PatchEntry> {
+    throw new Error(UNIMPLEMENTED);
+  }
+}
+
+type FakePersistenceOptions = {
+  commits: FakeCommit[];
+  /** Simulates a persistence whose bulk history surface is unusable. */
+  logStreamFailure?: 'omit' | 'reject';
+  /** SHAs deliberately withheld from the bulk read to force per-commit fallback. */
+  withholdFromBulk?: readonly string[];
+  writerRefs?: readonly string[];
+};
+
+class FakePersistence implements CorePersistence {
+  getNodeInfoCalls = 0;
+  logNodesStreamCalls = 0;
+  lastLogOptions: LogNodesOptions | null = null;
+
+  readonly #commits: FakeCommit[];
+  readonly #bySha: Map<string, FakeCommit>;
+  readonly #logStreamFailure: 'omit' | 'reject' | null;
+  readonly #withheld: ReadonlySet<string>;
+  readonly #writerRefs: readonly string[];
+
+  constructor({
+    commits,
+    logStreamFailure,
+    withholdFromBulk = [],
+    writerRefs = [],
+  }: FakePersistenceOptions) {
+    this.#commits = commits;
+    this.#bySha = new Map(commits.map((commit) => [commit.sha, commit]));
+    this.#logStreamFailure = logStreamFailure ?? null;
+    this.#withheld = new Set(withholdFromBulk);
+    this.#writerRefs = writerRefs;
+  }
+
+  async getNodeInfo(sha: string): Promise<NodeInfo> {
+    this.getNodeInfoCalls += 1;
+    const commit = this.#bySha.get(sha);
+    if (commit === undefined) {
+      throw new Error(`missing commit: ${sha}`);
+    }
+    return {
+      sha: commit.sha,
+      message: commit.message,
+      author: 'Author <author@test>',
+      date: '2026-08-15T00:00:00Z',
+      parents: [...commit.parents],
+    };
+  }
+
+  async logNodesStream(options: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
+    this.logNodesStreamCalls += 1;
+    this.lastLogOptions = options;
+    if (this.#logStreamFailure === 'omit') {
+      throw new TypeError('persistence.logNodesStream is not a function');
+    }
+    if (this.#logStreamFailure === 'reject') {
+      throw new Error('bulk history read failed');
+    }
+    return toLogStream(this.#commits.filter((commit) => !this.#withheld.has(commit.sha)));
+  }
+
+  async readRef(_ref: string): Promise<string | null> {
+    return this.#commits[0]?.sha ?? null;
+  }
+
+  async listRefs(prefix: string): Promise<string[]> {
+    return this.#writerRefs.map((writer) => `${prefix}${writer}`);
+  }
+
+  commitNode(_options: CommitNodeOptions): Promise<string> {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  showNode(_sha: string): Promise<string> {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  logNodes(_options: LogNodesOptions): Promise<string> {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  countNodes(_ref: string): Promise<number> {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  nodeExists(_sha: string): Promise<boolean> {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  ping(): Promise<PingResult> {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  updateRef(_ref: string, _oid: string): Promise<void> {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  deleteRef(_ref: string): Promise<void> {
+    throw new Error(UNIMPLEMENTED);
+  }
+
+  compareAndSwapRef(_ref: string, _newOid: string, _expectedOid: string | null): Promise<void> {
+    throw new Error(UNIMPLEMENTED);
+  }
+}
+
+function hostWith(
+  persistence: CorePersistence,
+  journal: PatchJournalPort | null = new FakeJournal(),
+): PatchDiscoveryHost {
   return {
-    _graphName: 'think',
+    _graphName: TEST_GRAPH,
     _persistence: persistence,
     _maxObservedLamport: 0,
     _logger: null,
     _patchJournal: journal,
-    _commitMessageCodec: fakeCodec,
+    _commitMessageCodec: new FakeCodec(),
   };
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 describe('PatchDiscovery batched chain reads', () => {
   it('loads a patch chain with one bulk history read and zero per-commit reads', async () => {
-    const commits = linearChain(50);
-    const counting = countingPersistence({ commits });
-    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+    const persistence = new FakePersistence({ commits: linearChain(50) });
+    const discovery = new PatchDiscovery(hostWith(persistence));
 
     const entries = await discovery.loadPatchChainFromSha(shaFor(0));
 
     expect(entries).toHaveLength(50);
     expect(entries[0]?.sha).toBe(shaFor(49));
     expect(entries[49]?.sha).toBe(shaFor(0));
-    expect((entries[0]?.patch as unknown as { lamport: number }).lamport).toBe(1);
-    expect(counting.logNodesStreamCalls()).toBe(1);
-    expect(counting.getNodeInfoCalls()).toBe(0);
+    expect(entries[0]?.patch.lamport).toBe(1);
+    expect(persistence.logNodesStreamCalls).toBe(1);
+    expect(persistence.getNodeInfoCalls).toBe(0);
+  });
+
+  it('requests the bulk history read with the chain log format', async () => {
+    const persistence = new FakePersistence({ commits: linearChain(4) });
+    const discovery = new PatchDiscovery(hostWith(persistence));
+
+    await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(persistence.lastLogOptions?.ref).toBe(shaFor(0));
+    expect(persistence.lastLogOptions?.format).toBe(CHAIN_LOG_FORMAT);
   });
 
   it('returns patches in chronological order identical to the per-commit walk', async () => {
     const commits = linearChain(7);
-    const batched = countingPersistence({ commits });
-    const legacy = countingPersistence({ commits, omitLogNodesStream: true });
+    const batched = new FakePersistence({ commits });
+    const legacy = new FakePersistence({ commits, logStreamFailure: 'omit' });
 
-    const batchedEntries = await new PatchDiscovery(hostWith(batched.persistence)).loadPatchChainFromSha(shaFor(0));
-    const legacyEntries = await new PatchDiscovery(hostWith(legacy.persistence)).loadPatchChainFromSha(shaFor(0));
+    const batchedEntries = await new PatchDiscovery(hostWith(batched)).loadPatchChainFromSha(shaFor(0));
+    const legacyEntries = await new PatchDiscovery(hostWith(legacy)).loadPatchChainFromSha(shaFor(0));
 
     expect(batchedEntries.map((entry) => entry.sha)).toEqual(legacyEntries.map((entry) => entry.sha));
   });
 
   it('stops at stopAtSha without reading past it', async () => {
-    const commits = linearChain(10);
-    const counting = countingPersistence({ commits });
-    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+    const persistence = new FakePersistence({ commits: linearChain(10) });
+    const discovery = new PatchDiscovery(hostWith(persistence));
 
     const entries = await discovery.loadPatchChainFromSha(shaFor(0), shaFor(4));
 
@@ -180,9 +327,8 @@ describe('PatchDiscovery batched chain reads', () => {
   });
 
   it('stops at the first non-patch commit', async () => {
-    const commits = linearChain(5, { rootKind: 'checkpoint' });
-    const counting = countingPersistence({ commits });
-    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+    const persistence = new FakePersistence({ commits: linearChain(5, { rootKind: 'checkpoint' }) });
+    const discovery = new PatchDiscovery(hostWith(persistence));
 
     const entries = await discovery.loadPatchChainFromSha(shaFor(0));
 
@@ -191,59 +337,104 @@ describe('PatchDiscovery batched chain reads', () => {
   });
 
   it('throws E_MISSING_JOURNAL when the journal is absent and patches exist', async () => {
-    const commits = linearChain(3);
-    const counting = countingPersistence({ commits });
-    const discovery = new PatchDiscovery(hostWith(counting.persistence, null));
+    const persistence = new FakePersistence({ commits: linearChain(3) });
+    const discovery = new PatchDiscovery(hostWith(persistence, null));
 
     await expect(discovery.loadPatchChainFromSha(shaFor(0))).rejects.toThrowError(PatchError);
   });
 
   it('falls back to per-commit reads when the persistence lacks logNodesStream', async () => {
-    const commits = linearChain(6);
-    const counting = countingPersistence({ commits, omitLogNodesStream: true });
-    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+    const persistence = new FakePersistence({ commits: linearChain(6), logStreamFailure: 'omit' });
+    const discovery = new PatchDiscovery(hostWith(persistence));
 
     const entries = await discovery.loadPatchChainFromSha(shaFor(0));
 
     expect(entries).toHaveLength(6);
-    expect(counting.getNodeInfoCalls()).toBe(6);
+    expect(persistence.getNodeInfoCalls).toBe(6);
   });
 
-  it('preserves journal read order oldest-first regardless of read concurrency', async () => {
-    const commits = linearChain(20);
-    const counting = countingPersistence({ commits });
-    const resolved: number[] = [];
-    const journal = {
-      async readPatch(message: PatchCommitMessage): Promise<Patch> {
-        await new Promise((resolve) => setTimeout(resolve, (message.lamport % 3) * 2));
-        resolved.push(message.lamport);
-        return { lamport: message.lamport, ops: [] } as unknown as Patch;
-      },
-    } as unknown as PatchJournalPort;
-    const discovery = new PatchDiscovery(hostWith(counting.persistence, journal));
+  it('falls back to per-commit reads when the bulk history read rejects', async () => {
+    const persistence = new FakePersistence({ commits: linearChain(6), logStreamFailure: 'reject' });
+    const discovery = new PatchDiscovery(hostWith(persistence));
 
     const entries = await discovery.loadPatchChainFromSha(shaFor(0));
 
-    expect(entries.map((entry) => (entry.patch as unknown as { lamport: number }).lamport)).toEqual(
+    expect(entries).toHaveLength(6);
+    expect(persistence.logNodesStreamCalls).toBe(1);
+    expect(persistence.getNodeInfoCalls).toBe(6);
+  });
+
+  it('reads per-commit only for commits the bulk history read omitted', async () => {
+    const persistence = new FakePersistence({
+      commits: linearChain(6),
+      withholdFromBulk: [shaFor(3)],
+    });
+    const discovery = new PatchDiscovery(hostWith(persistence));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries).toHaveLength(6);
+    expect(entries.map((entry) => entry.sha)).toEqual([
+      shaFor(5),
+      shaFor(4),
+      shaFor(3),
+      shaFor(2),
+      shaFor(1),
+      shaFor(0),
+    ]);
+    expect(persistence.logNodesStreamCalls).toBe(1);
+    expect(persistence.getNodeInfoCalls).toBe(1);
+  });
+
+  it('preserves journal read order oldest-first regardless of read concurrency', async () => {
+    const persistence = new FakePersistence({ commits: linearChain(20) });
+    const journal = new FakeJournal(async (message) => {
+      await delay((message.lamport % 3) * 2);
+      return patchFor(message.lamport);
+    });
+    const discovery = new PatchDiscovery(hostWith(persistence, journal));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries.map((entry) => entry.patch.lamport)).toEqual(
       Array.from({ length: 20 }, (_unused, index) => index + 1),
     );
-    expect(resolved).toHaveLength(20);
+    expect(journal.reads).toHaveLength(20);
+  });
+
+  it('reports the earliest pending failure when several payload reads reject', async () => {
+    // pending is tip-to-root, so lamport 4 precedes lamport 2. Lamport 4 is
+    // made the SLOWER rejection: index order must beat rejection timing.
+    const persistence = new FakePersistence({ commits: linearChain(5) });
+    const journal = new FakeJournal(async (message) => {
+      if (message.lamport === 4) {
+        await delay(30);
+        throw new Error('slow failure at lamport 4');
+      }
+      if (message.lamport === 2) {
+        throw new Error('fast failure at lamport 2');
+      }
+      return patchFor(message.lamport);
+    });
+    const discovery = new PatchDiscovery(hostWith(persistence, journal));
+
+    await expect(discovery.loadPatchChainFromSha(shaFor(0))).rejects.toThrowError(
+      'slow failure at lamport 4',
+    );
   });
 
   it('discovers ticks with one bulk history read per writer', async () => {
-    const commits = linearChain(30);
-    const counting = countingPersistence({ commits });
-    const persistence = counting.persistence as unknown as {
-      listRefs(prefix: string): Promise<string[]>;
-    };
-    persistence.listRefs = vi.fn(async (prefix: string) => [`${prefix}writer-a`]);
-    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+    const persistence = new FakePersistence({
+      commits: linearChain(30),
+      writerRefs: [TEST_WRITER],
+    });
+    const discovery = new PatchDiscovery(hostWith(persistence));
 
     const result = await discovery.discoverTicks();
 
     expect(result.maxTick).toBe(30);
-    expect(result.perWriter.get('writer-a')?.ticks).toHaveLength(30);
-    expect(counting.logNodesStreamCalls()).toBe(1);
-    expect(counting.getNodeInfoCalls()).toBe(0);
+    expect(result.perWriter.get(TEST_WRITER)?.ticks).toHaveLength(30);
+    expect(persistence.logNodesStreamCalls).toBe(1);
+    expect(persistence.getNodeInfoCalls).toBe(0);
   });
 });

--- a/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
+++ b/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { PatchDiscovery, type PatchDiscoveryHost } from '../../../../../src/domain/services/controllers/PatchDiscovery.ts';
+import WarpStream from '../../../../../src/domain/stream/WarpStream.ts';
+import PatchError from '../../../../../src/domain/errors/PatchError.ts';
+import type { CorePersistence } from '../../../../../src/domain/types/WarpPersistence.ts';
+import type { CommitLogChunk, LogNodesOptions, NodeInfo } from '../../../../../src/ports/CommitPort.ts';
+import type CommitMessageCodecPort from '../../../../../src/ports/CommitMessageCodecPort.ts';
+import type { PatchCommitMessage } from '../../../../../src/ports/CommitMessageCodecPort.ts';
+import type PatchJournalPort from '../../../../../src/ports/PatchJournalPort.ts';
+import type Patch from '../../../../../src/domain/types/Patch.ts';
+
+/**
+ * Spawn-count law for patch-chain traversal.
+ *
+ * Loading a chain of N patch commits must issue ONE bulk history read
+ * (`logNodesStream`) instead of N per-commit `getNodeInfo` reads. On the
+ * Git adapter every `getNodeInfo` call is a `git show` subprocess, so the
+ * per-commit walk makes every materialization O(history × spawn latency).
+ */
+
+interface FakeCommit {
+  sha: string;
+  parents: string[];
+  message: string;
+}
+
+/** Builds a linear chain: chain[0] is the tip, last element is the root. */
+function linearChain(length: number, options: { rootKind?: string } = {}): FakeCommit[] {
+  const commits: FakeCommit[] = [];
+  for (let index = 0; index < length; index += 1) {
+    const sha = shaFor(index);
+    const parentSha = index + 1 < length ? shaFor(index + 1) : null;
+    const isRoot = index === length - 1;
+    const kind = isRoot && options.rootKind !== undefined ? options.rootKind : 'patch';
+    commits.push({
+      sha,
+      parents: parentSha === null ? [] : [parentSha],
+      message: `${kind}:${length - index}`,
+    });
+  }
+  return commits;
+}
+
+function shaFor(index: number): string {
+  return index.toString(16).padStart(40, 'a');
+}
+
+/** Formats commits the way GitLogParser expects logNodesStream records. */
+function toLogStream(commits: FakeCommit[]): WarpStream<CommitLogChunk> {
+  const records = commits.map(
+    (commit) => `${commit.sha}\nAuthor <author@test>\n2026-08-15T00:00:00Z\n${commit.parents.join(' ')}\n${commit.message}`,
+  );
+  const joined = records.join('\0') + (records.length > 0 ? '\0' : '');
+  return WarpStream.of<CommitLogChunk>(joined);
+}
+
+interface CountingPersistenceOptions {
+  commits: FakeCommit[];
+  omitLogNodesStream?: boolean;
+}
+
+interface CountingPersistence {
+  persistence: CorePersistence;
+  getNodeInfoCalls: () => number;
+  logNodesStreamCalls: () => number;
+}
+
+function countingPersistence({ commits, omitLogNodesStream = false }: CountingPersistenceOptions): CountingPersistence {
+  const bySha = new Map(commits.map((commit) => [commit.sha, commit]));
+  let getNodeInfoCount = 0;
+  let logNodesStreamCount = 0;
+
+  const base = {
+    async getNodeInfo(sha: string): Promise<NodeInfo> {
+      getNodeInfoCount += 1;
+      const commit = bySha.get(sha);
+      if (commit === undefined) {
+        throw new Error(`missing commit: ${sha}`);
+      }
+      return {
+        sha: commit.sha,
+        message: commit.message,
+        author: 'Author <author@test>',
+        date: '2026-08-15T00:00:00Z',
+        parents: [...commit.parents],
+      };
+    },
+    async readRef(_ref: string): Promise<string | null> {
+      return commits[0]?.sha ?? null;
+    },
+    async listRefs(_prefix: string): Promise<string[]> {
+      return [];
+    },
+  };
+
+  const withStream = omitLogNodesStream
+    ? base
+    : {
+        ...base,
+        async logNodesStream(_options: LogNodesOptions): Promise<WarpStream<CommitLogChunk>> {
+          logNodesStreamCount += 1;
+          return toLogStream(commits);
+        },
+      };
+
+  return {
+    persistence: withStream as unknown as CorePersistence,
+    getNodeInfoCalls: () => getNodeInfoCount,
+    logNodesStreamCalls: () => logNodesStreamCount,
+  };
+}
+
+/** Codec for `<kind>:<lamport>` fake messages. */
+const fakeCodec = {
+  detectKind(message: string): string {
+    const kind = message.split(':')[0];
+    return kind === 'patch' ? 'patch' : 'other';
+  },
+  decodePatch(message: string): PatchCommitMessage {
+    const lamport = Number(message.split(':')[1]);
+    return { kind: 'patch', lamport } as unknown as PatchCommitMessage;
+  },
+} as unknown as CommitMessageCodecPort;
+
+function fakeJournal(): PatchJournalPort {
+  return {
+    async readPatch(message: PatchCommitMessage): Promise<Patch> {
+      return { lamport: message.lamport, ops: [] } as unknown as Patch;
+    },
+  } as unknown as PatchJournalPort;
+}
+
+function hostWith(persistence: CorePersistence, journal: PatchJournalPort | null = fakeJournal()): PatchDiscoveryHost {
+  return {
+    _graphName: 'think',
+    _persistence: persistence,
+    _maxObservedLamport: 0,
+    _logger: null,
+    _patchJournal: journal,
+    _commitMessageCodec: fakeCodec,
+  };
+}
+
+describe('PatchDiscovery batched chain reads', () => {
+  it('loads a patch chain with one bulk history read and zero per-commit reads', async () => {
+    const commits = linearChain(50);
+    const counting = countingPersistence({ commits });
+    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries).toHaveLength(50);
+    expect(entries[0]?.sha).toBe(shaFor(49));
+    expect(entries[49]?.sha).toBe(shaFor(0));
+    expect((entries[0]?.patch as unknown as { lamport: number }).lamport).toBe(1);
+    expect(counting.logNodesStreamCalls()).toBe(1);
+    expect(counting.getNodeInfoCalls()).toBe(0);
+  });
+
+  it('returns patches in chronological order identical to the per-commit walk', async () => {
+    const commits = linearChain(7);
+    const batched = countingPersistence({ commits });
+    const legacy = countingPersistence({ commits, omitLogNodesStream: true });
+
+    const batchedEntries = await new PatchDiscovery(hostWith(batched.persistence)).loadPatchChainFromSha(shaFor(0));
+    const legacyEntries = await new PatchDiscovery(hostWith(legacy.persistence)).loadPatchChainFromSha(shaFor(0));
+
+    expect(batchedEntries.map((entry) => entry.sha)).toEqual(legacyEntries.map((entry) => entry.sha));
+  });
+
+  it('stops at stopAtSha without reading past it', async () => {
+    const commits = linearChain(10);
+    const counting = countingPersistence({ commits });
+    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0), shaFor(4));
+
+    expect(entries.map((entry) => entry.sha)).toEqual([shaFor(3), shaFor(2), shaFor(1), shaFor(0)]);
+  });
+
+  it('stops at the first non-patch commit', async () => {
+    const commits = linearChain(5, { rootKind: 'checkpoint' });
+    const counting = countingPersistence({ commits });
+    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries).toHaveLength(4);
+    expect(entries.map((entry) => entry.sha)).not.toContain(shaFor(4));
+  });
+
+  it('throws E_MISSING_JOURNAL when the journal is absent and patches exist', async () => {
+    const commits = linearChain(3);
+    const counting = countingPersistence({ commits });
+    const discovery = new PatchDiscovery(hostWith(counting.persistence, null));
+
+    await expect(discovery.loadPatchChainFromSha(shaFor(0))).rejects.toThrowError(PatchError);
+  });
+
+  it('falls back to per-commit reads when the persistence lacks logNodesStream', async () => {
+    const commits = linearChain(6);
+    const counting = countingPersistence({ commits, omitLogNodesStream: true });
+    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries).toHaveLength(6);
+    expect(counting.getNodeInfoCalls()).toBe(6);
+  });
+
+  it('preserves journal read order oldest-first regardless of read concurrency', async () => {
+    const commits = linearChain(20);
+    const counting = countingPersistence({ commits });
+    const resolved: number[] = [];
+    const journal = {
+      async readPatch(message: PatchCommitMessage): Promise<Patch> {
+        await new Promise((resolve) => setTimeout(resolve, (message.lamport % 3) * 2));
+        resolved.push(message.lamport);
+        return { lamport: message.lamport, ops: [] } as unknown as Patch;
+      },
+    } as unknown as PatchJournalPort;
+    const discovery = new PatchDiscovery(hostWith(counting.persistence, journal));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries.map((entry) => (entry.patch as unknown as { lamport: number }).lamport)).toEqual(
+      Array.from({ length: 20 }, (_unused, index) => index + 1),
+    );
+    expect(resolved).toHaveLength(20);
+  });
+
+  it('discovers ticks with one bulk history read per writer', async () => {
+    const commits = linearChain(30);
+    const counting = countingPersistence({ commits });
+    const persistence = counting.persistence as unknown as {
+      listRefs(prefix: string): Promise<string[]>;
+    };
+    persistence.listRefs = vi.fn(async (prefix: string) => [`${prefix}writer-a`]);
+    const discovery = new PatchDiscovery(hostWith(counting.persistence));
+
+    const result = await discovery.discoverTicks();
+
+    expect(result.maxTick).toBe(30);
+    expect(result.perWriter.get('writer-a')?.ticks).toHaveLength(30);
+    expect(counting.logNodesStreamCalls()).toBe(1);
+    expect(counting.getNodeInfoCalls()).toBe(0);
+  });
+});

--- a/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
+++ b/test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts
@@ -22,6 +22,7 @@ import PatchJournalPort, {
 } from '../../../../../src/ports/PatchJournalPort.ts';
 import type PatchEntry from '../../../../../src/domain/artifacts/PatchEntry.ts';
 import type { CorePersistence } from '../../../../../src/domain/types/WarpPersistence.ts';
+import LoggerPort from '../../../../../src/ports/LoggerPort.ts';
 import type {
   CommitLogChunk,
   CommitNodeOptions,
@@ -295,15 +296,33 @@ class FakePersistence implements CorePersistence {
 function hostWith(
   persistence: CorePersistence,
   journal: PatchJournalPort | null = new FakeJournal(),
+  logger: LoggerPort | null = null,
 ): PatchDiscoveryHost {
   return {
     _graphName: TEST_GRAPH,
     _persistence: persistence,
     _maxObservedLamport: 0,
-    _logger: null,
+    _logger: logger,
     _patchJournal: journal,
     _commitMessageCodec: new FakeCodec(),
   };
+}
+
+/** Captures warn() calls so a silent fallback can be asserted against. */
+class RecordingLogger extends LoggerPort {
+  readonly warnings: string[] = [];
+
+  override warn(message: string): void {
+    this.warnings.push(message);
+  }
+
+  override debug(): void { /* unused by these tests */ }
+  override info(): void { /* unused by these tests */ }
+  override error(): void { /* unused by these tests */ }
+
+  override child(): LoggerPort {
+    return this;
+  }
 }
 
 function delay(ms: number): Promise<void> {
@@ -508,6 +527,62 @@ describe('PatchDiscovery batched chain reads', () => {
     await expect(discovery.loadPatchChainFromSha(shaFor(0))).rejects.toThrowError(
       'slow failure at lamport 4',
     );
+  });
+
+  it('returns the whole chain when stopAtSha is not part of it', async () => {
+    // A stale checkpoint frontier can name a commit that is not an ancestor of
+    // this tip. Bounding the read must never drop patches the walk still needs:
+    // over-exclusion loses history silently, which is worse than reading too much.
+    const unrelated = 'e'.repeat(40);
+    const persistence = new FakePersistence({ commits: linearChain(6) });
+    const discovery = new PatchDiscovery(hostWith(persistence));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0), unrelated);
+
+    expect(entries.map((entry) => entry.sha)).toEqual([
+      shaFor(5), shaFor(4), shaFor(3), shaFor(2), shaFor(1), shaFor(0),
+    ]);
+  });
+
+  it('warns when the bulk read is unusable so the slow path is not silent', async () => {
+    // A silent fallback restores the per-commit cost this class exists to
+    // remove. The degradation must be observable, not merely correct.
+    const logger = new RecordingLogger();
+    const persistence = new FakePersistence({ commits: linearChain(4), logStreamFailure: 'reject' });
+    const discovery = new PatchDiscovery(hostWith(persistence, new FakeJournal(), logger));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries).toHaveLength(4);
+    expect(logger.warnings).toHaveLength(1);
+    expect(logger.warnings[0]).toMatch(/falling back to per-commit/i);
+  });
+
+  it('does not warn when the bulk read succeeds', async () => {
+    const logger = new RecordingLogger();
+    const persistence = new FakePersistence({ commits: linearChain(4) });
+    const discovery = new PatchDiscovery(hostWith(persistence, new FakeJournal(), logger));
+
+    await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(logger.warnings).toEqual([]);
+  });
+
+  it('stops instead of spinning when the chain contains a parent cycle', async () => {
+    // Corrupt history: the root points back at the tip. The walk needs no I/O
+    // per step now, so an unguarded cycle would spin the event loop forever.
+    const commits = linearChain(4);
+    const root = commits[3];
+    if (root === undefined) {
+      throw new Error('fixture chain too short');
+    }
+    root.parents = [shaFor(0)];
+    const persistence = new FakePersistence({ commits });
+    const discovery = new PatchDiscovery(hostWith(persistence));
+
+    const entries = await discovery.loadPatchChainFromSha(shaFor(0));
+
+    expect(entries.map((entry) => entry.sha)).toEqual([shaFor(3), shaFor(2), shaFor(1), shaFor(0)]);
   });
 
   it('discovers ticks with one bulk history read per writer', async () => {

--- a/test/unit/infrastructure/adapters/AdapterConformance.ts
+++ b/test/unit/infrastructure/adapters/AdapterConformance.ts
@@ -9,6 +9,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import GitLogParser from '../../../../src/domain/services/GitLogParser.ts';
 
+/** The record format GitLogParser expects: sha, author, date, parents, body. */
+const LOG_NODE_FORMAT = '%H%n%an <%ae>%n%aI%n%P%n%B';
+
+/** Comfortably above every chain these tests build, so `limit` never truncates. */
+const LOG_NODE_LIMIT = 50;
+
 /**
  * @param {string} name - Adapter display name for describe blocks
  * @param {() => Promise<{adapter: any, cleanup?: () => Promise<void>}>} factory
@@ -110,11 +116,10 @@ export function describeAdapterConformance(name, factory) {
         const b = await adapter.commitNode({ message: 'second commit', parents: [a] });
         await adapter.updateRef('refs/warp/test/writers/log', b);
 
-        const format = '%H%n%an <%ae>%n%aI%n%P%n%B';
         const stream = await adapter.logNodesStream({
           ref: 'refs/warp/test/writers/log',
-          limit: 10,
-          format,
+          limit: LOG_NODE_LIMIT,
+          format: LOG_NODE_FORMAT,
         });
 
         const parser = new GitLogParser();
@@ -143,8 +148,8 @@ export function describeAdapterConformance(name, factory) {
       }): Promise<string[]> {
         const stream = await adapter.logNodesStream({
           ref: options.ref,
-          limit: 50,
-          format: '%H%n%an <%ae>%n%aI%n%P%n%B',
+          limit: LOG_NODE_LIMIT,
+          format: LOG_NODE_FORMAT,
           ...(options.firstParent === undefined ? {} : { firstParent: options.firstParent }),
           ...(options.stopAt === undefined ? {} : { stopAt: options.stopAt }),
         });

--- a/test/unit/infrastructure/adapters/AdapterConformance.ts
+++ b/test/unit/infrastructure/adapters/AdapterConformance.ts
@@ -126,6 +126,85 @@ export function describeAdapterConformance(name, factory) {
         expect(nodes[0]?.sha).toBe(b);
         expect(nodes[1]?.sha).toBe(a);
       });
+
+      // ── LogNodesOptions traversal contract ──────────────────────
+      //
+      // `firstParent` and `stopAt` are persistence contracts, not caller
+      // conventions. An adapter that accepts them and ignores them silently
+      // reads history its caller will never use, and — because a side branch
+      // consumes `limit` — can truncate the very chain it was asked for.
+      // Both are asserted here so no adapter can opt out.
+
+      /** Reads a chain and returns the SHA of each emitted commit. */
+      async function emittedShas(options: {
+        readonly ref: string;
+        readonly firstParent?: boolean;
+        readonly stopAt?: string;
+      }): Promise<string[]> {
+        const stream = await adapter.logNodesStream({
+          ref: options.ref,
+          limit: 50,
+          format: '%H%n%an <%ae>%n%aI%n%P%n%B',
+          ...(options.firstParent === undefined ? {} : { firstParent: options.firstParent }),
+          ...(options.stopAt === undefined ? {} : { stopAt: options.stopAt }),
+        });
+        const shas: string[] = [];
+        for await (const node of new GitLogParser().parse(stream)) {
+          shas.push(node.sha);
+        }
+        return shas;
+      }
+
+      /** root <- mainline <- merge, with `side` reachable only as a 2nd parent. */
+      async function mergeChain(): Promise<{
+        root: string; mainline: string; side: string; merge: string;
+      }> {
+        const root = await adapter.commitNode({ message: 'root' });
+        const mainline = await adapter.commitNode({ message: 'mainline', parents: [root] });
+        const side = await adapter.commitNode({ message: 'side', parents: [root] });
+        const merge = await adapter.commitNode({ message: 'merge', parents: [mainline, side] });
+        await adapter.updateRef('refs/warp/test/writers/merge', merge);
+        return { root, mainline, side, merge };
+      }
+
+      it('logNodesStream honours firstParent by excluding merge side branches', async () => {
+        const { root, mainline, side, merge } = await mergeChain();
+
+        const shas = await emittedShas({ ref: 'refs/warp/test/writers/merge', firstParent: true });
+
+        expect(shas).toEqual(expect.arrayContaining([merge, mainline, root]));
+        expect(shas).not.toContain(side);
+      });
+
+      it('logNodesStream includes merge side branches by default', async () => {
+        const { side } = await mergeChain();
+
+        const shas = await emittedShas({ ref: 'refs/warp/test/writers/merge' });
+
+        expect(shas).toContain(side);
+      });
+
+      it('logNodesStream honours stopAt by excluding it and its ancestors', async () => {
+        const { root, mainline, merge } = await mergeChain();
+
+        const shas = await emittedShas({
+          ref: 'refs/warp/test/writers/merge',
+          firstParent: true,
+          stopAt: mainline,
+        });
+
+        expect(shas).toContain(merge);
+        expect(shas).not.toContain(mainline);
+        expect(shas).not.toContain(root);
+      });
+
+      it('logNodesStream reads the whole chain when stopAt is absent', async () => {
+        const { root, mainline, merge } = await mergeChain();
+
+        const shas = await emittedShas({ ref: 'refs/warp/test/writers/merge', firstParent: true });
+
+        expect(shas).toEqual(expect.arrayContaining([merge, mainline, root]));
+      });
     });
 
     // ── BlobPort ────────────────────────────────────────────────────

--- a/test/unit/infrastructure/adapters/GitTimelineHistoryAdapter.firstParent.test.ts
+++ b/test/unit/infrastructure/adapters/GitTimelineHistoryAdapter.firstParent.test.ts
@@ -47,6 +47,34 @@ describe('GitTimelineHistoryAdapter first-parent traversal', () => {
     expect(args.indexOf('--first-parent')).toBeLessThan(args.indexOf('refs/warp/think/writers/w'));
   });
 
+  it('bounds logNodes to a rev range when stopAt is given', async () => {
+    await adapter.logNodes({ ref: 'refs/warp/think/writers/w', limit: 5, stopAt: 'refs/warp/think/checkpoints/head' });
+
+    const { args } = mockPlumbing.execute.mock.calls[0][0];
+    expect(args).toContain('refs/warp/think/checkpoints/head..refs/warp/think/writers/w');
+    expect(args).not.toContain('refs/warp/think/writers/w');
+  });
+
+  it('bounds logNodesStream to a rev range when stopAt is given', async () => {
+    await adapter.logNodesStream({ ref: 'refs/warp/think/writers/w', limit: 10, stopAt: 'refs/warp/think/checkpoints/head' });
+
+    const { args } = mockPlumbing.executeStream.mock.calls[0][0];
+    expect(args).toContain('refs/warp/think/checkpoints/head..refs/warp/think/writers/w');
+    expect(args).not.toContain('refs/warp/think/writers/w');
+  });
+
+  it('passes the bare ref when stopAt is absent', async () => {
+    await adapter.logNodesStream({ ref: 'refs/warp/think/writers/w', limit: 10 });
+
+    expect(mockPlumbing.executeStream.mock.calls[0][0].args).toContain('refs/warp/think/writers/w');
+  });
+
+  it('rejects a stopAt that would reach the command line unvalidated', async () => {
+    await expect(
+      adapter.logNodesStream({ ref: 'refs/warp/think/writers/w', limit: 10, stopAt: '--upload-pack=evil' }),
+    ).rejects.toThrow();
+  });
+
   it('omits --first-parent from logNodesStream by default', async () => {
     await adapter.logNodesStream({ ref: 'refs/warp/think/writers/w', limit: 10 });
 

--- a/test/unit/infrastructure/adapters/GitTimelineHistoryAdapter.firstParent.test.ts
+++ b/test/unit/infrastructure/adapters/GitTimelineHistoryAdapter.firstParent.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import GitTimelineHistoryAdapter from '../../../../src/infrastructure/adapters/GitTimelineHistoryAdapter.ts';
+
+/**
+ * First-parent traversal law.
+ *
+ * Patch-chain readers walk first parents only. When they ask history for a
+ * chain, the underlying `git log` must be constrained the same way, or a
+ * merge's side branch is read and paid for without ever being walked.
+ */
+describe('GitTimelineHistoryAdapter first-parent traversal', () => {
+  let mockPlumbing;
+  let adapter;
+
+  beforeEach(() => {
+    mockPlumbing = {
+      emptyTree: '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
+      execute: vi.fn().mockResolvedValue(''),
+      executeStream: vi.fn().mockResolvedValue({
+        async *[Symbol.asyncIterator]() {
+          // no chunks
+        },
+      }),
+    };
+    adapter = new GitTimelineHistoryAdapter({ plumbing: mockPlumbing });
+  });
+
+  it('passes --first-parent to logNodes when requested', async () => {
+    await adapter.logNodes({ ref: 'refs/warp/think/writers/w', limit: 5, firstParent: true });
+
+    const { args } = mockPlumbing.execute.mock.calls[0][0];
+    expect(args).toContain('--first-parent');
+    expect(args.indexOf('--first-parent')).toBeLessThan(args.indexOf('refs/warp/think/writers/w'));
+  });
+
+  it('omits --first-parent from logNodes by default', async () => {
+    await adapter.logNodes({ ref: 'refs/warp/think/writers/w', limit: 5 });
+
+    expect(mockPlumbing.execute.mock.calls[0][0].args).not.toContain('--first-parent');
+  });
+
+  it('passes --first-parent to logNodesStream when requested', async () => {
+    await adapter.logNodesStream({ ref: 'refs/warp/think/writers/w', limit: 10, firstParent: true });
+
+    const { args } = mockPlumbing.executeStream.mock.calls[0][0];
+    expect(args).toContain('--first-parent');
+    expect(args.indexOf('--first-parent')).toBeLessThan(args.indexOf('refs/warp/think/writers/w'));
+  });
+
+  it('omits --first-parent from logNodesStream by default', async () => {
+    await adapter.logNodesStream({ ref: 'refs/warp/think/writers/w', limit: 10 });
+
+    expect(mockPlumbing.executeStream.mock.calls[0][0].args).not.toContain('--first-parent');
+  });
+});

--- a/test/unit/infrastructure/adapters/InMemoryGraphAdapter.firstParent.test.ts
+++ b/test/unit/infrastructure/adapters/InMemoryGraphAdapter.firstParent.test.ts
@@ -56,6 +56,36 @@ async function drain(stream: AsyncIterable<string | Uint8Array>): Promise<string
   return chunks.join('');
 }
 
+describe('InMemoryGraphAdapter stopAt range', () => {
+  it('excludes the stopAt commit and its ancestors', async () => {
+    const { adapter, shas } = await mergeDag();
+
+    const emitted = emittedShas(
+      await adapter.logNodes({
+        ref: 'refs/heads/main',
+        limit: 50,
+        format: RECORD_FORMAT,
+        firstParent: true,
+        stopAt: shas.mainline,
+      }),
+    );
+
+    expect(emitted).toContain(shas.merge);
+    expect(emitted).not.toContain(shas.mainline);
+    expect(emitted).not.toContain(shas.root);
+  });
+
+  it('emits the whole chain when stopAt is absent', async () => {
+    const { adapter, shas } = await mergeDag();
+
+    const emitted = emittedShas(
+      await adapter.logNodes({ ref: 'refs/heads/main', limit: 50, format: RECORD_FORMAT, firstParent: true }),
+    );
+
+    expect(emitted).toEqual(expect.arrayContaining([shas.merge, shas.mainline, shas.root]));
+  });
+});
+
 describe('InMemoryGraphAdapter first-parent traversal', () => {
   it('logNodes emits only the first-parent chain when firstParent is true', async () => {
     const { adapter, shas } = await mergeDag();

--- a/test/unit/infrastructure/adapters/InMemoryGraphAdapter.firstParent.test.ts
+++ b/test/unit/infrastructure/adapters/InMemoryGraphAdapter.firstParent.test.ts
@@ -75,6 +75,28 @@ describe('InMemoryGraphAdapter stopAt range', () => {
     expect(emitted).not.toContain(shas.root);
   });
 
+  it('excludes nothing when stopAt is not an ancestor', async () => {
+    // `X..Y` excludes only what is reachable from X. A stopAt on an unrelated
+    // branch must therefore leave Y's history intact — over-exclusion would
+    // drop commits the caller still needs.
+    const { adapter, shas } = await mergeDag();
+
+    const emitted = emittedShas(
+      await adapter.logNodes({
+        ref: 'refs/heads/main',
+        limit: 50,
+        format: RECORD_FORMAT,
+        firstParent: true,
+        stopAt: shas.side,
+      }),
+    );
+
+    expect(emitted).toContain(shas.merge);
+    expect(emitted).toContain(shas.mainline);
+    // `root` IS reachable from `side`, so it is correctly excluded.
+    expect(emitted).not.toContain(shas.root);
+  });
+
   it('emits the whole chain when stopAt is absent', async () => {
     const { adapter, shas } = await mergeDag();
 

--- a/test/unit/infrastructure/adapters/InMemoryGraphAdapter.firstParent.test.ts
+++ b/test/unit/infrastructure/adapters/InMemoryGraphAdapter.firstParent.test.ts
@@ -97,6 +97,28 @@ describe('InMemoryGraphAdapter stopAt range', () => {
     expect(emitted).not.toContain(shas.root);
   });
 
+  it('resolves a stopAt ref name, not just a SHA', async () => {
+    // Callers bound reads with a checkpoint ref, not a raw SHA. An adapter that
+    // only understood SHAs would silently exclude nothing and let an unbounded
+    // read pass review here while the Git adapter bounded it correctly.
+    const { adapter, shas } = await mergeDag();
+    await adapter.updateRef('refs/warp/checkpoints/head', shas.mainline);
+
+    const emitted = emittedShas(
+      await adapter.logNodes({
+        ref: 'refs/heads/main',
+        limit: 50,
+        format: RECORD_FORMAT,
+        firstParent: true,
+        stopAt: 'refs/warp/checkpoints/head',
+      }),
+    );
+
+    expect(emitted).toContain(shas.merge);
+    expect(emitted).not.toContain(shas.mainline);
+    expect(emitted).not.toContain(shas.root);
+  });
+
   it('emits the whole chain when stopAt is absent', async () => {
     const { adapter, shas } = await mergeDag();
 

--- a/test/unit/infrastructure/adapters/InMemoryGraphAdapter.firstParent.test.ts
+++ b/test/unit/infrastructure/adapters/InMemoryGraphAdapter.firstParent.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import InMemoryGraphAdapter from '../../../../test/helpers/InMemoryGraphAdapter.ts';
+
+/**
+ * First-parent traversal contract for the in-memory persistence.
+ *
+ * `LogNodesOptions.firstParent` is a persistence contract, not a caller
+ * convention: a conforming adapter must not emit a merge's side branch at all.
+ * Verifying only that PatchDiscovery follows `parents[0]` would leave an
+ * adapter free to stream side-parent commits and still pass.
+ */
+
+const RECORD_FORMAT = '%H%n%an <%ae>%n%aI%n%P%n%B';
+
+/**
+ * Extracts the SHA of each emitted commit record.
+ *
+ * Asserting on emitted commits rather than raw text matters: a merge record
+ * legitimately names its side parent in the parents field even when that
+ * commit is correctly excluded from the walk.
+ */
+function emittedShas(output: string): string[] {
+  return output
+    .split('\0')
+    .filter((record) => record.length > 0)
+    .map((record) => record.split('\n')[0] ?? '');
+}
+
+/**
+ * Builds a merge DAG:
+ *
+ *   root <- mainline <- merge
+ *   root <- side     <-'
+ *
+ * `merge` has parents [mainline, side]; `side` is reachable only as a second
+ * parent, so first-parent traversal must never emit it.
+ */
+async function mergeDag(): Promise<{
+  adapter: InMemoryGraphAdapter;
+  shas: { root: string; mainline: string; side: string; merge: string };
+}> {
+  const adapter = new InMemoryGraphAdapter();
+  const root = await adapter.commitNode({ message: 'root' });
+  const mainline = await adapter.commitNode({ message: 'mainline', parents: [root] });
+  const side = await adapter.commitNode({ message: 'side', parents: [root] });
+  const merge = await adapter.commitNode({ message: 'merge', parents: [mainline, side] });
+  await adapter.updateRef('refs/heads/main', merge);
+  return { adapter, shas: { root, mainline, side, merge } };
+}
+
+async function drain(stream: AsyncIterable<string | Uint8Array>): Promise<string> {
+  const chunks: string[] = [];
+  for await (const chunk of stream) {
+    chunks.push(typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk));
+  }
+  return chunks.join('');
+}
+
+describe('InMemoryGraphAdapter first-parent traversal', () => {
+  it('logNodes emits only the first-parent chain when firstParent is true', async () => {
+    const { adapter, shas } = await mergeDag();
+
+    const shasEmitted = emittedShas(
+      await adapter.logNodes({ ref: 'refs/heads/main', limit: 50, format: RECORD_FORMAT, firstParent: true }),
+    );
+
+    expect(shasEmitted).toEqual(expect.arrayContaining([shas.merge, shas.mainline, shas.root]));
+    expect(shasEmitted).not.toContain(shas.side);
+  });
+
+  it('logNodes emits the side parent by default', async () => {
+    const { adapter, shas } = await mergeDag();
+
+    const shasEmitted = emittedShas(
+      await adapter.logNodes({ ref: 'refs/heads/main', limit: 50, format: RECORD_FORMAT }),
+    );
+
+    expect(shasEmitted).toContain(shas.side);
+  });
+
+  it('logNodesStream emits only the first-parent chain when firstParent is true', async () => {
+    const { adapter, shas } = await mergeDag();
+
+    const shasEmitted = emittedShas(
+      await drain(
+        await adapter.logNodesStream({
+          ref: 'refs/heads/main',
+          limit: 50,
+          format: RECORD_FORMAT,
+          firstParent: true,
+        }),
+      ),
+    );
+
+    expect(shasEmitted).toEqual(expect.arrayContaining([shas.merge, shas.mainline, shas.root]));
+    expect(shasEmitted).not.toContain(shas.side);
+  });
+
+  it('logNodesStream emits the side parent by default', async () => {
+    const { adapter, shas } = await mergeDag();
+
+    const shasEmitted = emittedShas(
+      await drain(
+        await adapter.logNodesStream({ ref: 'refs/heads/main', limit: 50, format: RECORD_FORMAT }),
+      ),
+    );
+
+    expect(shasEmitted).toContain(shas.side);
+  });
+});

--- a/test/unit/scripts/PerformanceModel.test.ts
+++ b/test/unit/scripts/PerformanceModel.test.ts
@@ -432,7 +432,7 @@ function policy(): PerformancePolicy {
       cpuRegressionRatio: 1.15,
       gitCommandRegressionRatio: 1.05,
     },
-    schemaVersion: 1,
+    schemaVersion: 2,
     streaming: {
       maxRssBytes: 256 * 1024 * 1024,
       peakHeapUsedBytes: 96 * 1024 * 1024,

--- a/test/unit/scripts/PerformanceModel.test.ts
+++ b/test/unit/scripts/PerformanceModel.test.ts
@@ -167,6 +167,40 @@ describe('v19 performance result contract', () => {
     ]);
   });
 
+  it('fails a Git-command blowup the CPU envelope would absorb', () => {
+    const blowup = replaceDistribution(
+      validResult(),
+      'cold-materialize',
+      'gitCommandCount',
+      distribution(3_505),
+    );
+
+    expect(evaluatePerformanceGate(blowup, null, policy()).failures).toEqual([
+      'cold-materialize median Git commands: 3505 exceeds 12',
+    ]);
+  });
+
+  it('fails Git-command creep that stays inside every absolute ceiling', () => {
+    const base = validResult();
+    const creep = replaceDistribution(
+      base,
+      'warm-materialize',
+      'gitCommandCount',
+      distribution(11),
+    );
+
+    expect(evaluatePerformanceGate(creep, base, policy()).failures).toEqual([
+      'warm-materialize median Git command regression: 11 exceeds 10',
+    ]);
+  });
+
+  it('accepts an unchanged Git-command count', () => {
+    const base = validResult();
+
+    expect(evaluatePerformanceGate(validResult(), base, policy()).failures)
+      .toEqual([]);
+  });
+
   it('allows the git-cas versions under test to differ', () => {
     const base = validResult();
     const head: PerformanceResult = {
@@ -345,7 +379,11 @@ function replaceSample(
 function replaceDistribution(
   result: PerformanceResult,
   scenario: PerformanceScenarioName,
-  metric: 'cpuTotalMs' | 'maxRssBytes' | 'peakHeapUsedBytes' | 'wallMs',
+  metric: 'cpuTotalMs'
+    | 'gitCommandCount'
+    | 'maxRssBytes'
+    | 'peakHeapUsedBytes'
+    | 'wallMs',
   value: Distribution,
 ): PerformanceResult {
   const current = result.scenarios[scenario];
@@ -369,6 +407,11 @@ function policy(): PerformancePolicy {
         'incremental-materialize': 1_000,
         'warm-materialize': 1_000,
       },
+      gitCommandMedian: {
+        'cold-materialize': 12,
+        'incremental-materialize': 12,
+        'warm-materialize': 12,
+      },
       maxRssBytes: {
         'cold-materialize': 256 * 1024 * 1024,
         'incremental-materialize': 256 * 1024 * 1024,
@@ -387,6 +430,7 @@ function policy(): PerformancePolicy {
         'warm-materialize': 50,
       },
       cpuRegressionRatio: 1.15,
+      gitCommandRegressionRatio: 1.05,
     },
     schemaVersion: 1,
     streaming: {

--- a/test/unit/scripts/performance-workflow.test.ts
+++ b/test/unit/scripts/performance-workflow.test.ts
@@ -1,12 +1,57 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import z from 'zod';
 import { PerformancePolicySchema }
   from '../../../scripts/performance/GatePerformance.ts';
 import { validatePerformanceExecutionOrder }
   from '../../../scripts/performance/PerformanceComparisonModel.ts';
 
 const root = process.cwd();
+
+/**
+ * The calibration record, validated rather than asserted.
+ *
+ * These files are the evidence a threshold change is reviewed against, so a
+ * malformed one should fail loudly here instead of silently satisfying a cast.
+ */
+const CalibrationSchema = z.object({
+  corpus: z.object({
+    baseNodeCount: z.number(),
+    suffixNodeCount: z.number(),
+  }),
+  environment: z.object({
+    node: z.string(),
+    platform: z.string(),
+    runner: z.string(),
+  }),
+  localCalibration: z.object({
+    observed: z.record(z.string(), z.object({
+      gitCommandMedian: z.number().int().nonnegative(),
+    })),
+  }),
+  policyRationale: z.object({
+    cpuRegressionRatio: z.number(),
+    gitCommandRegressionRatio: z.number(),
+    streamingMaxRssBytes: z.number(),
+    streamingPeakHeapUsedBytes: z.number(),
+  }),
+  rejectedProfiles: z.array(z.unknown()),
+});
+
+function readBenchmarkJson(name: string): unknown {
+  const text = readFileSync(resolve(root, `benchmarks/v19/${name}`), 'utf8');
+  const parsed: unknown = JSON.parse(text);
+  return parsed;
+}
+
+function readPolicy(): z.infer<typeof PerformancePolicySchema> {
+  return PerformancePolicySchema.parse(readBenchmarkJson('policy.json'));
+}
+
+function readCalibration(): z.infer<typeof CalibrationSchema> {
+  return CalibrationSchema.parse(readBenchmarkJson('calibration.json'));
+}
 const workflow = readFileSync(
   resolve(root, '.github/workflows/performance.yml'),
   'utf8',
@@ -67,27 +112,8 @@ describe('v19 performance workflow', () => {
   });
 
   it('keeps calibration and threshold changes in ordinary source review', () => {
-    const policy = PerformancePolicySchema.parse(JSON.parse(readFileSync(
-      resolve(root, 'benchmarks/v19/policy.json'),
-      'utf8',
-    )) as unknown);
-    const calibration = JSON.parse(readFileSync(
-      resolve(root, 'benchmarks/v19/calibration.json'),
-      'utf8',
-    )) as {
-      corpus?: { baseNodeCount?: number; suffixNodeCount?: number };
-      environment?: { node?: string; platform?: string; runner?: string };
-      localCalibration?: {
-        observed?: Readonly<Record<string, { gitCommandMedian?: number }>>;
-      };
-      policyRationale?: {
-        cpuRegressionRatio?: number;
-        gitCommandRegressionRatio?: number;
-        streamingMaxRssBytes?: number;
-        streamingPeakHeapUsedBytes?: number;
-      };
-      rejectedProfiles?: readonly unknown[];
-    };
+    const policy = readPolicy();
+    const calibration = readCalibration();
 
     expect(policy.relative.cpuRegressionRatio).toBe(1.15);
     expect(policy.streaming).toEqual({
@@ -103,34 +129,22 @@ describe('v19 performance workflow', () => {
       platform: 'linux',
       runner: 'github-hosted ubuntu-24.04',
     });
-    expect(calibration.policyRationale?.cpuRegressionRatio).toBe(1.15);
-    expect(calibration.policyRationale?.gitCommandRegressionRatio)
+    expect(calibration.policyRationale.cpuRegressionRatio).toBe(1.15);
+    expect(calibration.policyRationale.gitCommandRegressionRatio)
       .toBe(policy.relative.gitCommandRegressionRatio);
-    expect(calibration.policyRationale?.streamingMaxRssBytes)
+    expect(calibration.policyRationale.streamingMaxRssBytes)
       .toBe(policy.streaming.maxRssBytes);
-    expect(calibration.policyRationale?.streamingPeakHeapUsedBytes)
+    expect(calibration.policyRationale.streamingPeakHeapUsedBytes)
       .toBe(policy.streaming.peakHeapUsedBytes);
     expect(calibration.rejectedProfiles).toHaveLength(1);
   });
 
   it('keeps every absolute Git-command ceiling above its calibrated observation', () => {
-    const policy = PerformancePolicySchema.parse(JSON.parse(readFileSync(
-      resolve(root, 'benchmarks/v19/policy.json'),
-      'utf8',
-    )) as unknown);
-    const calibration = JSON.parse(readFileSync(
-      resolve(root, 'benchmarks/v19/calibration.json'),
-      'utf8',
-    )) as {
-      localCalibration?: {
-        observed?: Readonly<Record<string, { gitCommandMedian?: number }>>;
-      };
-    };
-    const observed = calibration.localCalibration?.observed;
+    const policy = readPolicy();
+    const observed = readCalibration().localCalibration.observed;
 
-    expect(observed).toBeDefined();
     for (const [scenario, ceiling] of Object.entries(policy.absolute.gitCommandMedian)) {
-      const measured = observed?.[scenario]?.gitCommandMedian;
+      const measured = observed[scenario]?.gitCommandMedian;
       expect(measured, `${scenario} has a calibrated Git-command count`)
         .toBeTypeOf('number');
       expect(ceiling, `${scenario} ceiling exceeds its calibrated count`)

--- a/test/unit/scripts/performance-workflow.test.ts
+++ b/test/unit/scripts/performance-workflow.test.ts
@@ -77,8 +77,12 @@ describe('v19 performance workflow', () => {
     )) as {
       corpus?: { baseNodeCount?: number; suffixNodeCount?: number };
       environment?: { node?: string; platform?: string; runner?: string };
+      localCalibration?: {
+        observed?: Readonly<Record<string, { gitCommandMedian?: number }>>;
+      };
       policyRationale?: {
         cpuRegressionRatio?: number;
+        gitCommandRegressionRatio?: number;
         streamingMaxRssBytes?: number;
         streamingPeakHeapUsedBytes?: number;
       };
@@ -100,11 +104,38 @@ describe('v19 performance workflow', () => {
       runner: 'github-hosted ubuntu-24.04',
     });
     expect(calibration.policyRationale?.cpuRegressionRatio).toBe(1.15);
+    expect(calibration.policyRationale?.gitCommandRegressionRatio)
+      .toBe(policy.relative.gitCommandRegressionRatio);
     expect(calibration.policyRationale?.streamingMaxRssBytes)
       .toBe(policy.streaming.maxRssBytes);
     expect(calibration.policyRationale?.streamingPeakHeapUsedBytes)
       .toBe(policy.streaming.peakHeapUsedBytes);
     expect(calibration.rejectedProfiles).toHaveLength(1);
+  });
+
+  it('keeps every absolute Git-command ceiling above its calibrated observation', () => {
+    const policy = PerformancePolicySchema.parse(JSON.parse(readFileSync(
+      resolve(root, 'benchmarks/v19/policy.json'),
+      'utf8',
+    )) as unknown);
+    const calibration = JSON.parse(readFileSync(
+      resolve(root, 'benchmarks/v19/calibration.json'),
+      'utf8',
+    )) as {
+      localCalibration?: {
+        observed?: Readonly<Record<string, { gitCommandMedian?: number }>>;
+      };
+    };
+    const observed = calibration.localCalibration?.observed;
+
+    expect(observed).toBeDefined();
+    for (const [scenario, ceiling] of Object.entries(policy.absolute.gitCommandMedian)) {
+      const measured = observed?.[scenario]?.gitCommandMedian;
+      expect(measured, `${scenario} has a calibrated Git-command count`)
+        .toBeTypeOf('number');
+      expect(ceiling, `${scenario} ceiling exceeds its calibrated count`)
+        .toBeGreaterThan(measured ?? Number.POSITIVE_INFINITY);
+    }
   });
 
   it('requires current green main performance evidence for v19 releases', () => {

--- a/test/unit/scripts/performance-workflow.test.ts
+++ b/test/unit/scripts/performance-workflow.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from 'vitest';
 import z from 'zod';
 import { PerformancePolicySchema }
   from '../../../scripts/performance/GatePerformance.ts';
+import { PERFORMANCE_SCENARIOS }
+  from '../../../scripts/performance/PerformanceModel.ts';
 import { validatePerformanceExecutionOrder }
   from '../../../scripts/performance/PerformanceComparisonModel.ts';
 
@@ -15,6 +17,23 @@ const root = process.cwd();
  * These files are the evidence a threshold change is reviewed against, so a
  * malformed one should fail loudly here instead of silently satisfying a cast.
  */
+const ObservedCountsSchema = z.object({
+  gitCommandMedian: z.number().int().nonnegative(),
+});
+
+/**
+ * Command counts per scenario.
+ *
+ * Keyed by the three scenario names rather than by string: the top-level
+ * `observed` block also carries a `streaming` entry that has no command count,
+ * and a permissive record would either reject it or let a missing scenario pass.
+ */
+const ScenarioCountsSchema = z.object({
+  'cold-materialize': ObservedCountsSchema,
+  'incremental-materialize': ObservedCountsSchema,
+  'warm-materialize': ObservedCountsSchema,
+});
+
 const CalibrationSchema = z.object({
   corpus: z.object({
     baseNodeCount: z.number(),
@@ -26,17 +45,19 @@ const CalibrationSchema = z.object({
     runner: z.string(),
   }),
   localCalibration: z.object({
-    observed: z.record(z.string(), z.object({
-      gitCommandMedian: z.number().int().nonnegative(),
-    })),
+    observed: ScenarioCountsSchema,
   }),
+  observed: ScenarioCountsSchema,
   policyRationale: z.object({
     cpuRegressionRatio: z.number(),
     gitCommandRegressionRatio: z.number(),
     streamingMaxRssBytes: z.number(),
     streamingPeakHeapUsedBytes: z.number(),
   }),
-  rejectedProfiles: z.array(z.unknown()),
+  rejectedProfiles: z.array(z.object({
+    baseNodeCount: z.number().int().positive(),
+    reason: z.string().min(1),
+  })),
 });
 
 function readBenchmarkJson(name: string): unknown {
@@ -139,16 +160,20 @@ describe('v19 performance workflow', () => {
     expect(calibration.rejectedProfiles).toHaveLength(1);
   });
 
-  it('keeps every absolute Git-command ceiling above its calibrated observation', () => {
+  it('keeps every Git-command ceiling above both calibrated observations', () => {
+    // The reference runner is primary: the gate runs there, so a ceiling below
+    // the CI observation would pass a local-only check and then fail on merge.
     const policy = readPolicy();
-    const observed = readCalibration().localCalibration.observed;
+    const calibration = readCalibration();
 
-    for (const [scenario, ceiling] of Object.entries(policy.absolute.gitCommandMedian)) {
-      const measured = observed[scenario]?.gitCommandMedian;
-      expect(measured, `${scenario} has a calibrated Git-command count`)
-        .toBeTypeOf('number');
-      expect(ceiling, `${scenario} ceiling exceeds its calibrated count`)
-        .toBeGreaterThan(measured ?? Number.POSITIVE_INFINITY);
+    // Iterating the canonical scenario list, not the policy's own keys, so a
+    // scenario dropped from the policy fails here instead of silently passing.
+    for (const scenario of PERFORMANCE_SCENARIOS) {
+      const ceiling = policy.absolute.gitCommandMedian[scenario];
+      expect(ceiling, `${scenario} ceiling clears the reference-runner count`)
+        .toBeGreaterThan(calibration.observed[scenario].gitCommandMedian);
+      expect(ceiling, `${scenario} ceiling clears the local count`)
+        .toBeGreaterThan(calibration.localCalibration.observed[scenario].gitCommandMedian);
     }
   });
 


### PR DESCRIPTION
## Summary

Materializing a graph walked every writer chain one commit at a time: one `git show` subprocess per patch commit (via `getNodeInfo`), serially, plus one `git cat-file blob` per payload. Every read was O(history × subprocess-spawn latency).

- `PatchDiscovery.loadPatchChainFromSha` and `PatchDiscovery.discoverTicks` now fetch chain metadata with **one `logNodesStream` bulk read per chain**, parsed with the existing `GitLogParser`.
- Patch payload reads run with **bounded concurrency (8)**, preserving chronological order and legacy error behavior.
- Persistences without a usable bulk log surface — or commits missing from the bulk read — **fall back to the legacy per-commit walk**, preserving the existing error surface (including test doubles that omit `sha` from `getNodeInfo` results).

## Measurements (real workload: Think mind, 500 thoughts, ~1,750 patch commits, 7 writer chains)

| Metric | Before | After |
|---|---|---|
| Cold `--recent` read | 82.9 s | 8.9 s |
| git subprocesses | 3,505 | 1,792 |
| Per-commit `git show` | 1,745 | 0 (3 × `git log -z`) |

Remaining spawn volume is per-blob payload reads (`assetStorage.open`), logged as a follow-up: batching those needs a `git cat-file --batch`-style surface in git-cas.

## Testing

- New `test/unit/domain/services/controllers/PatchDiscovery.batched.test.ts`: spawn-count law (one bulk read, zero per-commit reads), order/stop/kind/journal semantics, fallback path, concurrency-order preservation, `discoverTicks` batching. Written red against the legacy loop first.
- Full stable unit suite green (all shards), lint clean, `tsc` publish config clean.


Fixes #848
